### PR TITLE
feat(build): add library-mode bundle for embedded mount()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 
 # Build output
 dist/
+dist-lib/
 build/
 
 # Environment

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:lib": "vite build --config vite.lib.config.ts --base=/demo/play/",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/vite.lib.config.ts
+++ b/vite.lib.config.ts
@@ -1,0 +1,38 @@
+// vite.lib.config.ts — library-mode build for embedding the game in host pages.
+//
+// Companion to vite.config.ts. The standalone HTML build (vite.config.ts) emits
+// dist/index.html + a hashed JS bundle that auto-mounts via index.html's inline
+// script. This config emits a single ESM module exporting { mount, MountOptions,
+// MountedGame } with no top-level side effects, so a host page (e.g. an Astro
+// page on subterrans.com) can import it and call mount(target) itself.
+//
+// Phaser is bundled inline (rollupOptions.external = []) so the host doesn't
+// need it as its own dependency. Sprite URLs in src/render/game-scene.ts use
+// import.meta.env.BASE_URL — invoke this build with --base=/demo/play/ so the
+// asset URLs bake in to the website's deploy path.
+
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  // Suppress copying public/* into dist-lib/. Sprite assets live in the
+  // website's deploy at /demo/play/assets/sprites/* — the library bundle
+  // doesn't need to ship duplicates. Sprite URLs are baked into the JS via
+  // import.meta.env.BASE_URL = "/demo/play/" (set by --base on the CLI).
+  publicDir: false,
+  build: {
+    target: 'es2022',
+    outDir: 'dist-lib',
+    emptyOutDir: true,
+    lib: {
+      entry: 'src/main.ts',
+      formats: ['es'],
+      fileName: () => 'index.js',
+    },
+    rollupOptions: {
+      // Bundle dependencies (Phaser) into the library output. Vite's library
+      // mode externalizes package.json dependencies by default — we override
+      // so consumers don't need Phaser in their own dependency graph.
+      external: [],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds a second Vite build that emits `dist-lib/index.js` — a single ESM module exporting `{ mount }` with no top-level side effects, so a host page (e.g. an Astro page on subterrans.com) can `import { mount } from '<lib>'` and call it themselves.
- The standalone HTML build (`npm run build` → `dist/index.html`) is untouched. It still auto-mounts via `index.html`'s inline script (Vite hoists that call into the standalone bundle), exactly as today.
- Without this, the website couldn't actually consume the `mount()` API from #3 — Vite's HTML processing inlines the standalone's `mount(document.getElementById('game'))` call, so importing that bundle from a host page would auto-mount onto whatever element it could find.

## Files

- `vite.lib.config.ts` (new) — library-mode config: `lib.entry = 'src/main.ts'`, `formats: ['es']`, `fileName: () => 'index.js'`, `outDir: 'dist-lib'`, `publicDir: false`, `rollupOptions.external: []`.
- `package.json` — adds `"build:lib": "vite build --config vite.lib.config.ts --base=/demo/play/"`.
- `.gitignore` — adds `dist-lib/` alongside `dist/`.

### Why `publicDir: false`

The website's deploy already places sprites at `/demo/play/assets/sprites/*.svg`. The library bundle bakes those paths into the JS via `import.meta.env.BASE_URL` (set by `--base=/demo/play/` on the CLI). Copying `public/*` into `dist-lib/` would just ship duplicate SVGs the host page never reads.

### Why `rollupOptions.external: []`

Vite library mode externalizes `package.json` `dependencies` by default (Phaser, in our case). Overriding to `[]` bundles Phaser inline so consumers don't need it as their own dep — the website's Astro project can import the bundle directly without adding Phaser to its dependency graph.

## Acceptance check

- ✅ `npm run build` (standalone) — emits `dist/index.html` (0.51 kB) + `dist/assets/index-*.js` (1.30 MB), visually identical to before.
- ✅ `npm run build:lib` — emits `dist-lib/index.js` (1.78 MB ESM), nothing else.
- ✅ Bundle exports only `mount`: `export { oa as mount };` is the only export statement.
- ✅ No auto-mount on import: the only `getElementById(...)` calls are minified Phaser internals (parent-string resolution); no `getElementById("game")` or top-level `mount(...)` call survives. The single `new c.Game(n)` lives inside `mount()`'s body.
- ✅ Phaser bundled inline: zero `^import` or `^require(` statements at the top of the bundle.
- ✅ Sprite URLs bake to `/demo/play/assets/sprites/*` (verified via grep on the bundle).
- ✅ `npm run verify` clean — lint, typecheck, FNDN-07 sim-boundary grep, asset-path guard, 1399 vitest tests.

## Test plan

- [x] `rm -rf dist dist-lib && npm run build && npm run build:lib` — both succeed
- [x] Inspect `dist-lib/index.js` for top-level mount/getElementById calls
- [x] Confirm sprite URLs in `dist-lib/index.js` resolve to `/demo/play/assets/sprites/`
- [x] `npm run verify` green
- [ ] Manual: serve `dist-lib/index.js` from the website's deploy and call `mount(someDiv)` on the Astro page (deferred until that page lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)