### PR TITLE
ci: auto-bump website submodule on push to main

### DIFF
--- a/.github/workflows/bump-website.yml
+++ b/.github/workflows/bump-website.yml
@@ -1,0 +1,47 @@
+name: Bump website submodule
+
+# When main moves here, push a matching submodule bump to the website repo.
+# The website's deploy workflow then picks it up and ships the new game build.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: bump-website
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure SSH for website repo
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.WEBSITE_DEPLOY_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Clone website repo
+        run: git clone git@github.com:LightAxe/subterrans-web.git website
+
+      - name: Bump submodule SHA
+        working-directory: website
+        env:
+          GAME_SHA: ${{ github.sha }}
+        run: |
+          git submodule update --init vendor/game
+          git -C vendor/game fetch origin "$GAME_SHA"
+          git -C vendor/game checkout "$GAME_SHA"
+
+          if git diff --quiet vendor/game; then
+            echo "Submodule already at $GAME_SHA — nothing to do."
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add vendor/game
+          git commit -m "chore(game): bump submodule to ${GAME_SHA:0:7}"
+          git push origin main


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/bump-website.yml` that fires on every push to `main` and `workflow_dispatch`.
- The job clones `LightAxe/subterrans-web` over SSH (using a deploy key stored as `WEBSITE_DEPLOY_KEY`), checks out `vendor/game` at the new SHA, and pushes a single bump commit.
- The website repo's existing deploy workflow then ships the new game build automatically.

## Setup already done
- Public key registered on `LightAxe/subterrans-web` as a write-enabled deploy key (title: `game-repo-auto-bump`).
- Private key stored on this repo as actions secret `WEBSITE_DEPLOY_KEY`.

## Test plan
- [ ] Merge this PR and confirm the workflow runs on the resulting push to `main`.
- [ ] Verify a bump commit appears on `LightAxe/subterrans-web` `main` referencing the new SHA.
- [ ] Confirm the website's Deploy workflow runs end-to-end and `/demo/play` serves the new build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)