### PR TITLE
fix(sim): chamber-authoritative food storage (issue #15)

### DIFF
--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -283,6 +283,20 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       }));
       expect(hasSave()).toBe(false);
     });
+    it('rejects v1 saves (issue #15 — chamber-authoritative food storage)', () => {
+      // Pre-#15 saves stored the entire stockpile in `colony.foodStored`
+      // and projected slices into `chamber.foodStored` on each reconcile.
+      // Loading them under v2 would either double-count (slices + pool) or
+      // silently truncate to BASE on the next reconcile. The version bump
+      // forces the loader to reject the save and boot a fresh scenario,
+      // which is the documented behaviour for breaking format changes.
+      const w = createScenario(42);
+      localStorage.setItem(SAVE_KEY, JSON.stringify({
+        version: 1, seed: 42, inputLog: [], snapshot: serializeWorldState(w),
+      }));
+      expect(hasSave()).toBe(false);
+      expect(loadSave()).toBeNull();
+    });
     it('loadSave returns a SaveFile with seed + inputLog + snapshot fields', () => {
       const w = createScenario(42);
       const inputLog: SimCommand[] = [

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -11,6 +11,7 @@ import { tick } from '../sim/tick.js';
 import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
 import type { SimCommand } from '../sim/commands.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
+import { ChamberType } from '../sim/enums.js';
 
 describe('save.ts (SCEN-04 + SCEN-06)', () => {
   // Use window.localStorage to ensure jsdom's implementation (not Node 25 native localStorage)
@@ -87,6 +88,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       const s = serializeWorldState(w);
       expect(s.colonies[String(PLAYER_COLONY_ID)]!.priorityFoodPileId).toBeNull();
     });
+    it('preserves ColonyRecord.foodFlowFieldDirty (issue #15)', () => {
+      const w = createScenario(42);
+      w.colonies[PLAYER_COLONY_ID]!.foodFlowFieldDirty = true;
+      const s = serializeWorldState(w);
+      expect(s.colonies[String(PLAYER_COLONY_ID)]!.foodFlowFieldDirty).toBe(true);
+    });
   });
 
   describe('deserializeWorldState — round-trip', () => {
@@ -130,6 +137,45 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       w.colonies[PLAYER_COLONY_ID]!.priorityFoodPileId = null;
       const w2 = deserializeWorldState(serializeWorldState(w));
       expect(w2.colonies[PLAYER_COLONY_ID]!.priorityFoodPileId).toBeNull();
+    });
+    it('round-trips ColonyRecord.foodFlowFieldDirty through serialize → deserialize (issue #15)', () => {
+      const w = createScenario(42);
+      w.colonies[PLAYER_COLONY_ID]!.foodFlowFieldDirty = true;
+      const w2 = deserializeWorldState(serializeWorldState(w));
+      expect(w2.colonies[PLAYER_COLONY_ID]!.foodFlowFieldDirty).toBe(true);
+    });
+    it('pre-#15 saves (foodFlowFieldDirty absent) deserialize to false', () => {
+      // Backwards compat: a save written before issue #15 lacked the field.
+      // Loader must default it to false rather than throw.
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      const colonyKey = String(PLAYER_COLONY_ID);
+      delete (s.colonies[colonyKey] as { foodFlowFieldDirty?: boolean }).foodFlowFieldDirty;
+      const w2 = deserializeWorldState(s);
+      expect(w2.colonies[PLAYER_COLONY_ID]!.foodFlowFieldDirty).toBe(false);
+    });
+    it('round-trips per-chamber chamber.foodStored independently (issue #15)', () => {
+      // Issue #15 regression: under the old pool-only model, save + reload
+      // would re-derive chamber.foodStored from colony.foodStored at the next
+      // reconcile, hiding any per-chamber drift. Post-#15, chamber.foodStored
+      // is authoritative — the save MUST faithfully preserve each chamber's
+      // contents, including disparate values across chambers.
+      const w = createScenario(42);
+      const colony = w.colonies[PLAYER_COLONY_ID]!;
+      colony.chambers.push({
+        chamberId: 999, chamberType: ChamberType.FoodStorage, foodStored: 1234,
+        posX: 10 << 8, posY: 5 << 8, width: 3, height: 3,
+      });
+      colony.chambers.push({
+        chamberId: 998, chamberType: ChamberType.FoodStorage, foodStored: 4321,
+        posX: 14 << 8, posY: 5 << 8, width: 3, height: 3,
+      });
+      const w2 = deserializeWorldState(serializeWorldState(w));
+      const c2 = w2.colonies[PLAYER_COLONY_ID]!;
+      const ch1 = c2.chambers.find(c => c.chamberId === 999)!;
+      const ch2 = c2.chambers.find(c => c.chamberId === 998)!;
+      expect(ch1.foodStored).toBe(1234);
+      expect(ch2.foodStored).toBe(4321);
     });
     it('round-trips non-zero ants.searchWave through serialize → deserialize (Phase 9 / 09 digger-reassignment memo)', () => {
       // Regression guard: if searchWave is dropped, Continue/autosave silently

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -433,8 +433,21 @@ function parseSaveFile(raw: string): SaveFile {
   return parsed as SaveFile;
 }
 
+/**
+ * Opportunistically purge the v1 key so existing players don't carry the
+ * rejected pre-#15 envelope around in localStorage indefinitely. v2 fully
+ * supersedes v1; pre-bump saves are intentionally rejected (parseSaveFile
+ * throws SaveVersionMismatchError), so there is no recovery path that needs
+ * the old data. Called from both hasSave and loadSave so the purge fires on
+ * the first save-touching operation, regardless of which one runs first.
+ */
+function purgeLegacySaves(): void {
+  try { localStorage.removeItem('subterrans:save:v1'); } catch { /* quota / private mode — silent: best-effort cleanup, no UX signal */ }
+}
+
 export function hasSave(): boolean {
   try {
+    purgeLegacySaves();
     const raw = localStorage.getItem(SAVE_KEY);
     if (raw === null) return false;
     parseSaveFile(raw);
@@ -446,12 +459,7 @@ export function hasSave(): boolean {
 
 export function loadSave(): SaveFile | null {
   try {
-    // Issue #15 follow-up: opportunistically purge the v1 key on load so
-    // existing players don't carry the rejected pre-#15 envelope around in
-    // localStorage indefinitely. v2 fully supersedes v1; pre-bump saves are
-    // intentionally rejected (parseSaveFile throws SaveVersionMismatchError),
-    // so there is no recovery path that needs the old data.
-    try { localStorage.removeItem('subterrans:save:v1'); } catch { /* quota / private mode */ }
+    purgeLegacySaves();
     const raw = localStorage.getItem(SAVE_KEY);
     if (raw === null) return null;
     return parseSaveFile(raw);

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -446,6 +446,12 @@ export function hasSave(): boolean {
 
 export function loadSave(): SaveFile | null {
   try {
+    // Issue #15 follow-up: opportunistically purge the v1 key on load so
+    // existing players don't carry the rejected pre-#15 envelope around in
+    // localStorage indefinitely. v2 fully supersedes v1; pre-bump saves are
+    // intentionally rejected (parseSaveFile throws SaveVersionMismatchError),
+    // so there is no recovery path that needs the old data.
+    try { localStorage.removeItem('subterrans:save:v1'); } catch { /* quota / private mode */ }
     const raw = localStorage.getItem(SAVE_KEY);
     if (raw === null) return null;
     return parseSaveFile(raw);

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -28,8 +28,22 @@ import { createPheromoneGrid } from '../sim/pheromone/pheromone-store.js';
 import type { FoodPile, FoodPileId } from '../sim/food.js';
 import { MAX_ENTITIES } from '../sim/constants.js';
 
-export const SAVE_FORMAT_VERSION = 1 as const;
-export const SAVE_KEY = 'subterrans:save:v1' as const;
+// SAVE_FORMAT_VERSION is bumped on any breaking change to the on-disk shape
+// or to invariants that survivors must respect. Pre-bump saves are rejected
+// by parseSaveFile (SaveVersionMismatchError) — the loadSave/hasSave path
+// returns null, so the caller boots a fresh scenario instead of corrupting
+// state. Per the original save.ts header note, version bumps "intentionally
+// invalidate old saves (intentional for beta)".
+//
+// History:
+//   v1 — Phase 9 / SCEN-04 baseline.
+//   v2 — Issue #15: chamber-authoritative food storage. Pre-v2 saves stored
+//        the entire stockpile in `colony.foodStored` (chambers held projected
+//        slices, recomputed each reconcile). Loading those into v2 would
+//        either double-count (slices + pool) or silently truncate to BASE on
+//        the next reconcile. Reject them — fresh scenarios are cheap in beta.
+export const SAVE_FORMAT_VERSION = 2 as const;
+export const SAVE_KEY = 'subterrans:save:v2' as const;
 export const AUTOSAVE_INTERVAL_MS = 30_000 as const;
 
 export class SaveVersionMismatchError extends Error {
@@ -315,8 +329,12 @@ function deserializeAnts(saved: SerializedAnts, capacity: number): AntComponents
 
 function deserializeColony(s: SerializedColony): ColonyRecord {
   const c = createColonyRecord(s.colonyId, s.queenEntityId);
-  // createColonyRecord does NOT set the 3 Phase 3 extension fields — caller-side contract
-  // (colony-store.ts comment). Set them explicitly alongside scalar fields.
+  // createColonyRecord does NOT set the Phase 3 extension fields nor the
+  // issue-#15 `foodFlowFieldDirty` field — caller-side contract (see the
+  // colony-store.ts factory docblock). Set them explicitly alongside scalar
+  // fields. `foodFlowFieldDirty` is `?? false` defensively even though v2
+  // saves should always include it; pre-v2 saves are rejected upstream by
+  // parseSaveFile (SaveVersionMismatchError).
   c.queenStarvationTimer = s.queenStarvationTimer;
   c.foodStored           = s.foodStored;
   c.workerCount          = s.workerCount;

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -92,6 +92,7 @@ interface SerializedColony {
   entrances: NestEntrance[];
   rallyPoint: { tileX: number; tileY: number } | null;
   digFlowFieldDirty: boolean;
+  foodFlowFieldDirty?: boolean;  // Issue #15 — defaults false on old saves
   killCount: number;   // Plan 09-01
   priorityFoodPileId: FoodPileId | null;  // Phase 9 / PRD §3d — per-colony priority food target
 }
@@ -184,6 +185,7 @@ function serializeColony(c: ColonyRecord): SerializedColony {
     entrances:            c.entrances.map((e) => ({ ...e })),
     rallyPoint:           c.rallyPoint === null ? null : { ...c.rallyPoint },
     digFlowFieldDirty:    c.digFlowFieldDirty,
+    foodFlowFieldDirty:   c.foodFlowFieldDirty,
     killCount:            c.killCount,
     priorityFoodPileId:   c.priorityFoodPileId,
   };
@@ -333,6 +335,7 @@ function deserializeColony(s: SerializedColony): ColonyRecord {
   c.entrances            = s.entrances.map((e) => ({ ...e }));
   c.rallyPoint           = s.rallyPoint === null ? null : { ...s.rallyPoint };
   c.digFlowFieldDirty    = s.digFlowFieldDirty;
+  c.foodFlowFieldDirty   = s.foodFlowFieldDirty ?? false;
   c.killCount            = s.killCount;
   c.priorityFoodPileId   = s.priorityFoodPileId ?? null;
   return c;

--- a/src/render/ai-controller.integration.test.ts
+++ b/src/render/ai-controller.integration.test.ts
@@ -29,6 +29,7 @@ import { FP_SHIFT } from '../sim/fixed.js';
 import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
 import type { WorldState } from '../sim/types.js';
 import type { ColonyRecord } from '../sim/colony/colony-store.js';
+import { colonyFoodTotal } from '../sim/colony/colony-system.js';
 
 // -----------------------------------------------------------------------------
 // Scenario constants
@@ -57,7 +58,10 @@ function snapshotColony(world: WorldState, colony: ColonyRecord): Snapshot {
   return {
     tick: world.tick,
     workerCount: colony.workerCount,
-    foodStored: colony.foodStored,
+    // Issue #15: deposits now land in chamber.foodStored, not the pool. The
+    // diagnostic snapshot reads colonyFoodTotal so the value reflects the
+    // colony's actual stockpile rather than just the entrance-shaft fallback.
+    foodStored: colonyFoodTotal(colony),
     eggCount: colony.eggCount,
     larvaeCount: colony.larvaeCount,
     chamberTypes: colony.chambers.map((c) => c.chamberType),
@@ -157,11 +161,16 @@ describe('AI-only scenario 3000 ticks', () => {
       `Nursery chamber missing. ${ctx}`,
     ).toBeDefined();
 
-    // 6. Food stored > 0
-    expect(
-      aiColony!.foodStored,
-      `AI colony foodStored is not > 0 (found ${aiColony!.foodStored}). ${ctx}`,
-    ).toBeGreaterThan(0);
+    // 6. Food stored > 0 (issue #15: read total stash — entrance pool plus
+    // every FoodStorage chamber. Post-#15 deposits land in chambers, not the
+    // pool, so reading colony.foodStored alone would silently regress to
+    // "did the entrance-shaft fallback fire at least once" — not what this
+    // assertion is testing.)
+    {
+      const total = colonyFoodTotal(aiColony!);
+      expect(total, `AI colony food total is not > 0 (found ${total}). ${ctx}`)
+        .toBeGreaterThan(0);
+    }
 
     // 7. Chamber uniqueness: exactly 1 Queen, exactly 1 Nursery, ≥1 FoodStorage
     expect(

--- a/src/render/ai-controller.test.ts
+++ b/src/render/ai-controller.test.ts
@@ -53,6 +53,7 @@ function addColony(world: WorldState, colonyId: ColonyId, queenEntityId: number)
   colony.entrances = [];
   colony.rallyPoint = null;
   colony.digFlowFieldDirty = false;
+  colony.foodFlowFieldDirty = false;
   world.colonies[colonyId] = colony;
   return colony;
 }

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -16,6 +16,7 @@ import { ChamberType } from '../sim/enums.js';
 import { UndergroundTileState, ugGet } from '../sim/terrain.js';
 import { FP_SHIFT } from '../sim/fixed.js';
 import { CHAMBER_DIMENSIONS } from '../sim/colony/chamber.js';
+import { colonyFoodTotal } from '../sim/colony/colony-system.js';
 
 export const AI_DIG_INTERVAL = 40 as const;       // every 2 seconds @ 20Hz
 export const AI_DIG_MARK_BUDGET = 5 as const;
@@ -202,9 +203,12 @@ export function aiChamberPlacement(world: WorldState, colony: ColonyRecord): voi
       world.commandQueue.push(cmd);
     }
   }
-  // Food storage — if food stockpile crossed threshold and no FoodStorage yet
+  // Food storage — if food stockpile crossed threshold and no FoodStorage yet.
+  // Issue #15: read total stash (entrance pool + every chamber.foodStored), not
+  // the chamberless fallback bucket — colony.foodStored alone is now only the
+  // entrance pool, so the AI gate would never fire once the first chamber filled.
   if (
-    colony.foodStored >= AI_FOOD_STORAGE_THRESHOLD
+    colonyFoodTotal(colony) >= AI_FOOD_STORAGE_THRESHOLD
     && !colony.chambers.some((c) => c.chamberType === ChamberType.FoodStorage)
   ) {
     const placement = findOpenChamberSpot(world, colony, 5, ChamberType.FoodStorage);  // near-surface storage

--- a/src/render/draw-underground.test.ts
+++ b/src/render/draw-underground.test.ts
@@ -414,11 +414,11 @@ describe('drawUndergroundEntities', () => {
   it('FoodStorage half-full → proportional count of food-cache sprites', () => {
     const foodDims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage];
     const totalTiles = foodDims.width * foodDims.height;
-    world.colonies[PLAYER_COLONY_ID]!.foodStored = Math.floor(FOOD_CHAMBER_CAPACITY / 2);
+    // Issue #15: chamber.foodStored is the authoritative per-chamber stockpile.
     world.colonies[PLAYER_COLONY_ID]!.chambers = [{
       chamberId:   10,
       chamberType: ChamberType.FoodStorage,
-      foodStored:  0, // stale — should be ignored; colony.foodStored is truth
+      foodStored:  Math.floor(FOOD_CHAMBER_CAPACITY / 2),
       posX:        5 << FP_SHIFT,
       posY:        5 << FP_SHIFT,
       width:       foodDims.width,
@@ -438,11 +438,10 @@ describe('drawUndergroundEntities', () => {
 
   it('FoodStorage full → food-cache sprite per tile, bottom row included', () => {
     const foodDims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage];
-    world.colonies[PLAYER_COLONY_ID]!.foodStored = FOOD_CHAMBER_CAPACITY;
     world.colonies[PLAYER_COLONY_ID]!.chambers = [{
       chamberId:   11,
       chamberType: ChamberType.FoodStorage,
-      foodStored:  0, // stale; projection uses colony.foodStored
+      foodStored:  FOOD_CHAMBER_CAPACITY,
       posX:        5 << FP_SHIFT,
       posY:        5 << FP_SHIFT,
       width:       foodDims.width,
@@ -473,19 +472,19 @@ describe('drawUndergroundEntities', () => {
       .toBeGreaterThanOrEqual(1);
   });
 
-  it('FoodStorage fill responds to colony.foodStored even when chamber.foodStored is stale', () => {
-    // Regression: ChamberRecord.foodStored is refreshed only on tickReconcile
-    // (every RECONCILE_INTERVAL_TICKS). Between reconciles a forager can top
-    // up colony.foodStored by a large amount and the old chamber-field read
-    // would still show an empty chamber. The projection must mirror
-    // tickReconcile's distribution from colony.foodStored directly.
+  it('FoodStorage fill reads chamber.foodStored directly (issue #15 chamber-authoritative)', () => {
+    // Issue #15 changed the model: chamber.foodStored is the authoritative
+    // per-chamber stockpile, written by ant deposits inside the footprint and
+    // read directly by render. There's no projection from colony.foodStored.
     const foodDims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage];
     const totalTiles = foodDims.width * foodDims.height;
-    world.colonies[PLAYER_COLONY_ID]!.foodStored = FOOD_CHAMBER_CAPACITY; // pool is full
+    // Set the entrance pool full just to confirm it does NOT bleed into the
+    // chamber visual — the bug we fixed.
+    world.colonies[PLAYER_COLONY_ID]!.foodStored = 9999;
     world.colonies[PLAYER_COLONY_ID]!.chambers = [{
       chamberId:   12,
       chamberType: ChamberType.FoodStorage,
-      foodStored:  0, // STALE — reconcile hasn't run yet after the deposit
+      foodStored:  FOOD_CHAMBER_CAPACITY, // full per chamber.foodStored
       posX:        5 << FP_SHIFT,
       posY:        5 << FP_SHIFT,
       width:       foodDims.width,
@@ -495,26 +494,25 @@ describe('drawUndergroundEntities', () => {
     const cam = makeCamera(5, 5, 20, 20);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
-    // Even though chamber.foodStored=0, the chamber visual must read as full.
     expect(sprites.staticOfKind('food-cache').length).toBe(totalTiles);
   });
 
-  it('projectFoodStorageFill distributes pool across multiple chambers in order', () => {
-    // Mirror tickReconcile: first chamber fills to capacity, second gets the
-    // remainder, etc. Independent of ChamberRecord.foodStored values.
+  it('projectFoodStorageFill returns each chamber.foodStored independently (issue #15)', () => {
+    // Per-chamber authoritative model: each chamber stands on its own. Reading
+    // one does NOT consume from the others.
     const foodDims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage];
     const capa = FOOD_CHAMBER_CAPACITY;
     const colony = createColonyRecord(PLAYER_COLONY_ID, 999);
     colony.chambers = [
-      { chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: 0,
+      { chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: capa,
         posX: 0, posY: 0, width: foodDims.width, height: foodDims.height },
-      { chamberId: 2, chamberType: ChamberType.FoodStorage, foodStored: 0,
+      { chamberId: 2, chamberType: ChamberType.FoodStorage, foodStored: Math.floor(capa / 2),
         posX: 0, posY: 0, width: foodDims.width, height: foodDims.height },
       { chamberId: 3, chamberType: ChamberType.FoodStorage, foodStored: 0,
         posX: 0, posY: 0, width: foodDims.width, height: foodDims.height },
     ];
-    // Pool holds exactly 1.5 chambers worth of food.
-    colony.foodStored = capa + Math.floor(capa / 2);
+    // Entrance pool is irrelevant to the per-chamber readout.
+    colony.foodStored = 12345;
 
     expect(projectFoodStorageFill(colony, 1)).toBe(capa);
     expect(projectFoodStorageFill(colony, 2)).toBe(Math.floor(capa / 2));

--- a/src/render/draw-underground.ts
+++ b/src/render/draw-underground.ts
@@ -239,10 +239,11 @@ export function drawUndergroundEntities(
       gfx.fillRect(screenX + w - 2, screenY,         2, h);     // right
     }
     // FoodStorage fill visualization — per-tile amber food-cache sprites
-    // stacked from the chamber floor upward. Fill count is driven by the
-    // *projected* per-chamber share of colony.foodStored (NOT the lagging
-    // ChamberRecord.foodStored), so deposits show the instant the forager
-    // returns instead of snapping into place at the next reconcile tick.
+    // stacked from the chamber floor upward. Issue #15: ChamberRecord.foodStored
+    // IS the authoritative source — `projectFoodStorageFill` returns it directly,
+    // not a lagging projection of colony.foodStored as before the chamber-
+    // authoritative refactor. Deposits show the moment antDepositFood writes
+    // the chamber, no reconcile lag.
     //
     // Each tile in the chamber footprint can hold one food-cache SVG; the
     // ratio `projected / FOOD_CHAMBER_CAPACITY` maps to the number of filled

--- a/src/render/draw-underground.ts
+++ b/src/render/draw-underground.ts
@@ -57,35 +57,26 @@ const CHAMBER_COLORS: Record<number, number> = {
 };
 
 // ---------------------------------------------------------------------------
-// projectFoodStorageFill — responsive per-chamber fill (09 render polish)
+// projectFoodStorageFill — per-chamber fill readout
 //
-// colony.foodStored is the authoritative pooled total (PRD §2 reconcile
-// contract). ChamberRecord.foodStored is *derived* state refreshed only on
-// tickReconcile (every RECONCILE_INTERVAL_TICKS), so reading it for the
-// per-chamber visual lags real deposits by up to one reconcile interval.
-//
-// This projection mirrors tickReconcile's distribution logic exactly: walk
-// completed FoodStorage chambers in colony.chambers order and hand each one
-// up to FOOD_CHAMBER_CAPACITY units from the pool. Pure — never mutates
-// colony, chamber, or any sim state. Render-only view.
+// Issue #15: ChamberRecord.foodStored is now the authoritative per-chamber
+// stockpile (it grows when an ant deposits inside the chamber footprint, drains
+// when the queen withdraws). Render reads it directly — there is nothing to
+// "project" anymore, but the function name is preserved so callers don't
+// need to know the model changed.
 // ---------------------------------------------------------------------------
 
 /**
- * Projected fill (0..FOOD_CHAMBER_CAPACITY) for the named FoodStorage chamber,
- * derived live from colony.foodStored rather than the lagging
- * ChamberRecord.foodStored field. Returns 0 if chamberId isn't a FoodStorage
- * chamber in this colony.
+ * Fill (0..FOOD_CHAMBER_CAPACITY) for the named FoodStorage chamber. Returns 0
+ * if chamberId isn't a FoodStorage chamber in this colony.
  */
 export function projectFoodStorageFill(colony: ColonyRecord, chamberId: number): number {
-  let distributed = 0;
   for (const ch of colony.chambers) {
     if (ch.chamberType !== ChamberType.FoodStorage) continue;
-    const available = colony.foodStored - distributed;
-    const fill = available <= 0
-      ? 0
-      : available < FOOD_CHAMBER_CAPACITY ? available : FOOD_CHAMBER_CAPACITY;
-    if (ch.chamberId === chamberId) return fill;
-    distributed += fill;
+    if (ch.chamberId !== chamberId) continue;
+    const fill = ch.foodStored;
+    if (fill <= 0) return 0;
+    return fill < FOOD_CHAMBER_CAPACITY ? fill : FOOD_CHAMBER_CAPACITY;
   }
   return 0;
 }

--- a/src/render/hud-stats.ts
+++ b/src/render/hud-stats.ts
@@ -36,7 +36,7 @@ import type { ColonyRecord } from '../sim/colony/colony-store.js';
 import { isAlive } from '../sim/ant/ant-store.js';
 import { FP_SHIFT } from '../sim/fixed.js';
 import { STARVATION_GRACE_TICKS } from '../sim/constants.js';
-import { colonyFoodCapacity } from '../sim/colony/colony-system.js';
+import { colonyFoodCapacity, colonyFoodTotal } from '../sim/colony/colony-system.js';
 
 export interface HudStats {
   antCount:       number;
@@ -91,7 +91,10 @@ export function computeHudStats(world: WorldState, colony: ColonyRecord): HudSta
   // larvae are excluded because they cannot execute any task; folding them in
   // produced a "total headcount" the player read as "usable headcount".
   const antCount     = colony.workerCount + queenBit;
-  const foodDisplay  = colony.foodStored >> FP_SHIFT;
+  // Issue #15: foodTotal sums the entrance pool (colony.foodStored) plus every
+  // FoodStorage chamber's per-chamber foodStored — the HUD must show the
+  // player the whole stash, not just the chamberless fallback bucket.
+  const foodDisplay  = colonyFoodTotal(colony) >> FP_SHIFT;
   const foodCapacity = colonyFoodCapacity(colony) >> FP_SHIFT;
 
   let queenHealthPct = 0;

--- a/src/render/minimap.test.ts
+++ b/src/render/minimap.test.ts
@@ -188,7 +188,7 @@ const stubColonies: WorldState['colonies'] = {
     eggCount: 0, larvaeCount: 0, nurseCount: 0,
     eggs: [], larvae: [], workers: [], chambers: [],
     defeated: false, reconcileCountdown: 0,
-    rallyPoint: null, digFlowFieldDirty: false,
+    rallyPoint: null, digFlowFieldDirty: false, foodFlowFieldDirty: false,
     killCount: 0,
     priorityFoodPileId: null,
   } as WorldState['colonies'][number],

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -267,50 +267,50 @@ describe('antDepositFood', () => {
     expect(world.ants.subTask[antId]).toBe(ForagingSubState.CarryingFood);
   });
 
-  it('5c. capacity grows with completed FoodStorage chambers — ant deposits fully into authoritative pool', () => {
-    const { world, colony, antId } = setupForagerWorld();
+  it('5c. ant standing inside FoodStorage footprint → deposit goes to chamber.foodStored, pool untouched', () => {
+    // Ant placed at (1,1) — inside the chamber at (0,0) width=3 height=3.
+    const { world, colony, antId } = setupForagerWorld(1 << FP_SHIFT, 1 << FP_SHIFT);
     world.ants.foodCarrying[antId] = 512;
     world.ants.task[antId] = AntTask.Foraging;
     world.ants.subTask[antId] = ForagingSubState.CarryingFood;
-    // One completed FoodStorage chamber → capacity = BASE + FOOD_CHAMBER_CAPACITY.
-    // Pool is at BASE; the extra FOOD_CHAMBER_CAPACITY of headroom comes from the chamber.
     colony.chambers.push({
       chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: 0,
       posX: 0, posY: 0, width: 3, height: 3,
     });
+    // Pool is already at BASE; further pool deposits would be impossible. The
+    // chamber-authoritative path lets the ant deposit anyway because the
+    // chamber has its own bucket.
     colony.foodStored = BASE_FOOD_STORAGE_CAPACITY;
 
     antDepositFood(world, colony, antId);
 
-    // Authoritative pool is the only writer — deposit adds 512 directly to
-    // colony.foodStored. Chamber.foodStored is derived state and is NOT
-    // written by antDepositFood (tickReconcile projects it from the pool).
-    expect(colony.foodStored).toBe(BASE_FOOD_STORAGE_CAPACITY + 512);
-    expect(colony.chambers[0]!.foodStored).toBe(0); // untouched by deposit
+    // Issue #15: chamber gets the deposit; entrance pool is untouched.
+    expect(colony.chambers[0]!.foodStored).toBe(512);
+    expect(colony.foodStored).toBe(BASE_FOOD_STORAGE_CAPACITY);
     expect(world.ants.foodCarrying[antId]).toBe(0);
-    // Full deposit → idle-checkpoint.
     expect(world.ants.task[antId]).toBe(AntTask.Idle);
     expect(world.ants.subTask[antId]).toBe(0);
   });
 
-  it('5d. pool at capacity with FoodStorage chamber → no deposit, leftover stays on ant', () => {
-    const { world, colony, antId } = setupForagerWorld();
+  it('5d. ant inside FULL FoodStorage chamber → no deposit, leftover stays on ant', () => {
+    const { world, colony, antId } = setupForagerWorld(1 << FP_SHIFT, 1 << FP_SHIFT);
     world.ants.foodCarrying[antId] = 512;
     world.ants.task[antId] = AntTask.Foraging;
     world.ants.subTask[antId] = ForagingSubState.CarryingFood;
-    // Chamber's derived foodStored is irrelevant to the capacity check —
-    // capacity only counts the chamber's presence, not its current value.
+    // Chamber at cap — antDepositFood must skip it (issue #15: full chambers
+    // are not deposit targets).
     colony.chambers.push({
-      chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: 0,
+      chamberId: 100, chamberType: ChamberType.FoodStorage,
+      foodStored: FOOD_CHAMBER_CAPACITY,
       posX: 0, posY: 0, width: 3, height: 3,
     });
-    // Pool at BASE + FOOD_CHAMBER_CAPACITY → cap with one chamber
-    colony.foodStored = BASE_FOOD_STORAGE_CAPACITY + FOOD_CHAMBER_CAPACITY;
+    // Pool also at cap → no fallback room either.
+    colony.foodStored = BASE_FOOD_STORAGE_CAPACITY;
 
     antDepositFood(world, colony, antId);
 
-    expect(colony.foodStored).toBe(BASE_FOOD_STORAGE_CAPACITY + FOOD_CHAMBER_CAPACITY);
-    expect(colony.chambers[0]!.foodStored).toBe(0); // derived state, untouched
+    expect(colony.chambers[0]!.foodStored).toBe(FOOD_CHAMBER_CAPACITY);
+    expect(colony.foodStored).toBe(BASE_FOOD_STORAGE_CAPACITY);
     expect(world.ants.foodCarrying[antId]).toBe(512);
     expect(world.ants.task[antId]).toBe(AntTask.Foraging);
     expect(world.ants.subTask[antId]).toBe(ForagingSubState.CarryingFood);
@@ -1780,32 +1780,39 @@ describe('tickAntMovement — underground passability guard', () => {
 });
 
 // ---------------------------------------------------------------------------
-// antDepositFood — authoritative-pool deposit model (09 backlog memo)
+// antDepositFood — chamber-authoritative deposit model (issue #15)
 //
-// colony.foodStored is the single source of truth; chamber.foodStored is a
-// derived projection recomputed by tickReconcile from the pool. Deposits only
-// write colony.foodStored (capped at colonyFoodCapacity); chamber.foodStored
-// is never written here.
+// chamber.foodStored is authoritative per FoodStorage chamber. An ant standing
+// inside a non-full chamber footprint deposits THERE. An ant outside any
+// FoodStorage footprint (or with no chambers existing) falls back to the
+// entrance-shaft pool `colony.foodStored`. There is no magical pool→chamber
+// redistribution — fill requires an actual ant visit.
 // ---------------------------------------------------------------------------
 
-describe('antDepositFood — authoritative-pool deposit (09 backlog memo)', () => {
-  function makeFoodStorageChamber(id: number, stored = 0): ColonyRecord['chambers'][number] {
+describe('antDepositFood — chamber-authoritative deposit (issue #15)', () => {
+  function makeFoodStorageChamber(
+    id: number,
+    stored: number,
+    posTileX: number,
+    posTileY: number,
+  ): ColonyRecord['chambers'][number] {
     return {
       chamberId: id,
       chamberType: ChamberType.FoodStorage,
       foodStored: stored,
-      posX: 0,
-      posY: 0,
+      posX: posTileX << FP_SHIFT,
+      posY: posTileY << FP_SHIFT,
       width: 4,
       height: 3,
     };
   }
 
-  it('14. colony has food storage chamber → deposit writes only to colony.foodStored; chamber.foodStored untouched', () => {
+  it('14. ant inside FoodStorage footprint → deposit writes ONLY chamber.foodStored; entrance pool untouched', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
-    colony.chambers.push(makeFoodStorageChamber(1, 0));
+    colony.entrances = []; colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false; colony.foodFlowFieldDirty = false;
+    colony.chambers.push(makeFoodStorageChamber(1, 0, 0, 0));
     colony.foodStored = 0;
     world.colonies[COLONY_ID] = colony;
 
@@ -1820,20 +1827,21 @@ describe('antDepositFood — authoritative-pool deposit (09 backlog memo)', () =
 
     antDepositFood(world, colony, antId);
 
-    // Authoritative pool receives all 500; chamber.foodStored is derived
-    // state and stays at its pre-deposit value (reconcile will later
-    // project from colony.foodStored).
-    expect(colony.foodStored).toBe(500);
-    expect(colony.chambers[0]!.foodStored).toBe(0);
+    // Chamber receives all 500; entrance pool untouched.
+    expect(colony.chambers[0]!.foodStored).toBe(500);
+    expect(colony.foodStored).toBe(0);
     expect(world.ants.foodCarrying[antId]).toBe(0);
     expect(world.ants.task[antId]).toBe(AntTask.Idle);
+    // Chamber not yet full → no flow-field re-seed signal needed.
+    expect(colony.foodFlowFieldDirty).toBe(false);
   });
 
-  it('15. colony has no food storage chamber → deposit writes colony.foodStored up to BASE capacity', () => {
+  it('15. colony has no food storage chamber → deposit writes entrance pool up to BASE capacity', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
-    // No chambers → capacity = BASE_FOOD_STORAGE_CAPACITY.
+    colony.entrances = []; colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false; colony.foodFlowFieldDirty = false;
+    // No chambers → capacity = BASE_FOOD_STORAGE_CAPACITY (entrance pool only).
     colony.foodStored = 0;
     world.colonies[COLONY_ID] = colony;
 
@@ -1853,18 +1861,16 @@ describe('antDepositFood — authoritative-pool deposit (09 backlog memo)', () =
     expect(world.ants.task[antId]).toBe(AntTask.Idle);
   });
 
-  it('16. deposit with N chambers adds to colony.foodStored up to BASE + N × FOOD_CHAMBER_CAPACITY', () => {
+  it('16. ant in chamber 0 fills it to cap → chamber.foodStored hits FOOD_CHAMBER_CAPACITY and foodFlowFieldDirty fires', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
-    // Two chambers → capacity = BASE + 2 × FOOD_CHAMBER_CAPACITY.
-    // chamber.foodStored values in the fixtures below are irrelevant to the
-    // capacity arithmetic (only chamber count matters) and should not be
-    // mutated by the deposit.
-    colony.chambers.push(makeFoodStorageChamber(1, 1234));
-    colony.chambers.push(makeFoodStorageChamber(2,  567));
-    // Pool already holds BASE + 1×CHAMBER so only 1×CHAMBER of headroom remains.
-    colony.foodStored = BASE_FOOD_STORAGE_CAPACITY + FOOD_CHAMBER_CAPACITY;
+    colony.entrances = []; colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false; colony.foodFlowFieldDirty = false;
+    // Two chambers in different parts of the grid. Ant only stands in chamber[0].
+    // chamber[0] starts with 1234 stored, so headroom = 5120-1234 = 3886.
+    colony.chambers.push(makeFoodStorageChamber(1, 1234, 0,  0));
+    colony.chambers.push(makeFoodStorageChamber(2,    0, 8,  8));
+    colony.foodStored = 0;
     world.colonies[COLONY_ID] = colony;
 
     const antId = allocateEntityId(world);
@@ -1874,18 +1880,50 @@ describe('antDepositFood — authoritative-pool deposit (09 backlog memo)', () =
       task: AntTask.Foraging,
       subTask: ForagingSubState.CarryingFood,
     });
-    // Deposit exactly the remaining 1×CHAMBER of headroom.
-    world.ants.foodCarrying[antId] = FOOD_CHAMBER_CAPACITY;
+    // Deposit exactly the headroom of chamber[0] (will fill it to cap).
+    world.ants.foodCarrying[antId] = FOOD_CHAMBER_CAPACITY - 1234;
 
     antDepositFood(world, colony, antId);
 
-    // All CHAMBER goes into the pool, bringing it to the cap.
-    expect(colony.foodStored).toBe(BASE_FOOD_STORAGE_CAPACITY + 2 * FOOD_CHAMBER_CAPACITY);
-    // Chamber-foodStored fixtures are untouched (derived state).
-    expect(colony.chambers[0]!.foodStored).toBe(1234);
-    expect(colony.chambers[1]!.foodStored).toBe(567);
+    // chamber[0] reaches FOOD_CHAMBER_CAPACITY; chamber[1] is untouched (no ant
+    // visit). Issue #15: the OLD bug was redistributing the pool across
+    // chambers without a visit — this test guards against regression.
+    expect(colony.chambers[0]!.foodStored).toBe(FOOD_CHAMBER_CAPACITY);
+    expect(colony.chambers[1]!.foodStored).toBe(0);
+    expect(colony.foodStored).toBe(0);
     expect(world.ants.foodCarrying[antId]).toBe(0);
     expect(world.ants.task[antId]).toBe(AntTask.Idle);
+    // Full↔not-full boundary crossed → flow-field must re-seed next tick.
+    expect(colony.foodFlowFieldDirty).toBe(true);
+  });
+
+  it('17. issue #15 regression — ant outside FoodStorage footprint does NOT cause distant chambers to fill', () => {
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    const colony = createColonyRecord(COLONY_ID, 0);
+    colony.entrances = []; colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false; colony.foodFlowFieldDirty = false;
+    // Two chambers, both far from the ant's tile.
+    colony.chambers.push(makeFoodStorageChamber(1, 0,  8, 8));
+    colony.chambers.push(makeFoodStorageChamber(2, 0, 16, 8));
+    colony.foodStored = 0;
+    world.colonies[COLONY_ID] = colony;
+
+    const antId = allocateEntityId(world);
+    initAnt(world.ants, antId, {
+      colonyId: COLONY_ID,
+      posX: 0, posY: 0, // outside both chamber footprints
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.CarryingFood,
+    });
+    world.ants.foodCarrying[antId] = 1000;
+
+    antDepositFood(world, colony, antId);
+
+    // Distant chambers must NOT receive any food — that's the bug we fixed.
+    expect(colony.chambers[0]!.foodStored).toBe(0);
+    expect(colony.chambers[1]!.foodStored).toBe(0);
+    // Fallback pool gets the deposit.
+    expect(colony.foodStored).toBe(1000);
   });
 });
 
@@ -2089,10 +2127,11 @@ describe('tickForagerActions', () => {
     expect(world.ants.subTask[antId]).toBe(ForagingSubState.SearchingFood);
   });
 
-  it('underground CarryingFood ant on a FoodStorage chamber tile → deposits to authoritative pool and flips to Idle', () => {
+  it('underground CarryingFood ant on a FoodStorage chamber tile → deposits to chamber.foodStored and flips to Idle', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = []; colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false; colony.foodFlowFieldDirty = false;
     colony.chambers.push({
       chamberId: 1,
       chamberType: ChamberType.FoodStorage,
@@ -2115,10 +2154,9 @@ describe('tickForagerActions', () => {
 
     tickForagerActions(world);
 
-    // Deposit writes the authoritative pool; chamber.foodStored is derived
-    // state and reconcile projects it on the next 100-tick boundary.
-    expect(colony.foodStored).toBe(500);
-    expect(colony.chambers[0]!.foodStored).toBe(0);
+    // Issue #15: deposit lands in chamber.foodStored, NOT the entrance pool.
+    expect(colony.chambers[0]!.foodStored).toBe(500);
+    expect(colony.foodStored).toBe(0);
     expect(world.ants.foodCarrying[antId]).toBe(0);
     expect(world.ants.task[antId]).toBe(AntTask.Idle);
   });

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -31,8 +31,8 @@
 
 import type { WorldState } from '../types.js';
 import type { AntComponents } from './ant-store.js';
-import type { ColonyRecord } from '../colony/colony-store.js';
-import { colonyFoodCapacity, hasCompletedChamber } from '../colony/colony-system.js';
+import type { ColonyRecord, ChamberRecord } from '../colony/colony-store.js';
+import { hasCompletedChamber } from '../colony/colony-system.js';
 import { AntTask, ForagingSubState, DiggingSubState, NursingSubState, ChamberType, PheromoneType } from '../enums.js';
 import {
   WORKER_CARRY_CAPACITY,
@@ -50,6 +50,8 @@ import {
   EXCURSION_WOBBLE_PERCENT,
   ENTRANCE_DEPOSIT_SUPPRESS_RADIUS,
   QUEEN_EGG_INTERVAL_TICKS,
+  FOOD_CHAMBER_CAPACITY,
+  BASE_FOOD_STORAGE_CAPACITY,
 } from '../constants.js';
 import { FP_SHIFT, FP_ONE } from '../fixed.js';
 import { Rng } from '../rng.js';
@@ -158,8 +160,8 @@ export function antPickupFood(
 //
 // Transfers ants.foodCarrying[antId] into the colony food pool.
 // On full deposit: zeros foodCarrying and writes task=Idle, subTask=0
-// (Errata E-01 idle-checkpoint transition). On partial deposit (pool
-// at capacity): leaves leftover on the ant and preserves
+// (Errata E-01 idle-checkpoint transition). On partial deposit (chamber +
+// fallback pool at capacity): leaves leftover on the ant and preserves
 // Foraging+CarryingFood for a next-tick retry.
 //
 // Errata E-01 (2026-04-16) is authoritative for the completion-write contract:
@@ -167,56 +169,100 @@ export function antPickupFood(
 //   Plan 10 step 9 next tick reassigns — back to Foraging+SearchingFood if allocation
 //   still demands forage, or to a different task if the triangle shifted.
 //
-// 09 backlog memo — food source-of-truth model:
-//   colony.foodStored is the authoritative pooled total (fp). Deposits go
-//   directly to the pool, clamped at colonyFoodCapacity(colony) =
-//   BASE_FOOD_STORAGE_CAPACITY + N × FOOD_CHAMBER_CAPACITY where N is the
-//   count of COMPLETED FoodStorage chambers.
+// Issue #15 (2026-04-26) — food source-of-truth model:
+//   chamber.foodStored is the authoritative store for each FoodStorage
+//   chamber, capped at FOOD_CHAMBER_CAPACITY. colony.foodStored is the
+//   entrance-shaft / chamberless-fallback pool, capped at
+//   BASE_FOOD_STORAGE_CAPACITY. Total capacity is unchanged:
+//   BASE + N × FOOD_CHAMBER_CAPACITY.
 //
-//   ChamberRecord.foodStored is DERIVED visualization state, recomputed by
-//   tickReconcile from the authoritative pool (each chamber filled up to
-//   FOOD_CHAMBER_CAPACITY in array order). antDepositFood MUST NOT write
-//   chamber.foodStored — doing so would be silently erased by the next
-//   reconcile AND would hide the food from queen/larvae consumption, which
-//   reads only colony.foodStored.
+//   Deposit selection: an ant standing inside a non-full FoodStorage
+//   chamber footprint deposits THERE (only). An ant at the chamberless
+//   fallback site (entrance shaft top, when no FoodStorage chamber exists
+//   or the field routed it home that way) deposits into colony.foodStored.
+//   Pre-#15 the colony pool received every deposit and tickReconcile
+//   "magically" redistributed across all chambers; that redistribution is
+//   gone — chamber fill now requires an actual ant visit.
 //
 // Early-return if foodCarrying <= 0 (defensive guard per PRD §4c — deposit is only
 // called when an ant arrives carrying food; the guard pins exact no-op behavior).
 // ---------------------------------------------------------------------------
 
 /**
- * Deposit all food an ant is carrying into the authoritative colony pool.
+ * Deposit food the ant is carrying into the FoodStorage chamber it stands
+ * in (preferred), or the entrance-shaft pool (fallback).
  *
- * The pool (colony.foodStored) is the single source of truth for stored food;
- * per-chamber ChamberRecord.foodStored values are projected by tickReconcile
- * and MUST NOT be written here (they would be overwritten and would mask the
- * food from consumption, which reads colony.foodStored directly).
+ * Chamber path: if the ant's tile lies inside a non-full FoodStorage
+ * chamber footprint, deposit up to that chamber's remaining capacity
+ * (FOOD_CHAMBER_CAPACITY - chamber.foodStored). If the chamber transitions
+ * full as a result, mark colony.foodFlowFieldDirty so step 9 re-seeds the
+ * food flow-field excluding the now-full chamber on the next tick.
  *
- * Deposit is clamped to colonyFoodCapacity(colony) = BASE + N × CHAMBER.
+ * Fallback path: if no FoodStorage chamber footprint matches, deposit into
+ * colony.foodStored up to BASE_FOOD_STORAGE_CAPACITY. This is the chamberless
+ * early-game path AND the entrance-shaft top deposit site
+ * `tickForagerActions` (b) routes to when chambers are full or absent.
+ *
  * Leftover that does not fit stays on ants.foodCarrying; the ant keeps
  * task=Foraging, subTask=CarryingFood so step 16b retries next tick once
- * consumption opens space. On FULL deposit (foodCarrying reaches 0),
- * Errata E-01 idle-checkpoint fires: task=Idle, subTask=0, step 10a
- * reassigns next tick.
+ * consumption opens space (or the flow-field redirects to another chamber).
+ *
+ * On FULL deposit (foodCarrying reaches 0), Errata E-01 idle-checkpoint
+ * fires: task=Idle, subTask=0, step 10a reassigns next tick.
  *
  * Early-returns if foodCarrying === 0 (no-op; no task transition occurs).
  *
  * @param world    WorldState (reads ants, writes ants.foodCarrying, task, subTask).
- * @param colony   ColonyRecord (writes colony.foodStored; never writes chambers).
+ * @param colony   ColonyRecord (writes chamber.foodStored OR colony.foodStored;
+ *                 may set colony.foodFlowFieldDirty when a chamber fills).
  * @param antId    Entity ID of the depositing forager.
  */
 export function antDepositFood(world: WorldState, colony: ColonyRecord, antId: number): void {
   const amount = world.ants.foodCarrying[antId]!;
   if (amount <= 0) return;
 
-  // 09 backlog memo — pool is authoritative. Deposit directly to
-  // colony.foodStored clamped at colonyFoodCapacity. Chambers are derived
-  // state and are left untouched here; tickReconcile projects them.
-  const capacity = colonyFoodCapacity(colony);
-  const space = capacity - colony.foodStored;
-  const toPool = amount < space ? amount : (space > 0 ? space : 0);
-  colony.foodStored += toPool;
-  const remaining = amount - toPool;
+  const tileX = world.ants.posX[antId]! >> FP_SHIFT;
+  const tileY = world.ants.posY[antId]! >> FP_SHIFT;
+
+  // Chamber path — pick the FoodStorage chamber whose footprint contains the
+  // ant's tile. Iterates colony.chambers in storage order; the first match
+  // wins (chambers don't overlap by construction). A full chamber is NOT a
+  // match — the ant deposits nothing here and the leftover keeps it routing
+  // until the food flow-field steers it to a non-full chamber.
+  let chamber: ChamberRecord | null = null;
+  for (let c = 0; c < colony.chambers.length; c++) {
+    const ch = colony.chambers[c]!;
+    if (ch.chamberType !== ChamberType.FoodStorage) continue;
+    if (ch.foodStored >= FOOD_CHAMBER_CAPACITY) continue;
+    const baseX = ch.posX >> FP_SHIFT;
+    const baseY = ch.posY >> FP_SHIFT;
+    if (
+      tileX >= baseX && tileX < baseX + ch.width &&
+      tileY >= baseY && tileY < baseY + ch.height
+    ) {
+      chamber = ch;
+      break;
+    }
+  }
+
+  let remaining = amount;
+  if (chamber !== null) {
+    const space = FOOD_CHAMBER_CAPACITY - chamber.foodStored;
+    const toChamber = remaining < space ? remaining : space;
+    chamber.foodStored += toChamber;
+    remaining -= toChamber;
+    if (chamber.foodStored >= FOOD_CHAMBER_CAPACITY) {
+      // Full↔not-full boundary crossed — re-seed the food flow-field next
+      // tick so other carriers redirect to a remaining non-full chamber.
+      colony.foodFlowFieldDirty = true;
+    }
+  } else {
+    // Fallback — entrance-shaft / chamberless pool. Cap at BASE.
+    const space = BASE_FOOD_STORAGE_CAPACITY - colony.foodStored;
+    const toPool = remaining < space ? remaining : (space > 0 ? space : 0);
+    colony.foodStored += toPool;
+    remaining -= toPool;
+  }
 
   world.ants.foodCarrying[antId] = remaining;
 
@@ -225,10 +271,10 @@ export function antDepositFood(world: WorldState, colony: ColonyRecord, antId: n
   // Plan 10 step 9 next tick reassigns (back to Foraging+SearchingFood if allocation
   // still demands forage, or to a different task if the triangle shifted).
   //
-  // 09 backlog memo — near-full deposit: if leftover remains on the ant (colony /
-  // chambers were at capacity), preserve the Foraging + CarryingFood state and the
-  // active outbound heading so routeForagerPriority can re-route the ant back to
-  // the chamber next tick without a round-trip through Idle.
+  // Near-full deposit: if leftover remains on the ant (chamber + fallback pool both
+  // at capacity), preserve the Foraging + CarryingFood state and the active outbound
+  // heading so routeForagerPriority can re-route the ant back to a chamber next tick
+  // without a round-trip through Idle.
   if (remaining === 0) {
     world.ants.task[antId] = AntTask.Idle;
     world.ants.subTask[antId] = 0;
@@ -329,11 +375,16 @@ export function tickForagerActions(world: WorldState): void {
       const tileX = ants.posX[id]! >> FP_SHIFT;
       const tileY = ants.posY[id]! >> FP_SHIFT;
 
-      // (a) FoodStorage chamber Open tile.
+      // (a) FoodStorage chamber Open tile — only NON-FULL chambers count
+      // (issue #15). A worker standing on a full chamber tile is a no-op
+      // here; the food flow-field excludes full chambers (see chamber-flow.ts
+      // + tick.ts step 9), so on the next tick movement steers them to a
+      // non-full chamber if one exists, or to the entrance fallback (b) below.
       let depositSite = false;
       for (let c = 0; c < colony.chambers.length; c++) {
         const chamber = colony.chambers[c]!;
         if (chamber.chamberType !== ChamberType.FoodStorage) continue;
+        if (chamber.foodStored >= FOOD_CHAMBER_CAPACITY) continue;
         const baseX = chamber.posX >> FP_SHIFT;
         const baseY = chamber.posY >> FP_SHIFT;
         if (
@@ -2331,6 +2382,12 @@ export function tickAntMovement(
         for (let c = 0; c < colony.chambers.length; c++) {
           const chamber = colony.chambers[c]!;
           if (chamber.chamberType !== ChamberType.FoodStorage) continue;
+          // Issue #15 — skip full chambers in fallback target selection too,
+          // mirroring the food flow-field's seed exclusion. The flow-field
+          // is the primary path; this Manhattan fallback only fires when the
+          // chamberFlowFields cache is absent (test harnesses) — both paths
+          // must agree on which chambers are valid deposit targets.
+          if (chamber.foodStored >= FOOD_CHAMBER_CAPACITY) continue;
           const baseX = chamber.posX >> FP_SHIFT;
           const baseY = chamber.posY >> FP_SHIFT;
           for (let ty = 0; ty < chamber.height; ty++) {

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -32,7 +32,7 @@
 import type { WorldState } from '../types.js';
 import type { AntComponents } from './ant-store.js';
 import type { ColonyRecord, ChamberRecord } from '../colony/colony-store.js';
-import { hasCompletedChamber } from '../colony/colony-system.js';
+import { hasCompletedChamber, isFoodChamberDepositable } from '../colony/colony-system.js';
 import { AntTask, ForagingSubState, DiggingSubState, NursingSubState, ChamberType, PheromoneType } from '../enums.js';
 import {
   WORKER_CARRY_CAPACITY,
@@ -226,14 +226,17 @@ export function antDepositFood(world: WorldState, colony: ColonyRecord, antId: n
 
   // Chamber path — pick the FoodStorage chamber whose footprint contains the
   // ant's tile. Iterates colony.chambers in storage order; the first match
-  // wins (chambers don't overlap by construction). A full chamber is NOT a
-  // match — the ant deposits nothing here and the leftover keeps it routing
-  // until the food flow-field steers it to a non-full chamber.
+  // wins (chambers don't overlap by construction). A "saturated" chamber
+  // (free space < FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP) is NOT a match — the
+  // hysteresis predicate `isFoodChamberDepositable` matches the BFS seed
+  // filter in tick.ts step 9, so an ant routing past a saturated chamber
+  // toward a truly-empty one cannot dribble its load into the saturated
+  // chamber 2 fp at a time. See FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP rationale
+  // in constants.ts (issue #15 follow-up — stuck-ant repro).
   let chamber: ChamberRecord | null = null;
   for (let c = 0; c < colony.chambers.length; c++) {
     const ch = colony.chambers[c]!;
-    if (ch.chamberType !== ChamberType.FoodStorage) continue;
-    if (ch.foodStored >= FOOD_CHAMBER_CAPACITY) continue;
+    if (!isFoodChamberDepositable(ch)) continue;
     const baseX = ch.posX >> FP_SHIFT;
     const baseY = ch.posY >> FP_SHIFT;
     if (
@@ -247,13 +250,17 @@ export function antDepositFood(world: WorldState, colony: ColonyRecord, antId: n
 
   let remaining = amount;
   if (chamber !== null) {
+    // We entered this branch via isFoodChamberDepositable, so pre-deposit
+    // the chamber was depositable. If this deposit pushes it across into
+    // saturated territory (free space < FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP),
+    // re-seed the food flow-field next tick so other carriers redirect to
+    // a remaining depositable chamber. This boundary check matches the
+    // BFS seed filter in tick.ts step 9, keeping the routing invariant.
     const space = FOOD_CHAMBER_CAPACITY - chamber.foodStored;
     const toChamber = remaining < space ? remaining : space;
     chamber.foodStored += toChamber;
     remaining -= toChamber;
-    if (chamber.foodStored >= FOOD_CHAMBER_CAPACITY) {
-      // Full↔not-full boundary crossed — re-seed the food flow-field next
-      // tick so other carriers redirect to a remaining non-full chamber.
+    if (!isFoodChamberDepositable(chamber)) {
       colony.foodFlowFieldDirty = true;
     }
   } else {
@@ -375,16 +382,18 @@ export function tickForagerActions(world: WorldState): void {
       const tileX = ants.posX[id]! >> FP_SHIFT;
       const tileY = ants.posY[id]! >> FP_SHIFT;
 
-      // (a) FoodStorage chamber Open tile — only NON-FULL chambers count
-      // (issue #15). A worker standing on a full chamber tile is a no-op
-      // here; the food flow-field excludes full chambers (see chamber-flow.ts
-      // + tick.ts step 9), so on the next tick movement steers them to a
-      // non-full chamber if one exists, or to the entrance fallback (b) below.
+      // (a) FoodStorage chamber Open tile — only DEPOSITABLE chambers count
+      // (issue #15 follow-up). A worker standing on a saturated chamber tile
+      // (free space < FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP) is a no-op here;
+      // the food flow-field excludes saturated chambers from BFS seeding (see
+      // tick.ts step 9), so on the next tick movement steers them to a
+      // depositable chamber if one exists, or to the entrance fallback (b)
+      // below. The shared `isFoodChamberDepositable` predicate keeps the
+      // movement, deposit, and BFS seed paths in lockstep.
       let depositSite = false;
       for (let c = 0; c < colony.chambers.length; c++) {
         const chamber = colony.chambers[c]!;
-        if (chamber.chamberType !== ChamberType.FoodStorage) continue;
-        if (chamber.foodStored >= FOOD_CHAMBER_CAPACITY) continue;
+        if (!isFoodChamberDepositable(chamber)) continue;
         const baseX = chamber.posX >> FP_SHIFT;
         const baseY = chamber.posY >> FP_SHIFT;
         if (
@@ -2381,13 +2390,14 @@ export function tickAntMovement(
         let bestDist = -1;
         for (let c = 0; c < colony.chambers.length; c++) {
           const chamber = colony.chambers[c]!;
-          if (chamber.chamberType !== ChamberType.FoodStorage) continue;
-          // Issue #15 — skip full chambers in fallback target selection too,
-          // mirroring the food flow-field's seed exclusion. The flow-field
-          // is the primary path; this Manhattan fallback only fires when the
-          // chamberFlowFields cache is absent (test harnesses) — both paths
-          // must agree on which chambers are valid deposit targets.
-          if (chamber.foodStored >= FOOD_CHAMBER_CAPACITY) continue;
+          // Issue #15 follow-up — skip saturated chambers in fallback target
+          // selection too, mirroring the food flow-field's seed exclusion in
+          // tick.ts step 9. The flow-field is the primary path; this Manhattan
+          // fallback only fires when the chamberFlowFields cache is absent
+          // (test harnesses) — both paths must agree on which chambers are
+          // valid deposit targets, otherwise the fallback would route a
+          // carrier into a saturated chamber it would refuse to deposit into.
+          if (!isFoodChamberDepositable(chamber)) continue;
           const baseX = chamber.posX >> FP_SHIFT;
           const baseY = chamber.posY >> FP_SHIFT;
           for (let ty = 0; ty < chamber.height; ty++) {

--- a/src/sim/chamber-flow.ts
+++ b/src/sim/chamber-flow.ts
@@ -83,9 +83,9 @@ export function ensureChamberFlowFields(
 
 /**
  * Multi-source BFS from every Open tile inside any chamber whose type is
- * present in `chamberTypes`. Expands through Open and BeingDug tiles. Marked
- * and Solid are walls (same contract as entrance-flow.ts — a non-digger
- * can't traverse Marked).
+ * present in `chamberTypes` AND (optionally) passes `chamberFilter`.
+ * Expands through Open and BeingDug tiles. Marked and Solid are walls
+ * (same contract as entrance-flow.ts — a non-digger can't traverse Marked).
  *
  * Output at each reachable tile is the direction an ant should step to head
  * one tile closer to the nearest seeded chamber tile. Reachable chamber
@@ -94,11 +94,15 @@ export function ensureChamberFlowFields(
  * Deterministic: seed order is chamber array order × row-major footprint
  * iteration; BFS expansion order is N/E/S/W.
  *
- * @param underground   Colony underground grid (read-only).
- * @param chambers      Colony chambers array (completed chambers only).
- * @param chamberTypes  Types to seed from (e.g. [FoodStorage] or [Queen, Nursery]).
- * @param out           Pre-allocated Int32Array of length W*H. Filled in-place.
- * @param queue         Pre-allocated Int32Array of length W*H for BFS queue.
+ * @param underground    Colony underground grid (read-only).
+ * @param chambers       Colony chambers array (completed chambers only).
+ * @param chamberTypes   Types to seed from (e.g. [FoodStorage] or [Queen, Nursery]).
+ * @param out            Pre-allocated Int32Array of length W*H. Filled in-place.
+ * @param queue          Pre-allocated Int32Array of length W*H for BFS queue.
+ * @param chamberFilter  Optional per-chamber predicate (issue #15) — only
+ *                       chambers returning true are seeded. Used by the food
+ *                       field to exclude FoodStorage chambers at capacity so
+ *                       carriers redirect to non-full chambers.
  */
 export function computeChamberFlowField(
   underground: UndergroundGrid,
@@ -106,6 +110,7 @@ export function computeChamberFlowField(
   chamberTypes: ReadonlyArray<ChamberType>,
   out: Int32Array,
   queue: Int32Array,
+  chamberFilter?: (chamber: ChamberRecord) => boolean,
 ): void {
   const { data, width, height } = underground;
 
@@ -122,6 +127,7 @@ export function computeChamberFlowField(
       if (chamber.chamberType === chamberTypes[t]!) { matches = true; break; }
     }
     if (!matches) continue;
+    if (chamberFilter !== undefined && !chamberFilter(chamber)) continue;
 
     const baseX = chamber.posX >> FP_SHIFT;
     const baseY = chamber.posY >> FP_SHIFT;

--- a/src/sim/colony/colony-store.ts
+++ b/src/sim/colony/colony-store.ts
@@ -154,13 +154,16 @@ export interface ColonyRecord {
 // createColonyRecord — factory producing a fresh ColonyRecord (PRD §2 line 455)
 //
 // IMPORTANT: per accepted Phase 3 PRD §2a, this factory DOES NOT initialize
-// the 3 Phase 3 extension fields (entrances, rallyPoint, digFlowFieldDirty).
-// Callers MUST assign those 3 fields immediately after the factory call:
+// the Phase 3 extension fields (entrances, rallyPoint, digFlowFieldDirty),
+// nor the issue-#15 extension `foodFlowFieldDirty`. Callers MUST assign all
+// four fields immediately after the factory call:
 //   const colony = createColonyRecord(colonyId, queenEntityId);
-//   colony.entrances        = [];
-//   colony.rallyPoint       = null;
-//   colony.digFlowFieldDirty = false;
-// Callers: createScenario (Plan 07), copyWorldState new-colony fallback (Plan 03 Task 2).
+//   colony.entrances         = [];
+//   colony.rallyPoint        = null;
+//   colony.digFlowFieldDirty  = false;
+//   colony.foodFlowFieldDirty = false;
+// Callers: createScenario (Plan 07), copyWorldState new-colony fallback (Plan 03 Task 2),
+// deserializeColony (save.ts — defaults `foodFlowFieldDirty` to false on pre-#15 saves).
 //
 // Default values (Phase 2 fields):
 //   - foodStored=0, workerCount=0, eggCount=0, larvaeCount=0, nurseCount=0

--- a/src/sim/colony/colony-store.ts
+++ b/src/sim/colony/colony-store.ts
@@ -128,6 +128,13 @@ export interface ColonyRecord {
   /** Phase 3 PRD §2 — set true when any tile passability in this colony's underground changes (per research Pitfall 3). Cleared by tick.ts step 9 after flow-field recomputation. Assigned caller-side per PRD §2a extension contract. */
   digFlowFieldDirty: boolean;
 
+  /** Issue #15 — set true when a FoodStorage chamber crosses the full↔not-full
+   *  boundary, so step 9 re-seeds the food chamber flow-field excluding any
+   *  newly-full chambers. Independent from `digFlowFieldDirty` because food
+   *  fill changes don't affect tile topology — only the food field's seed set.
+   *  Cleared by tick.ts step 9 after recompute. Initialized to false. */
+  foodFlowFieldDirty: boolean;
+
   /** Phase 9 / CMBT-06/07 / PRD §1a — cumulative count of enemies killed by this colony's ants.
    *  Incremented inside combat.killAnt (Plan 02) when ants from this colony win a combat round.
    *  Initialized to 0 in createColonyRecord. Round-trips through copyWorldState + save. */

--- a/src/sim/colony/colony-system.test.ts
+++ b/src/sim/colony/colony-system.test.ts
@@ -164,6 +164,61 @@ describe('withdrawFood', () => {
     expect(result).toBe(true);
     expect(colony.foodStored).toBe(0);
   });
+
+  // Issue #15 — drain-order contract: chambers in array order first, then the
+  // entrance pool. Other downstream code (HUD, AI gates) relies on chambers
+  // emptying before the pool so the dirty-flag / re-seed cadence is stable.
+  // A future refactor that flips the order would silently regress.
+  it('drains chambers before the entrance pool (issue #15)', () => {
+    const { colony } = setupWorldWithQueen(100);
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: 200,
+      posX: 0, posY: 0, width: 1, height: 1,
+    });
+    const result = withdrawFood(colony, 50);
+    expect(result).toBe(true);
+    expect(colony.chambers[0]!.foodStored).toBe(150); // chamber drained
+    expect(colony.foodStored).toBe(100);              // pool untouched
+  });
+
+  it('drains the entrance pool only after every chamber is empty (issue #15)', () => {
+    const { colony } = setupWorldWithQueen(100);
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: 30,
+      posX: 0, posY: 0, width: 1, height: 1,
+    });
+    const result = withdrawFood(colony, 50);
+    expect(result).toBe(true);
+    expect(colony.chambers[0]!.foodStored).toBe(0);   // chamber drained first
+    expect(colony.foodStored).toBe(80);               // remaining 20 from pool
+  });
+
+  it('sets foodFlowFieldDirty only on chamber full→not-full transitions (issue #15)', () => {
+    const { colony } = setupWorldWithQueen(0);
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: FOOD_CHAMBER_CAPACITY,
+      posX: 0, posY: 0, width: 1, height: 1,
+    });
+    colony.chambers.push({
+      chamberId: 2, chamberType: ChamberType.FoodStorage, foodStored: 100,
+      posX: 0, posY: 0, width: 1, height: 1,
+    });
+    colony.foodFlowFieldDirty = false;
+
+    // Drain chamber 0 (full) — must fire dirty.
+    withdrawFood(colony, 1);
+    expect(colony.foodFlowFieldDirty).toBe(true);
+
+    // Reset and drain again from chamber 0 (now not-full) — must NOT fire.
+    colony.foodFlowFieldDirty = false;
+    withdrawFood(colony, 1);
+    expect(colony.foodFlowFieldDirty).toBe(false);
+
+    // Drain chamber 1 (not-full from setup) — must NOT fire.
+    colony.foodFlowFieldDirty = false;
+    withdrawFood(colony, 50);
+    expect(colony.foodFlowFieldDirty).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/sim/colony/colony-system.test.ts
+++ b/src/sim/colony/colony-system.test.ts
@@ -36,6 +36,7 @@ import {
   QUEEN_FOOD_PER_TICK,
   LARVA_FOOD_PER_TICK,
   FOOD_CHAMBER_CAPACITY,
+  FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP,
   BASE_FOOD_STORAGE_CAPACITY,
 } from '../constants.js';
 import { createUndergroundGrid, ugSet, UndergroundTileState } from '../terrain.js';
@@ -193,31 +194,59 @@ describe('withdrawFood', () => {
     expect(colony.foodStored).toBe(80);               // remaining 20 from pool
   });
 
-  it('sets foodFlowFieldDirty only on chamber full→not-full transitions (issue #15)', () => {
+  it('sets foodFlowFieldDirty only on saturated→depositable transitions (issue #15 follow-up)', () => {
+    // Hysteresis: a chamber is "saturated" while free space <
+    // FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP. The flow-field re-seed must fire
+    // ONLY when withdraw pushes a chamber across the saturation boundary —
+    // not on every cap → cap-N drain. A naive full→not-full trigger fires on
+    // a single QUEEN_FOOD_PER_TICK=2 drain and pins carriers mid-traversal
+    // (see /tmp/stuck-dump.json — seed 1294596103 tick 1876).
+    const HYST = FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP;
     const { colony } = setupWorldWithQueen(0);
+    // Chamber 0: full → still saturated after small drains until we reach
+    // the depositable threshold (free space >= HYST).
     colony.chambers.push({
       chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: FOOD_CHAMBER_CAPACITY,
       posX: 0, posY: 0, width: 1, height: 1,
     });
+    // Chamber 1: starts depositable (free space > HYST) — drains within the
+    // depositable band must NOT fire dirty.
     colony.chambers.push({
       chamberId: 2, chamberType: ChamberType.FoodStorage, foodStored: 100,
       posX: 0, posY: 0, width: 1, height: 1,
     });
     colony.foodFlowFieldDirty = false;
 
-    // Drain chamber 0 (full) — must fire dirty.
+    // Tiny drain from chamber 0 — saturated → still saturated (free space < HYST).
+    // Must NOT fire dirty (this is the queen-drain oscillation case).
     withdrawFood(colony, 1);
+    expect(colony.foodFlowFieldDirty).toBe(false);
+
+    // Drain enough to cross the saturation boundary — saturated → depositable.
+    // Chamber 0 now has free space == HYST. Must fire dirty.
+    withdrawFood(colony, HYST - 1);
     expect(colony.foodFlowFieldDirty).toBe(true);
 
-    // Reset and drain again from chamber 0 (now not-full) — must NOT fire.
+    // Reset. Further drain in the depositable band — must NOT re-fire.
     colony.foodFlowFieldDirty = false;
     withdrawFood(colony, 1);
     expect(colony.foodFlowFieldDirty).toBe(false);
 
-    // Drain chamber 1 (not-full from setup) — must NOT fire.
+    // Drain across both chambers within the depositable band — must NOT fire.
+    // Withdraw drains chamber 0 (lower index) before chamber 1. Total chamber
+    // food at this point is 4607 + 100 = 4707; withdraw exactly 4707 to fully
+    // drain both. Chamber 0: depositable (free 513) → empty (free CAP) — both
+    // depositable. Chamber 1: depositable (free 5020) → empty — both
+    // depositable. No saturated→depositable transition occurs, so dirty
+    // must stay false. (Withdrawing `FOOD_CHAMBER_CAPACITY` here would
+    // exceed colonyFoodTotal=4707 and trigger withdrawFood's all-or-nothing
+    // early-return — assertion would pass vacuously without exercising the
+    // drain loop.)
     colony.foodFlowFieldDirty = false;
-    withdrawFood(colony, 50);
+    expect(withdrawFood(colony, 4707)).toBe(true);
     expect(colony.foodFlowFieldDirty).toBe(false);
+    expect(colony.chambers[0]!.foodStored).toBe(0);
+    expect(colony.chambers[1]!.foodStored).toBe(0);
   });
 });
 

--- a/src/sim/colony/colony-system.test.ts
+++ b/src/sim/colony/colony-system.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   withdrawFood,
+  colonyFoodTotal,
   colonyFoodCapacity,
   tickFoodConsumption,
   tickStarvationCheck,
@@ -162,6 +163,59 @@ describe('withdrawFood', () => {
     const result = withdrawFood(colony, 50);
     expect(result).toBe(true);
     expect(colony.foodStored).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// colonyFoodTotal — issue #15 regression guard
+//
+// colonyFoodTotal is the canonical "total stored food" reader post-#15.
+// HUD displays, AI thresholds, and forager-economy code all read it. A
+// regression that drops the chamber-summing branch (e.g. reverting it to
+// `return colony.foodStored` alone) would silently break every consumer.
+// These tests guard against that by exercising both contributions.
+// ---------------------------------------------------------------------------
+
+describe('colonyFoodTotal — issue #15', () => {
+  it('sums entrance pool only when no chambers exist', () => {
+    const { colony } = setupWorldWithQueen(123);
+    expect(colonyFoodTotal(colony)).toBe(123);
+  });
+
+  it('includes FoodStorage chamber food in the total', () => {
+    const { colony } = setupWorldWithQueen(0);
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: 200,
+      posX: 0, posY: 0, width: 1, height: 1,
+    });
+    colony.chambers.push({
+      chamberId: 2, chamberType: ChamberType.FoodStorage, foodStored: 50,
+      posX: 0, posY: 0, width: 1, height: 1,
+    });
+    expect(colonyFoodTotal(colony)).toBe(250);
+  });
+
+  it('sums entrance pool + every FoodStorage chamber', () => {
+    const { colony } = setupWorldWithQueen(100);
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: 200,
+      posX: 0, posY: 0, width: 1, height: 1,
+    });
+    expect(colonyFoodTotal(colony)).toBe(300);
+  });
+
+  it('excludes non-FoodStorage chamber types from the total', () => {
+    const { colony } = setupWorldWithQueen(100);
+    // A non-FoodStorage chamber's foodStored is meaningless — must not contribute.
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.Queen, foodStored: 999,
+      posX: 0, posY: 0, width: 1, height: 1,
+    });
+    colony.chambers.push({
+      chamberId: 2, chamberType: ChamberType.Nursery, foodStored: 999,
+      posX: 0, posY: 0, width: 1, height: 1,
+    });
+    expect(colonyFoodTotal(colony)).toBe(100);
   });
 });
 

--- a/src/sim/colony/colony-system.test.ts
+++ b/src/sim/colony/colony-system.test.ts
@@ -526,17 +526,18 @@ describe('tickReconcile', () => {
     expect(colony.foodStored).toBe(BASE_FOOD_STORAGE_CAPACITY);
   });
 
-  it('20b. reconcile clamps foodStored to BASE + N × FOOD_CHAMBER_CAPACITY when FoodStorage chambers exist', () => {
+  it('20b. reconcile clamps the entrance pool to BASE and each chamber.foodStored to FOOD_CHAMBER_CAPACITY independently (issue #15)', () => {
     const { world, colony } = setupWorldWithQueen();
+    // Issue #15: chamber.foodStored is per-chamber authoritative; the entrance
+    // pool (`colony.foodStored`) caps at BASE alone — chambers are NOT a
+    // capacity extension of the pool. Reconcile defensively clamps each side.
     colony.chambers.push(
-      { chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: 0, posX: 0, posY: 0, width: 3, height: 3 },
+      { chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: FOOD_CHAMBER_CAPACITY + 200, posX: 0, posY: 0, width: 3, height: 3 },
     );
-    const cap = BASE_FOOD_STORAGE_CAPACITY + FOOD_CHAMBER_CAPACITY;
-    colony.foodStored = cap + 1000; // overshoot
+    colony.foodStored = BASE_FOOD_STORAGE_CAPACITY + 1000; // pool overshoot
     colony.reconcileCountdown = 1;
     tickReconcile(world, colony);
-    expect(colony.foodStored).toBe(cap);
-    // Chamber distribution still caps at FOOD_CHAMBER_CAPACITY — no inflation
+    expect(colony.foodStored).toBe(BASE_FOOD_STORAGE_CAPACITY);
     expect(colony.chambers[0]!.foodStored).toBe(FOOD_CHAMBER_CAPACITY);
   });
 
@@ -557,9 +558,12 @@ describe('tickReconcile', () => {
     expect(colony.foodStored).toBe(1000 - QUEEN_FOOD_PER_TICK);
   });
 
-  it('22. reconcile derives FoodStorage chamber contents from authoritative foodStored', () => {
+  it('22. reconcile NEVER redistributes the entrance pool across chambers (issue #15 regression)', () => {
+    // Pre-#15 the pool projected over N chambers, magically filling any chamber
+    // an ant had never visited. The post-#15 contract: chamber.foodStored is
+    // independent — it grows only when an ant deposits inside that chamber's
+    // footprint. Reconcile is forbidden from moving food across boundaries.
     const { world, colony } = setupWorldWithQueen(8000);
-    // Add two FoodStorage chambers and one Nursery (non-food)
     colony.chambers.push(
       { chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: 0, posX: 0, posY: 0, width: 3, height: 3 },
       { chamberId: 101, chamberType: ChamberType.Nursery,     foodStored: 0, posX: 4, posY: 0, width: 3, height: 3 },
@@ -569,32 +573,29 @@ describe('tickReconcile', () => {
     colony.reconcileCountdown = 1;
     tickReconcile(world, colony);
 
-    // Two FoodStorage chambers × FOOD_CHAMBER_CAPACITY = 10240; we have 8000, so:
-    // Chamber 0 gets min(8000, 5120) = 5120; distributed 5120
-    // Chamber 2 gets min(8000-5120, 5120) = 2880
-    // Nursery untouched
-    // colony.foodStored stays 8000 (authoritative — never overwritten)
-    expect(colony.chambers[0]!.foodStored).toBe(FOOD_CHAMBER_CAPACITY);
-    expect(colony.chambers[1]!.foodStored).toBe(0); // Nursery — untouched
-    expect(colony.chambers[2]!.foodStored).toBe(8000 - FOOD_CHAMBER_CAPACITY);
-    expect(colony.foodStored).toBe(8000);
+    // No ant deposits happened → all FoodStorage chambers stay at 0.
+    expect(colony.chambers[0]!.foodStored).toBe(0);
+    expect(colony.chambers[1]!.foodStored).toBe(0);
+    expect(colony.chambers[2]!.foodStored).toBe(0);
+    // Entrance pool clamps to BASE (8000 > BASE = 2048).
+    expect(colony.foodStored).toBe(BASE_FOOD_STORAGE_CAPACITY);
   });
 
-  it('23. reconcile overshoot clamped — colony.foodStored is pulled down to colonyFoodCapacity (09 backlog memo)', () => {
-    // Pre-memo behaviour was "colony.foodStored stays authoritative unchanged".
-    // Post-memo: reconcile defensively clamps to BASE + N × FOOD_CHAMBER_CAPACITY
-    // so an overshoot introduced by any non-deposit write path is corrected.
-    const { world, colony } = setupWorldWithQueen(15000);
+  it('23. reconcile defensively clamps a per-chamber overshoot down to FOOD_CHAMBER_CAPACITY (issue #15)', () => {
+    // The deposit + withdraw paths cap at source, but reconcile is the safety
+    // net for any drift. Direct chamber overshoot is clamped here.
+    const { world, colony } = setupWorldWithQueen(0);
     colony.chambers.push(
-      { chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: 0, posX: 0, posY: 0, width: 3, height: 3 },
+      { chamberId: 100, chamberType: ChamberType.FoodStorage,
+        foodStored: FOOD_CHAMBER_CAPACITY + 12345, // simulated drift
+        posX: 0, posY: 0, width: 3, height: 3 },
     );
 
     colony.reconcileCountdown = 1;
     tickReconcile(world, colony);
 
-    const cap = BASE_FOOD_STORAGE_CAPACITY + FOOD_CHAMBER_CAPACITY; // 7168
     expect(colony.chambers[0]!.foodStored).toBe(FOOD_CHAMBER_CAPACITY);
-    expect(colony.foodStored).toBe(cap);
+    expect(colony.foodStored).toBe(0);
   });
 });
 

--- a/src/sim/colony/colony-system.ts
+++ b/src/sim/colony/colony-system.ts
@@ -110,7 +110,6 @@ export function withdrawFood(colony: ColonyRecord, amount: number): boolean {
   }
   if (remaining > 0) {
     colony.foodStored -= remaining;
-    remaining = 0;
   }
   return true;
 }
@@ -118,15 +117,21 @@ export function withdrawFood(colony: ColonyRecord, amount: number): boolean {
 // ---------------------------------------------------------------------------
 // colonyFoodCapacity — 09 backlog memo: BASE + N × FOOD_CHAMBER_CAPACITY
 //
-// Returns the authoritative capacity for colony.foodStored. N counts only
-// COMPLETED FoodStorage chambers (entries in colony.chambers). Pending
-// FoodStorage chambers do NOT contribute — capacity grows only when the
-// chamber is fully excavated and promoted by checkPendingChambers.
+// Returns the colony's TOTAL food-storage capacity (entrance pool + every
+// FoodStorage chamber). Compare against `colonyFoodTotal(colony)`, not
+// `colony.foodStored` alone — post-#15, `colony.foodStored` caps at BASE
+// (the entrance pool only) while each FoodStorage chamber caps at
+// FOOD_CHAMBER_CAPACITY. N counts only COMPLETED FoodStorage chambers
+// (entries in colony.chambers). Pending FoodStorage chambers do NOT
+// contribute — capacity grows only when the chamber is fully excavated
+// and promoted by checkPendingChambers.
 // ---------------------------------------------------------------------------
 
 /**
  * Total colony food-storage capacity (fp): BASE + N × FOOD_CHAMBER_CAPACITY,
  * where N is the number of completed FoodStorage chambers in colony.chambers.
+ * Post-#15 this is the cap for `colonyFoodTotal(colony)` (pool + chambers),
+ * not for `colony.foodStored` (which caps at BASE alone).
  *
  * Pending FoodStorage chambers (world.pendingChambers) do NOT contribute —
  * promotion happens in checkPendingChambers once excavation completes.
@@ -315,6 +320,10 @@ export function tickDeathCleanup(world: WorldState, colony: ColonyRecord): void 
  * The recount pass (PRD §2) filters alive===1 entities in each bucket and
  * corrects eggCount, larvaeCount, workerCount. Doubles as a cleanup pass —
  * dead slots found during recount are swap-removed from the bucket.
+ * Issue #15: also clamps `colony.foodStored` to [0, BASE_FOOD_STORAGE_CAPACITY]
+ * and each FoodStorage chamber's `foodStored` to [0, FOOD_CHAMBER_CAPACITY] —
+ * defensive only; the deposit/withdraw paths cap at their own sources.
+ * NEVER redistributes food across chambers (that was the pre-#15 magic-fill bug).
  * Resets reconcileCountdown to RECONCILE_INTERVAL_TICKS after recount.
  *
  * CLNY-07: cached fields are guaranteed accurate at most RECONCILE_INTERVAL_TICKS

--- a/src/sim/colony/colony-system.ts
+++ b/src/sim/colony/colony-system.ts
@@ -43,24 +43,75 @@ import { ugGet, ugSet, UndergroundTileState } from '../terrain.js';
 import { FP_SHIFT } from '../fixed.js';
 
 // ---------------------------------------------------------------------------
-// withdrawFood — chamberless food withdrawal helper (PRD §4c)
+// withdrawFood / colonyFoodTotal — chamber-authoritative food withdrawal (issue #15)
 //
-// Phase 6 chamberless-fallback: unconditionally draws from colony.foodStored.
-// Phase 7 adds chamber-aware routing (UNDR-07), replacing this path.
+// Pre-issue-#15 the colony had a single `foodStored` pool that `tickReconcile`
+// projected across FoodStorage chambers. Foragers wrote the pool; once the
+// pool exceeded one chamber's slice, the SECOND chamber appeared full at the
+// next reconcile even though no ant had ever visited it. Players saw food
+// "magically appear" in distant rooms.
 //
-// Returns true if food was withdrawn, false if pool was empty.
+// New model: chamber.foodStored is the authoritative store for each
+// FoodStorage chamber. colony.foodStored persists as the entrance-shaft /
+// chamberless-fallback pool — used by the Phase 6 deposit-at-entrance path
+// (when no FoodStorage chamber exists, or when a forager deposits at the
+// entrance shaft top per `tickForagerActions` (b)) and seeded by scenarios
+// via STARTING_FOOD. Capacity contract: chambers cap at FOOD_CHAMBER_CAPACITY
+// each; the entrance pool caps at BASE_FOOD_STORAGE_CAPACITY. Total capacity
+// is unchanged: BASE + N × FOOD_CHAMBER_CAPACITY.
+//
+// Withdraw drains chambers in colony.chambers array order first, then the
+// entrance pool. Order matters for determinism — never sort.
 // ---------------------------------------------------------------------------
 
 /**
- * Attempt to withdraw `amount` food from `colony.foodStored`.
+ * Total stored food across the colony: entrance pool + every FoodStorage
+ * chamber. Use this for HUD displays, AI thresholds, and any code that
+ * previously read `colony.foodStored` as the colony total.
  *
- * Phase 6 chamberless fallback: draws directly from the colony pool.
- * Returns true on success (foodStored decremented by `amount`).
- * Returns false if foodStored < amount (no partial withdrawal — all-or-nothing).
+ * Reading `colony.foodStored` directly post-#15 yields ONLY the
+ * entrance-shaft pool, which is rarely what callers want.
+ */
+export function colonyFoodTotal(colony: ColonyRecord): number {
+  let total = colony.foodStored;
+  for (let i = 0; i < colony.chambers.length; i++) {
+    const ch = colony.chambers[i]!;
+    if (ch.chamberType === ChamberType.FoodStorage) total += ch.foodStored;
+  }
+  return total;
+}
+
+/**
+ * Attempt to withdraw `amount` food. All-or-nothing: returns false (no
+ * partial withdrawal) if the colony's combined stored food is below `amount`.
+ *
+ * Drain order is deterministic — FoodStorage chambers in colony.chambers
+ * array order, then the entrance-shaft pool (`colony.foodStored`). Each
+ * source contributes up to its current contents. If a chamber transitions
+ * from full to non-full as a result, the food flow-field is marked dirty so
+ * step 9 can re-seed routing on the next tick (foragers can now target the
+ * newly-non-full chamber).
  */
 export function withdrawFood(colony: ColonyRecord, amount: number): boolean {
-  if (colony.foodStored < amount) return false;
-  colony.foodStored -= amount;
+  if (colonyFoodTotal(colony) < amount) return false;
+
+  let remaining = amount;
+  for (let i = 0; i < colony.chambers.length && remaining > 0; i++) {
+    const ch = colony.chambers[i]!;
+    if (ch.chamberType !== ChamberType.FoodStorage) continue;
+    if (ch.foodStored <= 0) continue;
+    const wasFull = ch.foodStored >= FOOD_CHAMBER_CAPACITY;
+    const take = ch.foodStored < remaining ? ch.foodStored : remaining;
+    ch.foodStored -= take;
+    remaining -= take;
+    if (wasFull && ch.foodStored < FOOD_CHAMBER_CAPACITY) {
+      colony.foodFlowFieldDirty = true;
+    }
+  }
+  if (remaining > 0) {
+    colony.foodStored -= remaining;
+    remaining = 0;
+  }
   return true;
 }
 
@@ -312,28 +363,20 @@ export function tickReconcile(world: WorldState, colony: ColonyRecord): void {
   }
   colony.workerCount = workerCount;
 
-  // Food validation (PRD §2 reconcile contract):
-  // colony.foodStored is the authoritative pooled total — never overwritten here.
-  // When FoodStorage chambers exist, derive their contents from the authoritative
-  // total (each capped at FOOD_CHAMBER_CAPACITY). colony.foodStored stays unchanged.
+  // Food validation (issue #15 — chamber-authoritative model):
+  // chamber.foodStored is authoritative per FoodStorage chamber; colony.foodStored
+  // is the entrance-shaft fallback pool. Deposits + withdraws clamp at their
+  // sources, so reconcile is a defensive backstop against drift. NEVER redistribute
+  // across chambers — that was the old magic-fill bug fixed in #15.
   if (colony.foodStored < 0) colony.foodStored = 0;
-  // 09 backlog memo — defensively clamp to colonyFoodCapacity. Deposits are
-  // clamped at the antDepositFood source, so this should be a no-op in steady
-  // state; the clamp is a backstop against any future code path that writes
-  // colony.foodStored directly without going through antDepositFood.
-  const cap = colonyFoodCapacity(colony);
-  if (colony.foodStored > cap) colony.foodStored = cap;
-
-  if (colony.chambers.length > 0) {
-    let distributed = 0;
-    for (let i = 0; i < colony.chambers.length; i++) {
-      const ch = colony.chambers[i]!;
-      if (ch.chamberType !== ChamberType.FoodStorage) continue;
-      const available = colony.foodStored - distributed;
-      const fill = available < FOOD_CHAMBER_CAPACITY ? (available > 0 ? available : 0) : FOOD_CHAMBER_CAPACITY;
-      ch.foodStored = fill;
-      distributed += fill;
-    }
+  if (colony.foodStored > BASE_FOOD_STORAGE_CAPACITY) {
+    colony.foodStored = BASE_FOOD_STORAGE_CAPACITY;
+  }
+  for (let i = 0; i < colony.chambers.length; i++) {
+    const ch = colony.chambers[i]!;
+    if (ch.chamberType !== ChamberType.FoodStorage) continue;
+    if (ch.foodStored < 0) ch.foodStored = 0;
+    if (ch.foodStored > FOOD_CHAMBER_CAPACITY) ch.foodStored = FOOD_CHAMBER_CAPACITY;
   }
 
   // Recompute allocation with corrected counts (PRD §2 reconcile contract +

--- a/src/sim/colony/colony-system.ts
+++ b/src/sim/colony/colony-system.ts
@@ -27,7 +27,7 @@
 
 import type { WorldState } from '../types.js';
 import { allocateEntityId } from '../types.js';
-import type { ColonyRecord } from './colony-store.js';
+import type { ChamberRecord, ColonyRecord } from './colony-store.js';
 import type { ColonyId } from './colony-store.js';
 import {
   QUEEN_FOOD_PER_TICK,
@@ -35,6 +35,7 @@ import {
   STARVATION_GRACE_TICKS,
   RECONCILE_INTERVAL_TICKS,
   FOOD_CHAMBER_CAPACITY,
+  FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP,
   BASE_FOOD_STORAGE_CAPACITY,
 } from '../constants.js';
 import { ChamberType } from '../enums.js';
@@ -82,15 +83,43 @@ export function colonyFoodTotal(colony: ColonyRecord): number {
 }
 
 /**
+ * Issue #15 follow-up — single-source-of-truth predicate for "is this chamber
+ * an active deposit destination?" Used by:
+ *   - chamber-flow-field BFS seeding (tick.ts step 9)
+ *   - tickForagerActions step 16b deposit-site test
+ *   - antDepositFood chamber match
+ *   - tickAntMovement Manhattan fallback chamberTargetX selection
+ *
+ * Saturated (free space < FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP) chambers are
+ * EXCLUDED from all four sites in lockstep. This is what prevents the
+ * queen-drain-then-redeposit oscillation that pinned carriers on full-chamber
+ * tiles in seed-1294596103 tick-1876 (see the constant docs).
+ *
+ * Non-FoodStorage chambers always return false — the loops upstream already
+ * filter on chamberType, but this keeps the predicate self-contained so a
+ * single misuse can't accidentally treat a Queen/Nursery chamber as a food
+ * deposit target.
+ */
+export function isFoodChamberDepositable(chamber: ChamberRecord): boolean {
+  if (chamber.chamberType !== ChamberType.FoodStorage) return false;
+  return FOOD_CHAMBER_CAPACITY - chamber.foodStored >= FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP;
+}
+
+/**
  * Attempt to withdraw `amount` food. All-or-nothing: returns false (no
  * partial withdrawal) if the colony's combined stored food is below `amount`.
  *
  * Drain order is deterministic — FoodStorage chambers in colony.chambers
  * array order, then the entrance-shaft pool (`colony.foodStored`). Each
- * source contributes up to its current contents. If a chamber transitions
- * from full to non-full as a result, the food flow-field is marked dirty so
- * step 9 can re-seed routing on the next tick (foragers can now target the
- * newly-non-full chamber).
+ * source contributes up to its current contents.
+ *
+ * Issue #15 follow-up — flow-field dirty: fires only when a chamber crosses
+ * the saturation→depositable boundary (per isFoodChamberDepositable), not
+ * on every cap → cap-N drain. A QUEEN_FOOD_PER_TICK=2 nibble of a full
+ * chamber must NOT mark the field dirty — otherwise step 9 re-seeds the
+ * still-saturated chamber every tick and carriers on its footprint pin in
+ * the oscillation cycle described in the FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP
+ * constant docs.
  */
 export function withdrawFood(colony: ColonyRecord, amount: number): boolean {
   if (colonyFoodTotal(colony) < amount) return false;
@@ -100,11 +129,11 @@ export function withdrawFood(colony: ColonyRecord, amount: number): boolean {
     const ch = colony.chambers[i]!;
     if (ch.chamberType !== ChamberType.FoodStorage) continue;
     if (ch.foodStored <= 0) continue;
-    const wasFull = ch.foodStored >= FOOD_CHAMBER_CAPACITY;
+    const wasDepositable = isFoodChamberDepositable(ch);
     const take = ch.foodStored < remaining ? ch.foodStored : remaining;
     ch.foodStored -= take;
     remaining -= take;
-    if (wasFull && ch.foodStored < FOOD_CHAMBER_CAPACITY) {
+    if (!wasDepositable && isFoodChamberDepositable(ch)) {
       colony.foodFlowFieldDirty = true;
     }
   }

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -39,7 +39,9 @@ import {
 //
 // Gating order (PRD §4b line 980 + 09 reproduction-gate memo):
 //   1. Tick-modulo gate:  world.tick % QUEEN_EGG_INTERVAL_TICKS !== 0 → return
-//   2. Food threshold:    colony.foodStored < QUEEN_EGG_FOOD_THRESHOLD → return
+//   2. Food threshold:    colonyFoodTotal(colony) < QUEEN_EGG_FOOD_THRESHOLD → return
+//                         (issue #15 — total stash = entrance pool + every
+//                         FoodStorage chamber, NOT colony.foodStored alone)
 //   3. Queen alive:       world.ants.alive[colony.queenEntityId] !== 1 → return
 //   4. Queen chamber:     colony has at least one COMPLETED Queen chamber (09 memo)
 //   5. Nursery chamber:   colony has at least one COMPLETED Nursery chamber (09 memo)

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -21,7 +21,7 @@ import { allocateEntityId } from '../types.js';
 import { initAnt } from '../ant/ant-store.js';
 import type { ColonyRecord } from './colony-store.js';
 import { AntTask, ChamberType } from '../enums.js';
-import { hasCompletedChamber } from './colony-system.js';
+import { hasCompletedChamber, colonyFoodTotal } from './colony-system.js';
 import { Zone, ugGet, UndergroundTileState } from '../terrain.js';
 import { FP_SHIFT, FP_ONE } from '../fixed.js';
 import {
@@ -76,8 +76,11 @@ export function tickQueenEggProduction(world: WorldState, colony: ColonyRecord):
   // Gate 1: tick-modulo interval
   if ((world.tick % QUEEN_EGG_INTERVAL_TICKS) !== 0) return;
 
-  // Gate 2: food threshold
-  if (colony.foodStored < QUEEN_EGG_FOOD_THRESHOLD) return;
+  // Gate 2: food threshold — issue #15: read TOTAL stockpile (entrance pool +
+  // every FoodStorage chamber.foodStored). Pre-#15 this read colony.foodStored
+  // as the single pool; post-#15 colony.foodStored is only the entrance-shaft
+  // pool, so a colony whose entire stash lives in chambers would never lay.
+  if (colonyFoodTotal(colony) < QUEEN_EGG_FOOD_THRESHOLD) return;
 
   // Gate 3: queen alive
   if (world.ants.alive[colony.queenEntityId] !== 1) return;

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -69,6 +69,30 @@ export const FOOD_PICKUP_AMOUNT = 512; // 2 × FP_ONE
 export const FOOD_CHAMBER_CAPACITY = 5120; // 20 × FP_ONE
 
 /**
+ * Issue #15 follow-up — minimum free space (fp) a FoodStorage chamber must have
+ * to be considered an active deposit destination. Chambers with less free space
+ * than this are treated as "saturated" — excluded from BFS food-flow seeds AND
+ * rejected by the deposit-site test in tickForagerActions / antDepositFood.
+ *
+ * Why hysteresis: without it, a single QUEEN_FOOD_PER_TICK=2 drain immediately
+ * marks the chamber non-full again. The flow-field re-seeds from it, the BFS
+ * marks every tile inside the chamber footprint as -1 (source), and any
+ * carrier ant standing on one of those tiles (e.g. mid-traversal toward
+ * another, truly-empty chamber) gets pinned: movement reads -1 → hold; step
+ * 16b deposits 2 fp → chamber full again; queen drains 2 next tick; repeat.
+ * Carriers leak their entire load 2 fp at a time into the wrong chamber. See
+ * /tmp/stuck-dump.json — seed 1294596103 tick 1876, ants 17/19/22/23.
+ *
+ * Sized to FOOD_PICKUP_AMOUNT (one pickup-quantum) so a forager arriving with
+ * a fresh load is always either fully accepted by the targeted chamber or
+ * routed past it. With QUEEN_FOOD_PER_TICK=2 the chamber must be queen-drained
+ * for ~256 ticks (~13 s at 20 Hz) after the saturation point before it
+ * reappears as a BFS seed — long enough to suppress the per-tick oscillation,
+ * short enough that real consumption restores routing without UX-visible lag.
+ */
+export const FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP = FOOD_PICKUP_AMOUNT; // 512 fp = 2 × FP_ONE
+
+/**
  * 09 backlog memo — BASE colony storage capacity (fp) before any FoodStorage
  * chamber is built. Small enough that a player must build storage to grow
  * beyond the early colony: sized to roughly cover STARTING_FOOD plus a little

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -134,17 +134,18 @@ function buildWorld(seed: number): { world: WorldState; queenId: number; colonyI
     lifespan:  WORKER_LIFESPAN_TICKS,
   });
   world.colonies[1] = createColonyRecord(1, queenId);
-  world.colonies[1]!.foodStored = 100000;
-  // 09 backlog: seed enough FoodStorage chambers so colonyFoodCapacity accommodates
-  // the synthetic 100000fp head-start (tickReconcile now clamps foodStored to
-  // capacity, so a chamberless colony would lose all but BASE_FOOD_STORAGE_CAPACITY
-  // at tick 100 and starve the queen before Test 6's pipeline completes).
-  // 20 chambers ⇒ cap = 2048 + 20×5120 = 104448fp, comfortably above 100000.
+  // Issue #15: chamber.foodStored is now per-chamber authoritative. The
+  // synthetic 100000fp head-start has to live in chambers, not the entrance
+  // pool — reconcile clamps colony.foodStored to BASE alone so dumping 100000
+  // into the pool would collapse to 2048 on the first reconcile and starve
+  // the queen well before Test 6's pipeline completes. Spread the head-start
+  // across 20 chambers (5000fp each, all under FOOD_CHAMBER_CAPACITY=5120).
+  world.colonies[1]!.foodStored = 0;
   for (let i = 0; i < 20; i++) {
     world.colonies[1]!.chambers.push({
       chamberId:   1000 + i,
       chamberType: ChamberType.FoodStorage,
-      foodStored:  0,
+      foodStored:  5000,
       posX:        0,
       posY:        0,
       width:       3,
@@ -175,9 +176,10 @@ function buildWorld(seed: number): { world: WorldState; queenId: number; colonyI
   });
   world.ants.zone[queenId] = 1; // Zone.Underground — Gate 6 precondition
   // Phase 3 PRD §2a caller-side extension fields (factory does not set these):
-  world.colonies[1]!.entrances         = [];
-  world.colonies[1]!.rallyPoint        = null;
-  world.colonies[1]!.digFlowFieldDirty = false;
+  world.colonies[1]!.entrances          = [];
+  world.colonies[1]!.rallyPoint         = null;
+  world.colonies[1]!.digFlowFieldDirty  = false;
+  world.colonies[1]!.foodFlowFieldDirty = false;
   world.pheromoneGrids[pheromoneGridKey(1, PheromoneType.FoodTrail, 'surface')] =
     createPheromoneGrid(64, 64);
   return { world, queenId, colonyId: 1 as ColonyId };

--- a/src/sim/foraging-excursion.test.ts
+++ b/src/sim/foraging-excursion.test.ts
@@ -20,6 +20,7 @@ import { createScenario } from './scenario.js';
 import { tick } from './tick.js';
 import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from './constants.js';
 import { isAlive } from './ant/ant-store.js';
+import { colonyFoodTotal } from './colony/colony-system.js';
 
 interface SeedStats {
   playerQueenAlive: boolean;
@@ -34,15 +35,23 @@ function runSeed(seed: number, maxTicks: number): SeedStats {
   const world = createScenario(seed);
   let playerFirstDepositTick: number | null = null;
   let enemyFirstDepositTick: number | null = null;
-  let prevPlayerFood = world.colonies[PLAYER_COLONY_ID]!.foodStored;
-  let prevEnemyFood  = world.colonies[ENEMY_COLONY_ID]!.foodStored;
+  // Issue #15: deposits land in chamber.foodStored, not colony.foodStored
+  // alone. Track the colony total (entrance pool + every chamber) so the
+  // first-deposit detector remains accurate after the chamber-authoritative
+  // refactor. Pre-#15 a pool-only read worked because reconcile projected
+  // chamber slices from the pool — a single source of truth — and any
+  // deposit grew the pool. Post-#15 only chamberless-fallback deposits
+  // grow the pool, so a pool-only detector goes silent the moment the
+  // first ant reaches a chamber.
+  let prevPlayerFood = colonyFoodTotal(world.colonies[PLAYER_COLONY_ID]!);
+  let prevEnemyFood  = colonyFoodTotal(world.colonies[ENEMY_COLONY_ID]!);
 
   for (let t = 0; t < maxTicks; t++) {
     const cmds = world.commandQueue.splice(0);
     tick(world, cmds);
 
-    const playerFood = world.colonies[PLAYER_COLONY_ID]!.foodStored;
-    const enemyFood  = world.colonies[ENEMY_COLONY_ID]!.foodStored;
+    const playerFood = colonyFoodTotal(world.colonies[PLAYER_COLONY_ID]!);
+    const enemyFood  = colonyFoodTotal(world.colonies[ENEMY_COLONY_ID]!);
 
     if (playerFirstDepositTick === null && playerFood > prevPlayerFood) {
       playerFirstDepositTick = t;
@@ -60,8 +69,8 @@ function runSeed(seed: number, maxTicks: number): SeedStats {
   return {
     playerQueenAlive: isAlive(world.ants, playerColony.queenEntityId),
     enemyQueenAlive:  isAlive(world.ants, enemyColony.queenEntityId),
-    playerFoodStored: playerColony.foodStored,
-    enemyFoodStored:  enemyColony.foodStored,
+    playerFoodStored: colonyFoodTotal(playerColony),
+    enemyFoodStored:  colonyFoodTotal(enemyColony),
     playerFirstDepositTick,
     enemyFirstDepositTick,
   };

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -139,6 +139,7 @@ function initColony(
   colony.entrances         = [];
   colony.rallyPoint        = null;
   colony.digFlowFieldDirty = false;
+  colony.foodFlowFieldDirty = false;
   colony.foodStored        = STARTING_FOOD;
 
   // Phase 9 playability: seed each colony with one pre-excavated open entrance

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -2501,4 +2501,120 @@ describe('resetFlowFieldCaches — cross-world isolation', () => {
 
     resetFlowFieldCaches();
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #15 — cross-tick partial-deposit redirection.
+  //
+  // End-to-end check that exercises the full chamber-fill/redirect loop:
+  //
+  //  1. Carrier arrives at near chamber A, which has space for only part of
+  //     its load. antDepositFood writes the chamber up to cap, leaves the
+  //     leftover on the ant, and sets foodFlowFieldDirty.
+  //  2. On the next tick, step 9 re-seeds the food flow-field excluding A
+  //     (now full). The carrier — still holding the leftover — gets a
+  //     direction value pointing toward the only remaining seed (chamber B).
+  //  3. Carrier walks to B, deposits the leftover, flips Foraging→Idle.
+  //
+  // This wires together: dirty-flag cycle (deposit→step 9 next tick),
+  // chamberFilter integration in computeChamberFlowField, deposit-site
+  // selection in tickForagerActions, antDepositFood leftover semantics, and
+  // the Foraging→Idle transition. Round-1 unit tests cover each piece in
+  // isolation; this is the integration that catches a regression in any
+  // single piece misaligning with the rest.
+  // -------------------------------------------------------------------------
+  it('issue #15 — partial deposit at near chamber leaves leftover on ant; carrier then routes to far chamber', async () => {
+    const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } = await import('./terrain.js');
+    const { FP_ONE } = await import('./fixed.js');
+    const { initAnt: _initAnt } = await import('./ant/ant-store.js');
+    const { FOOD_CHAMBER_CAPACITY: CAP } = await import('./constants.js');
+
+    resetFlowFieldCaches();
+
+    const world = createWorldState(42);
+    const colonyId = 1 as ColonyId;
+    const queenId = allocateEntityId(world);
+    _initAnt(world.ants, queenId, {
+      colonyId,
+      posX: 1024, posY: 1024,
+      task: AntTask.Idle, subTask: 0,
+      speed: 0, lifespan: WORKER_LIFESPAN_TICKS,
+    });
+    // Kill the queen so tickFoodConsumption (step 3) doesn't drain chamber A
+    // mid-tick. This test is about the chamber-fill / food-flow-field-redirect
+    // path; queen consumption would steal 2fp/tick from A and reopen capacity,
+    // preventing the redirect from triggering. Killing the queen is fine for
+    // the few-tick window — `defeated` is checked on its own cadence.
+    world.ants.alive[queenId] = 0;
+    const colony = createColonyRecord(colonyId, queenId);
+    colony.foodStored = 0;
+    colony.digFlowFieldDirty = true; // first compute on tick 0
+    colony.foodFlowFieldDirty = false;
+    colony.rallyPoint = null;
+    colony.entrances = [{ entranceId: 1, surfaceTileX: 8, surfaceTileY: 5, isOpen: true }];
+    // Chamber A near (col 5) with `space` units of room. Chamber B far
+    // (col 14) is empty. The carrier holds `loadFp` such that the deposit
+    // into A fills A exactly to cap and leaves `loadFp - space` on the ant.
+    const space = 50;
+    const loadFp = space + 200;            // 250fp leaves 200 on the ant after A fills
+    const chamberA_initial = CAP - space;
+    colony.chambers.push({
+      chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: chamberA_initial,
+      posX: 5 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 1, height: 1,
+    });
+    colony.chambers.push({
+      chamberId: 101, chamberType: ChamberType.FoodStorage, foodStored: 0,
+      posX: 14 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 1, height: 1,
+    });
+    world.colonies[colonyId] = colony;
+
+    const ug = createUndergroundGrid(16, 16);
+    for (let x = 0; x < 16; x++) {
+      ugSet(ug, x, 0, UndergroundTileState.Open);
+      ugSet(ug, x, 1, UndergroundTileState.Open);
+      ugSet(ug, x, 2, UndergroundTileState.Open);
+      ugSet(ug, x, 3, UndergroundTileState.Open);
+    }
+    world.undergroundGrids[colonyId] = ug;
+
+    // Carrier ant starts ON chamber A's tile so antDepositFood fires this
+    // tick — keeps the test compact (≤30 ticks even with the redirect).
+    const antId = allocateEntityId(world);
+    _initAnt(world.ants, antId, {
+      colonyId,
+      posX: 5 << FP_SHIFT,
+      posY: 3 << FP_SHIFT,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.CarryingFood,
+      speed: FP_ONE,
+      lifespan: WORKER_LIFESPAN_TICKS,
+    });
+    world.ants.zone[antId] = Zone.Underground;
+    world.ants.foodCarrying[antId] = loadFp;
+    colony.workers.push(antId);
+    colony.workerCount = 1;
+
+    const chamberA = colony.chambers[0]!;
+    const chamberB = colony.chambers[1]!;
+
+    // Tick 0 — deposit fires, A fills to cap, leftover stays on ant, dirty
+    // flag set so step 9 next tick re-seeds the food field excluding A.
+    tick(world, []);
+    expect(chamberA.foodStored).toBe(CAP);
+    expect(world.ants.foodCarrying[antId]).toBe(loadFp - space);
+
+    // Drive the sim until B has the leftover. Bound by 30 ticks — the
+    // carrier walks from col 5 → col 14 = 9 tiles at 1 tile/tick, plus a
+    // small margin for the deposit + idle-flip handshake.
+    let landedInB = false;
+    for (let t = 0; t < 30; t++) {
+      tick(world, []);
+      if (chamberB.foodStored > 0) { landedInB = true; break; }
+    }
+    expect(landedInB).toBe(true);
+    // Queen is dead, no consumption — the leftover deposits cleanly into B.
+    expect(chamberB.foodStored).toBe(loadFp - space);
+    expect(world.ants.foodCarrying[antId]).toBe(0);
+
+    resetFlowFieldCaches();
+  });
 });

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -2415,4 +2415,90 @@ describe('resetFlowFieldCaches — cross-world isolation', () => {
 
     resetFlowFieldCaches();
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #15 regression: full FoodStorage chambers must drop out of the food
+  // flow-field. A second chamber further away should pick up the routing once
+  // the nearer chamber fills, instead of letting carriers stall at the cap.
+  // -------------------------------------------------------------------------
+  it('issue #15 — full FoodStorage chamber stops seeding the food flow-field; carriers redirect to non-full chamber', async () => {
+    const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } = await import('./terrain.js');
+    const { FP_ONE } = await import('./fixed.js');
+    const { initAnt: _initAnt } = await import('./ant/ant-store.js');
+    const { FOOD_CHAMBER_CAPACITY: CAP } = await import('./constants.js');
+
+    resetFlowFieldCaches();
+
+    const world = createWorldState(42);
+    const colonyId = 1 as ColonyId;
+    const queenId = allocateEntityId(world);
+    _initAnt(world.ants, queenId, {
+      colonyId,
+      posX: 1024, posY: 1024,
+      task: AntTask.Idle, subTask: 0,
+      speed: 0, lifespan: WORKER_LIFESPAN_TICKS,
+    });
+    const colony = createColonyRecord(colonyId, queenId);
+    colony.foodStored = 0;
+    colony.digFlowFieldDirty = true; // first compute on tick 0
+    colony.foodFlowFieldDirty = false;
+    colony.rallyPoint = null;
+    colony.entrances = [{ entranceId: 1, surfaceTileX: 8, surfaceTileY: 5, isOpen: true }];
+    // Two chambers on opposite ends of the open row. Chamber A (west, at col 2)
+    // is FULL — it must NOT seed the food field. Chamber B (east, at col 14)
+    // has room and should be the only seed.
+    //
+    // Chamber B is pushed FIRST so tickFoodConsumption (step 3) drains it for
+    // the queen's 2fp/tick stipend BEFORE chamber A — leaving chamber A at
+    // exactly capacity when the food flow-field recomputes at step 9. Without
+    // this ordering, withdrawFood would dip chamber A below the cap and the
+    // BFS would re-seed from the now-not-full chamber, defeating the test.
+    colony.chambers.push({
+      chamberId: 101, chamberType: ChamberType.FoodStorage, foodStored: 100,
+      posX: 14 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 1, height: 1,
+    });
+    colony.chambers.push({
+      chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: CAP,
+      posX: 2 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 1, height: 1,
+    });
+    world.colonies[colonyId] = colony;
+
+    const ug = createUndergroundGrid(16, 16);
+    for (let x = 0; x < 16; x++) {
+      ugSet(ug, x, 0, UndergroundTileState.Open);
+      ugSet(ug, x, 1, UndergroundTileState.Open);
+      ugSet(ug, x, 2, UndergroundTileState.Open);
+      ugSet(ug, x, 3, UndergroundTileState.Open);
+    }
+    world.undergroundGrids[colonyId] = ug;
+
+    // Carrier ant in the middle of row 3, holding food and routing home.
+    const antId = allocateEntityId(world);
+    _initAnt(world.ants, antId, {
+      colonyId,
+      posX: 8 << FP_SHIFT,
+      posY: 3 << FP_SHIFT,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.CarryingFood,
+      speed: FP_ONE,
+      lifespan: WORKER_LIFESPAN_TICKS,
+    });
+    world.ants.zone[antId] = Zone.Underground;
+    world.ants.foodCarrying[antId] = 100;
+    colony.workers.push(antId);
+    colony.workerCount = 1;
+
+    const beforeX = world.ants.posX[antId]! >> FP_SHIFT;
+    tick(world, []);
+    const afterX = world.ants.posX[antId]! >> FP_SHIFT;
+
+    // The full chamber is to the WEST (col 2); the open chamber is to the
+    // EAST (col 14). Pre-#15 the BFS would have seeded both and the carrier
+    // would have stepped west toward the closer (full) chamber, only to stall
+    // on a full-cap deposit. Post-#15 the food field excludes the full chamber
+    // and routes the carrier east toward the open one.
+    expect(afterX).toBeGreaterThan(beforeX);
+
+    resetFlowFieldCaches();
+  });
 });

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -2526,7 +2526,7 @@ describe('resetFlowFieldCaches — cross-world isolation', () => {
     const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } = await import('./terrain.js');
     const { FP_ONE } = await import('./fixed.js');
     const { initAnt: _initAnt } = await import('./ant/ant-store.js');
-    const { FOOD_CHAMBER_CAPACITY: CAP } = await import('./constants.js');
+    const { FOOD_CHAMBER_CAPACITY: CAP, FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP: HYST } = await import('./constants.js');
 
     resetFlowFieldCaches();
 
@@ -2554,8 +2554,15 @@ describe('resetFlowFieldCaches — cross-world isolation', () => {
     // Chamber A near (col 5) with `space` units of room. Chamber B far
     // (col 14) is empty. The carrier holds `loadFp` such that the deposit
     // into A fills A exactly to cap and leaves `loadFp - space` on the ant.
-    const space = 50;
-    const loadFp = space + 200;            // 250fp leaves 200 on the ant after A fills
+    //
+    // Issue #15 follow-up: under the deposit hysteresis, A must start
+    // DEPOSITABLE (free space >= HYST) so the deposit fires this tick. With
+    // free space < HYST the carrier would refuse to deposit at A entirely
+    // and route straight to B with full load — a different (also correct)
+    // path covered by the dedicated stuck-ant repro test below. Here we
+    // exercise the cross-tick redirect after a partial fill.
+    const space = HYST + 100;              // 612fp — depositable pre, saturated post
+    const loadFp = space + 200;            // 812fp leaves 200 on the ant after A fills
     const chamberA_initial = CAP - space;
     colony.chambers.push({
       chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: chamberA_initial,
@@ -2614,6 +2621,119 @@ describe('resetFlowFieldCaches — cross-world isolation', () => {
     // Queen is dead, no consumption — the leftover deposits cleanly into B.
     expect(chamberB.foodStored).toBe(loadFp - space);
     expect(world.ants.foodCarrying[antId]).toBe(0);
+
+    resetFlowFieldCaches();
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #15 follow-up — queen-drain oscillation stuck-ant regression.
+  //
+  // Repro from /tmp/stuck-dump.json (seed 1294596103 tick 1876):
+  //   - Chamber A is full (foodStored = CAP) and the queen consumes
+  //     QUEEN_FOOD_PER_TICK=2fp from it each tick.
+  //   - A carrier ant stands on chamber A's footprint en route to chamber B
+  //     (depositable, far away).
+  //
+  // Pre-fix (full→not-full re-seed): the queen's 2fp drain marks A non-full,
+  // step 9 re-seeds the BFS with A as a source, the carrier's tile reads
+  // direction = -1 (source), movement holds. Step 16b then deposits 2fp into
+  // A (matches what the queen just took), A is full again, queen drains 2,
+  // repeat. The carrier dribbles its entire load 2fp/tick into A and never
+  // reaches B.
+  //
+  // Post-fix (saturated→depositable hysteresis): A stays saturated (free
+  // space < HYST = 512fp) for ~256 ticks of queen drain before re-seeding.
+  // The carrier walks past A to B in well under that window. This test asserts
+  // the carrier's load arrives at B, not A.
+  // -------------------------------------------------------------------------
+  it('issue #15 follow-up — queen-drain oscillation does NOT pin a carrier on a near-full chamber', async () => {
+    const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } = await import('./terrain.js');
+    const { FP_ONE } = await import('./fixed.js');
+    const { initAnt: _initAnt } = await import('./ant/ant-store.js');
+    const { FOOD_CHAMBER_CAPACITY: CAP } = await import('./constants.js');
+
+    resetFlowFieldCaches();
+
+    const world = createWorldState(1294596103);
+    const colonyId = 1 as ColonyId;
+    const queenId = allocateEntityId(world);
+    // Queen position is decorative — withdrawFood drains chambers in array
+    // order regardless of queen tile, so chamber 0 (A) is drained first
+    // because it's pushed first below. Queen sits inside A's footprint
+    // purely to keep the test's mental model close to the dump scenario.
+    _initAnt(world.ants, queenId, {
+      colonyId,
+      posX: 5 << FP_SHIFT, posY: 3 << FP_SHIFT,
+      task: AntTask.Idle, subTask: 0,
+      speed: 0, lifespan: WORKER_LIFESPAN_TICKS,
+    });
+    const colony = createColonyRecord(colonyId, queenId);
+    colony.foodStored = 0;
+    colony.digFlowFieldDirty = true; // first compute on tick 0
+    colony.foodFlowFieldDirty = false;
+    colony.rallyPoint = null;
+    colony.entrances = [{ entranceId: 1, surfaceTileX: 8, surfaceTileY: 5, isOpen: true }];
+
+    // Chamber A near (col 5) full. Chamber B far (col 14) empty/depositable.
+    colony.chambers.push({
+      chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: CAP,
+      posX: 5 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 1, height: 1,
+    });
+    colony.chambers.push({
+      chamberId: 101, chamberType: ChamberType.FoodStorage, foodStored: 0,
+      posX: 14 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 1, height: 1,
+    });
+    world.colonies[colonyId] = colony;
+
+    const ug = createUndergroundGrid(16, 16);
+    for (let x = 0; x < 16; x++) {
+      ugSet(ug, x, 0, UndergroundTileState.Open);
+      ugSet(ug, x, 1, UndergroundTileState.Open);
+      ugSet(ug, x, 2, UndergroundTileState.Open);
+      ugSet(ug, x, 3, UndergroundTileState.Open);
+    }
+    world.undergroundGrids[colonyId] = ug;
+
+    // Carrier ant starts ON chamber A's tile holding a full pickup load.
+    // Pre-fix this is the pinned state (deposits 2/tick, queen drains 2/tick,
+    // never moves). Post-fix the carrier walks east to B.
+    const antId = allocateEntityId(world);
+    const carriedFp = 1024;
+    _initAnt(world.ants, antId, {
+      colonyId,
+      posX: 5 << FP_SHIFT,
+      posY: 3 << FP_SHIFT,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.CarryingFood,
+      speed: FP_ONE,
+      lifespan: WORKER_LIFESPAN_TICKS,
+    });
+    world.ants.zone[antId] = Zone.Underground;
+    world.ants.foodCarrying[antId] = carriedFp;
+    colony.workers.push(antId);
+    colony.workerCount = 1;
+
+    const chamberA = colony.chambers[0]!;
+    const chamberB = colony.chambers[1]!;
+    const aBefore = chamberA.foodStored;
+
+    // Drive 60 ticks — the carrier walks 9 tiles at 1 tile/tick to chamber B
+    // and deposits its full load. Generous margin for movement quirks.
+    let landedInB = false;
+    for (let t = 0; t < 60; t++) {
+      tick(world, []);
+      if (chamberB.foodStored > 0) { landedInB = true; break; }
+    }
+
+    expect(landedInB).toBe(true);
+    expect(chamberB.foodStored).toBe(carriedFp);
+    expect(world.ants.foodCarrying[antId]).toBe(0);
+    // Pre-fix the carrier would have leaked all 1024fp INTO A (matching the
+    // queen's drain), driving chamberA.foodStored above aBefore. Post-fix A
+    // never grows — the assertion is `<=` rather than `<` because the loop
+    // breaks on the tick the carrier deposits at B, which can be early enough
+    // that no queen tick has consumed yet (aBefore == aAfter is legitimate).
+    expect(chamberA.foodStored).toBeLessThanOrEqual(aBefore);
 
     resetFlowFieldCaches();
   });

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -97,6 +97,14 @@ const entranceFlowFields: EntranceFlowFields = createEntranceFlowFields();
 // tunnels (see chamber-flow.ts).
 const chamberFlowFields: ChamberFlowFields = createChamberFlowFields();
 
+// Issue #15 — module-level predicate hoisted out of the per-tick step-9 loop
+// so we don't allocate a closure on every colony × tick (hot path; the same
+// predicate is used by every colony every recompute). Skips chambers at
+// capacity from the food flow-field BFS seeds so carriers redirect to the
+// next non-full chamber instead of stalling on a full-chamber tile.
+const isChamberNotFull = (chamber: { foodStored: number }): boolean =>
+  chamber.foodStored < FOOD_CHAMBER_CAPACITY;
+
 /**
  * Clear every module-level flow-field cache keyed by colonyId.
  *
@@ -545,7 +553,9 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       chamberBufs.queue,
       // Issue #15: full chambers must not seed the BFS — otherwise carriers
       // route into a dead-end and stall on a tile whose chamber is at cap.
-      (ch) => ch.foodStored < FOOD_CHAMBER_CAPACITY,
+      // Predicate is hoisted to module scope (`isChamberNotFull`) to avoid
+      // per-tick closure allocation.
+      isChamberNotFull,
     );
     computeChamberFlowField(
       underground,

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -23,7 +23,6 @@ import {
   UNDERGROUND_GRID_HEIGHT,
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
-  FOOD_CHAMBER_CAPACITY,
 } from './constants.js';
 import { FP_SHIFT } from './fixed.js';
 import { allocateWorkers } from './behavior/allocation-system.js';
@@ -36,6 +35,7 @@ import {
   checkPendingChambers,
   checkEntranceCompletion,
   hasCompletedChamber,
+  isFoodChamberDepositable,
 } from './colony/colony-system.js';
 import {
   tickQueenEggProduction,
@@ -77,7 +77,7 @@ import type { ChamberFlowFields } from './chamber-flow.js';
 import { ugGet, ugSet, UndergroundTileState } from './terrain.js';
 import { CHAMBER_DIMENSIONS } from './colony/chamber.js';
 import type { PendingChamber } from './colony/chamber.js';
-import type { ColonyId, ChamberRecord } from './colony/colony-store.js';
+import type { ColonyId } from './colony/colony-store.js';
 import type { FoodPileId } from './food.js';
 
 // ---------------------------------------------------------------------------
@@ -96,16 +96,6 @@ const entranceFlowFields: EntranceFlowFields = createEntranceFlowFields();
 // ants). Prevents straight-line chamber steering into Solid dirt on bent
 // tunnels (see chamber-flow.ts).
 const chamberFlowFields: ChamberFlowFields = createChamberFlowFields();
-
-// Issue #15 — module-level predicate hoisted out of the per-tick step-9 loop
-// so we don't allocate a fresh closure on every colony recompute (gated by
-// digFlowFieldDirty / foodFlowFieldDirty / first-compute, but still a hot
-// path). Skips chambers at capacity from the food flow-field BFS seeds so
-// carriers redirect to the next non-full chamber instead of stalling on a
-// full-chamber tile. Typed against ChamberRecord so a future field rename
-// fails fast at the predicate site.
-const isChamberNotFull = (chamber: ChamberRecord): boolean =>
-  chamber.foodStored < FOOD_CHAMBER_CAPACITY;
 
 /**
  * Clear every module-level flow-field cache keyed by colonyId.
@@ -553,11 +543,13 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       FOOD_CHAMBER_TYPES,
       chamberBufs.food,
       chamberBufs.queue,
-      // Issue #15: full chambers must not seed the BFS — otherwise carriers
-      // route into a dead-end and stall on a tile whose chamber is at cap.
-      // Predicate is hoisted to module scope (`isChamberNotFull`) to avoid
-      // per-tick closure allocation.
-      isChamberNotFull,
+      // Issue #15 follow-up: saturated chambers (free space <
+      // FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP) must not seed the BFS — otherwise
+      // a carrier mid-traversal across a near-full chamber gets pinned by
+      // the queen-drain-then-redeposit oscillation. Shared with the deposit
+      // path in ant-system.ts via `isFoodChamberDepositable`, so seed
+      // exclusion and deposit refusal stay in lockstep.
+      isFoodChamberDepositable,
     );
     computeChamberFlowField(
       underground,

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -77,7 +77,7 @@ import type { ChamberFlowFields } from './chamber-flow.js';
 import { ugGet, ugSet, UndergroundTileState } from './terrain.js';
 import { CHAMBER_DIMENSIONS } from './colony/chamber.js';
 import type { PendingChamber } from './colony/chamber.js';
-import type { ColonyId } from './colony/colony-store.js';
+import type { ColonyId, ChamberRecord } from './colony/colony-store.js';
 import type { FoodPileId } from './food.js';
 
 // ---------------------------------------------------------------------------
@@ -98,11 +98,13 @@ const entranceFlowFields: EntranceFlowFields = createEntranceFlowFields();
 const chamberFlowFields: ChamberFlowFields = createChamberFlowFields();
 
 // Issue #15 — module-level predicate hoisted out of the per-tick step-9 loop
-// so we don't allocate a closure on every colony × tick (hot path; the same
-// predicate is used by every colony every recompute). Skips chambers at
-// capacity from the food flow-field BFS seeds so carriers redirect to the
-// next non-full chamber instead of stalling on a full-chamber tile.
-const isChamberNotFull = (chamber: { foodStored: number }): boolean =>
+// so we don't allocate a fresh closure on every colony recompute (gated by
+// digFlowFieldDirty / foodFlowFieldDirty / first-compute, but still a hot
+// path). Skips chambers at capacity from the food flow-field BFS seeds so
+// carriers redirect to the next non-full chamber instead of stalling on a
+// full-chamber tile. Typed against ChamberRecord so a future field rename
+// fails fast at the predicate site.
+const isChamberNotFull = (chamber: ChamberRecord): boolean =>
   chamber.foodStored < FOOD_CHAMBER_CAPACITY;
 
 /**

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -23,6 +23,7 @@ import {
   UNDERGROUND_GRID_HEIGHT,
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
+  FOOD_CHAMBER_CAPACITY,
 } from './constants.js';
 import { FP_SHIFT } from './fixed.js';
 import { allocateWorkers } from './behavior/allocation-system.js';
@@ -508,7 +509,12 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     const firstEntranceCompute = !(colony.colonyId in entranceFlowFields.fields);
     const firstDigCompute = !(colony.colonyId in digFlowFields.fields);
 
-    if (!colony.digFlowFieldDirty && !firstEntranceCompute && !firstDigCompute) continue;
+    if (
+      !colony.digFlowFieldDirty &&
+      !colony.foodFlowFieldDirty &&
+      !firstEntranceCompute &&
+      !firstDigCompute
+    ) continue;
 
     if (colony.digFlowFieldDirty || firstDigCompute) {
       const out = ensureDigFlowField(digFlowFields, colony.colonyId, gridSize);
@@ -526,7 +532,10 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // Recompute chamber flow-fields on the same cycle. Chamber completion
     // (which flips tile states from Marked/BeingDug to Open) is one of the
     // signals that sets digFlowFieldDirty upstream, so this cadence is
-    // sufficient to keep the fields fresh.
+    // sufficient to keep the fields fresh. Issue #15: the food field also
+    // recomputes when foodFlowFieldDirty fires (set when a FoodStorage chamber
+    // crosses the full↔not-full boundary) so carriers redirect away from full
+    // chambers without waiting for an unrelated topology change.
     const chamberBufs = ensureChamberFlowFields(chamberFlowFields, colony.colonyId, gridSize);
     computeChamberFlowField(
       underground,
@@ -534,6 +543,9 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       FOOD_CHAMBER_TYPES,
       chamberBufs.food,
       chamberBufs.queue,
+      // Issue #15: full chambers must not seed the BFS — otherwise carriers
+      // route into a dead-end and stall on a tile whose chamber is at cap.
+      (ch) => ch.foodStored < FOOD_CHAMBER_CAPACITY,
     );
     computeChamberFlowField(
       underground,
@@ -551,6 +563,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     );
 
     colony.digFlowFieldDirty = false;
+    colony.foodFlowFieldDirty = false;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -138,6 +138,7 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
       fresh.entrances         = [];
       fresh.rallyPoint        = null;
       fresh.digFlowFieldDirty = false;
+      fresh.foodFlowFieldDirty = false;
       fresh.killCount         = 0;
       fresh.priorityFoodPileId = null;
     }
@@ -226,6 +227,8 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
 
     // digFlowFieldDirty — boolean assignment
     d.digFlowFieldDirty = s.digFlowFieldDirty;
+    // foodFlowFieldDirty (issue #15) — boolean assignment
+    d.foodFlowFieldDirty = s.foodFlowFieldDirty;
   }
 
   // --- pheromoneGrids: delete stale dst keys; upsert each src grid ---


### PR DESCRIPTION
## Summary

Closes #15.

Pre-fix: `colony.foodStored` was a single abstract pool that `tickReconcile` projected across chambers. Foragers only ever deposited at the nearest food-storage room; food then "magically appeared" in distant chambers when the near one was full.

Post-fix: each FoodStorage `chamber.foodStored` is the authoritative store; `colony.foodStored` is just the entrance-shaft / chamberless fallback pool. Carriers redirect to the next non-full chamber when the closest fills, and the BFS food flow-field excludes full chambers as seeds so the redirect happens through the same routing system the rest of the game uses.

- New `colonyFoodTotal(colony)` helper — pool + every FoodStorage chamber. HUD, AI gates, reproduction gate, foraging diagnostics all read this instead of `colony.foodStored`.
- `withdrawFood` drains chambers in array order, then the pool. Sets `colony.foodFlowFieldDirty = true` on full→not-full transitions.
- `antDepositFood` deposits into the chamber containing the ant's tile, falls back to the entrance pool, leaves leftover on the ant when both are full. Sets `foodFlowFieldDirty` on not-full→full so step 9 re-seeds routing next tick.
- `chamberFilter` parameter on `computeChamberFlowField` — full chambers do not seed the BFS.
- `SAVE_FORMAT_VERSION` bumped 1→2; v1 saves rejected with a clean error and the legacy key purged from localStorage opportunistically.

Four rounds of adversarial QC review run before posting; round 4 returned no P0/P1 findings.

## Test plan

- [x] `pnpm test` — 1431 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] Direct unit tests for `colonyFoodTotal` (pool-only, chamber-only, mixed, non-FoodStorage exclusion)
- [x] `withdrawFood` draw-order regression (chambers before pool) + `foodFlowFieldDirty` transition semantics
- [x] Cross-tick partial-deposit redirect integration test (carrier fills near chamber, leftover stays on ant, foodFlowFieldDirty fires, carrier walks to far chamber and deposits)
- [x] Save round-trip including per-chamber food + `foodFlowFieldDirty` field
- [x] v1→v2 save rejection regression test
- [ ] Manual UAT before merge — load existing game, observe foragers redistributing food across chambers when the near one fills, no magic-fill in distant rooms

🤖 Generated with [Claude Code](https://claude.com/claude-code)