### PR TITLE
fix(input): continue drag-mark when click starts on already-claimed tile

### DIFF
--- a/src/input/underground-input.test.ts
+++ b/src/input/underground-input.test.ts
@@ -237,7 +237,11 @@ describe('handleUndergroundLeftClick', () => {
     expect(world.commandQueue).toHaveLength(0);
   });
 
-  it('is a no-op for a Marked tile (already claimed)', () => {
+  it('does not push a command for a Marked tile but still arms drag state', () => {
+    // Click on already-Marked tile must arm isDragging + lastMarkedTile so a
+    // continuation drag into adjacent Solid still marks dirt. Without the
+    // arming, the subsequent pointermove would observe isDragging=false and
+    // silently no-op for the rest of the gesture (the bug this fix addresses).
     const world = makeWorld();
     const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
     ugSet(grid, 5, 10, UndergroundTileState.Marked);
@@ -246,9 +250,15 @@ describe('handleUndergroundLeftClick', () => {
     const { x, y } = tileToScreen(5, 10, 64, 32);
     handleUndergroundLeftClick(world, vs, x, y, state);
     expect(world.commandQueue).toHaveLength(0);
+    expect(state.isDragging).toBe(true);
+    expect(state.lastMarkedTileX).toBe(5);
+    expect(state.lastMarkedTileY).toBe(10);
   });
 
-  it('is a no-op for a BeingDug tile (already claimed)', () => {
+  it('does not push a command for a BeingDug tile but still arms drag state', () => {
+    // Same arming contract as the Marked case — BeingDug tiles are also
+    // already-claimed, so no command is emitted, but a click that lands on
+    // one must arm the drag so the rest of the stroke can mark dirt.
     const world = makeWorld();
     const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
     ugSet(grid, 5, 10, UndergroundTileState.BeingDug);
@@ -257,15 +267,22 @@ describe('handleUndergroundLeftClick', () => {
     const { x, y } = tileToScreen(5, 10, 64, 32);
     handleUndergroundLeftClick(world, vs, x, y, state);
     expect(world.commandQueue).toHaveLength(0);
+    expect(state.isDragging).toBe(true);
+    expect(state.lastMarkedTileX).toBe(5);
+    expect(state.lastMarkedTileY).toBe(10);
   });
 
-  it('is a no-op for out-of-bounds tile coordinates', () => {
+  it('is a no-op for out-of-bounds tile coordinates and does not arm drag state', () => {
     const world = makeWorld();
     const vs = makeViewState('underground', 64, 32);
     const state = makeState();
     // screen coord that maps to tileX < 0
     handleUndergroundLeftClick(world, vs, -640, 0, state);
     expect(world.commandQueue).toHaveLength(0);
+    // Out-of-bounds is a rejection, not an accept-and-skip — drag must NOT arm.
+    expect(state.isDragging).toBe(false);
+    expect(state.lastMarkedTileX).toBe(-1);
+    expect(state.lastMarkedTileY).toBe(-1);
   });
 
   it('sets isDragging=true and records lastMarkedTile after a successful click', () => {
@@ -387,6 +404,54 @@ describe('handleUndergroundLeftClick', () => {
     handleUndergroundLeftClick(world, vs, x, y, state);
     expect(world.commandQueue).toHaveLength(0);
     expect(state.isDragging).toBe(false);
+  });
+
+  // The eager arm-on-click for already-claimed tiles must NOT bypass the
+  // rejection guards (HUD / pan / context menu). These are symmetric
+  // counterparts to the Solid-tile guard tests above — they pin the contract
+  // that arming only happens AFTER all guards have passed, regardless of
+  // tile state. A future refactor that moves arming above a guard would
+  // break these.
+  it('Marked-tile click does NOT arm drag when context menu is visible', () => {
+    const world = makeWorld();
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 5, 10, UndergroundTileState.Marked);
+    const vs = makeViewState('underground', 64, 32);
+    const state = makeState();
+    contextMenuState.visible = true;
+    const { x, y } = tileToScreen(5, 10, 64, 32);
+    handleUndergroundLeftClick(world, vs, x, y, state);
+    expect(state.isDragging).toBe(false);
+    expect(state.lastMarkedTileX).toBe(-1);
+    expect(state.lastMarkedTileY).toBe(-1);
+    expect(world.commandQueue).toHaveLength(0);
+  });
+
+  it('Marked-tile click does NOT arm drag when panInputState.spaceHeld is true', () => {
+    const world = makeWorld();
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 5, 10, UndergroundTileState.Marked);
+    const vs = makeViewState('underground', 64, 32);
+    const state = makeState();
+    panInputState.spaceHeld = true;
+    const { x, y } = tileToScreen(5, 10, 64, 32);
+    handleUndergroundLeftClick(world, vs, x, y, state);
+    expect(state.isDragging).toBe(false);
+    expect(state.lastMarkedTileX).toBe(-1);
+    expect(state.lastMarkedTileY).toBe(-1);
+  });
+
+  it('Marked-tile click does NOT arm drag when pointer is over HUD', () => {
+    const world = makeWorld();
+    const vs = makeViewState('underground', 64, 32);
+    const state = makeState();
+    // HUD-overlap rejection runs before screenToTile, so the underlying tile
+    // state at the world coord is irrelevant here — we just verify that the
+    // arm code never executes when HUD eats the click.
+    handleUndergroundLeftClick(world, vs, HUD.TRIANGLE.x + 5, HUD.TRIANGLE.y + 5, state);
+    expect(state.isDragging).toBe(false);
+    expect(state.lastMarkedTileX).toBe(-1);
+    expect(state.lastMarkedTileY).toBe(-1);
   });
 });
 
@@ -570,6 +635,96 @@ describe('handleUndergroundDrag', () => {
     const { x, y } = tileToScreen(10, 10, 64, 32);
     handleUndergroundDrag(world, vs, x, y, state);
     expect(world.commandQueue).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Click + drag handoff: starting on an already-claimed tile must still mark
+// newly-entered Solid tiles. Regression coverage for the "click on blue
+// to-be-dug tile then drag through dirt" bug.
+// ---------------------------------------------------------------------------
+
+describe('left-click + drag handoff', () => {
+  it('click on Marked then drag into adjacent Solid emits MarkDigTile on the Solid tile', () => {
+    const world = makeWorld({ tick: 3 });
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    // Player previously marked (5,10); now they click there and drag east
+    // through Solid dirt at (6,10). The dirt must end up marked.
+    ugSet(grid, 5, 10, UndergroundTileState.Marked);
+    // (6,10) stays Solid by default
+    const vs = makeViewState('underground', 64, 32);
+    const state = makeState();
+
+    // 1. pointerdown on the Marked tile.
+    const start = tileToScreen(5, 10, 64, 32);
+    handleUndergroundLeftClick(world, vs, start.x, start.y, state);
+    expect(world.commandQueue).toHaveLength(0);
+    expect(state.isDragging).toBe(true);
+
+    // 2. pointermove into the adjacent Solid tile.
+    const dragTo = tileToScreen(6, 10, 64, 32);
+    handleUndergroundDrag(world, vs, dragTo.x, dragTo.y, state);
+
+    // The Solid tile must have been marked.
+    expect(world.commandQueue).toHaveLength(1);
+    const cmd = world.commandQueue[0] as { type: string; tileX: number; tileY: number };
+    expect(cmd.type).toBe('MarkDigTile');
+    expect(cmd.tileX).toBe(6);
+    expect(cmd.tileY).toBe(10);
+  });
+
+  it('click on BeingDug then drag into adjacent Solid emits MarkDigTile on the Solid tile', () => {
+    // Same contract for BeingDug — the click is on an already-claimed tile,
+    // but the drag must still mark dirt encountered after the start.
+    const world = makeWorld({ tick: 5 });
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 5, 10, UndergroundTileState.BeingDug);
+    const vs = makeViewState('underground', 64, 32);
+    const state = makeState();
+
+    const start = tileToScreen(5, 10, 64, 32);
+    handleUndergroundLeftClick(world, vs, start.x, start.y, state);
+    expect(world.commandQueue).toHaveLength(0);
+    expect(state.isDragging).toBe(true);
+
+    const dragTo = tileToScreen(6, 10, 64, 32);
+    handleUndergroundDrag(world, vs, dragTo.x, dragTo.y, state);
+
+    expect(world.commandQueue).toHaveLength(1);
+    const cmd = world.commandQueue[0] as { type: string; tileX: number; tileY: number };
+    expect(cmd.type).toBe('MarkDigTile');
+    expect(cmd.tileX).toBe(6);
+    expect(cmd.tileY).toBe(10);
+  });
+
+  it('click on Marked then drag across multiple Solid tiles produces a continuous 4-connected mark sequence', () => {
+    // Multi-tile stroke variant — exercises the Bresenham interpolation
+    // starting from a Marked tile. Covers the realistic gesture: player taps
+    // an already-marked tile and sweeps through dirt to mark a corridor.
+    const world = makeWorld();
+    const vs = makeViewState('underground', 64, 32);
+    const state = makeState();
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 10, 10, UndergroundTileState.Marked);
+    // (11,10) through (13,10) stay Solid by default
+
+    const start = tileToScreen(10, 10, 64, 32);
+    handleUndergroundLeftClick(world, vs, start.x, start.y, state);
+    expect(world.commandQueue).toHaveLength(0);
+
+    const dragTo = tileToScreen(13, 10, 64, 32);
+    handleUndergroundDrag(world, vs, dragTo.x, dragTo.y, state);
+
+    const marks = world.commandQueue.map((c) => {
+      const cc = c as { tileX: number; tileY: number };
+      return `${cc.tileX},${cc.tileY}`;
+    });
+    // Every dirt tile crossed during the drag must be in the queue. The
+    // starting (Marked) tile is not re-emitted.
+    expect(marks).toContain('11,10');
+    expect(marks).toContain('12,10');
+    expect(marks).toContain('13,10');
+    expect(marks).not.toContain('10,10');
   });
 });
 

--- a/src/input/underground-input.ts
+++ b/src/input/underground-input.ts
@@ -40,9 +40,15 @@ import { contextMenuState, requestShowContextMenu } from '../render/context-menu
 export interface UndergroundInputState {
   /** True from the first pointerdown until pointerup — enables drag tile-mark. */
   isDragging: boolean;
-  /** Last tile X that had a MarkDigTileCommand emitted during this drag. */
+  /**
+   * X coord of the last tile the drag cursor has visited (debounce + Bresenham
+   * interpolation start). Seeded by the pointerdown click — including clicks
+   * on Marked/BeingDug tiles where no MarkDigTileCommand was emitted — so the
+   * subsequent drag interpolates from the actual click point, not from the
+   * last *emitted* mark. -1 sentinel means no drag in progress.
+   */
   lastMarkedTileX: number;
-  /** Last tile Y that had a MarkDigTileCommand emitted during this drag. */
+  /** Y coord counterpart to lastMarkedTileX. Same semantics — see above. */
   lastMarkedTileY: number;
 }
 
@@ -103,11 +109,22 @@ export function isTunnelEnd(world: WorldState, tileX: number, tileY: number, col
  * no state mutation. UIScene owns menu dismissal so the dismissal happens on
  * a deterministic frame boundary, not mid-pointerdown dispatch.
  *
- * Otherwise, if the clicked tile is Solid or Open, pushes MarkDigTileCommand
- * and sets isDragging=true to enable subsequent drag marks.
+ * Otherwise, arms the drag state (isDragging + lastMarkedTile) on every
+ * pointerdown that lands on a valid in-bounds tile, regardless of whether the
+ * tile is markable. This is intentional: a click-then-drag stroke that starts
+ * on an already-Marked or BeingDug tile must still mark newly-entered Solid
+ * tiles. Without the eager arm, the subsequent pointermove would observe
+ * isDragging=false and silently no-op for the rest of the gesture.
  *
- * No-ops if: activeView !== 'underground', pointer over HUD, out of bounds,
- * or tile is Marked/BeingDug (already claimed).
+ * Pushes MarkDigTileCommand only when the clicked tile is Solid or Open;
+ * Marked/BeingDug tiles are already claimed so emitting a command would just
+ * clutter the queue and replay log (the sim's MarkDigTile handler also drops
+ * non-Solid tiles, so a duplicate would be a no-op there too).
+ *
+ * No-ops entirely if: activeView !== 'underground', pointer over HUD, pan
+ * mode active, context menu visible, missing grid, or out of bounds. In all
+ * those cases the drag state is NOT armed — the gesture was rejected, not
+ * accepted-and-skipped.
  */
 export function handleUndergroundLeftClick(
   world: WorldState,
@@ -130,6 +147,13 @@ export function handleUndergroundLeftClick(
   const grid = world.undergroundGrids[PLAYER_COLONY_ID];
   if (!grid) return;
   if (tileX < 0 || tileY < 0 || tileX >= grid.width || tileY >= grid.height) return;
+  // Arm drag state up front (before the tile-state branch) so a stroke that
+  // begins on a Marked/BeingDug tile still marks subsequent Solid tiles. The
+  // debounce cursor is seeded to the clicked tile so the first Bresenham
+  // interpolation in handleUndergroundDrag starts from a real coordinate.
+  state.isDragging = true;
+  state.lastMarkedTileX = tileX;
+  state.lastMarkedTileY = tileY;
   // Only mark Solid or Open tiles (Marked/BeingDug are already claimed).
   const tileState = ugGet(grid, tileX, tileY);
   if (tileState !== UndergroundTileState.Solid && tileState !== UndergroundTileState.Open) return;
@@ -141,9 +165,6 @@ export function handleUndergroundLeftClick(
     issuedAtTick: world.tick,
   };
   world.commandQueue.push(cmd);
-  state.isDragging = true;
-  state.lastMarkedTileX = tileX;
-  state.lastMarkedTileY = tileY;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes a UX bug: clicking on a blue "to-be-dug" tile (Marked / BeingDug) and then dragging through adjacent dirt was silently doing nothing — `handleUndergroundLeftClick` returned early on already-claimed tiles without arming `state.isDragging`, so the drag handler aborted at its top guard for the rest of the gesture.
- Reorders `handleUndergroundLeftClick` so the drag-arming bookkeeping (`isDragging` + `lastMarkedTile` cursor) happens before the tile-state branch. Tile-state still gates command emission — already-claimed tiles don't push a redundant `MarkDigTileCommand` — but the stroke is now armed for the rest of the gesture.
- All rejection guards (HUD overlap, pan mode, context menu visible, out of bounds, missing grid, wrong view) still abort *before* arming. Tests pin both halves of the contract.
- Updates the field-level JSDoc on `UndergroundInputState.lastMarkedTileX/Y` — the field was inaccurately documented as "last tile that had a `MarkDigTileCommand` emitted"; it's actually the debounce + Bresenham start cursor and always was.

## Test plan
- [x] `npm run verify` — lint + typecheck + sim-boundary guard + asset-path guard + 1405/1405 vitest tests pass.
- [x] Two independent fresh-context AI code reviews (round 1: parallel; round 2: verification) — round 1 surfaced two P1 issues (stale JSDoc, missing symmetric guard-rejection coverage); both addressed in this PR; round 2 came back clean.
- [x] Manual: open the underground view, mark a tile, then click the marked tile and drag through dirt — the dirt should now turn blue along the drag path. Same flow on a `BeingDug` tile (blue dashed).
- [x] Manual sanity: confirm clicking on a marked tile *without* dragging still does nothing visible (no spurious commands, no UI flicker).
- [x] Manual sanity: confirm guard rejections still work — clicking a marked tile with the chamber context menu open should not arm a drag (release the menu, then drag elsewhere — should be a clean fresh stroke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)