### PR TITLE
docs(agents): codify branch + PR workflow as the rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,14 @@ Phase 1 targets web only. The architecture preserves portability for native wrap
 - **Deterministic replay tests**: A recorded input sequence + seed must always produce the same final world state. These tests catch non-determinism bugs.
 - **All tests run in CI** on every push and PR.
 
+## Branching & PR Workflow
+
+**All changes — including doc-only and one-line fixes — go through a feature branch and a pull request.** Direct pushes to `main` are not the path here, even when admin bypass is technically available. The `main` branch is protected: PR required, ≥1 approving review, force-pushes blocked, branch deletion blocked.
+
+Branch names: `feat/<short-description>`, `fix/<short-description>`, `chore/<short-description>`, `docs/<short-description>`. Open the PR against `main`, fill in the summary and test plan, and wait for review. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full mechanics.
+
+This applies to AI agents working in this repo as well as human contributors. The size of the change is not the criterion.
+
 ## PR Review Process
 
 Every PR is reviewed by two AI agents independently:


### PR DESCRIPTION
## Summary

- Add a **Branching & PR Workflow** section to AGENTS.md making explicit what branch protection already implies: every change goes through a feature branch and a PR, including doc-only and one-line fixes.
- Apply the rule to AI agents as well as human contributors. The size of the change is not the criterion.
- Note that admin bypass exists but is not the path; the audit line and skipped CI/review opportunity are the cost.

## Why

I had been pushing directly to \`main\` (using admin bypass) for the public-repo governance and BASE_URL fixes. Rob asked to switch to branch + PR for everything going forward. This PR codifies the rule in the repo's contributor guide so the new norm is documented, not just remembered.

The companion update in the outer (private) parent repo's AGENTS.md is committed separately — it's the agent-facing instruction for the workspace.

## Test plan

- [ ] AGENTS.md renders correctly on GitHub
- [ ] CONTRIBUTING.md cross-link still works
- [ ] Confirm this PR itself is the first artifact of the new workflow (it is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)