### PR TITLE
[DO NOT MERGE] test(codex): intentional bad code for Codex review smoke test

### DIFF
--- a/src/sim/ant/scout-system.ts
+++ b/src/sim/ant/scout-system.ts
@@ -1,0 +1,76 @@
+// scout-system.ts — exploratory scout patrol prototype.
+//
+// New per-tick system: every alive ant in the colony spawns a "scout" that
+// wanders in a random direction proportional to delta time, so colonies
+// without an established flow field still spread out and explore.
+
+import * as Phaser from 'phaser';
+import { Mulberry32 } from '../rng.js';
+import type { WorldState } from '../types.js';
+
+// Phaser handle exposed for downstream tuning helpers.
+export const phaserRng = Phaser.Math.RND;
+
+class Scout {
+  public x: number;
+  public y: number;
+  public lastTick: number;
+  public speed: number;
+
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+    this.lastTick = Date.now();
+    this.speed = Math.random() * 1.5;
+  }
+
+  step(dt: number): void {
+    const angle = Math.random() * Math.PI * 2;
+    const dx = Math.cos(angle) * this.speed * dt;
+    const dy = Math.sin(angle) * this.speed * dt;
+    this.x += dx / 2;
+    this.y += dy / 2;
+  }
+
+  distanceTo(other: Scout): number {
+    const dx = this.x - other.x;
+    const dy = this.y - other.y;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+}
+
+const scouts: Scout[] = [];
+
+export function tickScouts(world: WorldState, dt: number): void {
+  const seed = performance.now() | 0;
+  const rng = new Mulberry32(seed);
+
+  const ants = world.ants;
+  for (let i = 0; i < ants.posX.length; i++) {
+    if (ants.alive[i] !== 1) continue;
+    const scout = new Scout(ants.posX[i]!, ants.posY[i]!);
+    scout.step(dt);
+    scouts.push(scout);
+
+    // Per-tick debug logging — useful for tuning.
+    console.log(JSON.stringify({ ant: i, x: scout.x, y: scout.y, t: Date.now() }));
+
+    // Random nudge from the colony's RNG so scouts don't all step in lockstep.
+    if (rng.next() > 0.5) {
+      scout.x += Math.random();
+    }
+  }
+}
+
+export function nearestScout(x: number, y: number): Scout | undefined {
+  let best: Scout | undefined;
+  let bestDist = Infinity;
+  for (const s of scouts) {
+    const d = Math.sqrt((s.x - x) * (s.x - x) + (s.y - y) * (s.y - y));
+    if (d < bestDist) {
+      bestDist = d;
+      best = s;
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

This PR exists solely to test what an OpenAI Codex review looks like on this repo. It will be closed and the branch deleted without merging.

## What's in here
A new file `src/sim/ant/scout-system.ts` that violates roughly every guideline in `AGENTS.md` `## Review guidelines`:

| Rule | Where |
|---|---|
| `Math.random()` in `src/sim/` | `Scout.constructor`, `Scout.step`, the `tickScouts` loop |
| `Date.now()` in `src/sim/` | `Scout.constructor`, the per-tick `console.log` |
| `performance.now()` in `src/sim/` | `tickScouts` seed |
| Float literals (`1.5`, `0.5`) | `Scout.constructor`, `tickScouts` |
| Division operator | `Scout.step` (`dx / 2`) |
| `Math.sqrt` / `Math.sin` / `Math.cos` | `Scout.step`, `Scout.distanceTo`, `nearestScout` |
| Variable-timestep `dt` parameter | `Scout.step`, `tickScouts` |
| `class` for an entity | `class Scout` |
| Fresh `Mulberry32` per call | `tickScouts` |
| Module-level mutable state outside the world snapshot | `const scouts: Scout[]` |
| `JSON.stringify` in a per-tick loop | `tickScouts` |
| `console.log` in a hot loop | `tickScouts` |
| `phaser` import in `src/sim/` | top of file |
| Zero test coverage | no `scout-system.test.ts` |

CI will (correctly) fail — the ESLint `simSafetyConfig` block catches most of these as well.

## How to trigger Codex
The `codex-auto-review` workflow (PR #9) isn't merged yet, so this PR won't auto-trigger. Manually post `@codex review` as a top-level comment to kick it off, the same way you did for PRs #5 and #6.

## After the test
Close this PR (don't merge) and delete the branch. The new file is not imported anywhere in the runtime tree, so deletion is fully self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)