### PR TITLE
Phase 10: Auto-Assign Diggers (closes #13)

### DIFF
--- a/src/input/surface-input.test.ts
+++ b/src/input/surface-input.test.ts
@@ -115,7 +115,12 @@ function makeColony(overrides: {
     larvae: [],
     workers: [],
     chambers: [],
-    targetRatio: { forage: 33, dig: 33, fight: 34 },
+    // Phase 10 / CTRL-01' (LOCKED): targetRatio is two-field {forage, fight};
+    // dig is auto-assigned via CTRL-06. Original 33/33/34 was the percentage
+    // convention; rebalanced here to 50/50 (preserves the original "balanced"
+    // semantic intent — dig:33 dropped, residual forage/fight evened).
+    // computedAllocation + taskCensus remain 4-field (WorkerAllocation per D-03).
+    targetRatio: { forage: 50, fight: 50 },
     computedAllocation: { nurse: 0, forage: 0, dig: 0, fight: 0 },
     taskCensus: { nurse: 0, forage: 0, dig: 0, fight: 0 },
     defeated: false,

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -567,4 +567,151 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         .toBe(JSON.stringify(serializeWorldState(b)));
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Phase 10 / WR-09 — inputLog SetBehaviorRatio migration on load
+  //
+  // SCEN-06 requires that `createScenario(seed) + tick(cmds[t])` reproduce the
+  // loaded snapshot. Pre-Phase-10 v2 saves (issue #15 → Phase 10 transition)
+  // can carry SetBehaviorRatio entries shaped as `{forage, dig, fight}` in
+  // their inputLog. Replaying those verbatim under post-Phase-10 code would
+  // silently drop the dig weight and (for pure-dig players) collapse to an
+  // idle command. parseSaveFile walks inputLog and applies the same migration
+  // semantics as deserializeColony's targetRatio: drop dig, snap all-zero
+  // remainder to {forage:10, fight:0}, leave already-migrated entries alone.
+  // ---------------------------------------------------------------------------
+  describe('Phase 10 / WR-09 — inputLog migration on load', () => {
+    function writeSave(file: { version: number; seed: number; inputLog: unknown[]; snapshot: unknown }): void {
+      localStorage.setItem(SAVE_KEY, JSON.stringify(file));
+    }
+
+    it('typical legacy entry: SetBehaviorRatio { forage:5, dig:3, fight:2 } loads with dig dropped', () => {
+      const w = createScenario(42);
+      const legacyEntry = {
+        type: 'SetBehaviorRatio',
+        colonyId: PLAYER_COLONY_ID,
+        ratio: { forage: 5, dig: 3, fight: 2 },
+        issuedAtTick: 0,
+      };
+      writeSave({
+        version: SAVE_FORMAT_VERSION, seed: 42,
+        inputLog: [legacyEntry],
+        snapshot: serializeWorldState(w),
+      });
+      const loaded = loadSave()!;
+      expect(loaded.inputLog.length).toBe(1);
+      const ratio = (loaded.inputLog[0] as { ratio: unknown }).ratio;
+      expect(ratio).toEqual({ forage: 5, fight: 2 });
+      expect('dig' in (ratio as object)).toBe(false);
+    });
+
+    it('pure-dig legacy entry: { forage:0, dig:10, fight:0 } snaps to default { forage:10, fight:0 }', () => {
+      const w = createScenario(42);
+      const legacyEntry = {
+        type: 'SetBehaviorRatio',
+        colonyId: PLAYER_COLONY_ID,
+        ratio: { forage: 0, dig: 10, fight: 0 },
+        issuedAtTick: 0,
+      };
+      writeSave({
+        version: SAVE_FORMAT_VERSION, seed: 42,
+        inputLog: [legacyEntry],
+        snapshot: serializeWorldState(w),
+      });
+      const loaded = loadSave()!;
+      const ratio = (loaded.inputLog[0] as { ratio: unknown }).ratio;
+      expect(ratio).toEqual({ forage: 10, fight: 0 });
+    });
+
+    it('post-Phase-10 entry without dig field passes through unchanged (including idle {0,0})', () => {
+      const w = createScenario(42);
+      const modernIdle: SimCommand = {
+        type: 'SetBehaviorRatio',
+        colonyId: PLAYER_COLONY_ID as ColonyId,
+        ratio: { forage: 0, fight: 0 },
+        issuedAtTick: 7,
+      };
+      writeSave({
+        version: SAVE_FORMAT_VERSION, seed: 42,
+        inputLog: [modernIdle],
+        snapshot: serializeWorldState(w),
+      });
+      const loaded = loadSave()!;
+      expect((loaded.inputLog[0] as { ratio: unknown }).ratio).toEqual({ forage: 0, fight: 0 });
+    });
+
+    it('mixed inputLog: only SetBehaviorRatio entries are touched; other commands pass through', () => {
+      const w = createScenario(42);
+      writeSave({
+        version: SAVE_FORMAT_VERSION, seed: 42,
+        inputLog: [
+          { type: 'SetBehaviorRatio', colonyId: PLAYER_COLONY_ID, ratio: { forage: 5, dig: 3, fight: 2 }, issuedAtTick: 0 },
+          { type: 'MarkDigTile', colonyId: PLAYER_COLONY_ID, tileX: 7, tileY: 3, issuedAtTick: 5 },
+          { type: 'NoOp', issuedAtTick: 10 },
+        ],
+        snapshot: serializeWorldState(w),
+      });
+      const loaded = loadSave()!;
+      expect((loaded.inputLog[0] as { ratio: unknown }).ratio).toEqual({ forage: 5, fight: 2 });
+      expect(loaded.inputLog[1]).toMatchObject({ type: 'MarkDigTile', tileX: 7, tileY: 3 });
+      expect(loaded.inputLog[2]).toMatchObject({ type: 'NoOp' });
+    });
+
+    it('replay round-trip: pure-dig legacy inputLog → load → replay reproduces the migrated snapshot', () => {
+      // The full SCEN-06 contract: migrated inputLog applied to a fresh
+      // scenario reproduces the migrated snapshot byte-for-byte.
+      //
+      // Discriminating case: pure-dig legacy {forage:0, dig:5, fight:0} is
+      // the only shape where migrated and verbatim playback produce
+      // DIFFERENT results: migrated snaps to {forage:10, fight:0}, while
+      // verbatim replay through the post-Phase-10 handler reads {forage:0,
+      // fight:0} (idle, no allocation). Mid-dig and mid-forage cases like
+      // {forage:5, dig:3, fight:2} → {forage:5, fight:2} cannot
+      // discriminate — both paths give the same answer because the handler
+      // ignores the `dig` field regardless.
+      const seed = 42;
+      const original = createScenario(seed);
+      // Build the original world by applying the POST-MIGRATION shape:
+      // {forage:10, fight:0} at tick 5. This is the state the migrated
+      // legacy command should reproduce on replay.
+      const postMigrationCmd: SimCommand = {
+        type: 'SetBehaviorRatio',
+        colonyId: PLAYER_COLONY_ID as ColonyId,
+        ratio: { forage: 10, fight: 0 },
+        issuedAtTick: 5,
+      };
+      for (let t = 0; t < 50; t++) {
+        const cmds: SimCommand[] = (t === 5) ? [postMigrationCmd] : [];
+        tick(original, cmds);
+      }
+
+      // Persist with a LEGACY pure-dig entry in the inputLog.
+      const legacyEntry = {
+        type: 'SetBehaviorRatio',
+        colonyId: PLAYER_COLONY_ID,
+        ratio: { forage: 0, dig: 5, fight: 0 },
+        issuedAtTick: 5,
+      };
+      writeSave({
+        version: SAVE_FORMAT_VERSION, seed,
+        inputLog: [legacyEntry],
+        snapshot: serializeWorldState(original),
+      });
+
+      const loaded = loadSave()!;
+      // Sanity: the legacy entry got snapped to {forage:10, fight:0}.
+      expect((loaded.inputLog[0] as { ratio: unknown }).ratio).toEqual({ forage: 10, fight: 0 });
+
+      const replay = createScenario(loaded.seed);
+      const byTick: SimCommand[][] = [];
+      for (const c of loaded.inputLog) {
+        const t = c.issuedAtTick;
+        (byTick[t] ??= []).push(c);
+      }
+      for (let t = 0; t < 50; t++) tick(replay, byTick[t] ?? []);
+
+      expect(JSON.stringify(serializeWorldState(replay)))
+        .toBe(JSON.stringify(serializeWorldState(original)));
+    });
+  });
 });

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -470,4 +470,101 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(result).toEqual({ forage: 10, fight: 0 });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Phase 10 / D-04 — full save round-trip migration
+  //
+  // deserializeColony must invoke migrateBehaviorRatio so that loading a save
+  // with a pre-Phase-10 3-field targetRatio produces a runtime ColonyRecord
+  // with the post-Phase-10 2-field shape. Round-trip determinism: load legacy
+  // → save → reload yields a stable two-field-only serialized targetRatio.
+  // ---------------------------------------------------------------------------
+  describe('Phase 10 / D-04 — save round-trip migration', () => {
+    // Build a SerializedWorldState from createScenario, then mutate the player
+    // colony's targetRatio to the desired legacy/post shape. Using the live
+    // serializer keeps every other field of the envelope correct, so tests
+    // assert ONLY the migration behavior — not the rest of the envelope.
+    function legacySaveWithRatio(
+      legacy: { forage: number; dig?: number; fight: number },
+    ) {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      const colonyKey = String(PLAYER_COLONY_ID);
+      // Cast through unknown to inject the legacy 3-field shape (which the
+      // SerializedColony type now accepts via `dig?: number`).
+      (s.colonies[colonyKey] as { targetRatio: typeof legacy }).targetRatio = legacy;
+      return s;
+    }
+
+    it('typical legacy save: { forage: 5, dig: 3, fight: 2 } loads with dig dropped', () => {
+      // After deserialize, the runtime ColonyRecord has the post-Phase-10
+      // two-field shape. The `dig` key is GONE, not zeroed (verifies the
+      // migration is structural, not just numeric).
+      const s = legacySaveWithRatio({ forage: 5, dig: 3, fight: 2 });
+      const w2 = deserializeWorldState(s);
+      const ratio = w2.colonies[PLAYER_COLONY_ID]!.targetRatio;
+      expect(ratio).toEqual({ forage: 5, fight: 2 });
+      expect('dig' in ratio).toBe(false);
+    });
+    it('pure-dig legacy save: { forage: 0, dig: 10, fight: 0 } snaps to default { forage: 10, fight: 0 }', () => {
+      // The all-zero edge case: a pre-Phase-10 player who set pure dig had
+      // forage===0 AND fight===0 under the new contract. D-04 snaps to the
+      // DEFAULT_BEHAVIOR_RATIO { forage: 10, fight: 0 }.
+      const s = legacySaveWithRatio({ forage: 0, dig: 10, fight: 0 });
+      const w2 = deserializeWorldState(s);
+      const ratio = w2.colonies[PLAYER_COLONY_ID]!.targetRatio;
+      expect(ratio).toEqual({ forage: 10, fight: 0 });
+      expect('dig' in ratio).toBe(false);
+    });
+    it('already-migrated save: { forage: 7, fight: 3 } loads unchanged (no-op pass-through)', () => {
+      // Post-Phase-10 saves load idempotently — no re-snap, no field drift.
+      const s = legacySaveWithRatio({ forage: 7, fight: 3 });
+      const w2 = deserializeWorldState(s);
+      expect(w2.colonies[PLAYER_COLONY_ID]!.targetRatio).toEqual({ forage: 7, fight: 3 });
+    });
+    it('two-colony round-trip: each colony migrates independently', () => {
+      // Sanity: per-colony migration is independent. Player gets a typical
+      // legacy ratio (dig dropped); enemy gets the pure-dig edge case (snap).
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      (s.colonies[String(PLAYER_COLONY_ID)] as { targetRatio: { forage: number; dig: number; fight: number } })
+        .targetRatio = { forage: 5, dig: 3, fight: 2 };
+      (s.colonies[String(ENEMY_COLONY_ID)] as { targetRatio: { forage: number; dig: number; fight: number } })
+        .targetRatio = { forage: 0, dig: 10, fight: 0 };
+      const w2 = deserializeWorldState(s);
+      expect(w2.colonies[PLAYER_COLONY_ID]!.targetRatio).toEqual({ forage: 5, fight: 2 });
+      expect(w2.colonies[ENEMY_COLONY_ID]!.targetRatio).toEqual({ forage: 10, fight: 0 });
+    });
+    it('round-trip determinism: load legacy → save → re-load produces byte-stable two-field targetRatio', () => {
+      // Critical SCEN-06 contract: after migration, a re-saved snapshot
+      // serializes a CLEAN two-field targetRatio, and a second load is the
+      // idempotent no-op case in migrateBehaviorRatio. The second-save JSON
+      // must contain no `dig` field.
+      const s1 = legacySaveWithRatio({ forage: 5, dig: 3, fight: 2 });
+      const w2 = deserializeWorldState(s1);
+      const s2 = serializeWorldState(w2);
+      const reSerializedRatio = s2.colonies[String(PLAYER_COLONY_ID)]!.targetRatio;
+      expect(reSerializedRatio).toEqual({ forage: 5, fight: 2 });
+      expect('dig' in reSerializedRatio).toBe(false);
+      // Load a third time; the second-save JSON has no dig field, so this is
+      // the post-migration idempotent pass-through path.
+      const w3 = deserializeWorldState(s2);
+      expect(w3.colonies[PLAYER_COLONY_ID]!.targetRatio).toEqual({ forage: 5, fight: 2 });
+    });
+    it('round-trip determinism: post-load tick sequence is deterministic', () => {
+      // Two worlds loaded from the SAME legacy save and ticked the same
+      // number of ticks must produce byte-identical serialized state.
+      // This guards against migration introducing any non-determinism
+      // (e.g. iteration order, PRNG drift) in the load path.
+      const legacy = legacySaveWithRatio({ forage: 5, dig: 3, fight: 2 });
+      const a = deserializeWorldState(legacy);
+      const b = deserializeWorldState(legacy);
+      for (let t = 0; t < 30; t++) {
+        tick(a, []);
+        tick(b, []);
+      }
+      expect(JSON.stringify(serializeWorldState(a)))
+        .toBe(JSON.stringify(serializeWorldState(b)));
+    });
+  });
 });

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -456,17 +456,23 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       const twice = migrateBehaviorRatio(once);
       expect(twice).toEqual({ forage: 7, fight: 3 });
     });
-    it('(already-migrated, all-zero defensive) { forage: 0, fight: 0 } → { forage: 10, fight: 0 }', () => {
-      // A fresh post-Phase-10 save with all-zero values also triggers the snap.
-      // Defensive: prevents loading a save into a degenerate "no work assigned"
-      // state regardless of how it got there.
+    it('(already-migrated, intentional zeros) { forage: 0, fight: 0 } passes through unchanged (WR-10)', () => {
+      // Post-Phase-10 callers can legitimately set both fields to 0 (idle
+      // slider, AI exotic state, replay tooling). The snap is restricted to
+      // legacy or malformed inputs so snapshot-vs-replay determinism is
+      // preserved for valid two-field zeros.
       const result = migrateBehaviorRatio({ forage: 0, fight: 0 });
-      expect(result).toEqual({ forage: 10, fight: 0 });
+      expect(result).toEqual({ forage: 0, fight: 0 });
     });
     it('(missing fields defensive) {} → { forage: 10, fight: 0 }', () => {
       // Missing/non-numeric forage and fight default to 0, which then triggers
-      // the all-zero snap. Garbage in → safe default out.
+      // the malformed-input branch of the snap. Garbage in → safe default out.
       const result = migrateBehaviorRatio({});
+      expect(result).toEqual({ forage: 10, fight: 0 });
+    });
+    it('(NaN field defensive) { forage: NaN, fight: 0 } → { forage: 10, fight: 0 }', () => {
+      // NaN counts as malformed — the snap fires defensively.
+      const result = migrateBehaviorRatio({ forage: NaN, fight: 0 });
       expect(result).toEqual({ forage: 10, fight: 0 });
     });
   });

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -4,6 +4,7 @@ import {
   SAVE_FORMAT_VERSION, SAVE_KEY, AUTOSAVE_INTERVAL_MS,
   serializeWorldState, deserializeWorldState,
   hasSave, loadSave, deleteSave, tickAutosave,
+  migrateBehaviorRatio,
   type SaveFile,
 } from './save.js';
 import { createScenario } from '../sim/scenario.js';
@@ -420,6 +421,53 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
 
       expect(JSON.stringify(serializeWorldState(replay)))
         .toBe(JSON.stringify(serializeWorldState(original)));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Phase 10 / D-04 — silent BehaviorRatio migration on load
+  //
+  // Pre-Phase-10 saves serialize targetRatio as { forage, dig, fight } (3 fields).
+  // Phase 10 narrows BehaviorRatio to { forage, fight }. The migrateBehaviorRatio
+  // helper drops the dig field, snaps all-zero { forage:0, fight:0 } to the
+  // default { forage:10, fight:0 }, and is idempotent on already-migrated saves.
+  // No schema version bump per D-04 (pre-1.0, save compat is not a public contract).
+  // ---------------------------------------------------------------------------
+  describe('Phase 10 / D-04 — migrateBehaviorRatio', () => {
+    it('(typical) drops dig field: { forage: 5, dig: 3, fight: 2 } → { forage: 5, fight: 2 }', () => {
+      // The dig field is silently dropped — no proportional rescale.
+      const result = migrateBehaviorRatio({ forage: 5, dig: 3, fight: 2 });
+      expect(result).toEqual({ forage: 5, fight: 2 });
+      // Sanity: the `dig` key is GONE, not zeroed.
+      expect('dig' in result).toBe(false);
+    });
+    it('(all-zero edge / pre-Phase-10 pure-dig) snaps to { forage: 10, fight: 0 }', () => {
+      // Pre-Phase-10 player who set pure dig: { forage: 0, dig: 10, fight: 0 }.
+      // Under the two-role contract this would be all-zero; D-04 snaps to the
+      // DEFAULT_BEHAVIOR_RATIO { forage: 10, fight: 0 }.
+      const result = migrateBehaviorRatio({ forage: 0, dig: 10, fight: 0 });
+      expect(result).toEqual({ forage: 10, fight: 0 });
+    });
+    it('(already-migrated, idempotent) { forage: 7, fight: 3 } → { forage: 7, fight: 3 }', () => {
+      // No-op pass-through for post-Phase-10 saves (no dig field).
+      // Applying the helper twice produces the same result as applying once.
+      const once = migrateBehaviorRatio({ forage: 7, fight: 3 });
+      expect(once).toEqual({ forage: 7, fight: 3 });
+      const twice = migrateBehaviorRatio(once);
+      expect(twice).toEqual({ forage: 7, fight: 3 });
+    });
+    it('(already-migrated, all-zero defensive) { forage: 0, fight: 0 } → { forage: 10, fight: 0 }', () => {
+      // A fresh post-Phase-10 save with all-zero values also triggers the snap.
+      // Defensive: prevents loading a save into a degenerate "no work assigned"
+      // state regardless of how it got there.
+      const result = migrateBehaviorRatio({ forage: 0, fight: 0 });
+      expect(result).toEqual({ forage: 10, fight: 0 });
+    });
+    it('(missing fields defensive) {} → { forage: 10, fight: 0 }', () => {
+      // Missing/non-numeric forage and fight default to 0, which then triggers
+      // the all-zero snap. Garbage in → safe default out.
+      const result = migrateBehaviorRatio({});
+      expect(result).toEqual({ forage: 10, fight: 0 });
     });
   });
 });

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -383,7 +383,10 @@ function deserializeColony(s: SerializedColony): ColonyRecord {
   c.larvae               = [...s.larvae];
   c.workers              = [...s.workers];
   c.chambers             = s.chambers.map((ch) => ({ ...ch }));
-  c.targetRatio          = { ...s.targetRatio };
+  // Phase 10 / D-04 silent migration: legacy saves carry `targetRatio.dig`;
+  // migrateBehaviorRatio drops it, snaps all-zero to DEFAULT_BEHAVIOR_RATIO,
+  // and is idempotent on post-Phase-10 saves. See migrateBehaviorRatio docblock.
+  c.targetRatio          = migrateBehaviorRatio(s.targetRatio);
   c.computedAllocation   = { ...s.computedAllocation };
   c.taskCensus           = { ...s.taskCensus };
   c.defeated             = s.defeated;

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -99,7 +99,12 @@ interface SerializedColony {
   foodStored: number; workerCount: number; eggCount: number; larvaeCount: number; nurseCount: number;
   eggs: EntityId[]; larvae: EntityId[]; workers: EntityId[];
   chambers: ChamberRecord[];
-  targetRatio: BehaviorRatio;
+  // Phase 10 / D-04 silent-migration: serialized shape is the runtime BehaviorRatio
+  // (post-migration `{ forage, fight }`), but the legacy `dig` field is allowed for
+  // backward compatibility with pre-Phase-10 saves. Migration via migrateBehaviorRatio
+  // at load time (deserializeColony) silently drops the `dig` field — no schema
+  // version bump per D-04 (pre-1.0, save compat is not a public contract).
+  targetRatio: { forage: number; fight: number; dig?: number };
   computedAllocation: WorkerAllocation;
   taskCensus: WorkerAllocation;
   defeated: boolean; reconcileCountdown: number;
@@ -252,6 +257,39 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
 // ---------------------------------------------------------------------------
 // Deserialize helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Phase 10 / D-04 — silent BehaviorRatio migration on load.
+ *
+ * Pre-Phase-10 saves serialize targetRatio as `{ forage, dig, fight }` (3 fields).
+ * Phase 10 narrows BehaviorRatio to `{ forage, fight }`. This helper:
+ *   - drops the `dig` field (no proportional rescale)
+ *   - snaps all-zero `{ forage: 0, fight: 0 }` to `{ forage: 10, fight: 0 }`
+ *     (the player had pure dig under the old contract; default to 100% forage,
+ *     matching DEFAULT_BEHAVIOR_RATIO from Plan 01)
+ *   - leaves already-migrated saves untouched (idempotent)
+ *   - defensively defaults missing/non-numeric `forage` and `fight` to 0
+ *     (which then triggers the all-zero snap → `{ forage: 10, fight: 0 }`)
+ *
+ * No schema version bump — pre-1.0, save compat is not a public contract per D-04.
+ *
+ * Pure function: no PRNG, no clock, no side effects. Idempotent: applying twice
+ * produces the same output as applying once.
+ */
+export function migrateBehaviorRatio(
+  legacy: { forage?: number; dig?: number; fight?: number },
+): BehaviorRatio {
+  const forage = typeof legacy.forage === 'number' ? legacy.forage : 0;
+  const fight  = typeof legacy.fight  === 'number' ? legacy.fight  : 0;
+  // All-zero edge case: snap to { forage: 10, fight: 0 } per D-04.
+  // This covers the pre-Phase-10 pure-dig allocation { forage: 0, dig: N, fight: 0 }
+  // as well as defensively handling fresh saves with all-zero values or saves
+  // missing these fields entirely.
+  if (forage === 0 && fight === 0) {
+    return { forage: 10, fight: 0 };
+  }
+  return { forage, fight };
+}
 
 function copyIntoInt32(dst: Int32Array, src: readonly number[]): void {
   const n = src.length < dst.length ? src.length : dst.length;

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -279,12 +279,24 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
 export function migrateBehaviorRatio(
   legacy: { forage?: number; dig?: number; fight?: number },
 ): BehaviorRatio {
-  const forage = typeof legacy.forage === 'number' ? legacy.forage : 0;
-  const fight  = typeof legacy.fight  === 'number' ? legacy.fight  : 0;
+  // Defensive: reject NaN, +/-Infinity, and negatives. typeof NaN === 'number',
+  // so the typeof guard alone allows NaN to propagate into colony.targetRatio
+  // and contaminate every downstream allocateWorkers call (WR-01). A negative
+  // weight is also rejected to mirror the SetBehaviorRatio command handler in
+  // tick.ts step 5 (any negative weight → reject command).
+  const rawForage = legacy.forage;
+  const rawFight  = legacy.fight;
+  const forage = typeof rawForage === 'number' && Number.isFinite(rawForage) && rawForage >= 0
+    ? rawForage
+    : 0;
+  const fight  = typeof rawFight  === 'number' && Number.isFinite(rawFight)  && rawFight  >= 0
+    ? rawFight
+    : 0;
   // All-zero edge case: snap to { forage: 10, fight: 0 } per D-04.
   // This covers the pre-Phase-10 pure-dig allocation { forage: 0, dig: N, fight: 0 }
   // as well as defensively handling fresh saves with all-zero values or saves
-  // missing these fields entirely.
+  // missing these fields entirely. NaN / negative inputs are coerced to 0 above
+  // and therefore also land in this branch.
   if (forage === 0 && fight === 0) {
     return { forage: 10, fight: 0 };
   }

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -286,18 +286,20 @@ export function migrateBehaviorRatio(
   // tick.ts step 5 (any negative weight → reject command).
   const rawForage = legacy.forage;
   const rawFight  = legacy.fight;
-  const forage = typeof rawForage === 'number' && Number.isFinite(rawForage) && rawForage >= 0
-    ? rawForage
-    : 0;
-  const fight  = typeof rawFight  === 'number' && Number.isFinite(rawFight)  && rawFight  >= 0
-    ? rawFight
-    : 0;
-  // All-zero edge case: snap to { forage: 10, fight: 0 } per D-04.
-  // This covers the pre-Phase-10 pure-dig allocation { forage: 0, dig: N, fight: 0 }
-  // as well as defensively handling fresh saves with all-zero values or saves
-  // missing these fields entirely. NaN / negative inputs are coerced to 0 above
-  // and therefore also land in this branch.
-  if (forage === 0 && fight === 0) {
+  const isForageValid = typeof rawForage === 'number' && Number.isFinite(rawForage) && rawForage >= 0;
+  const isFightValid  = typeof rawFight  === 'number' && Number.isFinite(rawFight)  && rawFight  >= 0;
+  const forage = isForageValid ? rawForage : 0;
+  const fight  = isFightValid  ? rawFight  : 0;
+  // All-zero edge case: snap to { forage: 10, fight: 0 } per D-04 — but ONLY
+  // when the input is legacy (has the `dig` key) or malformed (missing/NaN/
+  // negative fields). A post-Phase-10 caller that intentionally writes
+  // { forage: 0, fight: 0 } (idle slider, AI controller exotic state, debug
+  // command replay) is preserved verbatim — otherwise migrateBehaviorRatio
+  // would silently mutate valid two-field zeros and break snapshot-vs-replay
+  // determinism for tools that compare them (WR-10).
+  const isLegacy = 'dig' in legacy;
+  const isMalformed = !isForageValid || !isFightValid;
+  if (forage === 0 && fight === 0 && (isLegacy || isMalformed)) {
     return { forage: 10, fight: 0 };
   }
   return { forage, fight };

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -475,6 +475,36 @@ function buildSaveFile(seed: number, inputLog: readonly SimCommand[], world: Wor
   };
 }
 
+/**
+ * Phase 10 / WR-09 — migrate a single inputLog entry on load.
+ *
+ * Pre-Phase-10 v2 saves (issue #15 bumped 1→2; Phase 10 narrowed without
+ * bumping per D-04) can carry `SetBehaviorRatio` commands shaped as
+ * `{ forage, dig, fight }`. The `dig` field is gone in the Phase 10 sim;
+ * replaying such a command verbatim would either silently drop the dig
+ * weight (turning legitimate dig-heavy commands into idle ones) or trip
+ * post-Phase-10 invariants. SCEN-06 replay truth requires the in-memory
+ * inputLog to match what the current sim accepts, so we migrate here
+ * rather than in the per-tick command handler.
+ *
+ * Migration semantics mirror `migrateBehaviorRatio` for the snapshot's
+ * persisted `targetRatio`:
+ *   - drop `dig` (no rescale)
+ *   - all-zero `{forage:0, fight:0}` snaps to DEFAULT_BEHAVIOR_RATIO
+ *     `{forage:10, fight:0}` (covers the pre-Phase-10 pure-dig case)
+ *
+ * Pure function, idempotent on already-migrated commands. Non-
+ * `SetBehaviorRatio` entries pass through untouched.
+ */
+function migrateInputLogCommand(cmd: SimCommand): SimCommand {
+  if (cmd.type !== 'SetBehaviorRatio') return cmd;
+  const ratioRaw = cmd.ratio as unknown as { forage?: number; dig?: number; fight?: number };
+  // Already in the two-field form (no `dig` key) — pass through.
+  if (!('dig' in ratioRaw)) return cmd;
+  const migrated = migrateBehaviorRatio(ratioRaw);
+  return { ...cmd, ratio: migrated };
+}
+
 function parseSaveFile(raw: string): SaveFile {
   const parsed = JSON.parse(raw) as { version?: unknown };
   if (typeof parsed.version !== 'number') {
@@ -483,7 +513,16 @@ function parseSaveFile(raw: string): SaveFile {
   if (parsed.version !== SAVE_FORMAT_VERSION) {
     throw new SaveVersionMismatchError(SAVE_FORMAT_VERSION, parsed.version);
   }
-  return parsed as SaveFile;
+  const file = parsed as SaveFile;
+  // WR-09: walk inputLog and migrate any legacy SetBehaviorRatio entries so
+  // SCEN-06 replay (`createScenario(seed) + tick(cmds[t])`) reproduces the
+  // migrated snapshot. Other command types pass through.
+  if (Array.isArray(file.inputLog)) {
+    for (let i = 0; i < file.inputLog.length; i++) {
+      file.inputLog[i] = migrateInputLogCommand(file.inputLog[i]!);
+    }
+  }
+  return file;
 }
 
 /**

--- a/src/render/ai-controller.test.ts
+++ b/src/render/ai-controller.test.ts
@@ -33,7 +33,7 @@ import type { WorldState } from '../sim/types.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
 import { createScenario } from '../sim/scenario.js';
 import { tick } from '../sim/tick.js';
-import { ENEMY_COLONY_ID, PLAYER_COLONY_ID } from '../sim/constants.js';
+import { ENEMY_COLONY_ID } from '../sim/constants.js';
 
 // ---------------------------------------------------------------------------
 // World builder helpers

--- a/src/render/ai-controller.test.ts
+++ b/src/render/ai-controller.test.ts
@@ -725,8 +725,13 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
     it('AI_QUEEN_CHAMBER_DEPTH is 10', () => expect(AI_QUEEN_CHAMBER_DEPTH).toBe(10));
     it('AI_FOOD_STORAGE_THRESHOLD is 8', () => expect(AI_FOOD_STORAGE_THRESHOLD).toBe(8));
     it('AI_NURSERY_THRESHOLD is 12', () => expect(AI_NURSERY_THRESHOLD).toBe(12));
-    it('AI_BEHAVIOR_RATIO has forage + dig + fight', () => {
-      expect(AI_BEHAVIOR_RATIO).toMatchObject({ forage: 5, dig: 3, fight: 2 });
+    it('AI_BEHAVIOR_RATIO has two-field shape (Phase 10 / D-05)', () => {
+      // Phase 10 / D-05 (LOCKED): BehaviorRatio is {forage, fight} only;
+      // dig is auto-assigned via CTRL-06 (tick.ts step 10a).
+      // Candidate A tuning: {forage:7, fight:3} preserves the original 5:2
+      // forage:fight emphasis on the two-role schema. See plan 10-04 SUMMARY.
+      expect(AI_BEHAVIOR_RATIO).toMatchObject({ forage: 7, fight: 3 });
+      expect(AI_BEHAVIOR_RATIO).not.toHaveProperty('dig');
     });
 
   });

--- a/src/render/ai-controller.test.ts
+++ b/src/render/ai-controller.test.ts
@@ -5,6 +5,10 @@
 // No Phaser imported — ai-controller.ts is pure TS and testable in Node.
 
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
 import {
   runAIController,
   aiInitialSetup,
@@ -24,9 +28,12 @@ import { createColonyRecord } from '../sim/colony/colony-store.js';
 import type { ColonyRecord, ChamberRecord } from '../sim/colony/colony-store.js';
 import { createUndergroundGrid, ugSet, UndergroundTileState } from '../sim/terrain.js';
 import { FP_SHIFT } from '../sim/fixed.js';
-import { ChamberType } from '../sim/enums.js';
+import { AntTask, ChamberType } from '../sim/enums.js';
 import type { WorldState } from '../sim/types.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
+import { createScenario } from '../sim/scenario.js';
+import { tick } from '../sim/tick.js';
+import { ENEMY_COLONY_ID, PLAYER_COLONY_ID } from '../sim/constants.js';
 
 // ---------------------------------------------------------------------------
 // World builder helpers
@@ -732,6 +739,77 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       // forage:fight emphasis on the two-role schema. See plan 10-04 SUMMARY.
       expect(AI_BEHAVIOR_RATIO).toMatchObject({ forage: 7, fight: 3 });
       expect(AI_BEHAVIOR_RATIO).not.toHaveProperty('dig');
+    });
+
+  });
+
+  // -------------------------------------------------------------------------
+  // Phase 10 / D-05 — AI auto-dig parity
+  //
+  // D-05 (LOCKED): the AI uses the SAME auto-dig path as the player.
+  // The AI keeps issuing MarkDigTileCommand at AI_DIG_INTERVAL cadence; the
+  // sim-tier auto-dig override (tick.ts step 10a, Plan 10-02) drives Idle
+  // ants into AntTask.Digging uniformly for both colonies (CLNY-08 invariant).
+  //
+  // These tests pin the end-to-end pipeline: runAIController + tick() →
+  // AI ant in Digging via auto-dig. Distinct from tick.test.ts Phase 10
+  // describe block (which exercises step 10a directly via MarkDigTile commands)
+  // — these prove the AI's natural cadence flows through the same wire.
+  // -------------------------------------------------------------------------
+  describe('Phase 10 / D-05 — AI auto-dig parity', () => {
+
+    it('AI ant reaches AntTask.Digging via auto-dig path within reasonable tick budget', () => {
+      // Build a real 2-colony scenario; AI drives ENEMY_COLONY_ID only — same
+      // pattern as ai-controller.integration.test.ts.
+      const world = createScenario(42);
+      const aiColony = world.colonies[ENEMY_COLONY_ID]!;
+      expect(aiColony, 'AI colony should exist at ENEMY_COLONY_ID').toBeDefined();
+
+      const countAntsByTask = (taskValue: number): number => {
+        let n = 0;
+        for (const wid of aiColony.workers) {
+          if (world.ants.alive[wid] === 1 && world.ants.task[wid] === taskValue) n += 1;
+        }
+        return n;
+      };
+
+      // t=0 preconditions: zero Digging ants in the AI colony.
+      expect(countAntsByTask(AntTask.Digging)).toBe(0);
+
+      // Run the controller per-tick like GameScene.onBeforeTick does.
+      // Generous upper bound: 200 ticks. AI_DIG_INTERVAL=40 so the AI marks
+      // tiles within the first 80 ticks; auto-dig + ant movement to the
+      // Marked tile usually completes within another 30-60 ticks.
+      const MAX_TICKS = 200;
+      let firstDiggerTick = -1;
+      for (let t = 0; t < MAX_TICKS; t++) {
+        runAIController(world, ENEMY_COLONY_ID);
+        const cmds = world.commandQueue.splice(0);
+        tick(world, cmds);
+        if (countAntsByTask(AntTask.Digging) >= 1) {
+          firstDiggerTick = t;
+          break;
+        }
+      }
+
+      // t=N outcomes: AI got a digger via the auto-dig path within budget.
+      expect(
+        firstDiggerTick,
+        `AI did not reach AntTask.Digging within ${MAX_TICKS} ticks via auto-dig`,
+      ).toBeGreaterThanOrEqual(0);
+      // CTRL-06 strict 1-cap: at most one ant in the AI colony is Digging.
+      expect(countAntsByTask(AntTask.Digging)).toBe(1);
+    }, 30_000);
+
+    it('CLNY-08 invariant: ai-controller.ts has no PLAYER_COLONY_ID branching', () => {
+      // Source-text scan via fs.readFileSync. Conservative regexes — match any
+      // branch on PLAYER_COLONY_ID (===) or `if (... isPlayer ...)` patterns.
+      // STATE.md Phase 08-03 decision confirms this pattern is supported
+      // (HUD-05 source-scan self-checks; @types/node installed as devDep).
+      const __dirname = dirname(fileURLToPath(import.meta.url));
+      const src = readFileSync(join(__dirname, 'ai-controller.ts'), 'utf8');
+      expect(src).not.toMatch(/PLAYER_COLONY_ID\s*===/);
+      expect(src).not.toMatch(/if\s*\([^)]*\bisPlayer\b/);
     });
 
   });

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -25,10 +25,23 @@ export const AI_FOOD_STORAGE_THRESHOLD = 8 as const;
 export const AI_NURSERY_THRESHOLD = 12 as const;
 
 /**
- * Fixed AI behavior ratio per RESEARCH.md (0–10 scale).
- * AI is forage-leaning with meaningful dig + fight allocation.
+ * Phase 10 / D-05 — fixed AI BehaviorRatio (CMBT-02, two-role schema).
+ *
+ * Two roles only: forage and fight. Digging is auto-assigned per CTRL-06
+ * (handled in tick.ts step 10a; mirrors auto-nurse / CLNY-09). The AI keeps
+ * issuing MarkDigTileCommand at AI_DIG_INTERVAL cadence; those Marked tiles
+ * drive the auto-dig path uniformly for both colonies (CLNY-08 colony parity).
+ *
+ * Tuning rationale (Candidate A — Plan 10-04 SUMMARY):
+ *   Original ratio was {forage:5, dig:3, fight:2} — 5:2 ≈ 2.5:1 forage:fight
+ *   emphasis. With dig auto-assigned (off the ratio entirely), Candidate A
+ *   {forage:7, fight:3} preserves that emphasis (7:3 ≈ 2.33:1) on the 0-10
+ *   integer scale. Minimal-surprise game-feel relative to the pre-Phase-10
+ *   baseline; alternative candidates {6,4} more aggressive and {8,2} more
+ *   passive were considered and rejected — see Plan 10-04 SUMMARY for the
+ *   full candidate matrix.
  */
-export const AI_BEHAVIOR_RATIO = { forage: 5, dig: 3, fight: 2 } as const;
+export const AI_BEHAVIOR_RATIO = { forage: 7, fight: 3 } as const;
 
 /** Entry point — called by GameScene per-tick (via GameLoopOpts.onBeforeTick). */
 export function runAIController(world: WorldState, aiColonyId: ColonyId): void {

--- a/src/render/minimap.test.ts
+++ b/src/render/minimap.test.ts
@@ -183,7 +183,12 @@ const stubColonies: WorldState['colonies'] = {
     foodStored: 0,
     queenStarvationTimer: 100,
     taskCensus: { nurse: 0, forage: 0, dig: 0, fight: 0 },
-    targetRatio: { forage: 100, dig: 0, fight: 0 },
+    // Phase 10 / CTRL-01' (LOCKED): targetRatio is two-field {forage, fight};
+    // dig is auto-assigned via CTRL-06. Original 100/0/0 was the percentage
+    // convention; preserved here as forage:100/fight:0 (matches D-04 default
+    // "100% forage" semantic). taskCensus + computedAllocation remain 4-field
+    // (WorkerAllocation per D-03).
+    targetRatio: { forage: 100, fight: 0 },
     computedAllocation: { nurse: 0, forage: 0, dig: 0, fight: 0 },
     eggCount: 0, larvaeCount: 0, nurseCount: 0,
     eggs: [], larvae: [], workers: [], chambers: [],

--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -99,7 +99,11 @@ describe('HUD zone layout', () => {
 
   it('HUD zone exact coordinates match PRD §6b', () => {
     expect(HUD.STATS).toMatchObject({ x: 8, y: 8, w: 200, h: 24 });
-    expect(HUD.TRIANGLE).toMatchObject({ x: 8, y: 456, w: 120, h: 120 });
+    // Phase 10 / issue #13 follow-up: TRIANGLE shrunk from 120×120 to 120×44
+    // when the widget collapsed from a 3-vertex triangle to a 1-D slider.
+    // Bottom edge (y + h = 576) is unchanged so neighbouring HUD zones'
+    // pixel anchors are undisturbed.
+    expect(HUD.TRIANGLE).toMatchObject({ x: 8, y: 532, w: 120, h: 44 });
     expect(HUD.MINIMAP).toMatchObject({ x: 632, y: 424, w: 160, h: 160 });
     expect(HUD.VIEW_TOGGLE).toMatchObject({ x: 632, y: 396, w: 80, h: 24 });
     expect(HUD.SPEED).toMatchObject({ x: 320, y: 552, w: 160, h: 32 });

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -128,8 +128,22 @@ export const COLOR_PHEROMONE_DANGER_STRONG = 0xff4000;
 export const HUD = {
   /** Colony stats bar: ant count, food stored, queen health. */
   STATS:       { x: 8,   y: 8,   w: 200, h: 24  },
-  /** Behavior allocation triangle widget. */
-  TRIANGLE:    { x: 8,   y: 456, w: 120, h: 120 },
+  /**
+   * Behavior allocation slider widget. Field name retained from the Phase 8
+   * 3-vertex triangle to minimize diff churn; Phase 10 / D-01 collapsed the
+   * widget to a 1-D Forage↔Fight slider, so the box no longer needs to be a
+   * 120×120 square. Issue #13 follow-up: shrunk to 120×44 to hug the slider
+   * track + extreme-icon labels and avoid the unsightly empty square that
+   * the original triangle bounding box left behind.
+   *
+   * Geometry is sized to keep `trackY = y + h/2` valid given the 22px label
+   * gap (`trackY - 22 == y` ⇒ labels render flush with the box top edge).
+   * h must stay ≥ 44 for that invariant to hold without re-deriving the
+   * track formula. Bottom edge (y + h = 576) is unchanged from the prior
+   * 120×120 layout so HUD-anchor pixel positions of neighboring zones are
+   * not disturbed.
+   */
+  TRIANGLE:    { x: 8,   y: 532, w: 120, h: 44 },
   /**
    * Speed controls zone.
    * Phase 9 layout reservation — Phase 8 draws nothing here.

--- a/src/render/triangle-widget.test.ts
+++ b/src/render/triangle-widget.test.ts
@@ -1,172 +1,325 @@
-// triangle-widget.test.ts — Vitest unit tests for triangle-widget.ts pure math.
+// triangle-widget.test.ts — Vitest unit tests for the Phase 10 / D-01 slider
+// widget primitives in triangle-widget.ts.
+//
+// (File-name note: the file under test is still `triangle-widget.ts` to
+// minimize the diff against ui-scene.ts; symbols are slider-prefixed. See
+// triangle-widget.ts header.)
 //
 // Tests run under Node (no Phaser). MockGfx pattern from draw-surface tests.
 
 import { describe, it, expect } from 'vitest';
 import {
-  TRIANGLE_VERTICES,
-  screenToBarycentric,
-  ratioToScreenPos,
-  isInsideTriangle,
-  createTriangleDragState,
+  SLIDER_GEOMETRY,
+  screenToSliderRatio,
+  ratioToSliderPos,
+  isInsideSlider,
+  drawSlider,
+  createSliderDragState,
 } from './triangle-widget.js';
+import type { GfxLike } from './draw-surface.js';
+import { HUD, COLOR_PLAYER_COLONY } from './sprites.js';
 
 // ---------------------------------------------------------------------------
-// screenToBarycentric — vertex round-trips
+// MockGfx — spy recorder implementing GfxLike (matches draw-surface.test.ts pattern)
 // ---------------------------------------------------------------------------
 
-describe('screenToBarycentric — vertex identity', () => {
-  it('forage vertex returns forage=100, dig=0, fight=0', () => {
-    const r = screenToBarycentric(TRIANGLE_VERTICES.forage.x, TRIANGLE_VERTICES.forage.y);
-    expect(r.forage).toBe(100);
-    expect(r.dig).toBe(0);
-    expect(r.fight).toBe(0);
-  });
+interface GfxCall {
+  method: string;
+  args: unknown[];
+}
 
-  it('dig vertex returns dig=100, forage=0, fight=0', () => {
-    const r = screenToBarycentric(TRIANGLE_VERTICES.dig.x, TRIANGLE_VERTICES.dig.y);
-    expect(r.forage).toBe(0);
-    expect(r.dig).toBe(100);
-    expect(r.fight).toBe(0);
-  });
+class MockGfx implements GfxLike {
+  calls: GfxCall[] = [];
 
-  it('fight vertex returns fight=100, forage=0, dig=0', () => {
-    const r = screenToBarycentric(TRIANGLE_VERTICES.fight.x, TRIANGLE_VERTICES.fight.y);
-    expect(r.forage).toBe(0);
-    expect(r.dig).toBe(0);
-    expect(r.fight).toBe(100);
-  });
-});
+  clear(): GfxLike { this.calls.push({ method: 'clear', args: [] }); return this; }
+  fillStyle(color: number, alpha?: number): GfxLike {
+    this.calls.push({ method: 'fillStyle', args: [color, alpha] }); return this;
+  }
+  lineStyle(width: number, color: number, alpha?: number): GfxLike {
+    this.calls.push({ method: 'lineStyle', args: [width, color, alpha] }); return this;
+  }
+  fillRect(x: number, y: number, w: number, h: number): GfxLike {
+    this.calls.push({ method: 'fillRect', args: [x, y, w, h] }); return this;
+  }
+  fillCircle(x: number, y: number, r: number): GfxLike {
+    this.calls.push({ method: 'fillCircle', args: [x, y, r] }); return this;
+  }
+  strokeCircle(x: number, y: number, r: number): GfxLike {
+    this.calls.push({ method: 'strokeCircle', args: [x, y, r] }); return this;
+  }
+  fillTriangle(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number): GfxLike {
+    this.calls.push({ method: 'fillTriangle', args: [x0, y0, x1, y1, x2, y2] }); return this;
+  }
 
-describe('screenToBarycentric — centroid', () => {
-  it('centroid returns forage=33, dig=33, fight=34 (sum=100)', () => {
-    const cx = (TRIANGLE_VERTICES.forage.x + TRIANGLE_VERTICES.dig.x + TRIANGLE_VERTICES.fight.x) / 3;
-    const cy = (TRIANGLE_VERTICES.forage.y + TRIANGLE_VERTICES.dig.y + TRIANGLE_VERTICES.fight.y) / 3;
-    const r = screenToBarycentric(cx, cy);
-    // fight = 100 - forage - dig, so the split may be 33/33/34 or 34/33/33 depending on rounding.
-    expect(r.forage + r.dig + r.fight).toBe(100);
-    // Each field should be close to 33 (within 2 due to integer rounding).
-    expect(r.forage).toBeGreaterThanOrEqual(32);
-    expect(r.forage).toBeLessThanOrEqual(35);
-    expect(r.dig).toBeGreaterThanOrEqual(32);
-    expect(r.dig).toBeLessThanOrEqual(35);
-    expect(r.fight).toBeGreaterThanOrEqual(32);
-    expect(r.fight).toBeLessThanOrEqual(35);
-  });
-});
+  callsOf(method: string): GfxCall[] {
+    return this.calls.filter(c => c.method === method);
+  }
+}
 
 // ---------------------------------------------------------------------------
-// ratioToScreenPos — vertex identity
+// SLIDER_GEOMETRY sanity (locked to HUD.TRIANGLE — single source of truth)
 // ---------------------------------------------------------------------------
 
-describe('ratioToScreenPos — vertex identity', () => {
-  it('forage=100 returns forage vertex coords', () => {
-    const pos = ratioToScreenPos({ forage: 100, dig: 0, fight: 0 });
-    expect(pos.x).toBeCloseTo(TRIANGLE_VERTICES.forage.x, 5);
-    expect(pos.y).toBeCloseTo(TRIANGLE_VERTICES.forage.y, 5);
+describe('SLIDER_GEOMETRY', () => {
+  it('trackLeft = HUD.TRIANGLE.x + 16', () => {
+    expect(SLIDER_GEOMETRY.trackLeft).toBe(HUD.TRIANGLE.x + 16);
   });
 
-  it('forage=50, dig=50, fight=0 returns midpoint of forage-dig edge', () => {
-    const mid = {
-      x: (TRIANGLE_VERTICES.forage.x + TRIANGLE_VERTICES.dig.x) / 2,
-      y: (TRIANGLE_VERTICES.forage.y + TRIANGLE_VERTICES.dig.y) / 2,
-    };
-    const pos = ratioToScreenPos({ forage: 50, dig: 50, fight: 0 });
-    expect(pos.x).toBeCloseTo(mid.x, 5);
-    expect(pos.y).toBeCloseTo(mid.y, 5);
+  it('trackRight = HUD.TRIANGLE.x + HUD.TRIANGLE.w - 16', () => {
+    expect(SLIDER_GEOMETRY.trackRight).toBe(HUD.TRIANGLE.x + HUD.TRIANGLE.w - 16);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Round-trip: screenToBarycentric(ratioToScreenPos(R)) ≈ R
-// ---------------------------------------------------------------------------
+  it('trackY at the vertical midpoint of HUD.TRIANGLE', () => {
+    expect(SLIDER_GEOMETRY.trackY).toBe(HUD.TRIANGLE.y + HUD.TRIANGLE.h / 2);
+  });
 
-describe('round-trip within 1-unit tolerance', () => {
-  it('{forage:40, dig:30, fight:30} round-trips within 1 unit', () => {
-    const R = { forage: 40, dig: 30, fight: 30 };
-    const pos = ratioToScreenPos(R);
-    const R2 = screenToBarycentric(pos.x, pos.y);
-    expect(Math.abs(R2.forage - R.forage)).toBeLessThanOrEqual(1);
-    expect(Math.abs(R2.dig    - R.dig   )).toBeLessThanOrEqual(1);
-    expect(Math.abs(R2.fight  - R.fight )).toBeLessThanOrEqual(1);
-    expect(R2.forage + R2.dig + R2.fight).toBe(100);
+  it('trackLen = trackRight - trackLeft', () => {
+    expect(SLIDER_GEOMETRY.trackLen).toBe(SLIDER_GEOMETRY.trackRight - SLIDER_GEOMETRY.trackLeft);
+  });
+
+  it('trackLen is positive (geometry sane)', () => {
+    expect(SLIDER_GEOMETRY.trackLen).toBeGreaterThan(0);
   });
 });
 
 // ---------------------------------------------------------------------------
-// isInsideTriangle
+// screenToSliderRatio — extremes and centerpoint
 // ---------------------------------------------------------------------------
 
-describe('isInsideTriangle', () => {
-  it('centroid is inside', () => {
-    const cx = (TRIANGLE_VERTICES.forage.x + TRIANGLE_VERTICES.dig.x + TRIANGLE_VERTICES.fight.x) / 3;
-    const cy = (TRIANGLE_VERTICES.forage.y + TRIANGLE_VERTICES.dig.y + TRIANGLE_VERTICES.fight.y) / 3;
-    expect(isInsideTriangle(cx, cy)).toBe(true);
+describe('screenToSliderRatio — extremes', () => {
+  it('left edge of track returns full forage', () => {
+    expect(screenToSliderRatio(SLIDER_GEOMETRY.trackLeft)).toEqual({ forage: 10, fight: 0 });
   });
 
-  it('point above forage vertex is outside', () => {
-    expect(isInsideTriangle(TRIANGLE_VERTICES.forage.x, TRIANGLE_VERTICES.forage.y - 10)).toBe(false);
+  it('right edge of track returns full fight', () => {
+    expect(screenToSliderRatio(SLIDER_GEOMETRY.trackRight)).toEqual({ forage: 0, fight: 10 });
   });
 
-  it('point below baseline is outside', () => {
-    expect(isInsideTriangle(TRIANGLE_VERTICES.dig.x, TRIANGLE_VERTICES.dig.y + 10)).toBe(false);
-  });
-
-  it('forage vertex is on boundary (inside by inclusive test)', () => {
-    expect(isInsideTriangle(TRIANGLE_VERTICES.forage.x, TRIANGLE_VERTICES.forage.y)).toBe(true);
+  it('exact center returns balanced 5/5', () => {
+    const center = (SLIDER_GEOMETRY.trackLeft + SLIDER_GEOMETRY.trackRight) / 2;
+    expect(screenToSliderRatio(center)).toEqual({ forage: 5, fight: 5 });
   });
 });
 
-// ---------------------------------------------------------------------------
-// Sum invariant — all outputs must sum to 100
-// ---------------------------------------------------------------------------
+describe('screenToSliderRatio — clamping', () => {
+  it('px far left of track clamps to forage:10', () => {
+    expect(screenToSliderRatio(SLIDER_GEOMETRY.trackLeft - 100)).toEqual({ forage: 10, fight: 0 });
+  });
 
-describe('sum invariant: forage+dig+fight === 100', () => {
-  const testPoints = [
-    [TRIANGLE_VERTICES.forage.x, TRIANGLE_VERTICES.forage.y],
-    [TRIANGLE_VERTICES.dig.x,    TRIANGLE_VERTICES.dig.y   ],
-    [TRIANGLE_VERTICES.fight.x,  TRIANGLE_VERTICES.fight.y ],
-    [68, 510],  // interior point
-    [50, 490],  // another interior point
-  ];
-  for (const [px, py] of testPoints) {
-    it(`sum=100 at (${px!.toFixed(1)}, ${py!.toFixed(1)})`, () => {
-      const r = screenToBarycentric(px!, py!);
-      expect(r.forage + r.dig + r.fight).toBe(100);
+  it('px far right of track clamps to fight:10', () => {
+    expect(screenToSliderRatio(SLIDER_GEOMETRY.trackRight + 100)).toEqual({ forage: 0, fight: 10 });
+  });
+
+  it('px = 0 (canvas left edge) clamps to forage:10', () => {
+    expect(screenToSliderRatio(0)).toEqual({ forage: 10, fight: 0 });
+  });
+
+  it('px = 1000 (canvas-right-extreme) clamps to fight:10', () => {
+    expect(screenToSliderRatio(1000)).toEqual({ forage: 0, fight: 10 });
+  });
+});
+
+describe('screenToSliderRatio — sum invariant', () => {
+  // Cover all 11 discrete steps along the track.
+  for (let step = 0; step <= 10; step++) {
+    const px = SLIDER_GEOMETRY.trackLeft + (step / 10) * SLIDER_GEOMETRY.trackLen;
+    it(`step ${step}: forage + fight === 10 at px=${px}`, () => {
+      const r = screenToSliderRatio(px);
+      expect(r.forage + r.fight).toBe(10);
+      expect(r.forage).toBeGreaterThanOrEqual(0);
+      expect(r.fight).toBeGreaterThanOrEqual(0);
     });
   }
 });
 
 // ---------------------------------------------------------------------------
-// Clamp: drag far outside triangle returns valid ratio summing to 100
+// ratioToSliderPos — inverse of screenToSliderRatio
 // ---------------------------------------------------------------------------
 
-describe('clamp: out-of-triangle drag', () => {
-  it('x=1000, y=1000 returns valid ratio summing to 100 with all fields >= 0', () => {
-    const r = screenToBarycentric(1000, 1000);
-    expect(r.forage).toBeGreaterThanOrEqual(0);
-    expect(r.dig).toBeGreaterThanOrEqual(0);
-    expect(r.fight).toBeGreaterThanOrEqual(0);
-    expect(r.forage + r.dig + r.fight).toBe(100);
+describe('ratioToSliderPos — extremes', () => {
+  it('forage=10, fight=0 returns track-left x', () => {
+    const pos = ratioToSliderPos({ forage: 10, fight: 0 });
+    expect(pos.x).toBe(SLIDER_GEOMETRY.trackLeft);
+    expect(pos.y).toBe(SLIDER_GEOMETRY.trackY);
   });
 
-  it('x=0, y=0 (far above triangle) returns valid ratio summing to 100', () => {
-    const r = screenToBarycentric(0, 0);
-    expect(r.forage).toBeGreaterThanOrEqual(0);
-    expect(r.dig).toBeGreaterThanOrEqual(0);
-    expect(r.fight).toBeGreaterThanOrEqual(0);
-    expect(r.forage + r.dig + r.fight).toBe(100);
+  it('forage=0, fight=10 returns track-right x', () => {
+    const pos = ratioToSliderPos({ forage: 0, fight: 10 });
+    expect(pos.x).toBe(SLIDER_GEOMETRY.trackRight);
+    expect(pos.y).toBe(SLIDER_GEOMETRY.trackY);
+  });
+
+  it('forage=5, fight=5 returns track midpoint', () => {
+    const pos = ratioToSliderPos({ forage: 5, fight: 5 });
+    expect(pos.x).toBe(SLIDER_GEOMETRY.trackLeft + SLIDER_GEOMETRY.trackLen / 2);
+    expect(pos.y).toBe(SLIDER_GEOMETRY.trackY);
+  });
+
+  it('forage=0, fight=0 (degenerate) pins to track center', () => {
+    const pos = ratioToSliderPos({ forage: 0, fight: 0 });
+    expect(pos.x).toBe(SLIDER_GEOMETRY.trackLeft + SLIDER_GEOMETRY.trackLen / 2);
+    expect(pos.y).toBe(SLIDER_GEOMETRY.trackY);
   });
 });
 
 // ---------------------------------------------------------------------------
-// createTriangleDragState
+// Round-trip: ratioToSliderPos(screenToSliderRatio(px)).x ≈ px (snap to step)
 // ---------------------------------------------------------------------------
 
-describe('createTriangleDragState', () => {
-  it('returns isDragging=false with forage=100 default', () => {
-    const s = createTriangleDragState();
+describe('round-trip: pixel → ratio → pixel snaps to nearest step', () => {
+  it('all integer px in [trackLeft, trackRight] round-trip within ½ step (~4.4px)', () => {
+    const stepPx = SLIDER_GEOMETRY.trackLen / 10;
+    for (let px = SLIDER_GEOMETRY.trackLeft; px <= SLIDER_GEOMETRY.trackRight; px++) {
+      const r = screenToSliderRatio(px);
+      const back = ratioToSliderPos(r);
+      // After Math.round in screenToSliderRatio, px snaps to its nearest discrete
+      // step pixel. Tolerance is half-a-step + 1 (rounding slack).
+      expect(Math.abs(back.x - px)).toBeLessThanOrEqual(stepPx / 2 + 1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isInsideSlider — hit-test against HUD.TRIANGLE zone
+// ---------------------------------------------------------------------------
+
+describe('isInsideSlider', () => {
+  it('returns true for a point inside HUD.TRIANGLE', () => {
+    expect(isInsideSlider(HUD.TRIANGLE.x + 10, HUD.TRIANGLE.y + 10)).toBe(true);
+  });
+
+  it('returns true for the track centerline', () => {
+    expect(isInsideSlider(SLIDER_GEOMETRY.trackLeft + 1, SLIDER_GEOMETRY.trackY)).toBe(true);
+  });
+
+  it('returns false for a point left of the zone', () => {
+    expect(isInsideSlider(HUD.TRIANGLE.x - 1, HUD.TRIANGLE.y + 10)).toBe(false);
+  });
+
+  it('returns false for a point above the zone', () => {
+    expect(isInsideSlider(HUD.TRIANGLE.x + 10, HUD.TRIANGLE.y - 1)).toBe(false);
+  });
+
+  it('returns false for a point right of the zone', () => {
+    expect(isInsideSlider(HUD.TRIANGLE.x + HUD.TRIANGLE.w, HUD.TRIANGLE.y + 10)).toBe(false);
+  });
+
+  it('returns false for a point below the zone', () => {
+    expect(isInsideSlider(HUD.TRIANGLE.x + 10, HUD.TRIANGLE.y + HUD.TRIANGLE.h)).toBe(false);
+  });
+
+  it('top-left corner is inside (inclusive)', () => {
+    expect(isInsideSlider(HUD.TRIANGLE.x, HUD.TRIANGLE.y)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// drawSlider — call sequence + visual coherence (HUD-05: Graphics + Text only)
+// ---------------------------------------------------------------------------
+
+describe('drawSlider', () => {
+  it('emits exactly the expected GfxLike methods (no Image / Sprite calls)', () => {
+    const gfx = new MockGfx();
+    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 10, fight: 0 });
+    const allowedMethods = new Set([
+      'fillStyle', 'lineStyle', 'fillRect', 'fillCircle', 'strokeCircle',
+    ]);
+    for (const c of gfx.calls) {
+      expect(allowedMethods.has(c.method)).toBe(true);
+    }
+  });
+
+  it('emits ≥ 8 GfxLike calls (background + track + 2 icons + 2 markers + style)', () => {
+    const gfx = new MockGfx();
+    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 10, fight: 0 });
+    // 4× fillRect (zone bg, track, forage icon, fight icon)
+    // 1× fillCircle (current marker)
+    // 1× strokeCircle (target marker)
+    // ≥ 5× fillStyle / lineStyle setup calls
+    expect(gfx.calls.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('emits exactly four fillRect calls (background, track, forage icon, fight icon)', () => {
+    const gfx = new MockGfx();
+    drawSlider(gfx, { forage: 5, fight: 5 }, { forage: 5, fight: 5 });
+    expect(gfx.callsOf('fillRect').length).toBe(4);
+  });
+
+  it('first fillRect is the zone background filling HUD.TRIANGLE exactly', () => {
+    const gfx = new MockGfx();
+    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 10, fight: 0 });
+    const firstFillRect = gfx.callsOf('fillRect')[0]!;
+    expect(firstFillRect.args).toEqual([
+      HUD.TRIANGLE.x, HUD.TRIANGLE.y, HUD.TRIANGLE.w, HUD.TRIANGLE.h,
+    ]);
+  });
+
+  it('emits exactly one fillCircle (current marker)', () => {
+    const gfx = new MockGfx();
+    drawSlider(gfx, { forage: 7, fight: 3 }, { forage: 5, fight: 5 });
+    expect(gfx.callsOf('fillCircle').length).toBe(1);
+  });
+
+  it('emits exactly one strokeCircle (target marker)', () => {
+    const gfx = new MockGfx();
+    drawSlider(gfx, { forage: 7, fight: 3 }, { forage: 5, fight: 5 });
+    expect(gfx.callsOf('strokeCircle').length).toBe(1);
+  });
+
+  it('current marker uses COLOR_PLAYER_COLONY', () => {
+    const gfx = new MockGfx();
+    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 0, fight: 10 });
+    // Find the fillStyle call immediately preceding the fillCircle call.
+    const fillCircleIdx = gfx.calls.findIndex(c => c.method === 'fillCircle');
+    expect(fillCircleIdx).toBeGreaterThan(0);
+    // Walk backwards to the most recent fillStyle.
+    let lastFillStyleColor: unknown = null;
+    for (let i = fillCircleIdx - 1; i >= 0; i--) {
+      if (gfx.calls[i]!.method === 'fillStyle') {
+        lastFillStyleColor = gfx.calls[i]!.args[0];
+        break;
+      }
+    }
+    expect(lastFillStyleColor).toBe(COLOR_PLAYER_COLONY);
+  });
+
+  it('current marker position tracks currentRatio', () => {
+    const gfx = new MockGfx();
+    drawSlider(gfx, { forage: 0, fight: 10 }, { forage: 10, fight: 0 });
+    const fillCircle = gfx.callsOf('fillCircle')[0]!;
+    const [cx] = fillCircle.args as [number, number, number];
+    expect(cx).toBe(SLIDER_GEOMETRY.trackRight);
+  });
+
+  it('target marker position tracks targetRatio independently of currentRatio', () => {
+    const gfx = new MockGfx();
+    drawSlider(gfx, { forage: 0, fight: 10 }, { forage: 10, fight: 0 });
+    const strokeCircle = gfx.callsOf('strokeCircle')[0]!;
+    const [tx] = strokeCircle.args as [number, number, number];
+    expect(tx).toBe(SLIDER_GEOMETRY.trackLeft);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSliderDragState — initial state matches DEFAULT_BEHAVIOR_RATIO shape
+// ---------------------------------------------------------------------------
+
+describe('createSliderDragState', () => {
+  it('returns isDragging=false with two-field targetRatio default', () => {
+    const s = createSliderDragState();
     expect(s.isDragging).toBe(false);
-    expect(s.targetRatio).toEqual({ forage: 100, dig: 0, fight: 0 });
+    expect(s.targetRatio).toEqual({ forage: 10, fight: 0 });
+  });
+
+  it('targetRatio has no `dig` field (Phase 10 schema; D-01 LOCKED)', () => {
+    const s = createSliderDragState();
+    expect(s.targetRatio).not.toHaveProperty('dig');
+  });
+
+  it('produces independent objects on each call', () => {
+    const a = createSliderDragState();
+    const b = createSliderDragState();
+    expect(a).not.toBe(b);
+    expect(a.targetRatio).not.toBe(b.targetRatio);
   });
 });

--- a/src/render/triangle-widget.ts
+++ b/src/render/triangle-widget.ts
@@ -1,126 +1,137 @@
-// triangle-widget.ts — Phase 8 behavior triangle widget pure math + Graphics draw.
+// triangle-widget.ts — Phase 10 / D-01 1-D Forage↔Fight slider widget.
 //
-// Provides: vertex geometry, barycentric coordinate math, screen/ratio conversion,
-// drag state, and a draw function. UI wiring lives in UIScene.
+// File-name note: this file used to host the 3-vertex behavior triangle
+// and is kept under the same name to minimize the diff against ui-scene.ts.
+// The exported symbols are slider-prefixed (`screenToSliderRatio`, etc.).
+// A future cleanup phase may rename the file to slider-widget.ts; until then,
+// the file name is a known misnomer documented here.
+//
+// Provides: track geometry, screen/ratio conversion, drag state, hit-test, draw.
+// All functions pure (no side effects). HUD-05: Graphics + Text only.
 //
 // This file has no Phaser imports — only GfxLike from draw-surface.ts.
-// All functions are pure (no side effects on external state).
 
 import { HUD, COLOR_PLAYER_COLONY } from './sprites.js';
 import type { GfxLike } from './draw-surface.js';
 
 // ---------------------------------------------------------------------------
-// Triangle vertex geometry (equilateral-ish inside HUD.TRIANGLE 120x120 at 8,456)
+// Slider track geometry inside HUD.TRIANGLE zone (x:[8,128), y:[456,576))
 //
-// Forage at top-center, Dig at bottom-left, Fight at bottom-right.
-// Margins keep vertices away from zone edges for readability.
+// Track centerline at the vertical midpoint of the zone. Track length spans
+// from a 16px inset on the left to a 16px inset on the right of the zone,
+// giving an 88-pixel-wide horizontal track. 4-pixel-thick rendered track.
 // ---------------------------------------------------------------------------
 
-const CX = HUD.TRIANGLE.x + HUD.TRIANGLE.w / 2; // 68 (horizontal center)
-const CY = HUD.TRIANGLE.y + 12;                  // 468 (top vertex, 12px from top)
-const BY = HUD.TRIANGLE.y + HUD.TRIANGLE.h - 8;  // 568 (bottom edge, 8px from bottom)
+const TRACK_LEFT  = HUD.TRIANGLE.x + 16;                  // 24
+const TRACK_RIGHT = HUD.TRIANGLE.x + HUD.TRIANGLE.w - 16; // 112
+const TRACK_Y     = HUD.TRIANGLE.y + HUD.TRIANGLE.h / 2;  // 516
+const TRACK_LEN   = TRACK_RIGHT - TRACK_LEFT;             // 88
 
-export const TRIANGLE_VERTICES = {
-  forage: { x: CX,                              y: CY },
-  dig:    { x: HUD.TRIANGLE.x + 8,              y: BY },
-  fight:  { x: HUD.TRIANGLE.x + HUD.TRIANGLE.w - 8, y: BY },
+export const SLIDER_GEOMETRY = {
+  trackLeft:  TRACK_LEFT,
+  trackRight: TRACK_RIGHT,
+  trackY:     TRACK_Y,
+  trackLen:   TRACK_LEN,
 } as const;
 
 // ---------------------------------------------------------------------------
-// TriangleDragState — mutable drag tracking (owned by UIScene)
+// SliderDragState — mutable drag tracking (owned by UIScene)
 // ---------------------------------------------------------------------------
 
-export interface TriangleDragState {
-  isDragging: boolean;
-  targetRatio: { forage: number; dig: number; fight: number };
+export interface SliderDragState {
+  isDragging:  boolean;
+  targetRatio: { forage: number; fight: number };
 }
 
-export function createTriangleDragState(): TriangleDragState {
-  return { isDragging: false, targetRatio: { forage: 100, dig: 0, fight: 0 } };
+export function createSliderDragState(): SliderDragState {
+  return { isDragging: false, targetRatio: { forage: 10, fight: 0 } };
 }
 
 // ---------------------------------------------------------------------------
-// screenToBarycentric — pixel coords to {forage, dig, fight} integer percentages
+// screenToSliderRatio — pixel x → integer 0–10 ratio
 //
-// Uses standard 2D signed-area barycentric formula.
-// Each weight is clamped to [0, 1] to project out-of-triangle points onto the
-// nearest edge (satisfies T-08-10 clamp mitigation).
-// fight = 100 - forage - dig guarantees sum === 100 exactly.
+// Position 0 (left) = full forage. Position 1 (right) = full fight.
+// Out-of-track px clamps to the nearest extreme. Output is always integer
+// 0–10 with `forage + fight === 10` exactly (snaps to 11 discrete steps).
+// y is intentionally ignored — slider is 1-D.
 // ---------------------------------------------------------------------------
 
-export function screenToBarycentric(px: number, py: number): { forage: number; dig: number; fight: number } {
-  const v0 = TRIANGLE_VERTICES.forage;
-  const v1 = TRIANGLE_VERTICES.dig;
-  const v2 = TRIANGLE_VERTICES.fight;
-  const denom = (v1.y - v2.y) * (v0.x - v2.x) + (v2.x - v1.x) * (v0.y - v2.y);
-  const w0 = ((v1.y - v2.y) * (px - v2.x) + (v2.x - v1.x) * (py - v2.y)) / denom;
-  const w1 = ((v2.y - v0.y) * (px - v2.x) + (v0.x - v2.x) * (py - v2.y)) / denom;
-  const w2 = 1 - w0 - w1;
-  // Clamp each weight to [0,1] so out-of-triangle drags project to nearest edge.
-  const f  = Math.max(0, Math.min(1, w0));
-  const d  = Math.max(0, Math.min(1, w1));
-  const fi = Math.max(0, Math.min(1, w2));
-  const sum = f + d + fi || 1; // guard against all-zero degenerate case
-  const forage = Math.round((f  / sum) * 100);
-  const dig    = Math.round((d  / sum) * 100);
-  const fight  = Math.max(0, 100 - forage - dig); // guarantee sum === 100
-  return { forage, dig, fight };
+export function screenToSliderRatio(px: number): { forage: number; fight: number } {
+  const t = (px - TRACK_LEFT) / TRACK_LEN;       // float in [0,1] (clamped below)
+  const tc = Math.max(0, Math.min(1, t));
+  // 11 discrete steps: 0,1,...,10. fight gets `Math.round(tc * 10)`; forage = 10 - fight.
+  const fight  = Math.round(tc * 10);
+  const forage = 10 - fight;
+  return { forage, fight };
 }
 
 // ---------------------------------------------------------------------------
-// ratioToScreenPos — inverse of screenToBarycentric: ratio -> pixel position
+// ratioToSliderPos — inverse of screenToSliderRatio: ratio → pixel position
 //
-// Weighted centroid of the three vertices.
+// Returns the centerline pixel position for a given ratio. If both fields
+// are zero (degenerate save-migration edge case), pins to the track center.
 // ---------------------------------------------------------------------------
 
-export function ratioToScreenPos(ratio: { forage: number; dig: number; fight: number }): { x: number; y: number } {
-  const total = ratio.forage + ratio.dig + ratio.fight || 1;
-  const wF  = ratio.forage / total;
-  const wD  = ratio.dig    / total;
-  const wFt = ratio.fight  / total;
-  return {
-    x: wF * TRIANGLE_VERTICES.forage.x + wD * TRIANGLE_VERTICES.dig.x + wFt * TRIANGLE_VERTICES.fight.x,
-    y: wF * TRIANGLE_VERTICES.forage.y + wD * TRIANGLE_VERTICES.dig.y + wFt * TRIANGLE_VERTICES.fight.y,
-  };
+export function ratioToSliderPos(ratio: { forage: number; fight: number }): { x: number; y: number } {
+  const total = ratio.forage + ratio.fight;
+  // Degenerate: pin to center if both are 0.
+  const t = total === 0 ? 0.5 : ratio.fight / total;
+  return { x: TRACK_LEFT + t * TRACK_LEN, y: TRACK_Y };
 }
 
 // ---------------------------------------------------------------------------
-// isInsideTriangle — point-in-triangle test via barycentric sign
-// ---------------------------------------------------------------------------
-
-export function isInsideTriangle(px: number, py: number): boolean {
-  const v0 = TRIANGLE_VERTICES.forage;
-  const v1 = TRIANGLE_VERTICES.dig;
-  const v2 = TRIANGLE_VERTICES.fight;
-  const denom = (v1.y - v2.y) * (v0.x - v2.x) + (v2.x - v1.x) * (v0.y - v2.y);
-  const w0 = ((v1.y - v2.y) * (px - v2.x) + (v2.x - v1.x) * (py - v2.y)) / denom;
-  const w1 = ((v2.y - v0.y) * (px - v2.x) + (v0.x - v2.x) * (py - v2.y)) / denom;
-  const w2 = 1 - w0 - w1;
-  return w0 >= 0 && w1 >= 0 && w2 >= 0;
-}
-
-// ---------------------------------------------------------------------------
-// drawTriangle — render the triangle widget onto a GfxLike (called per frame)
+// isInsideSlider — hit-test against the full HUD.TRIANGLE zone
 //
-// Draws: filled triangle background, current-ratio filled circle,
-// target-ratio outline circle. Labels are Phaser Text in UIScene.
+// Uses the full HUD slot (not just the visible track) so vertical slop on
+// click/drag still registers as a slider gesture. Matches the prior triangle
+// widget's hit zone for input continuity.
 // ---------------------------------------------------------------------------
 
-export function drawTriangle(
-  gfx: GfxLike,
-  currentRatio: { forage: number; dig: number; fight: number },
-  targetRatio:  { forage: number; dig: number; fight: number },
+export function isInsideSlider(px: number, py: number): boolean {
+  return (
+    px >= HUD.TRIANGLE.x &&
+    px < HUD.TRIANGLE.x + HUD.TRIANGLE.w &&
+    py >= HUD.TRIANGLE.y &&
+    py < HUD.TRIANGLE.y + HUD.TRIANGLE.h
+  );
+}
+
+// ---------------------------------------------------------------------------
+// drawSlider — render the slider widget onto a GfxLike (called per frame)
+//
+// Draws (in order): zone background, track line, forage icon (left, green
+// programmer-art square), fight icon (right, red programmer-art square),
+// current marker (filled circle in player-colony color), target marker
+// (white outline circle). Text labels ("Forage" / "Fight") live in UIScene.
+//
+// HUD-05 compliant: only fillRect / fillCircle / strokeCircle / fillStyle /
+// lineStyle calls. Zero asset loading; programmer-art icons.
+// ---------------------------------------------------------------------------
+
+export function drawSlider(
+  gfx:          GfxLike,
+  currentRatio: { forage: number; fight: number },
+  targetRatio:  { forage: number; fight: number },
 ): void {
-  const v = TRIANGLE_VERTICES;
-  // Filled triangle background
-  gfx.fillStyle(0x222222, 0.8);
-  gfx.fillTriangle(v.forage.x, v.forage.y, v.dig.x, v.dig.y, v.fight.x, v.fight.y);
-  // Current ratio marker (filled circle — actual task census)
-  const curr = ratioToScreenPos(currentRatio);
+  // Zone background — semi-transparent dark fill behind the slider so labels
+  // and markers stay readable against the surface beneath.
+  gfx.fillStyle(0x222222, 0.9);
+  gfx.fillRect(HUD.TRIANGLE.x, HUD.TRIANGLE.y, HUD.TRIANGLE.w, HUD.TRIANGLE.h);
+  // Track line (4px thick, mid-gray).
+  gfx.fillStyle(0x666666, 1);
+  gfx.fillRect(TRACK_LEFT, TRACK_Y - 2, TRACK_LEN, 4);
+  // Forage icon (left extreme): 12x12 green programmer-art square.
+  gfx.fillStyle(0x66cc66, 1);
+  gfx.fillRect(HUD.TRIANGLE.x + 4, TRACK_Y - 6, 12, 12);
+  // Fight icon (right extreme): 12x12 red programmer-art square.
+  gfx.fillStyle(0xcc6666, 1);
+  gfx.fillRect(HUD.TRIANGLE.x + HUD.TRIANGLE.w - 16, TRACK_Y - 6, 12, 12);
+  // Current marker (filled circle — current task census).
+  const cur = ratioToSliderPos(currentRatio);
   gfx.fillStyle(COLOR_PLAYER_COLONY, 1);
-  gfx.fillCircle(curr.x, curr.y, 6);
-  // Target ratio marker (outline circle — player-set allocation or drag preview)
-  const tgt = ratioToScreenPos(targetRatio);
+  gfx.fillCircle(cur.x, cur.y, 6);
+  // Target marker (outline circle — player-set target / drag preview).
+  const tgt = ratioToSliderPos(targetRatio);
   gfx.lineStyle(2, 0xffffff, 1);
   gfx.strokeCircle(tgt.x, tgt.y, 6);
 }

--- a/src/render/triangle-widget.ts
+++ b/src/render/triangle-widget.ts
@@ -15,7 +15,7 @@ import { HUD, COLOR_PLAYER_COLONY } from './sprites.js';
 import type { GfxLike } from './draw-surface.js';
 
 // ---------------------------------------------------------------------------
-// Slider track geometry inside HUD.TRIANGLE zone (x:[8,128), y:[456,576))
+// Slider track geometry inside HUD.TRIANGLE zone (x:[8,128), y:[532,576))
 //
 // Track centerline at the vertical midpoint of the zone. Track length spans
 // from a 16px inset on the left to a 16px inset on the right of the zone,
@@ -24,7 +24,7 @@ import type { GfxLike } from './draw-surface.js';
 
 const TRACK_LEFT  = HUD.TRIANGLE.x + 16;                  // 24
 const TRACK_RIGHT = HUD.TRIANGLE.x + HUD.TRIANGLE.w - 16; // 112
-const TRACK_Y     = HUD.TRIANGLE.y + HUD.TRIANGLE.h / 2;  // 516
+const TRACK_Y     = HUD.TRIANGLE.y + HUD.TRIANGLE.h / 2;  // 554
 const TRACK_LEN   = TRACK_RIGHT - TRACK_LEFT;             // 88
 
 export const SLIDER_GEOMETRY = {

--- a/src/render/triangle-widget.ts
+++ b/src/render/triangle-widget.ts
@@ -57,6 +57,14 @@ export function createSliderDragState(): SliderDragState {
 // ---------------------------------------------------------------------------
 
 export function screenToSliderRatio(px: number): { forage: number; fight: number } {
+  // WR-05: defensive guard against degenerate track geometry (TRACK_LEN <= 0).
+  // The test suite asserts `SLIDER_GEOMETRY.trackLen > 0` so this branch is
+  // currently unreachable in production, but a future HUD constants change
+  // could silently zero the denominator — `(px - TRACK_LEFT) / 0` is +/-Inf
+  // or NaN, `Math.max(0, Math.min(1, NaN)) === NaN`, and the function would
+  // return `{forage: NaN, fight: NaN}`, corrupting colony.targetRatio. Fall
+  // back to the safe default rather than poisoning state.
+  if (TRACK_LEN <= 0) return { forage: 10, fight: 0 };
   const t = (px - TRACK_LEFT) / TRACK_LEN;       // float in [0,1] (clamped below)
   const tc = Math.max(0, Math.min(1, t));
   // 11 discrete steps: 0,1,...,10. fight gets `Math.round(tc * 10)`; forage = 10 - fight.

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -235,8 +235,10 @@ export class UIScene extends Phaser.Scene {
     // cleanup may rename to `sliderLabels` alongside the file rename.
     //
     // Phase 8.5 invariant preserved: labels render INSIDE HUD.TRIANGLE zone
-    // (x: [8,128), y: [456,576)) so pointer clicks on the visible text don't
-    // fall through to world input. trackY=516 - 22 = 494, well inside the zone.
+    // (x: [8,128), y: [532,576)) so pointer clicks on the visible text don't
+    // fall through to world input. After issue #13's slider-zone shrink the
+    // label sits flush at the top edge — trackY=554 - 22 = 532 = HUD.TRIANGLE.y,
+    // and the 10px label text occupies y:[532,542], inside the zone.
     this.triangleLabels = [
       this.add.text(
         HUD.TRIANGLE.x + 4,

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -520,12 +520,19 @@ export class UIScene extends Phaser.Scene {
     // axis only.
     if (colony) {
       const ff = colony.taskCensus.forage + colony.taskCensus.fight;
+      // WR-03: when no worker is currently Foraging or Fighting (e.g. transient
+      // pure-nurse / pure-dig states in small colonies during a brood spike or
+      // a 1-worker colony with auto-dig active), the prior `{forage:100,fight:0}`
+      // fallback pinned the current marker to the forage extreme — visually
+      // contradicting the actual (zero-on-axis) state. Fall back to the player's
+      // intent (`targetRatio`) so the current marker overlays the target marker
+      // rather than fabricating an extreme position.
       const currentRatio = ff > 0
         ? {
             forage: Math.round(colony.taskCensus.forage * 100 / ff),
             fight:  Math.round(colony.taskCensus.fight  * 100 / ff),
           }
-        : { forage: 100, fight: 0 };
+        : { forage: colony.targetRatio.forage, fight: colony.targetRatio.fight };
       const targetRatio = this.dragState.isDragging
         ? this.dragState.targetRatio
         : colony.targetRatio;

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -89,12 +89,12 @@ export const SAVE_PROMPT_NEW_GAME_RECT = { x: 300, y: 320, w: 120, h: 32 } as co
 /** Canvas-local rect for the GameOver "Restart" button. */
 export const GAME_OVER_RESTART_RECT    = { x: 300, y: 320, w: 120, h: 32 } as const;
 import {
-  createTriangleDragState,
-  drawTriangle,
-  screenToBarycentric,
-  isInsideTriangle,
-  TRIANGLE_VERTICES,
-  type TriangleDragState,
+  createSliderDragState,
+  drawSlider,
+  screenToSliderRatio,
+  isInsideSlider,
+  SLIDER_GEOMETRY,
+  type SliderDragState,
 } from './triangle-widget.js';
 import { drawMinimap, applyMinimapClick } from './minimap.js';
 import {
@@ -180,7 +180,7 @@ export class UIScene extends Phaser.Scene {
   // Updated at the end of each update() when the menu is visible.
   private contextMenuVisibleItems: readonly ContextMenuItem[] = CONTEXT_MENU_ITEMS;
   private antActivityText!: Phaser.GameObjects.Text;
-  private dragState!: TriangleDragState;
+  private dragState!: SliderDragState;
 
   // Phase 9 Plan 06 — overlay groups (null = overlay not currently shown)
   private gameOverGroup: Phaser.GameObjects.GameObject[] = [];
@@ -195,7 +195,7 @@ export class UIScene extends Phaser.Scene {
 
   create() {
     this.gfx = this.add.graphics();
-    this.dragState = createTriangleDragState();
+    this.dragState = createSliderDragState();
 
     // HUD-02 stats row — three Texts confined to the 200x24 HUD.STATS rect,
     // two-row layout. Row 1: antsText (white, left) + foodText (green, right-
@@ -229,27 +229,24 @@ export class UIScene extends Phaser.Scene {
     );
     this.queenLabelText.setScrollFactor(0);
 
-    // Triangle vertex labels — static text, created once.
-    // Phase 8.5 HUD cleanup: offsets tightened so every label renders INSIDE
-    // HUD.TRIANGLE (x: [8,128), y: [456,576)). The old offsets placed text
-    // above/beside the zone (e.g. Forage at y=452, Dig at x=-4) which let
-    // pointer clicks on the visible text fall through to world input.
+    // Slider extreme labels — static text, created once. Phase 10 / D-01:
+    // 2 labels (Forage / Fight) replace the prior 3 triangle vertex labels.
+    // Field name `triangleLabels` retained to minimize diff churn — a future
+    // cleanup may rename to `sliderLabels` alongside the file rename.
+    //
+    // Phase 8.5 invariant preserved: labels render INSIDE HUD.TRIANGLE zone
+    // (x: [8,128), y: [456,576)) so pointer clicks on the visible text don't
+    // fall through to world input. trackY=516 - 22 = 494, well inside the zone.
     this.triangleLabels = [
       this.add.text(
-        TRIANGLE_VERTICES.forage.x - 18,
-        TRIANGLE_VERTICES.forage.y - 12,
+        HUD.TRIANGLE.x + 4,
+        SLIDER_GEOMETRY.trackY - 22,
         'Forage',
         { color: '#ffffff', fontSize: '10px' },
       ),
       this.add.text(
-        TRIANGLE_VERTICES.dig.x - 6,
-        TRIANGLE_VERTICES.dig.y - 12,
-        'Dig',
-        { color: '#ffffff', fontSize: '10px' },
-      ),
-      this.add.text(
-        TRIANGLE_VERTICES.fight.x - 28,
-        TRIANGLE_VERTICES.fight.y - 12,
+        HUD.TRIANGLE.x + HUD.TRIANGLE.w - 28,
+        SLIDER_GEOMETRY.trackY - 22,
         'Fight',
         { color: '#ffffff', fontSize: '10px' },
       ),
@@ -412,10 +409,10 @@ export class UIScene extends Phaser.Scene {
       }
       // Minimap click
       if (applyMinimapClick(this.viewState, pointer.x, pointer.y)) return;
-      // Behavior triangle drag start
-      if (isInsideTriangle(pointer.x, pointer.y)) {
+      // Behavior slider drag start (Phase 10 / D-01 — 1-D Forage↔Fight axis)
+      if (isInsideSlider(pointer.x, pointer.y)) {
         this.dragState.isDragging = true;
-        this.dragState.targetRatio = screenToBarycentric(pointer.x, pointer.y);
+        this.dragState.targetRatio = screenToSliderRatio(pointer.x);
         return;
       }
     });
@@ -423,7 +420,8 @@ export class UIScene extends Phaser.Scene {
     this.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
       if (!this.dragState.isDragging) return;
       if (!pointer.isDown) return;
-      this.dragState.targetRatio = screenToBarycentric(pointer.x, pointer.y);
+      // 1-D slider: only x is consulted; pointer y is ignored within drag.
+      this.dragState.targetRatio = screenToSliderRatio(pointer.x);
     });
 
     // Belt-and-suspenders: clear overlay window state on scene shutdown to
@@ -513,23 +511,25 @@ export class UIScene extends Phaser.Scene {
       }
     }
 
-    // Behavior triangle widget
+    // Behavior slider widget (Phase 10 / D-01 — 1-D Forage↔Fight axis).
+    // currentRatio denominator is forage + fight only — auto-dig (CTRL-06)
+    // and auto-nurse (CLNY-09) are demand-driven roles outside the player
+    // ratio and are visualized elsewhere (status indicators / future BACKLOG
+    // HUD). The slider's domain is the player-controlled axis; dual markers
+    // track player input (target) vs catch-up task census (current) on that
+    // axis only.
     if (colony) {
-      const total = colony.taskCensus.nurse
-                  + colony.taskCensus.forage
-                  + colony.taskCensus.dig
-                  + colony.taskCensus.fight;
-      const currentRatio = total > 0
+      const ff = colony.taskCensus.forage + colony.taskCensus.fight;
+      const currentRatio = ff > 0
         ? {
-            forage: Math.round(colony.taskCensus.forage * 100 / total),
-            dig:    Math.round(colony.taskCensus.dig    * 100 / total),
-            fight:  Math.round(colony.taskCensus.fight  * 100 / total),
+            forage: Math.round(colony.taskCensus.forage * 100 / ff),
+            fight:  Math.round(colony.taskCensus.fight  * 100 / ff),
           }
-        : { forage: 100, dig: 0, fight: 0 };
+        : { forage: 100, fight: 0 };
       const targetRatio = this.dragState.isDragging
         ? this.dragState.targetRatio
         : colony.targetRatio;
-      drawTriangle(this.gfx as unknown as import('./draw-surface.js').GfxLike, currentRatio, targetRatio);
+      drawSlider(this.gfx as unknown as import('./draw-surface.js').GfxLike, currentRatio, targetRatio);
     }
 
     // Minimap

--- a/src/sim/behavior/allocation-system.test.ts
+++ b/src/sim/behavior/allocation-system.test.ts
@@ -1,13 +1,20 @@
-// allocation-system.test.ts — Tests for PRD §7a/§7b allocation math
+// allocation-system.test.ts — Tests for PRD §7a/§7b allocation math (Phase 10 amendment).
+//
+// Phase 10 amendment (CTRL-01' / CTRL-06): BehaviorRatio is two-role
+// {forage, fight}; the WorkerAllocation `dig` field is always 0 from
+// allocateWorkers. Auto-dig (Plan 02 step 10a) writes
+// colony.computedAllocation.dig from need.dig AFTER allocateWorkers runs;
+// it consumes from the Idle pool, not from this split (D-02 wait-no-preempt).
 //
 // Coverage:
 //   - computeNurseCount (floor, cap-by-ceil(w/4), cap-by-workerCount, zeroes, no-nursery gate)
-//   - computeNurseCount cap table (ceil(w/4) for w=0..10)
-//   - allocateWorkers PRD §8b scenarios (high-brood, three-way split, CLNY-09)
-//   - Edge cases (zero ratio, zero workers, high brood cap, remainder=2, fight-heavy, unequal ratio)
+//   - computeNurseCount cap table (ceil(w/4) for w=0..17)
+//   - allocateWorkers PRD §8b' scenarios (high-brood, two-way split, CLNY-09)
+//   - Edge cases (zero ratio, zero workers, high brood cap, remainder=1, fight-heavy, unequal ratio)
 //   - 09 reproduction-gate memo: hasNursery=false → nurse=0 regardless of brood
+//   - Phase 10 contract: returned `dig` is always 0 (auto-dig owns the live value)
 //   - CTRL-04 immediate allocation proof
-//   - Sum invariant property sweep (20 fixed inputs, hasNursery true/false)
+//   - Sum invariant property sweep — nurse + forage + fight === workerCount
 
 import { describe, it, expect } from 'vitest';
 import { computeNurseCount, allocateWorkers } from './allocation-system.js';
@@ -67,29 +74,30 @@ describe('computeNurseCount — ceil(w/4) cap table', () => {
 });
 
 // ---------------------------------------------------------------------------
-// allocateWorkers — PRD §8b scenarios
+// allocateWorkers — PRD §8b' scenarios (Phase 10 two-role amendment)
 // ---------------------------------------------------------------------------
 
-describe('allocateWorkers — PRD §8b scenarios', () => {
+describe('allocateWorkers — PRD §8b\' scenarios', () => {
   it('5. Nurse Carveout at High Brood: workerCount=3, broodCount=30, forage-only, hasNursery', () => {
     // floor(30/3)=10, cap ceil(3/4)=1 → nurse=1; available=2 → forage=2
-    const result = allocateWorkers(3, 30, { forage: 10, dig: 0, fight: 0 }, true);
+    const result = allocateWorkers(3, 30, { forage: 10, fight: 0 }, true);
     expect(result).toEqual({ nurse: 1, forage: 2, dig: 0, fight: 0 });
-    expect(result.nurse + result.forage + result.dig + result.fight).toBe(3);
+    expect(result.nurse + result.forage + result.fight).toBe(3);
   });
 
-  it('6. Three-Way Split with Remainder: 10 workers, equal 1:1:1 ratio, 0 brood', () => {
-    // nurseCount=0, available=10; floor(10/3)=3 each, sum=9, remainder=1 → forage+1
-    const result = allocateWorkers(10, 0, { forage: 1, dig: 1, fight: 1 }, true);
-    expect(result).toEqual({ nurse: 0, forage: 4, dig: 3, fight: 3 });
-    expect(result.nurse + result.forage + result.dig + result.fight).toBe(10);
+  it('6. Two-Way Split with Remainder: 10 workers, 1:1 forage:fight, 0 brood — dig:0 from allocateWorkers', () => {
+    // Phase 10 amendment: dig is no longer ratio-driven; auto-dig owns the live count.
+    // nurseCount=0, available=10; floor(10/2)=5 each, sum=10, no remainder.
+    const result = allocateWorkers(10, 0, { forage: 1, fight: 1 }, true);
+    expect(result).toEqual({ nurse: 0, forage: 5, dig: 0, fight: 5 });
+    expect(result.nurse + result.forage + result.fight).toBe(10);
   });
 
   it('7. CLNY-09 proof: workerCount=10, broodCount=3, 100% forage → nurse enforced', () => {
     // floor(3/3)=1, cap ceil(10/4)=3 → nurse=1; available=9; all forage → forage=9
-    const result = allocateWorkers(10, 3, { forage: 10, dig: 0, fight: 0 }, true);
+    const result = allocateWorkers(10, 3, { forage: 10, fight: 0 }, true);
     expect(result).toEqual({ nurse: 1, forage: 9, dig: 0, fight: 0 });
-    expect(result.nurse + result.forage + result.dig + result.fight).toBe(10);
+    expect(result.nurse + result.forage + result.fight).toBe(10);
   });
 });
 
@@ -99,40 +107,67 @@ describe('allocateWorkers — PRD §8b scenarios', () => {
 
 describe('allocateWorkers — edge cases', () => {
   it('8. Zero ratio sum: all non-nurse workers go idle (returned as 0)', () => {
-    const result = allocateWorkers(5, 0, { forage: 0, dig: 0, fight: 0 }, true);
+    const result = allocateWorkers(5, 0, { forage: 0, fight: 0 }, true);
     expect(result).toEqual({ nurse: 0, forage: 0, dig: 0, fight: 0 });
   });
 
   it('9. Zero workers: all fields are 0', () => {
-    const result = allocateWorkers(0, 0, { forage: 10, dig: 0, fight: 0 }, true);
+    const result = allocateWorkers(0, 0, { forage: 10, fight: 0 }, true);
     expect(result).toEqual({ nurse: 0, forage: 0, dig: 0, fight: 0 });
   });
 
   it('10. High brood with nursery: cap by ceil(5/4)=2', () => {
     // floor(15/3)=5, cap ceil(5/4)=2 → nurse=2; available=3 → forage=3
-    const result = allocateWorkers(5, 15, { forage: 10, dig: 0, fight: 0 }, true);
+    const result = allocateWorkers(5, 15, { forage: 10, fight: 0 }, true);
     expect(result).toEqual({ nurse: 2, forage: 3, dig: 0, fight: 0 });
-    expect(result.nurse + result.forage + result.dig + result.fight).toBe(5);
+    expect(result.nurse + result.forage + result.fight).toBe(5);
   });
 
-  it('11. Remainder = 2 (forage then dig): 11 workers, equal 1:1:1 ratio', () => {
-    // nurseCount=0, available=11; floor(11/3)=3 each, sum=9, remainder=2
-    // forage+1=4, dig+1=4, fight+0=3 → sum=11
-    const result = allocateWorkers(11, 0, { forage: 1, dig: 1, fight: 1 }, true);
-    expect(result).toEqual({ nurse: 0, forage: 4, dig: 4, fight: 3 });
-    expect(result.nurse + result.forage + result.dig + result.fight).toBe(11);
+  it('11. Remainder = 1 (forage gets the bonus): 11 workers, 1:1 forage:fight', () => {
+    // Phase 10 amendment: with two roles, max remainder is 1 (forage takes it).
+    // nurseCount=0, available=11; floor(11/2)=5 each, sum=10, remainder=1 → forage+1
+    const result = allocateWorkers(11, 0, { forage: 1, fight: 1 }, true);
+    expect(result).toEqual({ nurse: 0, forage: 6, dig: 0, fight: 5 });
+    expect(result.nurse + result.forage + result.fight).toBe(11);
   });
 
   it('12. Fight-heavy: 100% fight → no remainder (exact division)', () => {
-    const result = allocateWorkers(10, 0, { forage: 0, dig: 0, fight: 1 }, true);
+    const result = allocateWorkers(10, 0, { forage: 0, fight: 1 }, true);
     expect(result).toEqual({ nurse: 0, forage: 0, dig: 0, fight: 10 });
-    expect(result.nurse + result.forage + result.dig + result.fight).toBe(10);
+    expect(result.nurse + result.forage + result.fight).toBe(10);
   });
 
-  it('13. Unequal ratio 3:2:1 with no remainder: 6 workers', () => {
-    const result = allocateWorkers(6, 0, { forage: 3, dig: 2, fight: 1 }, true);
-    expect(result).toEqual({ nurse: 0, forage: 3, dig: 2, fight: 1 });
-    expect(result.nurse + result.forage + result.dig + result.fight).toBe(6);
+  it('13. Unequal ratio 3:1 forage:fight: 6 workers → forage=4 (with remainder), fight=1', () => {
+    // Phase 10 amendment two-role math:
+    // total=4; forage = (6*3/4)|0 = 4; fight = (6*1/4)|0 = 1; remainder = 6 - 4 - 1 = 1 → forage+1=5
+    const result = allocateWorkers(6, 0, { forage: 3, fight: 1 }, true);
+    expect(result).toEqual({ nurse: 0, forage: 5, dig: 0, fight: 1 });
+    expect(result.nurse + result.forage + result.fight).toBe(6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 10 contract — `dig` is always 0 from allocateWorkers (CTRL-06 owns it)
+// ---------------------------------------------------------------------------
+
+describe('allocateWorkers — Phase 10 dig contract', () => {
+  it('returned `dig` is 0 across many shape combinations (auto-dig owns the live value)', () => {
+    const inputs: Array<[number, number, { forage: number; fight: number }, boolean]> = [
+      [10,  0,  { forage: 10, fight: 0 }, true],
+      [10,  0,  { forage: 0,  fight: 10 }, true],
+      [10,  0,  { forage: 1,  fight: 1 },  true],
+      [11,  0,  { forage: 1,  fight: 1 },  true],
+      [3,   30, { forage: 10, fight: 0 }, true],
+      [10,  3,  { forage: 10, fight: 0 }, true],
+      [10,  30, { forage: 1,  fight: 1 },  false],
+      [50,  0,  { forage: 10, fight: 5 },  true],
+      [0,   0,  { forage: 10, fight: 0 }, true],
+      [5,   0,  { forage: 0,  fight: 0 },  true],
+    ];
+    for (const [workers, brood, ratio, hasNursery] of inputs) {
+      const result = allocateWorkers(workers, brood, ratio, hasNursery);
+      expect(result.dig).toBe(0);
+    }
   });
 });
 
@@ -145,30 +180,31 @@ describe('allocateWorkers — 09 memo: hasNursery=false gate', () => {
     // Regression shape: 3 workers, heavy brood, forage-favored ratio, NO Nursery.
     // Without the gate, pre-09 allocation would force all 3 into nursing and
     // starve the colony. Post-09: nurse=0, available=3, all → forage.
-    const result = allocateWorkers(3, 30, { forage: 10, dig: 0, fight: 0 }, false);
+    const result = allocateWorkers(3, 30, { forage: 10, fight: 0 }, false);
     expect(result).toEqual({ nurse: 0, forage: 3, dig: 0, fight: 0 });
-    expect(result.nurse + result.forage + result.dig + result.fight).toBe(3);
+    expect(result.nurse + result.forage + result.fight).toBe(3);
   });
 
-  it('no nursery + high brood + 10 workers: nurse=0, full triangle split', () => {
-    // 10 workers, 30 brood, 1:1:1 ratio, no Nursery → brood is inert.
-    const result = allocateWorkers(10, 30, { forage: 1, dig: 1, fight: 1 }, false);
-    expect(result).toEqual({ nurse: 0, forage: 4, dig: 3, fight: 3 });
-    expect(result.nurse + result.forage + result.dig + result.fight).toBe(10);
+  it('no nursery + high brood + 10 workers, 1:1 forage:fight: nurse=0, full split', () => {
+    // 10 workers, 30 brood, 1:1 forage:fight, no Nursery → brood is inert.
+    // floor(10/2)=5 each, sum=10, no remainder.
+    const result = allocateWorkers(10, 30, { forage: 1, fight: 1 }, false);
+    expect(result).toEqual({ nurse: 0, forage: 5, dig: 0, fight: 5 });
+    expect(result.nurse + result.forage + result.fight).toBe(10);
   });
 
   it('no nursery + zero brood: identical to hasNursery=true (nurse=0 both ways)', () => {
-    const noNursery = allocateWorkers(10, 0, { forage: 3, dig: 2, fight: 1 }, false);
-    const yesNursery = allocateWorkers(10, 0, { forage: 3, dig: 2, fight: 1 }, true);
+    const noNursery  = allocateWorkers(10, 0, { forage: 3, fight: 1 }, false);
+    const yesNursery = allocateWorkers(10, 0, { forage: 3, fight: 1 }, true);
     expect(noNursery).toEqual(yesNursery);
   });
 
   it('no nursery leaves legacy brood inert: workers handle non-nurse tasks only', () => {
     // Save-compat: a legacy save may ship brood without a completed Nursery.
     // The gate must not crash; brood sits inert and workers handle foraging etc.
-    const result = allocateWorkers(5, 8, { forage: 5, dig: 5, fight: 0 }, false);
+    const result = allocateWorkers(5, 8, { forage: 5, fight: 0 }, false);
     expect(result.nurse).toBe(0);
-    expect(result.nurse + result.forage + result.dig + result.fight).toBe(5);
+    expect(result.nurse + result.forage + result.fight).toBe(5);
   });
 });
 
@@ -178,15 +214,15 @@ describe('allocateWorkers — 09 memo: hasNursery=false gate', () => {
 
 describe('allocateWorkers — CTRL-04 immediate allocation', () => {
   it('14. CTRL-04: two consecutive calls with different ratios return independent results', () => {
-    const alloc1 = allocateWorkers(10, 0, { forage: 10, dig: 0, fight: 0 }, true);
+    const alloc1 = allocateWorkers(10, 0, { forage: 10, fight: 0 }, true);
     expect(alloc1.forage).toBe(10);
     expect(alloc1.dig).toBe(0);
     expect(alloc1.fight).toBe(0);
 
-    const alloc2 = allocateWorkers(10, 0, { forage: 0, dig: 10, fight: 0 }, true);
-    expect(alloc2.dig).toBe(10);
+    const alloc2 = allocateWorkers(10, 0, { forage: 0, fight: 10 }, true);
     expect(alloc2.forage).toBe(0);
-    expect(alloc2.fight).toBe(0);
+    expect(alloc2.dig).toBe(0);
+    expect(alloc2.fight).toBe(10);
 
     // alloc1 is unchanged (pure function, no shared state)
     expect(alloc1.forage).toBe(10);
@@ -195,45 +231,48 @@ describe('allocateWorkers — CTRL-04 immediate allocation', () => {
 
 // ---------------------------------------------------------------------------
 // Sum invariant property sweep — 20 fixed inputs × hasNursery={true,false}
+// Phase 10 amendment: dig is 0 from allocateWorkers, so sum is nurse + forage + fight.
 // ---------------------------------------------------------------------------
 
 describe('allocateWorkers — sum invariant', () => {
-  const cases: Array<[number, number, { forage: number; dig: number; fight: number }]> = [
-    [10,  5,  { forage: 3, dig: 2, fight: 1 }],
-    [100, 50, { forage: 1, dig: 1, fight: 1 }],
-    [1,   0,  { forage: 1, dig: 0, fight: 0 }],
-    [50,  0,  { forage: 10, dig: 5, fight: 5 }],
-    [0,   0,  { forage: 10, dig: 0, fight: 0 }],
-    [20,  3,  { forage: 7, dig: 2, fight: 1 }],
-    [15,  15, { forage: 1, dig: 1, fight: 1 }],
-    [30,  90, { forage: 10, dig: 0, fight: 0 }],
-    [7,   6,  { forage: 2, dig: 2, fight: 2 }],
-    [8,   0,  { forage: 3, dig: 3, fight: 3 }],
-    [12,  9,  { forage: 5, dig: 3, fight: 2 }],
-    [25,  0,  { forage: 10, dig: 0, fight: 0 }],
-    [5,   5,  { forage: 10, dig: 5, fight: 5 }],
-    [3,   3,  { forage: 1, dig: 1, fight: 0 }],
-    [99,  0,  { forage: 4, dig: 3, fight: 3 }],
-    [10,  30, { forage: 1, dig: 0, fight: 0 }],
-    [6,   6,  { forage: 0, dig: 10, fight: 0 }],
-    [40,  12, { forage: 6, dig: 2, fight: 2 }],
-    [11,  0,  { forage: 1, dig: 1, fight: 1 }],
-    [100, 0,  { forage: 10, dig: 0, fight: 0 }],
+  const cases: Array<[number, number, { forage: number; fight: number }]> = [
+    [10,  5,  { forage: 3,  fight: 1 }],
+    [100, 50, { forage: 1,  fight: 1 }],
+    [1,   0,  { forage: 1,  fight: 0 }],
+    [50,  0,  { forage: 10, fight: 5 }],
+    [0,   0,  { forage: 10, fight: 0 }],
+    [20,  3,  { forage: 7,  fight: 1 }],
+    [15,  15, { forage: 1,  fight: 1 }],
+    [30,  90, { forage: 10, fight: 0 }],
+    [7,   6,  { forage: 2,  fight: 2 }],
+    [8,   0,  { forage: 3,  fight: 3 }],
+    [12,  9,  { forage: 5,  fight: 2 }],
+    [25,  0,  { forage: 10, fight: 0 }],
+    [5,   5,  { forage: 10, fight: 5 }],
+    [3,   3,  { forage: 1,  fight: 0 }],
+    [99,  0,  { forage: 4,  fight: 3 }],
+    [10,  30, { forage: 1,  fight: 0 }],
+    [6,   6,  { forage: 0,  fight: 10 }],
+    [40,  12, { forage: 6,  fight: 2 }],
+    [11,  0,  { forage: 1,  fight: 1 }],
+    [100, 0,  { forage: 10, fight: 0 }],
   ];
 
-  it('15a. nurse + forage + dig + fight === workerCount — hasNursery=true', () => {
+  it('15a. nurse + forage + fight === workerCount — hasNursery=true (Phase 10: dig is 0)', () => {
     for (const [workerCount, broodCount, ratio] of cases) {
       const result = allocateWorkers(workerCount, broodCount, ratio, true);
-      const sum = result.nurse + result.forage + result.dig + result.fight;
+      expect(result.dig).toBe(0);
+      const sum = result.nurse + result.forage + result.fight;
       expect(sum).toBe(workerCount);
     }
   });
 
-  it('15b. nurse + forage + dig + fight === workerCount — hasNursery=false', () => {
+  it('15b. nurse + forage + fight === workerCount — hasNursery=false (Phase 10: dig is 0)', () => {
     for (const [workerCount, broodCount, ratio] of cases) {
       const result = allocateWorkers(workerCount, broodCount, ratio, false);
       expect(result.nurse).toBe(0);
-      const sum = result.nurse + result.forage + result.dig + result.fight;
+      expect(result.dig).toBe(0);
+      const sum = result.nurse + result.forage + result.fight;
       expect(sum).toBe(workerCount);
     }
   });

--- a/src/sim/behavior/allocation-system.ts
+++ b/src/sim/behavior/allocation-system.ts
@@ -12,7 +12,11 @@
 // Remainder distribution: forage gets +1 if available > forage + fight (max remainder is 1
 // when both slots are positive). Fight never receives remainder.
 
-import type { BehaviorRatio, WorkerAllocation } from '../colony/colony-store.js';
+import type { BehaviorRatio, ColonyRecord, WorkerAllocation } from '../colony/colony-store.js';
+import type { AntComponents } from '../ant/ant-store.js';
+import type { UndergroundGrid } from '../terrain.js';
+import { UndergroundTileState } from '../terrain.js';
+import { AntTask } from '../enums.js';
 import { NURSE_RATIO } from '../constants.js';
 
 /**
@@ -110,4 +114,55 @@ export function allocateWorkers(
     dig:    0,
     fight:  fight,
   };
+}
+
+/**
+ * Phase 10 / CTRL-06 — auto-dig demand check (D-02 LOCKED).
+ *
+ * Returns 1 if (a) at least one Marked tile exists in the colony's underground
+ * grid AND (b) no ant in `colony.workers` currently has `task === AntTask.Digging`.
+ * Returns 0 otherwise.
+ *
+ * Strict 1-digger cap (per CONTEXT.md D-02): if ANY ant of the colony is already
+ * Digging, no new digger is auto-assigned this tick. This solves the tunnel-jam
+ * problem from issue #13.
+ *
+ * Scarcity policy is handled at the call site (tick.ts step 10a): if no ant is
+ * Idle, the demand goes unfulfilled this tick and Marked tiles wait. No
+ * preemption of foragers / fighters.
+ *
+ * Pure function. Reads only `colony.workers`, `ants.alive`, `ants.task`, and the
+ * underground grid `data` array — all deterministic state. No PRNG, no allocation,
+ * no float math. Same inputs → same output by construction (SCEN-06).
+ *
+ * Boolean-style 0/1 form chosen over a count: concurrency is locked at 1 by
+ * D-02; if a future phase lifts the cap, a count value would naturally generalize
+ * (`0..N`), but coding it as a count today would invite a future contributor to
+ * bump it to 2 without realizing the assertion is locked elsewhere.
+ *
+ * @param colony           - Colony record; iterated to detect any active digger.
+ * @param undergroundGrid  - Colony's underground grid; scanned for Marked tiles.
+ * @param ants             - Ant component store (alive + task arrays).
+ * @returns 1 if Marked tiles exist and no ant is Digging in this colony, else 0.
+ */
+export function computeDigDemand(
+  colony: ColonyRecord,
+  undergroundGrid: UndergroundGrid,
+  ants: AntComponents,
+): number {
+  // (b) Strict 1-digger cap — early exit on the cheaper check.
+  for (let i = 0; i < colony.workers.length; i++) {
+    const id = colony.workers[i]!;
+    if (ants.alive[id] !== 1) continue;
+    if (ants.task[id] === AntTask.Digging) return 0;
+  }
+  // (a) Marked tile presence — single linear scan over the grid's Uint8Array.
+  // Direct data[] access (matches the Phase 07-04 decision for computeDigFlowField:
+  // direct array access, not ugGet, in inner BFS loop for performance). Same fixed
+  // iteration order as BFS (linear i from 0).
+  const data = undergroundGrid.data;
+  for (let i = 0; i < data.length; i++) {
+    if (data[i] === UndergroundTileState.Marked) return 1;
+  }
+  return 0;
 }

--- a/src/sim/behavior/allocation-system.ts
+++ b/src/sim/behavior/allocation-system.ts
@@ -97,15 +97,27 @@ export function allocateWorkers(
   const nurseCount = computeNurseCount(broodCount, workerCount, hasNursery);
   const available = workerCount - nurseCount;
 
-  const total = ratio.forage + ratio.fight;
+  // WR-04: defensive clamp on ratio inputs. The BehaviorRatio interface declares
+  // `number` without enforcing non-negativity or integer-ness. The SetBehaviorRatio
+  // command handler in tick.ts step 5 rejects negatives, but direct mutations (tests,
+  // future render-layer code) and corrupted saves can still feed negative or
+  // fractional weights here. `| 0` truncates fractions to integers; `Math.max(0, …)`
+  // floors negatives to 0 so `(available * ratio.forage / total) | 0` cannot
+  // produce a negative integer (which would yield a nonsense allocation).
+  // eslint-disable-next-line no-restricted-syntax -- PRD §7b integer guard, not float math
+  const forageWeight = Math.max(0, ratio.forage | 0);
+  // eslint-disable-next-line no-restricted-syntax -- PRD §7b integer guard, not float math
+  const fightWeight  = Math.max(0, ratio.fight  | 0);
+
+  const total = forageWeight + fightWeight;
   if (total === 0 || available === 0) {
     return { nurse: nurseCount, forage: 0, dig: 0, fight: 0 };
   }
 
   // eslint-disable-next-line no-restricted-syntax -- PRD §7b integer ratio, not float math
-  const forage = ((available * ratio.forage) / total) | 0;
+  const forage = ((available * forageWeight) / total) | 0;
   // eslint-disable-next-line no-restricted-syntax -- PRD §7b integer ratio, not float math
-  const fight  = ((available * ratio.fight)  / total) | 0;
+  const fight  = ((available * fightWeight)  / total) | 0;
   const remainder = available - forage - fight;
 
   return {

--- a/src/sim/behavior/allocation-system.ts
+++ b/src/sim/behavior/allocation-system.ts
@@ -3,11 +3,14 @@
 // Pure, stateless functions. No tick integration, no ant reassignment, no colony state writes.
 // Downstream caller (Plan 10 tick.ts) reads the result and writes colony.computedAllocation.
 //
-// Invariant: result.nurse + result.forage + result.dig + result.fight === workerCount
-// for all non-negative inputs with finite ratio values.
+// Invariant: result.nurse + result.forage + result.fight === workerCount  (when no auto-dig
+// is active). The `dig` slot in the returned WorkerAllocation is always 0 from this function.
+// Phase 10 auto-dig (CTRL-06, plan 02) writes colony.computedAllocation.dig from need.dig
+// AFTER allocateWorkers in tick.ts step 10a; it consumes from the Idle pool, not from this
+// split (D-02 scarcity policy: wait, no preemption).
 //
-// Remainder distribution (PRD §7b line 1999): forage gets +1 first, dig gets +1 second,
-// fight never receives remainder. Max remainder is 2 (when all 3 ratio slots are > 0).
+// Remainder distribution: forage gets +1 if available > forage + fight (max remainder is 1
+// when both slots are positive). Fight never receives remainder.
 
 import type { BehaviorRatio, WorkerAllocation } from '../colony/colony-store.js';
 import { NURSE_RATIO } from '../constants.js';
@@ -49,30 +52,37 @@ export function computeNurseCount(
 }
 
 /**
- * Allocate workers across tasks according to PRD §7a (nurse carveout) and §7b (triangle floor-split).
+ * Allocate workers across tasks according to PRD §7a (nurse carveout) and §7b
+ * (two-role floor-split) under the Phase 10 amendment (CTRL-01' / CTRL-06).
  *
  * Algorithm:
  *  1. Nurse carveout (PRD §7a + 09 memo): nurses are computed BEFORE the
- *     triangle split. Gated on `hasNursery` and capped at ceil(workerCount/4)
+ *     two-role split. Gated on `hasNursery` and capped at ceil(workerCount/4)
  *     so nursing can never starve the triangle (see computeNurseCount).
- *  2. Remaining workers are split forage/dig/fight by integer floor of the ratio weights.
- *  3. Remainder distribution (PRD §7b): any leftover workers go forage-first, then dig.
- *     Fight never receives a remainder bonus via this path.
+ *  2. Remaining workers are split forage/fight by integer floor of the ratio weights.
+ *  3. Remainder distribution: any leftover workers go to forage. Max remainder is
+ *     1 when both slots are positive. Fight never receives a remainder bonus.
+ *  4. The returned `dig` slot is always 0. Phase 10 auto-dig (CTRL-06, plan 02)
+ *     writes colony.computedAllocation.dig from need.dig in tick.ts step 10a
+ *     AFTER this function runs. Per CONTEXT.md D-02, scarcity is "wait — no
+ *     preemption", so allocateWorkers does NOT reserve a slot for auto-dig;
+ *     auto-dig consumes from the Idle pool instead.
  *
- * Invariant: result.nurse + result.forage + result.dig + result.fight === workerCount
+ * Invariant: result.nurse + result.forage + result.fight === workerCount
+ *            (when no auto-dig is active that tick).
  *
  * Edge cases:
  *  - workerCount === 0: all fields are 0.
- *  - broodCount === 0: nurseCount === 0, all workers go to the triangle split.
+ *  - broodCount === 0: nurseCount === 0, all workers go to the two-role split.
  *  - hasNursery === false: nurseCount === 0 regardless of brood (09 memo gate).
- *  - total ratio === 0 (ratio {0,0,0}): all non-nurse workers are idle (0 allocated).
+ *  - total ratio === 0 (ratio {forage:0, fight:0}): all non-nurse workers are idle (0 allocated).
  *  - broodCount >> workerCount: nurseCount capped at ceil(workerCount/4).
  *
  * @param workerCount - Total workers to allocate.
  * @param broodCount  - Colony brood count, used for nurse carveout.
- * @param ratio       - Player/AI target task distribution triangle.
+ * @param ratio       - Player/AI target task distribution (two roles: forage / fight).
  * @param hasNursery  - True iff the colony owns a completed Nursery chamber.
- * @returns WorkerAllocation with exact per-task counts summing to workerCount.
+ * @returns WorkerAllocation; the `dig` field is always 0 from this function.
  */
 export function allocateWorkers(
   workerCount: number,
@@ -83,7 +93,7 @@ export function allocateWorkers(
   const nurseCount = computeNurseCount(broodCount, workerCount, hasNursery);
   const available = workerCount - nurseCount;
 
-  const total = ratio.forage + ratio.dig + ratio.fight;
+  const total = ratio.forage + ratio.fight;
   if (total === 0 || available === 0) {
     return { nurse: nurseCount, forage: 0, dig: 0, fight: 0 };
   }
@@ -91,15 +101,13 @@ export function allocateWorkers(
   // eslint-disable-next-line no-restricted-syntax -- PRD §7b integer ratio, not float math
   const forage = ((available * ratio.forage) / total) | 0;
   // eslint-disable-next-line no-restricted-syntax -- PRD §7b integer ratio, not float math
-  const dig    = ((available * ratio.dig)    / total) | 0;
-  // eslint-disable-next-line no-restricted-syntax -- PRD §7b integer ratio, not float math
   const fight  = ((available * ratio.fight)  / total) | 0;
-  const remainder = available - forage - dig - fight;
+  const remainder = available - forage - fight;
 
   return {
     nurse:  nurseCount,
     forage: forage + (remainder > 0 ? 1 : 0),
-    dig:    dig    + (remainder > 1 ? 1 : 0),
+    dig:    0,
     fight:  fight,
   };
 }

--- a/src/sim/colony/colony-store.test.ts
+++ b/src/sim/colony/colony-store.test.ts
@@ -78,11 +78,12 @@ describe('createColonyRecord', () => {
     expect(b.taskCensus.forage).toBe(0);
   });
 
-  it('(5) DEFAULT_BEHAVIOR_RATIO shape: forage=10, dig=0, fight=0', () => {
+  it('(5) DEFAULT_BEHAVIOR_RATIO shape: forage=10, fight=0 (Phase 10 amendment, CTRL-01\')', () => {
     const r = createColonyRecord(1, 0);
     expect(r.targetRatio.forage).toBe(10);
-    expect(r.targetRatio.dig).toBe(0);
     expect(r.targetRatio.fight).toBe(0);
+    // dig field intentionally absent on BehaviorRatio post-Phase-10 (CTRL-06 owns dig).
+    expect(Object.keys(r.targetRatio).sort()).toEqual(['fight', 'forage']);
   });
 
   it('(9) taskCensus has exactly the 4 WorkerAllocation fields from PRD §2 (nurse, forage, dig, fight)', () => {

--- a/src/sim/colony/colony-store.ts
+++ b/src/sim/colony/colony-store.ts
@@ -47,16 +47,17 @@ export interface WorkerAllocation {
 }
 
 // ---------------------------------------------------------------------------
-// BehaviorRatio — player-controlled task distribution triangle (PRD §2)
+// BehaviorRatio — player-controlled task distribution control (PRD §2 + Phase 10 amendment per CTRL-01')
 //
-// Three fields: forage, dig, fight. Values are percentages on an internal
-// scale of 0–10 (10 = 100%). The nurse task is computed from workerCount
-// and is not directly player-controlled.
+// Two roles: forage and fight. Digging is auto-assigned per CLNY-09-style
+// demand — see CTRL-06 and `tick.ts` step 10a (auto-dig path landed in
+// Plan 02). Values are integer percentages on a 0–10 scale (10 = 100%).
+// The nurse task is computed from workerCount and is not directly
+// player-controlled.
 // ---------------------------------------------------------------------------
 
 export interface BehaviorRatio {
   forage: number;
-  dig:    number;
   fight:  number;
 }
 

--- a/src/sim/colony/colony-system.test.ts
+++ b/src/sim/colony/colony-system.test.ts
@@ -627,9 +627,10 @@ describe('tickReconcile', () => {
     addLarva(world, colony);
     addLarva(world, colony);
 
+    // Phase 10 (CTRL-01'): targetRatio is two-role. Use a non-trivial split so
+    // reconcile actually has work to do; dig is auto-assigned in Plan 02 step 10a.
     colony.targetRatio.forage = 8;
-    colony.targetRatio.dig = 2;
-    colony.targetRatio.fight = 0;
+    colony.targetRatio.fight = 2;
 
     // Zero out allocation to prove reconcile recomputes it
     colony.computedAllocation.nurse = 0;

--- a/src/sim/commands.test.ts
+++ b/src/sim/commands.test.ts
@@ -34,13 +34,12 @@ describe('SimCommand', () => {
       const cmd: SetBehaviorRatioCommand = {
         type: 'SetBehaviorRatio',
         colonyId: 1,
-        ratio: { forage: 7, dig: 2, fight: 1 },
+        ratio: { forage: 7, fight: 1 },
         issuedAtTick: 10,
       };
       expect(cmd.type).toBe('SetBehaviorRatio');
       expect(cmd.colonyId).toBe(1);
       expect(cmd.ratio.forage).toBe(7);
-      expect(cmd.ratio.dig).toBe(2);
       expect(cmd.ratio.fight).toBe(1);
       expect(cmd.issuedAtTick).toBe(10);
     });
@@ -49,7 +48,7 @@ describe('SimCommand', () => {
       const cmd: SimCommand = {
         type: 'SetBehaviorRatio',
         colonyId: 2,
-        ratio: { forage: 10, dig: 0, fight: 0 },
+        ratio: { forage: 10, fight: 0 },
         issuedAtTick: 5,
       };
       expect(cmd.type).toBe('SetBehaviorRatio');
@@ -232,7 +231,7 @@ describe('SimCommand', () => {
       }
 
       expect(handleCommand({ type: 'NoOp', issuedAtTick: 0 })).toBe('noop@0');
-      expect(handleCommand({ type: 'SetBehaviorRatio', colonyId: 1, ratio: { forage: 5, dig: 3, fight: 2 }, issuedAtTick: 1 })).toBe('ratio:1');
+      expect(handleCommand({ type: 'SetBehaviorRatio', colonyId: 1, ratio: { forage: 5, fight: 2 }, issuedAtTick: 1 })).toBe('ratio:1');
       expect(handleCommand({ type: 'MarkDigTile', colonyId: 1, tileX: 4, tileY: 8, issuedAtTick: 2 })).toBe('dig:4,8');
       expect(handleCommand({ type: 'MarkFoodPile', colonyId: 1, tileX: 12, tileY: 16, issuedAtTick: 3 })).toBe('food:12,16');
       expect(handleCommand({ type: 'CancelDigMark', colonyId: 1, tileX: 5, tileY: 9, issuedAtTick: 4 })).toBe('cancel:5,9');

--- a/src/sim/constants.test.ts
+++ b/src/sim/constants.test.ts
@@ -161,21 +161,17 @@ describe('PRD §9c grid dimension constants', () => {
   });
 });
 
-describe('PRD §7 §2 DEFAULT_BEHAVIOR_RATIO', () => {
+describe('PRD §7 §2 + Phase 10 amendment (CTRL-01\') DEFAULT_BEHAVIOR_RATIO', () => {
   it('forage === 10', () => {
     expect(DEFAULT_BEHAVIOR_RATIO.forage).toBe(10);
-  });
-
-  it('dig === 0', () => {
-    expect(DEFAULT_BEHAVIOR_RATIO.dig).toBe(0);
   });
 
   it('fight === 0', () => {
     expect(DEFAULT_BEHAVIOR_RATIO.fight).toBe(0);
   });
 
-  it('has exactly forage, dig, fight keys', () => {
-    expect(Object.keys(DEFAULT_BEHAVIOR_RATIO).sort()).toStrictEqual(['dig', 'fight', 'forage']);
+  it('has exactly forage, fight keys (Phase 10: dig dropped — auto-assigned per CTRL-06)', () => {
+    expect(Object.keys(DEFAULT_BEHAVIOR_RATIO).sort()).toStrictEqual(['fight', 'forage']);
   });
 });
 

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -168,12 +168,12 @@ export const UNDERGROUND_GRID_HEIGHT = 64;
 // ---------------------------------------------------------------------------
 
 /**
- * PRD §7 §2 — Default task distribution triangle: forage 100%, dig 0%, fight 0%.
- * Values are percentages summing to 10 (internal scale: 10 = 100%).
+ * PRD §7 §2 + Phase 10 amendment (CTRL-01') — Default task distribution: forage 100%, fight 0%.
+ * Two roles only (digging is auto-assigned per CTRL-06 — see allocation-system.ts and
+ * tick.ts step 10a). Values are integer percentages on a 0–10 scale (10 = 100%).
  */
 export const DEFAULT_BEHAVIOR_RATIO = {
   forage: 10,
-  dig:    0,
   fight:  0,
 } as const;
 

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -240,7 +240,7 @@ describe('SCEN-06: Determinism proof', () => {
     const ratioCmd: SimCommand = {
       type: 'SetBehaviorRatio',
       colonyId: 1 as ColonyId,
-      ratio: { forage: 7, dig: 2, fight: 1 },
+      ratio: { forage: 7, fight: 1 },
       issuedAtTick: 50,
     };
     const digCmd: SimCommand = {
@@ -262,10 +262,12 @@ describe('SCEN-06: Determinism proof', () => {
   // Test 5: Same seed, different commands, different state
   it('Test 5: same seed + different commands at tick 50 produce different state', () => {
     const cmdsA: SimCommand[][] = [];
-    cmdsA[50] = [{ type: 'SetBehaviorRatio', colonyId: 1 as ColonyId, ratio: { forage: 10, dig: 0, fight: 0 }, issuedAtTick: 50 }];
+    cmdsA[50] = [{ type: 'SetBehaviorRatio', colonyId: 1 as ColonyId, ratio: { forage: 10, fight: 0 }, issuedAtTick: 50 }];
 
     const cmdsB: SimCommand[][] = [];
-    cmdsB[50] = [{ type: 'SetBehaviorRatio', colonyId: 1 as ColonyId, ratio: { forage: 0, dig: 10, fight: 0 }, issuedAtTick: 50 }];
+    // Phase 10 (CTRL-01'): pivot is forage↔fight, not forage↔dig (dig is auto-assigned per CTRL-06).
+    // Both runs still produce non-equal serialized state since the ratio drives a different forage/fight split.
+    cmdsB[50] = [{ type: 'SetBehaviorRatio', colonyId: 1 as ColonyId, ratio: { forage: 0, fight: 10 }, issuedAtTick: 50 }];
 
     const r1 = runSimulation(42, 100, cmdsA);
     const r2 = runSimulation(42, 100, cmdsB);
@@ -404,7 +406,6 @@ describe('Phase 6 SC 4: CTRL-04 one-tick immediate allocation', () => {
 
     // Set initial targetRatio → forage:10 (all 10 workers allocated to forage)
     world.colonies[1]!.targetRatio.forage = 10;
-    world.colonies[1]!.targetRatio.dig    = 0;
     world.colonies[1]!.targetRatio.fight  = 0;
 
     // Tick 0 (no commands): allocation reflects forage:10 ratio
@@ -412,11 +413,11 @@ describe('Phase 6 SC 4: CTRL-04 one-tick immediate allocation', () => {
     expect(world.colonies[1]!.computedAllocation.forage).toBe(10);
     expect(world.colonies[1]!.computedAllocation.dig).toBe(0);
 
-    // Tick 1: issue SetBehaviorRatio switching to all-dig
+    // Tick 1: issue SetBehaviorRatio pivoting forage↔fight (Phase 10 CTRL-01': dig is auto-assigned per CTRL-06)
     const cmd: SimCommand = {
       type: 'SetBehaviorRatio',
       colonyId: 1 as ColonyId,
-      ratio: { forage: 0, dig: 10, fight: 0 },
+      ratio: { forage: 0, fight: 10 },
       issuedAtTick: 1,
     };
     tick(world, [cmd]);
@@ -424,8 +425,8 @@ describe('Phase 6 SC 4: CTRL-04 one-tick immediate allocation', () => {
     // The new ratio takes effect in the SAME tick the command is issued (CTRL-04).
     // NOT in the "next tick after this one".
     expect(world.colonies[1]!.computedAllocation.forage).toBe(0);
-    expect(world.colonies[1]!.computedAllocation.dig).toBe(10);
-    expect(world.colonies[1]!.computedAllocation.fight).toBe(0);
+    expect(world.colonies[1]!.computedAllocation.dig).toBe(0);
+    expect(world.colonies[1]!.computedAllocation.fight).toBe(10);
   });
 });
 
@@ -450,7 +451,8 @@ describe('Phase 7: createScenario determinism with MarkDigTile commands', () => 
     cmds[30] = [{ type: 'CancelDigMark', colonyId, tileX: 10, tileY: 5, issuedAtTick: 30 }];
     cmds[50] = [{
       type: 'SetBehaviorRatio', colonyId,
-      ratio: { forage: 0, dig: 10, fight: 0 },
+      // Phase 10 (CTRL-01'): pivot forage↔fight (dig is auto-assigned per CTRL-06).
+      ratio: { forage: 0, fight: 10 },
       issuedAtTick: 50,
     }];
 

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -147,11 +147,13 @@ function initColony(
   // Without this, STARTING_WORKERS foragers can pick up food on the surface
   // but have no route underground to deposit — colony.foodStored never grows,
   // the queen starves in a few hundred ticks, and the player cannot recover
-  // until they manually designate + excavate a shaft (which also requires
-  // manually shifting the behavior triangle to allocate diggers, since default
-  // is forage:10 / dig:0 / fight:0). The starting entrance is the minimum
-  // thing that makes the prototype playable out of the box. Aligns with the
-  // Phase 8 Stabilization Memo item #4 ("expose a more legible initial
+  // until they manually designate + excavate a shaft. (Phase 10 CTRL-06:
+  // digging is now auto-assigned whenever Marked tiles exist and an ant is
+  // Idle — the player only needs to mark the shaft tiles; the default
+  // behavior ratio `{ forage: 10, fight: 0 }` no longer needs adjustment to
+  // make digging happen.) The starting entrance is the minimum thing that
+  // makes the prototype playable out of the box. Aligns with the Phase 8
+  // Stabilization Memo item #4 ("expose a more legible initial
   // entrance/opening state").
   const underground = world.undergroundGrids[colonyId];
   if (underground) {

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -159,10 +159,15 @@ describe('Step 1: command processing', () => {
       issuedAtTick: 1,
     };
     tick(world, [cmd2]);
-    // Same tick as issuance — new ratio takes effect
+    // Same tick as issuance — new ratio takes effect (CTRL-04 immediate-takeup).
+    // Phase 10 / CTRL-06: dig is auto-assigned per Marked-tile presence, NOT per ratio.
+    // With no Marked tiles in this colony's underground grid, computeDigDemand returns 0
+    // and the entire 10-worker pool flows to fight. Pre-Plan-02 this asserted dig:10
+    // (the old fallback when the triangle had a `dig` vertex); the rewire here pins
+    // CTRL-04 against the two-role widget contract.
     expect(world.colonies[colonyId]!.computedAllocation.forage).toBe(0);
-    expect(world.colonies[colonyId]!.computedAllocation.dig).toBe(10);
-    expect(world.colonies[colonyId]!.computedAllocation.fight).toBe(0);
+    expect(world.colonies[colonyId]!.computedAllocation.dig).toBe(0);
+    expect(world.colonies[colonyId]!.computedAllocation.fight).toBe(10);
   });
 
   // Test 4: SetBehaviorRatio rejects negative weights
@@ -551,8 +556,11 @@ describe('Step ordering observable proofs', () => {
     colony.computedAllocation.fight  = 0;
     colony.targetRatio.forage = 0;
     colony.targetRatio.fight  = 0;
-    // Phase 10 (CTRL-06): dig is auto-assigned via need.dig, not via targetRatio.
-    // Plan 02 will rewrite this test to drive digging via Marked tile presence.
+    // Phase 10 (CTRL-06): dig is auto-assigned via need.dig from Marked tiles, not
+    // via targetRatio. Step 10a's auto-dig override will set computedAllocation.dig=0
+    // here (no Marked tiles, no active digger). The pre-set dig=1 above is noise but
+    // harmless: the assertion below — "mid-carry forager NOT preempted by Idle-eligibility"
+    // — depends only on the eligibility predicate, not on which task has demand.
 
     tick(world, []);
 
@@ -658,13 +666,14 @@ describe('Step ordering observable proofs', () => {
       w.ants.foodCarrying[carryWid] = 256;
       colony.workers.push(carryWid);
 
-      // Allocation: forage:2, dig:2, fight:1, nurse:1 (sum=6=workerCount)
-      // Step 9(a) counts: actualForage=1 (mid-carry), actualIdle=5
-      // need: forage=1, dig=2, fight=1, nurse=1 (total=5 = eligibles)
+      // Pre-seed computedAllocation; step 8 will overwrite via allocateWorkers under
+      // the actual ratio. Phase 10 (CTRL-06): dig is auto-assigned per Marked-tile
+      // presence (none in this fixture → dig=0). The test's load-bearing assertion is
+      // the non-negative invariant + sum=workerCount + mid-carry-not-preempted, all
+      // of which hold for any valid allocation that step 10a produces.
       colony.computedAllocation = { nurse: 1, forage: 2, dig: 2, fight: 1 };
       colony.targetRatio.forage = 10;
       colony.targetRatio.fight  = 3;
-      // Phase 10 (CTRL-06): dig is auto-assigned; plan 02 will rewire this test.
 
       tick(w, []);
 
@@ -754,8 +763,9 @@ describe('09 reproduction-gate memo — starvation-shape regression', () => {
 
     colony.targetRatio.forage = 3;
     colony.targetRatio.fight  = 0;
-    // Phase 10 (CTRL-06): dig is auto-assigned per Marked tile presence;
-    // plan 02 will rewire this test if it relies on dig allocation outcome.
+    // Phase 10 (CTRL-06): dig is auto-assigned via Marked-tile presence; this fixture
+    // has no Marked tiles so computedAllocation.dig stays 0 and the assertions below
+    // (nurse=0 under no-Nursery memo gate; brood inert; sum=workerCount) hold.
 
     tick(w, []);
 
@@ -1523,8 +1533,10 @@ describe('Phase 7: Integration tests', () => {
     const colony = world.colonies[colonyId]!;
 
     // Phase 10 (CTRL-06): dig is auto-assigned via need.dig from Marked tiles.
-    // Setting targetRatio is no longer the lever; the Marked tile below drives auto-dig.
-    // Plan 02 will rewrite this test against the new contract.
+    // The MarkDigTile below is now the load-bearing lever (not targetRatio). Setting
+    // forage:0/fight:0 means the eligibles loop has no forage/fight pull, so the
+    // auto-dig override (which reduces forage by 1 only when forage>0) leaves dig as
+    // the only positive-need slot — exactly one Idle ant becomes Digging per the cap.
     colony.targetRatio.forage = 0;
     colony.targetRatio.fight  = 0;
 
@@ -2976,9 +2988,14 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     tick(world, []);
     expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Open);
 
-    // Tick 2: with no Marked tiles, tickDigExecution releases ant to Idle, step 10a reassigns.
-    // Under the auto-dig contract, computedAllocation.dig returns to 0 (no Marked) and
-    // need.forage drives the assignment (ratio is forage:10).
+    // Tick 2: step 10a sees the ant still as Digging (release hasn't fired yet —
+    // tickDigExecution runs at step 10b, AFTER step 10a). Then at step 10b the dormant-
+    // digger release path flips Digging → Idle since no Marked source remains.
+    tick(world, []);
+    expect(world.ants.task[wid]).toBe(AntTask.Idle);
+
+    // Tick 3: step 10a sees the now-Idle ant; with no Marked tiles, computeDigDemand
+    // returns 0 and the canonical iteration assigns to Foraging per the {forage:10, fight:0} ratio.
     tick(world, []);
 
     // t=N outcomes

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -3224,42 +3224,6 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     expect(world.ants.task[wid]).toBe(AntTask.Nursing);
   });
 
-  it('Test 10 (WR-09): legacy SetBehaviorRatio with `dig` field migrates on replay', () => {
-    // Pre-Phase-10 v2 inputLogs (issue #15 bumped SAVE_FORMAT_VERSION 1→2;
-    // Phase 10 narrowed BehaviorRatio without bumping again per D-04). When
-    // a debug-snapshot replay tool re-executes such a log under post-Phase-10
-    // code, `SetBehaviorRatio { forage:0, dig:5, fight:0 }` (pure dig) must
-    // not silently become `{forage:0, fight:0}` (idle). The handler detects
-    // the legacy `dig` field and snaps the all-zero remainder to the
-    // DEFAULT_BEHAVIOR_RATIO {forage:10, fight:0}, mirroring
-    // migrateBehaviorRatio in platform/save.ts.
-    const { world, colonyId } = makeWorldWithColony(42);
-
-    // Legacy command with the `dig` field — cast through unknown so the
-    // typed handler accepts it for the runtime replay.
-    const legacy: SimCommand = {
-      type: 'SetBehaviorRatio',
-      colonyId,
-      ratio: { forage: 0, dig: 5, fight: 0 } as unknown as { forage: number; fight: number },
-      issuedAtTick: 0,
-    };
-    tick(world, [legacy]);
-    const colony = world.colonies[colonyId]!;
-    expect(colony.targetRatio.forage).toBe(10); // snapped from {0, _, 0}
-    expect(colony.targetRatio.fight).toBe(0);
-
-    // Counterpoint: a post-Phase-10 command with no `dig` field passes through
-    // unchanged, even when both fields are 0 (legitimate idle-slider command).
-    const modern: SimCommand = {
-      type: 'SetBehaviorRatio',
-      colonyId,
-      ratio: { forage: 0, fight: 0 },
-      issuedAtTick: 1,
-    };
-    tick(world, [modern]);
-    expect(colony.targetRatio.forage).toBe(0); // post-Phase-10 idle: no snap
-    expect(colony.targetRatio.fight).toBe(0);
-  });
 
   it('Test 8 (WR-07): dig slot reserved while digger is active → nurse not preempted by forage', () => {
     // Regression for codex P1 v2: in a 2-worker / brood-heavy / forage-only

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -117,13 +117,12 @@ describe('Step 1: command processing', () => {
     const cmd: SimCommand = {
       type: 'SetBehaviorRatio',
       colonyId: colonyId,
-      ratio: { forage: 5, dig: 3, fight: 2 },
+      ratio: { forage: 5, fight: 2 },
       issuedAtTick: 0,
     };
     tick(world, [cmd]);
     const colony = world.colonies[colonyId]!;
     expect(colony.targetRatio.forage).toBe(5);
-    expect(colony.targetRatio.dig).toBe(3);
     expect(colony.targetRatio.fight).toBe(2);
   });
 
@@ -143,7 +142,7 @@ describe('Step 1: command processing', () => {
     const cmd1: SimCommand = {
       type: 'SetBehaviorRatio',
       colonyId,
-      ratio: { forage: 10, dig: 0, fight: 0 },
+      ratio: { forage: 10, fight: 0 },
       issuedAtTick: 0,
     };
     tick(world, [cmd1]);
@@ -156,7 +155,7 @@ describe('Step 1: command processing', () => {
     const cmd2: SimCommand = {
       type: 'SetBehaviorRatio',
       colonyId,
-      ratio: { forage: 0, dig: 10, fight: 0 },
+      ratio: { forage: 0, fight: 10 },
       issuedAtTick: 1,
     };
     tick(world, [cmd2]);
@@ -173,7 +172,7 @@ describe('Step 1: command processing', () => {
     const cmd: SimCommand = {
       type: 'SetBehaviorRatio',
       colonyId,
-      ratio: { forage: -1, dig: 5, fight: 5 },
+      ratio: { forage: -1, fight: 5 },
       issuedAtTick: 0,
     };
     tick(world, [cmd]);
@@ -185,7 +184,7 @@ describe('Step 1: command processing', () => {
     const cmd: SimCommand = {
       type: 'SetBehaviorRatio',
       colonyId: 999 as ColonyId,
-      ratio: { forage: 5, dig: 5, fight: 0 },
+      ratio: { forage: 5, fight: 0 },
       issuedAtTick: 0,
     };
     expect(() => tick(world, [cmd])).not.toThrow();
@@ -232,7 +231,7 @@ describe('Step 1: command processing', () => {
       cmds.push({
         type: 'SetBehaviorRatio',
         colonyId,
-        ratio: { forage: r, dig: 0, fight: 0 },
+        ratio: { forage: r, fight: 0 },
         issuedAtTick: 0,
       });
     }
@@ -277,7 +276,7 @@ describe('Step ordering observable proofs', () => {
     const cmd: SimCommand = {
       type: 'SetBehaviorRatio',
       colonyId,
-      ratio: { forage: 0, dig: 0, fight: 0 },
+      ratio: { forage: 0, fight: 0 },
       issuedAtTick: 0,
     };
     tick(world, [cmd]);
@@ -420,7 +419,6 @@ describe('Step ordering observable proofs', () => {
     colony.computedAllocation.fight  = 0;
     colony.computedAllocation.nurse  = 0;
     colony.targetRatio.forage = 10;
-    colony.targetRatio.dig    = 0;
     colony.targetRatio.fight  = 0;
 
     // Tick 1: step 10a sees Digging (not Idle) → skipped. Step 10b tickDigExecution
@@ -477,7 +475,6 @@ describe('Step ordering observable proofs', () => {
     colony.computedAllocation.fight  = 1;
     colony.taskCensus.forage = 1;
     colony.targetRatio.forage = 0;
-    colony.targetRatio.dig    = 0;
     colony.targetRatio.fight  = 10;
 
     tick(world, []);
@@ -553,8 +550,9 @@ describe('Step ordering observable proofs', () => {
     colony.computedAllocation.dig    = 1;
     colony.computedAllocation.fight  = 0;
     colony.targetRatio.forage = 0;
-    colony.targetRatio.dig    = 10;
     colony.targetRatio.fight  = 0;
+    // Phase 10 (CTRL-06): dig is auto-assigned via need.dig, not via targetRatio.
+    // Plan 02 will rewrite this test to drive digging via Marked tile presence.
 
     tick(world, []);
 
@@ -612,7 +610,6 @@ describe('Step ordering observable proofs', () => {
 
       // targetRatio that produces {nurse:3, forage:4, dig:0, fight:3} via allocateWorkers(10, 9, ratio).
       colony.targetRatio.forage = 4;
-      colony.targetRatio.dig    = 0;
       colony.targetRatio.fight  = 3;
 
       tick(w, []);
@@ -666,8 +663,8 @@ describe('Step ordering observable proofs', () => {
       // need: forage=1, dig=2, fight=1, nurse=1 (total=5 = eligibles)
       colony.computedAllocation = { nurse: 1, forage: 2, dig: 2, fight: 1 };
       colony.targetRatio.forage = 10;
-      colony.targetRatio.dig    = 5;
       colony.targetRatio.fight  = 3;
+      // Phase 10 (CTRL-06): dig is auto-assigned; plan 02 will rewire this test.
 
       tick(w, []);
 
@@ -719,7 +716,6 @@ describe('09 reproduction-gate memo — starvation-shape regression', () => {
     // Forage-favored triangle; no chambers at all (intentional — this is the
     // pre-excavation colony state from the memo).
     colony.targetRatio.forage = 10;
-    colony.targetRatio.dig    = 0;
     colony.targetRatio.fight  = 0;
 
     tick(w, []);
@@ -757,8 +753,9 @@ describe('09 reproduction-gate memo — starvation-shape regression', () => {
     }
 
     colony.targetRatio.forage = 3;
-    colony.targetRatio.dig    = 2;
     colony.targetRatio.fight  = 0;
+    // Phase 10 (CTRL-06): dig is auto-assigned per Marked tile presence;
+    // plan 02 will rewire this test if it relies on dig allocation outcome.
 
     tick(w, []);
 
@@ -801,7 +798,6 @@ describe('09 reproduction-gate memo — starvation-shape regression', () => {
     });
 
     colony.targetRatio.forage = 10;
-    colony.targetRatio.dig    = 0;
     colony.targetRatio.fight  = 0;
 
     tick(w, []);
@@ -1526,9 +1522,10 @@ describe('Phase 7: Integration tests', () => {
     const colonyId = PLAYER_COLONY_ID as ColonyId;
     const colony = world.colonies[colonyId]!;
 
-    // Set high dig ratio so workers reassign to Digging
+    // Phase 10 (CTRL-06): dig is auto-assigned via need.dig from Marked tiles.
+    // Setting targetRatio is no longer the lever; the Marked tile below drives auto-dig.
+    // Plan 02 will rewrite this test against the new contract.
     colony.targetRatio.forage = 0;
-    colony.targetRatio.dig    = 10;
     colony.targetRatio.fight  = 0;
 
     // Mark a tile adjacent to the pre-excavated player shaft (entrance column=24,

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -12,7 +12,7 @@ import type { SimCommand } from './commands.js';
 import { initAnt } from './ant/ant-store.js';
 import { createColonyRecord } from './colony/colony-store.js';
 import { createPheromoneGrid, phGet, phSet, pheromoneGridKey } from './pheromone/pheromone-store.js';
-import { AntTask, ForagingSubState, PheromoneType, FightingSubState, ChamberType } from './enums.js';
+import { AntTask, ForagingSubState, PheromoneType, FightingSubState, ChamberType, NursingSubState } from './enums.js';
 import type { WorldState } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 import {
@@ -1533,11 +1533,14 @@ describe('Phase 7: Integration tests', () => {
     const colony = world.colonies[colonyId]!;
 
     // Phase 10 (CTRL-06): dig is auto-assigned via need.dig from Marked tiles.
-    // The MarkDigTile below is now the load-bearing lever (not targetRatio). Setting
-    // forage:0/fight:0 means the eligibles loop has no forage/fight pull, so the
-    // auto-dig override (which reduces forage by 1 only when forage>0) leaves dig as
-    // the only positive-need slot — exactly one Idle ant becomes Digging per the cap.
-    colony.targetRatio.forage = 0;
+    // The MarkDigTile below is the load-bearing lever (not targetRatio). Per
+    // D-02 LOCKED + WR-06, auto-dig carves from `computedAllocation.forage`,
+    // so a non-zero forage budget is required for dig to fire. Forage-only
+    // ratio guarantees the carve reserves exactly one slot for dig (forage
+    // budget = N − 1, dig budget = 1) on the activation tick; subsequent
+    // ticks see `computeDigDemand` return 0 because an ant is already
+    // Digging, so the strict 1-cap holds across the 10-tick window.
+    colony.targetRatio.forage = 10;
     colony.targetRatio.fight  = 0;
 
     // Mark a tile adjacent to the pre-excavated player shaft (entrance column=24,
@@ -3062,5 +3065,109 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     let playerDiggingT1 = 0;
     for (const wid of playerColony.workers) if (world.ants.task[wid] === AntTask.Digging) playerDiggingT1 += 1;
     expect(playerDiggingT1).toBe(0);
+  });
+
+  it('Test 6 (WR-06): nurse cap eats the only worker → auto-dig waits, nurse not preempted', () => {
+    // Regression for the codex P1 finding: in a brood-heavy 1-worker colony,
+    // the nurse cap (ceil(1/4)=1) eats the entire pool, leaving forage budget = 0.
+    // Without WR-06, the auto-dig override would still set computedAllocation.dig=1
+    // and the forage→dig→fight→nurse iteration would assign the only Idle ant to
+    // Digging — starving nurse. With the gate, dig is suppressed and nurse wins.
+    //
+    // The load-bearing setup here is brood + Nursery + workerCount=1 (driving the
+    // cap); targetRatio is irrelevant (the cap saturates first and forage_share
+    // would be 0 even with forage=10).
+    const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    const colony = world.colonies[colonyId]!;
+    const underground = world.undergroundGrids[colonyId]!;
+
+    colony.workerCount = 1;
+    const wid = allocateEntityId(world);
+    initAnt(world.ants, wid, {
+      colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
+      task: AntTask.Idle, subTask: 0,
+    });
+    world.ants.zone[wid] = 1;
+    colony.workers.push(wid);
+
+    for (let e = 0; e < 30; e++) {
+      const lid = allocateEntityId(world);
+      initAnt(world.ants, lid, { colonyId, posX: 100, posY: 100, task: AntTask.Idle, subTask: 0, speed: 0 });
+      colony.larvae.push(lid);
+      colony.larvaeCount += 1;
+    }
+    colony.chambers.push({
+      chamberId: 9100, chamberType: ChamberType.Nursery,
+      foodStored: 0, posX: 0, posY: 0, width: 2, height: 2,
+    });
+
+    // t=0 preconditions
+    expect(colony.workers.length).toBe(1);
+    expect(world.ants.task[wid]).toBe(AntTask.Idle);
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Solid);
+
+    // Mark a tile + tick. allocateWorkers will compute nurse=1, forage=0; the
+    // auto-dig override must observe forage=0 and suppress dig demand.
+    const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 25, tileY: 1, issuedAtTick: 0 };
+    tick(world, [cmd]);
+
+    // t=N outcomes — nurse cap is the actual cause; explicitly assert it.
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Marked); // Mark persists — waiting
+    expect(colony.computedAllocation.nurse).toBe(1);
+    expect(colony.computedAllocation.forage).toBe(0); // <- nurse cap, not targetRatio, drove this
+    expect(colony.computedAllocation.dig).toBe(0); // suppressed (no forage slot to carve)
+    expect(world.ants.task[wid]).toBe(AntTask.Nursing); // nurse won, not dig
+    expect(world.ants.subTask[wid]).toBe(NursingSubState.MovingToBrood); // freshly assigned, not just inherited
+  });
+
+  it('Test 7 (WR-06): slider-to-fight (forage:0, no brood) → auto-dig waits, ratio respected', () => {
+    // Symmetric regression: when the player slams the 1-D slider all the way to
+    // Fight ({forage:0, fight:10}) with no brood, allocation = {nurse:0, forage:0,
+    // dig:0, fight:N}. Per D-02 LOCKED ("carve from forage"), the WR-06 gate
+    // treats this as a scarcity-wait — Marks sit until the player widens the
+    // forage band. This pins the gate's blast radius beyond the codex P1 case.
+    const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    const colony = world.colonies[colonyId]!;
+    const underground = world.undergroundGrids[colonyId]!;
+
+    // 3 Idle workers, no brood, no Nursery → nurse=0, forage=0, fight=3.
+    colony.workerCount = 3;
+    const widList: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const wid = allocateEntityId(world);
+      initAnt(world.ants, wid, {
+        colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
+        task: AntTask.Idle, subTask: 0,
+      });
+      world.ants.zone[wid] = 1;
+      colony.workers.push(wid);
+      widList.push(wid);
+    }
+
+    colony.targetRatio.forage = 0;
+    colony.targetRatio.fight  = 10;
+
+    // t=0 preconditions
+    let initialIdle = 0;
+    for (const id of widList) if (world.ants.task[id] === AntTask.Idle) initialIdle += 1;
+    expect(initialIdle).toBe(3);
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Solid);
+
+    const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 25, tileY: 1, issuedAtTick: 0 };
+    tick(world, [cmd]);
+
+    // t=N outcomes — Mark waits, all 3 workers go to Fighting (player ratio respected).
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Marked);
+    expect(colony.computedAllocation.forage).toBe(0);
+    expect(colony.computedAllocation.fight).toBe(3);
+    expect(colony.computedAllocation.dig).toBe(0); // suppressed under D-02 carve-from-forage
+    let diggingCount = 0;
+    let fightingCount = 0;
+    for (const id of widList) {
+      if (world.ants.task[id] === AntTask.Digging) diggingCount += 1;
+      if (world.ants.task[id] === AntTask.Fighting) fightingCount += 1;
+    }
+    expect(diggingCount).toBe(0);
+    expect(fightingCount).toBe(3);
   });
 });

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -3124,17 +3124,16 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     expect(world.ants.subTask[wid]).toBe(NursingSubState.MovingToBrood); // freshly assigned, not just inherited
   });
 
-  it('Test 7 (WR-06): slider-to-fight (forage:0, no brood) → auto-dig waits, ratio respected', () => {
-    // Symmetric regression: when the player slams the 1-D slider all the way to
-    // Fight ({forage:0, fight:10}) with no brood, allocation = {nurse:0, forage:0,
-    // dig:0, fight:N}. Per D-02 LOCKED ("carve from forage"), the WR-06 gate
-    // treats this as a scarcity-wait — Marks sit until the player widens the
-    // forage band. This pins the gate's blast radius beyond the codex P1 case.
+  it('Test 7 (WR-08): slider-to-fight (forage:0, no brood) → dig carves from fight, issue #13 honored', () => {
+    // When the player slams the 1-D slider all the way to Fight ({forage:0,
+    // fight:10}) with no brood, allocation = {nurse:0, forage:0, dig:0,
+    // fight:N}. Issue #13's promise ("auto-assign one digger when a Mark
+    // exists and an ant is Idle") still holds because the WR-08 carve falls
+    // back to fight when forage is empty. nurse is still never carved.
     const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
     const colony = world.colonies[colonyId]!;
     const underground = world.undergroundGrids[colonyId]!;
 
-    // 3 Idle workers, no brood, no Nursery → nurse=0, forage=0, fight=3.
     colony.workerCount = 3;
     const widList: number[] = [];
     for (let i = 0; i < 3; i++) {
@@ -3151,7 +3150,6 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     colony.targetRatio.forage = 0;
     colony.targetRatio.fight  = 10;
 
-    // t=0 preconditions
     let initialIdle = 0;
     for (const id of widList) if (world.ants.task[id] === AntTask.Idle) initialIdle += 1;
     expect(initialIdle).toBe(3);
@@ -3160,19 +3158,107 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 25, tileY: 1, issuedAtTick: 0 };
     tick(world, [cmd]);
 
-    // t=N outcomes — Mark waits, all 3 workers go to Fighting (player ratio respected).
+    // t=N outcomes — Mark dug, 1 worker Digging, 2 Fighting (carve from fight).
     expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Marked);
     expect(colony.computedAllocation.forage).toBe(0);
-    expect(colony.computedAllocation.fight).toBe(3);
-    expect(colony.computedAllocation.dig).toBe(0); // suppressed under D-02 carve-from-forage
+    expect(colony.computedAllocation.fight).toBe(3); // canonical post-allocation; carve is local
+    expect(colony.computedAllocation.dig).toBe(1);
     let diggingCount = 0;
     let fightingCount = 0;
     for (const id of widList) {
       if (world.ants.task[id] === AntTask.Digging) diggingCount += 1;
       if (world.ants.task[id] === AntTask.Fighting) fightingCount += 1;
     }
-    expect(diggingCount).toBe(0);
-    expect(fightingCount).toBe(3);
+    expect(diggingCount).toBe(1);
+    expect(fightingCount).toBe(2);
+  });
+
+  it('Test 9 (WR-08): all-nurse colony (forage=fight=0) → auto-dig genuinely waits', () => {
+    // Counterpoint to Test 7 — and a future-regression guard against any
+    // attempt to carve from nurse when both ratio-driven roles are empty.
+    // When forage AND fight are both 0 (e.g., 1-worker brood-heavy colony
+    // where the nurse cap pinned the only worker to nurse), there is no
+    // ratio-driven slot to carve from. nurse is never carved (CLNY-09),
+    // so dig waits — same scarcity-wait philosophy as no-Idle-ant case.
+    // This case passes under both the old `forage > 0` gate and the new
+    // forage→fight rule; its job is to lock in the "never carve from nurse"
+    // floor so a future contributor doesn't extend the fallback chain.
+    const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    const colony = world.colonies[colonyId]!;
+    const underground = world.undergroundGrids[colonyId]!;
+
+    // 1 worker, brood-heavy + Nursery so nurse cap (ceil(1/4)=1) pins everything.
+    colony.workerCount = 1;
+    const wid = allocateEntityId(world);
+    initAnt(world.ants, wid, {
+      colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
+      task: AntTask.Idle, subTask: 0,
+    });
+    world.ants.zone[wid] = 1;
+    colony.workers.push(wid);
+
+    for (let e = 0; e < 30; e++) {
+      const lid = allocateEntityId(world);
+      initAnt(world.ants, lid, { colonyId, posX: 100, posY: 100, task: AntTask.Idle, subTask: 0, speed: 0 });
+      colony.larvae.push(lid);
+      colony.larvaeCount += 1;
+    }
+    colony.chambers.push({
+      chamberId: 9300, chamberType: ChamberType.Nursery,
+      foodStored: 0, posX: 0, posY: 0, width: 2, height: 2,
+    });
+
+    // Slider-to-fight; combined with the nurse cap this leaves zero ratio
+    // budget for any carve — the all-nurse case.
+    colony.targetRatio.forage = 0;
+    colony.targetRatio.fight  = 10;
+
+    const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 25, tileY: 1, issuedAtTick: 0 };
+    tick(world, [cmd]);
+
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Marked); // Mark waits
+    expect(colony.computedAllocation.nurse).toBe(1);
+    expect(colony.computedAllocation.forage).toBe(0);
+    expect(colony.computedAllocation.fight).toBe(0); // nurse cap ate available
+    expect(colony.computedAllocation.dig).toBe(0); // no ratio-driven slot to carve
+    expect(world.ants.task[wid]).toBe(AntTask.Nursing);
+  });
+
+  it('Test 10 (WR-09): legacy SetBehaviorRatio with `dig` field migrates on replay', () => {
+    // Pre-Phase-10 v2 inputLogs (issue #15 bumped SAVE_FORMAT_VERSION 1→2;
+    // Phase 10 narrowed BehaviorRatio without bumping again per D-04). When
+    // a debug-snapshot replay tool re-executes such a log under post-Phase-10
+    // code, `SetBehaviorRatio { forage:0, dig:5, fight:0 }` (pure dig) must
+    // not silently become `{forage:0, fight:0}` (idle). The handler detects
+    // the legacy `dig` field and snaps the all-zero remainder to the
+    // DEFAULT_BEHAVIOR_RATIO {forage:10, fight:0}, mirroring
+    // migrateBehaviorRatio in platform/save.ts.
+    const { world, colonyId } = makeWorldWithColony(42);
+
+    // Legacy command with the `dig` field — cast through unknown so the
+    // typed handler accepts it for the runtime replay.
+    const legacy: SimCommand = {
+      type: 'SetBehaviorRatio',
+      colonyId,
+      ratio: { forage: 0, dig: 5, fight: 0 } as unknown as { forage: number; fight: number },
+      issuedAtTick: 0,
+    };
+    tick(world, [legacy]);
+    const colony = world.colonies[colonyId]!;
+    expect(colony.targetRatio.forage).toBe(10); // snapped from {0, _, 0}
+    expect(colony.targetRatio.fight).toBe(0);
+
+    // Counterpoint: a post-Phase-10 command with no `dig` field passes through
+    // unchanged, even when both fields are 0 (legitimate idle-slider command).
+    const modern: SimCommand = {
+      type: 'SetBehaviorRatio',
+      colonyId,
+      ratio: { forage: 0, fight: 0 },
+      issuedAtTick: 1,
+    };
+    tick(world, [modern]);
+    expect(colony.targetRatio.forage).toBe(0); // post-Phase-10 idle: no snap
+    expect(colony.targetRatio.fight).toBe(0);
   });
 
   it('Test 8 (WR-07): dig slot reserved while digger is active → nurse not preempted by forage', () => {

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -2735,3 +2735,315 @@ describe('resetFlowFieldCaches — cross-world isolation', () => {
     resetFlowFieldCaches();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 10 / CTRL-06 — auto-dig demand-driven role (D-02 LOCKED)
+// ---------------------------------------------------------------------------
+//
+// These tests pin the contract added in Plan 10-02 (and locked by CONTEXT.md D-02):
+//
+//   - need.dig = (Marked tile count > 0 && no ant currently Digging) ? 1 : 0
+//   - When need.dig > 0 and at least one ant is Idle, step 10a auto-assigns
+//     exactly ONE Idle ant to AntTask.Digging (strict 1-digger cap).
+//   - When dig work exists but no ant is Idle, the simulation WAITS — no
+//     preemption of foragers/fighters.
+//   - When a Digging ant finishes (tile clears or it dies), it transitions to
+//     Idle; step 10a next tick reassigns it (auto-dig if more Marked tiles,
+//     else forage/fight per ratio).
+//   - The AI colony uses the SAME path — there is no isPlayer / colonyId
+//     branching in the auto-dig logic (CLNY-08 invariant).
+//
+// Discipline (per Plan 09.1-03 conventions): every test asserts BOTH t=0
+// preconditions (so a fixture-drift pass doesn't masquerade as a green) AND
+// t=N outcomes (the specific behavioral claim). Diagnostic for "feature missing
+// vs. feature broken" is encoded into the precondition asserts.
+// ---------------------------------------------------------------------------
+
+describe('Phase 10 / CTRL-06 auto-dig', () => {
+  /**
+   * Build a single-colony world with an underground grid pre-shaped so that
+   * (24, 1) is Open (mirrors the entrance shaft created by createScenario but
+   * runs against makeWorldWithColony for fast setup). The tile (25, 1) starts
+   * Solid; tests can MarkDigTile to flip it to Marked.
+   */
+  function makeWorldWithUndergroundForAutoDig(seed = 42): {
+    world: WorldState;
+    colonyId: ColonyId;
+    queenId: number;
+  } {
+    const { world, colonyId, queenId } = makeWorldWithColony(seed);
+    const colony = world.colonies[colonyId]!;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
+    const ug = createUndergroundGrid(UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
+    // Open the entrance shaft so a Marked tile at (25, y) has a reachable Open
+    // neighbor for the BFS flow field; matches the shape used by SC 1.
+    ug.data[0 * UNDERGROUND_GRID_WIDTH + 24] = UndergroundTileState.Open;
+    ug.data[1 * UNDERGROUND_GRID_WIDTH + 24] = UndergroundTileState.Open;
+    world.undergroundGrids[colonyId] = ug;
+    return { world, colonyId, queenId };
+  }
+
+  it('Test 1: demand activation — Marked tile + Idle ant → ant becomes Digging within 1 tick', () => {
+    const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    const colony = world.colonies[colonyId]!;
+    const underground = world.undergroundGrids[colonyId]!;
+
+    // Add 3 Idle workers (one will be picked; the strict cap holds the others).
+    colony.workerCount = 3;
+    for (let i = 0; i < 3; i++) {
+      const wid = allocateEntityId(world);
+      initAnt(world.ants, wid, { colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT, task: AntTask.Idle, subTask: 0 });
+      world.ants.zone[wid] = 1; // Underground; matches the Open shaft cell
+      colony.workers.push(wid);
+    }
+
+    // Forage-only ratio so non-dig demand is 0; auto-dig is the only signal.
+    colony.targetRatio.forage = 10;
+    colony.targetRatio.fight  = 0;
+
+    // t=0 preconditions
+    expect(colony.workers.length).toBe(3);
+    let initialIdle = 0;
+    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Idle) initialIdle += 1;
+    expect(initialIdle).toBe(3);
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Solid);
+    let initialDigging = 0;
+    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) initialDigging += 1;
+    expect(initialDigging).toBe(0);
+    expect(colony.computedAllocation.dig).toBe(0);
+
+    // Mark a tile adjacent to the Open shaft.
+    const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 25, tileY: 1, issuedAtTick: 0 };
+    tick(world, [cmd]);
+
+    // t=N outcomes
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Marked);
+    expect(colony.computedAllocation.dig).toBe(1);
+    let diggingCount = 0;
+    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) diggingCount += 1;
+    expect(diggingCount).toBeGreaterThanOrEqual(1);
+    // Strict cap holds even on the activation tick.
+    expect(diggingCount).toBe(1);
+  });
+
+  it('Test 2: 1-digger cap — 5 Marked tiles + 5 Idle ants → exactly 1 Digging at t=1 and t=2', () => {
+    const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    const colony = world.colonies[colonyId]!;
+    const underground = world.undergroundGrids[colonyId]!;
+
+    colony.workerCount = 5;
+    for (let i = 0; i < 5; i++) {
+      const wid = allocateEntityId(world);
+      initAnt(world.ants, wid, { colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT, task: AntTask.Idle, subTask: 0 });
+      world.ants.zone[wid] = 1;
+      colony.workers.push(wid);
+    }
+    colony.targetRatio.forage = 10;
+    colony.targetRatio.fight  = 0;
+
+    // Mark 5 tiles in a column adjacent to the Open shaft.
+    const markCmds: SimCommand[] = [];
+    for (let dy = 1; dy <= 5; dy++) {
+      markCmds.push({ type: 'MarkDigTile', colonyId, tileX: 25, tileY: dy, issuedAtTick: 0 });
+    }
+
+    // t=0 preconditions
+    expect(colony.workers.length).toBe(5);
+    for (let dy = 1; dy <= 5; dy++) {
+      expect(ugGet(underground, 25, dy)).toBe(UndergroundTileState.Solid);
+    }
+    let initialDigging = 0;
+    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) initialDigging += 1;
+    expect(initialDigging).toBe(0);
+
+    tick(world, markCmds);
+
+    // t=1: cap holds — exactly 1 ant Digging despite 5 Marked tiles + 5 Idle.
+    let markedCount = 0;
+    for (let dy = 1; dy <= 5; dy++) {
+      if (ugGet(underground, 25, dy) === UndergroundTileState.Marked) markedCount += 1;
+    }
+    expect(markedCount).toBe(5);
+    expect(colony.computedAllocation.dig).toBe(1);
+    let digT1 = 0;
+    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) digT1 += 1;
+    expect(digT1).toBe(1);
+
+    tick(world, []);
+
+    // t=2: still exactly 1 — cap holds across ticks while a digger is active.
+    let digT2 = 0;
+    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) digT2 += 1;
+    expect(digT2).toBe(1);
+    expect(colony.computedAllocation.dig).toBe(0); // a digger is active → demand satisfied
+  });
+
+  it('Test 3: scarcity wait — Marked tile + 0 Idle ants → 0 Digging; foragers not preempted', () => {
+    const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    const colony = world.colonies[colonyId]!;
+    const underground = world.undergroundGrids[colonyId]!;
+
+    // 3 mid-cycle foragers carrying food (not Idle, not eligible for reassignment).
+    colony.workerCount = 3;
+    const foragerIds: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const wid = allocateEntityId(world);
+      initAnt(world.ants, wid, {
+        colonyId,
+        posX: 24 << FP_SHIFT,
+        posY: 1 << FP_SHIFT,
+        task: AntTask.Foraging,
+        subTask: ForagingSubState.CarryingFood,
+      });
+      world.ants.zone[wid] = 1;
+      world.ants.foodCarrying[wid] = 256; // mid-cycle; PRD §7c — not idle-checkpoint eligible
+      colony.workers.push(wid);
+      foragerIds.push(wid);
+    }
+    colony.targetRatio.forage = 10;
+    colony.targetRatio.fight  = 0;
+    // Pre-populate computedAllocation so step 10a doesn't try to reassign these.
+    colony.computedAllocation = { nurse: 0, forage: 3, dig: 0, fight: 0 };
+
+    // t=0 preconditions
+    let initialIdle = 0;
+    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Idle) initialIdle += 1;
+    expect(initialIdle).toBe(0);
+    let initialDigging = 0;
+    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) initialDigging += 1;
+    expect(initialDigging).toBe(0);
+    // Snapshot foragers' tasks at t=0 — they must NOT be preempted at t=N.
+    const t0Tasks: Record<number, number> = {};
+    for (const wid of foragerIds) t0Tasks[wid] = world.ants.task[wid]!;
+
+    const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 25, tileY: 1, issuedAtTick: 0 };
+    tick(world, [cmd]);
+
+    // Run 4 more ticks — wait policy: dig demand persists, no auto-assignment.
+    for (let i = 0; i < 4; i++) tick(world, []);
+
+    // t=N=5 outcomes
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Marked); // tile still Marked (nobody reached it)
+    let diggingCount = 0;
+    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) diggingCount += 1;
+    expect(diggingCount).toBe(0);
+    // No forager was preempted to dig.
+    for (const wid of foragerIds) {
+      expect(world.ants.task[wid]).toBe(t0Tasks[wid]);
+    }
+    // Demand check fired every tick — colony.computedAllocation.dig is 1 (Marked tile present, no ant Digging).
+    expect(colony.computedAllocation.dig).toBe(1);
+  });
+
+  it('Test 4: return-to-Idle reassign — Digging ant finishes → next tick goes Foraging (no more Marked)', () => {
+    const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    const colony = world.colonies[colonyId]!;
+    const underground = world.undergroundGrids[colonyId]!;
+
+    // Place a worker already in Digging+Excavating ON a BeingDug tile with digTicksRemaining=1.
+    // After 1 tick, tickDigExecution opens the tile and flips back to MovingToTile.
+    // With no remaining Marked tiles, the next tick releases ant to Idle, and step 10a
+    // reassigns to Foraging per the {forage:10, fight:0} ratio.
+    colony.workerCount = 1;
+    const wid = allocateEntityId(world);
+    initAnt(world.ants, wid, {
+      colonyId,
+      posX: 25 << FP_SHIFT,
+      posY: 1 << FP_SHIFT,
+      task: AntTask.Digging,
+      subTask: DiggingSubState.Excavating,
+    });
+    world.ants.zone[wid] = 1;
+    world.ants.digTileX[wid] = 25;
+    world.ants.digTileY[wid] = 1;
+    world.ants.digTicksRemaining[wid] = 1;
+    underground.data[1 * UNDERGROUND_GRID_WIDTH + 25] = UndergroundTileState.BeingDug;
+    colony.workers.push(wid);
+    colony.digFlowFieldDirty = true;
+
+    colony.targetRatio.forage = 10;
+    colony.targetRatio.fight  = 0;
+
+    // t=0 preconditions
+    expect(world.ants.task[wid]).toBe(AntTask.Digging);
+    expect(world.ants.subTask[wid]).toBe(DiggingSubState.Excavating);
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.BeingDug);
+    expect(world.ants.digTicksRemaining[wid]).toBe(1);
+
+    // Tick 1: excavation completes (digTicksRemaining 1→0), tile becomes Open, ant → MovingToTile.
+    tick(world, []);
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Open);
+
+    // Tick 2: with no Marked tiles, tickDigExecution releases ant to Idle, step 10a reassigns.
+    // Under the auto-dig contract, computedAllocation.dig returns to 0 (no Marked) and
+    // need.forage drives the assignment (ratio is forage:10).
+    tick(world, []);
+
+    // t=N outcomes
+    expect(world.ants.task[wid]).toBe(AntTask.Foraging);
+    expect(colony.computedAllocation.dig).toBe(0);
+  });
+
+  it('Test 5: AI parity — Marked tile + Idle ant in AI colony → AI ant becomes Digging via the same path', () => {
+    // CLNY-08 self-check: the auto-dig path is colony-symmetric. A MarkDigTileCommand with
+    // colonyId === ENEMY_COLONY_ID drives an AI ant into Digging through the SAME step 10a
+    // wire that the player uses. No isPlayer / colonyId branching.
+    const world = createScenario(42);
+    const aiColonyId = ENEMY_COLONY_ID as ColonyId;
+    const playerColonyId = PLAYER_COLONY_ID as ColonyId;
+    const aiColony = world.colonies[aiColonyId]!;
+    const aiUg = world.undergroundGrids[aiColonyId]!;
+
+    // Use a Marked tile adjacent to the AI's pre-excavated entrance shaft. createScenario
+    // opens the entrance shaft for both colonies the same way (see scenario.ts:167-168).
+    // We pick a tile reachable from the AI's Open region. ENEMY_START_X is the shaft column.
+    // Any tile (col±1, row 1) where col is the AI shaft is reachable; we use a fixed
+    // offset that sits next to the shaft and flip Solid→Marked via MarkDigTile.
+    let aiShaftCol = -1;
+    for (let x = 0; x < UNDERGROUND_GRID_WIDTH; x++) {
+      if (aiUg.data[1 * UNDERGROUND_GRID_WIDTH + x] === UndergroundTileState.Open) {
+        aiShaftCol = x;
+        break;
+      }
+    }
+    expect(aiShaftCol).toBeGreaterThanOrEqual(0); // sanity: scenario.ts opened a shaft
+    const markX = aiShaftCol + 1;
+    const markY = 1;
+    expect(ugGet(aiUg, markX, markY)).toBe(UndergroundTileState.Solid);
+
+    // Force AI workers to be Idle and underground at the shaft so they can pick up dig work.
+    // STARTING_WORKERS spawn surface-side; for this test we just relocate one.
+    expect(aiColony.workers.length).toBeGreaterThan(0);
+    const aiWorkerId = aiColony.workers[0]!;
+    world.ants.task[aiWorkerId] = AntTask.Idle;
+    world.ants.subTask[aiWorkerId] = 0;
+    world.ants.posX[aiWorkerId] = aiShaftCol << FP_SHIFT;
+    world.ants.posY[aiWorkerId] = 1 << FP_SHIFT;
+    world.ants.zone[aiWorkerId] = 1; // Underground — needed for tickDigExecution claim path
+
+    // t=0 preconditions
+    let aiDiggingT0 = 0;
+    for (const wid of aiColony.workers) if (world.ants.task[wid] === AntTask.Digging) aiDiggingT0 += 1;
+    expect(aiDiggingT0).toBe(0);
+    expect(world.ants.task[aiWorkerId]).toBe(AntTask.Idle);
+
+    // Issue MarkDigTile on the AI colony — same command surface as the player.
+    const cmd: SimCommand = { type: 'MarkDigTile', colonyId: aiColonyId, tileX: markX, tileY: markY, issuedAtTick: 0 };
+    tick(world, [cmd]);
+
+    // t=N outcomes — AI colony has exactly 1 Digging ant via the auto-dig path.
+    expect(ugGet(aiUg, markX, markY)).toBe(UndergroundTileState.Marked);
+    expect(aiColony.computedAllocation.dig).toBe(1);
+    let aiDiggingT1 = 0;
+    for (const wid of aiColony.workers) if (world.ants.task[wid] === AntTask.Digging) aiDiggingT1 += 1;
+    expect(aiDiggingT1).toBe(1);
+
+    // Player colony got NO Digging ants (no Mark in player colony) — proves the path is colony-scoped.
+    const playerColony = world.colonies[playerColonyId]!;
+    let playerDiggingT1 = 0;
+    for (const wid of playerColony.workers) if (world.ants.task[wid] === AntTask.Digging) playerDiggingT1 += 1;
+    expect(playerDiggingT1).toBe(0);
+  });
+});

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -2892,7 +2892,11 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     let digT2 = 0;
     for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) digT2 += 1;
     expect(digT2).toBe(1);
-    expect(colony.computedAllocation.dig).toBe(0); // a digger is active → demand satisfied
+    // WR-07: slot stays reserved (dig=1) while a digger is active so the
+    // forage carve persists across ticks; without the reservation, the
+    // canonical iteration would over-book forage/fight and starve nurse
+    // for the duration of every dig job (codex P1 v2).
+    expect(colony.computedAllocation.dig).toBe(1);
   });
 
   it('Test 3: scarcity wait — Marked tile + 0 Idle ants → 0 Digging; foragers not preempted', () => {
@@ -3169,5 +3173,75 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     }
     expect(diggingCount).toBe(0);
     expect(fightingCount).toBe(3);
+  });
+
+  it('Test 8 (WR-07): dig slot reserved while digger is active → nurse not preempted by forage', () => {
+    // Regression for codex P1 v2: in a 2-worker / brood-heavy / forage-only
+    // colony with one ant actively excavating, the second (Idle) ant must
+    // become a nurse, not a forager. allocateWorkers gives {nurse:1, forage:1,
+    // fight:0}; without WR-07 the carve disappears mid-dig (rawDigDemand=0
+    // under the 1-cap) and the forage→…→nurse iteration assigns the Idle
+    // ant to Foraging — starving nurse for the entire dig duration. WR-07
+    // holds digDemand=1 while actualDig>0, preserving the carve.
+    const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    const colony = world.colonies[colonyId]!;
+    const underground = world.undergroundGrids[colonyId]!;
+
+    // Worker A: actively excavating with a long countdown so the dig persists
+    // across the tick under test.
+    colony.workerCount = 2;
+    const widDigger = allocateEntityId(world);
+    initAnt(world.ants, widDigger, {
+      colonyId, posX: 25 << FP_SHIFT, posY: 1 << FP_SHIFT,
+      task: AntTask.Digging, subTask: DiggingSubState.Excavating,
+    });
+    world.ants.zone[widDigger] = 1;
+    world.ants.digTileX[widDigger] = 25;
+    world.ants.digTileY[widDigger] = 1;
+    world.ants.digTicksRemaining[widDigger] = 10;
+    underground.data[1 * UNDERGROUND_GRID_WIDTH + 25] = UndergroundTileState.BeingDug;
+    colony.workers.push(widDigger);
+    colony.digFlowFieldDirty = true;
+
+    // Worker B: Idle, the candidate for nurse vs forage.
+    const widIdle = allocateEntityId(world);
+    initAnt(world.ants, widIdle, {
+      colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
+      task: AntTask.Idle, subTask: 0,
+    });
+    world.ants.zone[widIdle] = 1;
+    colony.workers.push(widIdle);
+
+    // Brood + Nursery so nurse=1, available=1, allocation={nurse:1, forage:1}.
+    for (let e = 0; e < 30; e++) {
+      const lid = allocateEntityId(world);
+      initAnt(world.ants, lid, { colonyId, posX: 100, posY: 100, task: AntTask.Idle, subTask: 0, speed: 0 });
+      colony.larvae.push(lid);
+      colony.larvaeCount += 1;
+    }
+    colony.chambers.push({
+      chamberId: 9200, chamberType: ChamberType.Nursery,
+      foodStored: 0, posX: 0, posY: 0, width: 2, height: 2,
+    });
+
+    colony.targetRatio.forage = 10;
+    colony.targetRatio.fight  = 0;
+
+    // t=0 preconditions
+    expect(world.ants.task[widDigger]).toBe(AntTask.Digging);
+    expect(world.ants.task[widIdle]).toBe(AntTask.Idle);
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.BeingDug);
+    expect(world.ants.digTicksRemaining[widDigger]).toBe(10);
+
+    tick(world, []);
+
+    // t=N outcomes — digger persists, idle ant goes to Nursing (not Foraging).
+    expect(world.ants.task[widDigger]).toBe(AntTask.Digging);
+    expect(world.ants.digTicksRemaining[widDigger]).toBe(9); // step 10b decremented
+    expect(colony.computedAllocation.nurse).toBe(1);
+    expect(colony.computedAllocation.forage).toBe(1); // canonical post-allocation; carve is local
+    expect(colony.computedAllocation.dig).toBe(1); // slot reserved while digger active
+    expect(world.ants.task[widIdle]).toBe(AntTask.Nursing);
+    expect(world.ants.subTask[widIdle]).toBe(NursingSubState.MovingToBrood);
   });
 });

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -3173,6 +3173,57 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     expect(fightingCount).toBe(2);
   });
 
+  it('Test 10 (WR-11): zero-ratio {forage:0, fight:0} with Idle ants → dig fires (CTRL-06 honored without a carve source)', () => {
+    // codex P2 follow-up to PR #26: WR-10 leaves {forage:0, fight:0} as a
+    // valid post-Phase-10 targetRatio (snap-to-default only fires for
+    // legacy/malformed inputs). With both ratio-driven roles at 0 there is
+    // nothing to carve from, but the unallocated remainder
+    // (workerCount - nurseCount) sits Idle. Without WR-11 the CTRL-06
+    // promise — "assign one digger when a Mark exists and an ant is Idle" —
+    // silently breaks. WR-11 fires digDemand directly when Idle ants exist
+    // (workerCount > nurseCount), keeping CLNY-09 nurse intact.
+    const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    const colony = world.colonies[colonyId]!;
+    const underground = world.undergroundGrids[colonyId]!;
+
+    // 3 workers, no brood — auto-nurse stays at 0 so all 3 are Idle.
+    colony.workerCount = 3;
+    const widList: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const wid = allocateEntityId(world);
+      initAnt(world.ants, wid, {
+        colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
+        task: AntTask.Idle, subTask: 0,
+      });
+      world.ants.zone[wid] = 1;
+      colony.workers.push(wid);
+      widList.push(wid);
+    }
+
+    // Valid post-Phase-10 zero-ratio. WR-10 keeps this as-is (the snap only
+    // catches legacy {forage:0, dig:N, fight:0} inputs).
+    colony.targetRatio.forage = 0;
+    colony.targetRatio.fight  = 0;
+
+    const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 25, tileY: 1, issuedAtTick: 0 };
+    tick(world, [cmd]);
+
+    // CTRL-06 honored — exactly one ant Digging despite zero ratio budget.
+    expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Marked);
+    expect(colony.computedAllocation.nurse).toBe(0);
+    expect(colony.computedAllocation.forage).toBe(0);
+    expect(colony.computedAllocation.fight).toBe(0);
+    expect(colony.computedAllocation.dig).toBe(1);
+    let diggingCount = 0;
+    let idleCount    = 0;
+    for (const id of widList) {
+      if (world.ants.task[id] === AntTask.Digging) diggingCount += 1;
+      if (world.ants.task[id] === AntTask.Idle)    idleCount    += 1;
+    }
+    expect(diggingCount).toBe(1);
+    expect(idleCount).toBe(2); // remaining Idle ants stay Idle (no other role demands)
+  });
+
   it('Test 9 (WR-08): all-nurse colony (forage=fight=0) → auto-dig genuinely waits', () => {
     // Counterpoint to Test 7 — and a future-regression guard against any
     // attempt to carve from nurse when both ratio-driven roles are empty.

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -635,10 +635,30 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // is Idle, the eligibles loop simply has nothing to assign — Marked tiles wait
     // until an ant naturally goes Idle. Foragers/fighters mid-cycle are NOT preempted.
     // The forage carve is bookkeeping only when no Idle ants are present.
+    //
+    // WR-06: dig is only honored when a forage slot exists to carve from. D-02
+    // LOCKED ties the carve specifically to `computedAllocation.forage`, so when
+    // forage is 0 we treat the situation as a scarcity-wait. Two reachable
+    // examples, both equally suppressed by the same gate:
+    //
+    //   (a) brood-heavy nurse cap (codex P1): {forage:0, fight:0, nurse:1, 1
+    //       worker}. Without the gate, the forage→dig→fight→nurse iteration
+    //       would steal the only Idle ant from nurse and break the CLNY-09
+    //       nurse carveout invariant.
+    //   (b) slider-to-fight (no brood): player sets {forage:0, fight:10},
+    //       allocation becomes {nurse:0, forage:0, dig:0, fight:N}. Without
+    //       the gate, dig would steal from the player's fight ratio. Per
+    //       D-02 ("carve from forage"), the Mark waits until the player
+    //       widens the forage band — symmetric with the no-Idle-ant case
+    //       described above.
+    //
+    // Both cases follow the same rule: auto-dig consumes from forage's slack;
+    // when forage has no slack, auto-dig waits.
     const undergroundGrid10a = world.undergroundGrids[colony.colonyId];
-    const digDemand = undergroundGrid10a !== undefined
+    const rawDigDemand = undergroundGrid10a !== undefined
       ? computeDigDemand(colony, undergroundGrid10a, world.ants)
       : 0;
+    const digDemand = (rawDigDemand > 0 && colony.computedAllocation.forage > 0) ? 1 : 0;
     colony.computedAllocation.dig = digDemand;
     // WR-02: carve a forage slot LOCALLY so need.forage budgets one fewer
     // forager when a digger is needed, but DO NOT mutate
@@ -650,7 +670,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // identical to the prior `computedAllocation.forage - actualForage`
     // because the in-place decrement was an algebraic equivalent of this
     // local subtraction.
-    const carvedForage = (digDemand > 0 && colony.computedAllocation.forage > 0)
+    const carvedForage = digDemand > 0
       ? colony.computedAllocation.forage - 1
       : colony.computedAllocation.forage;
 

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -211,7 +211,11 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
             nextFight  = 0;
           }
         }
-        // Validate ratio fields: any negative weight rejects the command.
+        // Validate ratio fields: reject NaN, +/-Infinity, and negatives.
+        // `NaN < 0` is false, so the negative-only check would let NaN poison
+        // colony.targetRatio and contaminate every downstream allocateWorkers
+        // call (mirrors the NaN guard in migrateBehaviorRatio per WR-01).
+        if (!Number.isFinite(nextForage) || !Number.isFinite(nextFight)) break;
         if (nextForage < 0 || nextFight < 0) break;
         // Field-by-field copy to preserve object identity for copyWorldState determinism.
         colony.targetRatio.forage = nextForage;

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -185,17 +185,37 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         // Colony lookup; silently skip if colony does not exist (PRD §5 T-01-02).
         const colony = world.colonies[cmd.colonyId];
         if (colony === undefined) break;
-        // Validate ratio fields: any negative weight rejects the command.
         // Phase 10 (CTRL-01'): two-role widget — only forage / fight; digging is
-        // auto-assigned per CTRL-06 in step 10a (Plan 02). Legacy pre-Phase-10
-        // inputLog entries with a `dig` field are migrated at the save boundary
-        // (parseSaveFile applies migrateInputLogCommand to every entry on load),
-        // so this handler trusts the typed two-field shape — no runtime
-        // migration needed.
-        if (cmd.ratio.forage < 0 || cmd.ratio.fight < 0) break;
+        // auto-assigned per CTRL-06 in step 10a (Plan 02).
+        //
+        // WR-09 — defense in depth. The canonical migration site for pre-
+        // Phase-10 `{forage, dig, fight}` shapes is `parseSaveFile` in
+        // platform/save.ts (it walks inputLog on load so SCEN-06 replay
+        // reproduces the migrated snapshot). This handler also runs the
+        // same migration inline as a belt-and-suspenders guard for any
+        // call path that reaches the dispatcher without going through
+        // loadSave (debug-snapshot replay tools, ad-hoc tests, future
+        // remote-command surfaces). Inline to avoid a sim → platform
+        // dependency. Idempotent on already-migrated commands: the
+        // `'dig' in ratioRaw` guard short-circuits when the legacy key
+        // is absent, so post-Phase-10 commands (including a legitimate
+        // {forage:0, fight:0} idle slider) pass through unchanged.
+        const ratioRaw = cmd.ratio as unknown as { forage?: number; dig?: number; fight?: number };
+        let nextForage = cmd.ratio.forage;
+        let nextFight  = cmd.ratio.fight;
+        if ('dig' in ratioRaw) {
+          // Mirrors migrateBehaviorRatio in platform/save.ts: drop dig,
+          // snap all-zero remainder to DEFAULT_BEHAVIOR_RATIO {10, 0}.
+          if (nextForage === 0 && nextFight === 0) {
+            nextForage = 10;
+            nextFight  = 0;
+          }
+        }
+        // Validate ratio fields: any negative weight rejects the command.
+        if (nextForage < 0 || nextFight < 0) break;
         // Field-by-field copy to preserve object identity for copyWorldState determinism.
-        colony.targetRatio.forage = cmd.ratio.forage;
-        colony.targetRatio.fight  = cmd.ratio.fight;
+        colony.targetRatio.forage = nextForage;
+        colony.targetRatio.fight  = nextFight;
         // CTRL-04: run allocateWorkers immediately in the same tick the command is issued.
         // alloc0.dig is 0 here under the two-role contract — auto-dig (Plan 02 step 10a)
         // overwrites colony.computedAllocation.dig later in this same tick when need.dig > 0.

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -713,10 +713,36 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       } else if (colony.computedAllocation.fight > 0) {
         digDemand = 1;
         carvedFight = colony.computedAllocation.fight - 1;
+      } else if (colony.workerCount > colony.nurseCount) {
+        // WR-11 (codex P2 follow-up): zero-ratio case. WR-10 leaves
+        // {forage:0, fight:0} as a valid post-Phase-10 targetRatio (the
+        // snap-to-default only fires for legacy/malformed inputs). With
+        // both ratio-driven roles at 0, allocateWorkers returns 0 for
+        // forage and fight; the unallocated remainder
+        // (workerCount - nurseCount) sits Idle. Without this branch the
+        // CTRL-06 promise — "assign one digger when a Mark exists and an
+        // ant is Idle" — silently breaks for {0,0} ratios. Skip the carve
+        // (nothing to carve) and set demand directly; the eligibles loop
+        // pulls one Idle ant per CTRL-06.
+        //
+        // CLNY-09 nurse invariant preserved: this branch is gated on
+        // workerCount > nurseCount, so the all-nurse colony (1-worker
+        // brood-heavy where nurseCap pins everyone) still falls through
+        // to the dig-waits path.
+        //
+        // Wind-down drift (accepted): if the player flips to {0,0} while
+        // non-nurse workers are still mid-Forage/Fight from a prior tick,
+        // computedAllocation.dig stays at 1 for one or more ticks while
+        // taskCensus.dig remains 0 (no Idle ant to assign). Same one-tick
+        // self-correcting drift WR-07 already accepts on the wind-down
+        // edge — gating here on actual Idle presence would require a
+        // pre-scan of the workforce before the carve, which costs more
+        // than the cosmetic invariant is worth.
+        digDemand = 1;
       }
-      // else: ratio-driven budget is fully pinned by nurse (or workerCount
-      // is 0). Dig waits — same wait-no-preemption philosophy as the
-      // no-Idle-ant scarcity case.
+      // else: every worker is pinned to nurse (1-worker brood-heavy) —
+      // dig waits. Same wait-no-preemption philosophy as the no-Idle-ant
+      // scarcity case.
     }
     colony.computedAllocation.dig = digDemand;
     // WR-02: the carve is LOCAL to the eligibles loop. We do NOT mutate

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -187,31 +187,15 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         if (colony === undefined) break;
         // Validate ratio fields: any negative weight rejects the command.
         // Phase 10 (CTRL-01'): two-role widget — only forage / fight; digging is
-        // auto-assigned per CTRL-06 in step 10a (Plan 02).
+        // auto-assigned per CTRL-06 in step 10a (Plan 02). Legacy pre-Phase-10
+        // inputLog entries with a `dig` field are migrated at the save boundary
+        // (parseSaveFile applies migrateInputLogCommand to every entry on load),
+        // so this handler trusts the typed two-field shape — no runtime
+        // migration needed.
         if (cmd.ratio.forage < 0 || cmd.ratio.fight < 0) break;
-        // WR-09: defend against pre-Phase-10 inputLog replays. Legacy v2 saves
-        // (issue #15 → Phase 10 transition) carry SetBehaviorRatio commands
-        // shaped as {forage, dig, fight}; replay tools (debug-snapshot,
-        // replay-truth tests) re-execute the inputLog verbatim, so reading
-        // only forage/fight here would silently turn `{forage:0, dig:N,
-        // fight:0}` into a no-dig idle command. Mirror the platform/save.ts
-        // migrateBehaviorRatio semantic inline (sim/ cannot import platform/):
-        // when the legacy `dig` field is present and the remaining ratio is
-        // all-zero, snap to DEFAULT_BEHAVIOR_RATIO {forage:10, fight:0}.
-        // Post-Phase-10 commands have no `dig` and pass through unchanged
-        // (idempotent), preserving a legitimate {forage:0, fight:0} idle
-        // command if any caller emits one.
-        const ratioRaw = cmd.ratio as { forage: number; dig?: unknown; fight: number };
-        const isLegacy = 'dig' in ratioRaw;
-        let nextForage = cmd.ratio.forage;
-        let nextFight  = cmd.ratio.fight;
-        if (isLegacy && nextForage === 0 && nextFight === 0) {
-          nextForage = 10;
-          nextFight  = 0;
-        }
         // Field-by-field copy to preserve object identity for copyWorldState determinism.
-        colony.targetRatio.forage = nextForage;
-        colony.targetRatio.fight  = nextFight;
+        colony.targetRatio.forage = cmd.ratio.forage;
+        colony.targetRatio.fight  = cmd.ratio.fight;
         // CTRL-04: run allocateWorkers immediately in the same tick the command is issued.
         // alloc0.dig is 0 here under the two-role contract — auto-dig (Plan 02 step 10a)
         // overwrites colony.computedAllocation.dig later in this same tick when need.dig > 0.

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -640,9 +640,19 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       ? computeDigDemand(colony, undergroundGrid10a, world.ants)
       : 0;
     colony.computedAllocation.dig = digDemand;
-    if (digDemand > 0 && colony.computedAllocation.forage > 0) {
-      colony.computedAllocation.forage -= 1;
-    }
+    // WR-02: carve a forage slot LOCALLY so need.forage budgets one fewer
+    // forager when a digger is needed, but DO NOT mutate
+    // `colony.computedAllocation.forage`. The persisted field is the
+    // step-8 / SetBehaviorRatio result (= targetRatio × workerCount); any
+    // mid-tick consumer (renderer, debug HUD, autosave snapshot) that reads
+    // it between tick boundaries sees the canonical allocation, not a
+    // post-carve value. Determinism is preserved: `need.forage` below is
+    // identical to the prior `computedAllocation.forage - actualForage`
+    // because the in-place decrement was an algebraic equivalent of this
+    // local subtraction.
+    const carvedForage = (digDemand > 0 && colony.computedAllocation.forage > 0)
+      ? colony.computedAllocation.forage - 1
+      : colony.computedAllocation.forage;
 
     // (b) Collect ants at PRD §7c idle checkpoints, sorted ascending by EntityId (SCEN-06 determinism).
     //     The eligibility predicate is `task === AntTask.Idle` — the single, uniform rule per §7c
@@ -663,7 +673,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     //     Canonical target iteration order: forage → dig → fight → nurse (matches PRD §7a result shape).
     //     This deterministic if/else chain is the ONLY selection strategy.
     const need = {
-      forage: colony.computedAllocation.forage - actualForage,
+      forage: carvedForage                     - actualForage,
       dig:    colony.computedAllocation.dig    - actualDig,
       fight:  colony.computedAllocation.fight  - actualFight,
       nurse:  colony.computedAllocation.nurse  - actualNurse,

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -186,12 +186,15 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         const colony = world.colonies[cmd.colonyId];
         if (colony === undefined) break;
         // Validate ratio fields: any negative weight rejects the command.
-        if (cmd.ratio.forage < 0 || cmd.ratio.dig < 0 || cmd.ratio.fight < 0) break;
+        // Phase 10 (CTRL-01'): two-role widget — only forage / fight; digging is
+        // auto-assigned per CTRL-06 in step 10a (Plan 02).
+        if (cmd.ratio.forage < 0 || cmd.ratio.fight < 0) break;
         // Field-by-field copy to preserve object identity for copyWorldState determinism.
         colony.targetRatio.forage = cmd.ratio.forage;
-        colony.targetRatio.dig    = cmd.ratio.dig;
         colony.targetRatio.fight  = cmd.ratio.fight;
         // CTRL-04: run allocateWorkers immediately in the same tick the command is issued.
+        // alloc0.dig is 0 here under the two-role contract — auto-dig (Plan 02 step 10a)
+        // overwrites colony.computedAllocation.dig later in this same tick when need.dig > 0.
         const brood0 = colony.eggCount + colony.larvaeCount;
         const hasNursery0 = hasCompletedChamber(colony, ChamberType.Nursery);
         const alloc0 = allocateWorkers(colony.workerCount, brood0, colony.targetRatio, hasNursery0);

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -25,7 +25,7 @@ import {
   SURFACE_GRID_HEIGHT,
 } from './constants.js';
 import { FP_SHIFT } from './fixed.js';
-import { allocateWorkers } from './behavior/allocation-system.js';
+import { allocateWorkers, computeDigDemand } from './behavior/allocation-system.js';
 import {
   tickReconcile,
   tickFoodConsumption,
@@ -616,6 +616,32 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       else if (t === AntTask.Fighting) actualFight  += 1;
       else if (t === AntTask.Nursing)  actualNurse  += 1;
       else                             actualIdle   += 1;
+    }
+
+    // Phase 10 / CTRL-06 (D-02 LOCKED) — auto-dig demand override.
+    // need.dig = (Marked tile present in colony grid) AND (no ant currently Digging) ? 1 : 0.
+    // Mirrors auto-nurse (CLNY-09): demand-driven role outside the player ratio.
+    //
+    // Per D-02 ("third demand-driven check, BEFORE the forage/fight split"), the
+    // override carves a slot out of `computedAllocation.forage` so the canonical
+    // forage→dig→fight→nurse iteration below assigns one Idle ant to Digging
+    // instead of letting forage absorb the whole Idle pool. (Without the carve,
+    // `need.forage = computedAllocation.forage - actualForage` would saturate the
+    // eligibles loop and `need.dig > 0` would never fire even with 1 free worker.)
+    // Strict 1-digger cap falls out for free: computeDigDemand returns 0 when any
+    // ant of the colony is already Digging, so we don't double-carve.
+    //
+    // Scarcity policy (D-02 — wait, no preemption): if dig demand exists but no ant
+    // is Idle, the eligibles loop simply has nothing to assign — Marked tiles wait
+    // until an ant naturally goes Idle. Foragers/fighters mid-cycle are NOT preempted.
+    // The forage carve is bookkeeping only when no Idle ants are present.
+    const undergroundGrid10a = world.undergroundGrids[colony.colonyId];
+    const digDemand = undergroundGrid10a !== undefined
+      ? computeDigDemand(colony, undergroundGrid10a, world.ants)
+      : 0;
+    colony.computedAllocation.dig = digDemand;
+    if (digDemand > 0 && colony.computedAllocation.forage > 0) {
+      colony.computedAllocation.forage -= 1;
     }
 
     // (b) Collect ants at PRD §7c idle checkpoints, sorted ascending by EntityId (SCEN-06 determinism).

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -654,11 +654,32 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     //
     // Both cases follow the same rule: auto-dig consumes from forage's slack;
     // when forage has no slack, auto-dig waits.
+    //
+    // WR-07 (codex P1 v2): the dig slot must stay reserved while a digger is
+    // actively excavating, not only on the activation tick. `computeDigDemand`
+    // returns 0 as soon as any ant is Digging (the strict 1-cap), so without
+    // an extra hold on `actualDig > 0` the carve disappears mid-dig and the
+    // forage→…→nurse iteration overbooks the remaining workforce — starving
+    // nurse for the duration of every multi-tick dig. Holding `digDemand=1`
+    // while a digger is active makes `need.dig = 1 - actualDig = 0` (no new
+    // assignment) but keeps the forage budget = N − 1, so a freshly-Idle
+    // worker reaches the nurse branch instead of being stolen by forage.
+    //
+    // Wind-down semantics: `actualDig > 0` also fires for the single tick
+    // between excavation completion (step 10b flips the tile Open and the
+    // ant's subTask back to MovingToTile) and the dormant-digger release
+    // (step 10b next tick flips Digging → Idle when no Marked source
+    // remains). For that one tick `computedAllocation.dig = 1` even though
+    // no useful dig work is happening; the next tick the count drops to
+    // 0 and allocation self-corrects. Accepted: a stricter gate would
+    // need to introspect Mark/BeingDug grid state, and the drift is one
+    // tick / one slot per dig job.
     const undergroundGrid10a = world.undergroundGrids[colony.colonyId];
     const rawDigDemand = undergroundGrid10a !== undefined
       ? computeDigDemand(colony, undergroundGrid10a, world.ants)
       : 0;
-    const digDemand = (rawDigDemand > 0 && colony.computedAllocation.forage > 0) ? 1 : 0;
+    const wantDigSlot = rawDigDemand > 0 || actualDig > 0;
+    const digDemand = (wantDigSlot && colony.computedAllocation.forage > 0) ? 1 : 0;
     colony.computedAllocation.dig = digDemand;
     // WR-02: carve a forage slot LOCALLY so need.forage budgets one fewer
     // forager when a digger is needed, but DO NOT mutate

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -189,9 +189,29 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         // Phase 10 (CTRL-01'): two-role widget — only forage / fight; digging is
         // auto-assigned per CTRL-06 in step 10a (Plan 02).
         if (cmd.ratio.forage < 0 || cmd.ratio.fight < 0) break;
+        // WR-09: defend against pre-Phase-10 inputLog replays. Legacy v2 saves
+        // (issue #15 → Phase 10 transition) carry SetBehaviorRatio commands
+        // shaped as {forage, dig, fight}; replay tools (debug-snapshot,
+        // replay-truth tests) re-execute the inputLog verbatim, so reading
+        // only forage/fight here would silently turn `{forage:0, dig:N,
+        // fight:0}` into a no-dig idle command. Mirror the platform/save.ts
+        // migrateBehaviorRatio semantic inline (sim/ cannot import platform/):
+        // when the legacy `dig` field is present and the remaining ratio is
+        // all-zero, snap to DEFAULT_BEHAVIOR_RATIO {forage:10, fight:0}.
+        // Post-Phase-10 commands have no `dig` and pass through unchanged
+        // (idempotent), preserving a legitimate {forage:0, fight:0} idle
+        // command if any caller emits one.
+        const ratioRaw = cmd.ratio as { forage: number; dig?: unknown; fight: number };
+        const isLegacy = 'dig' in ratioRaw;
+        let nextForage = cmd.ratio.forage;
+        let nextFight  = cmd.ratio.fight;
+        if (isLegacy && nextForage === 0 && nextFight === 0) {
+          nextForage = 10;
+          nextFight  = 0;
+        }
         // Field-by-field copy to preserve object identity for copyWorldState determinism.
-        colony.targetRatio.forage = cmd.ratio.forage;
-        colony.targetRatio.fight  = cmd.ratio.fight;
+        colony.targetRatio.forage = nextForage;
+        colony.targetRatio.fight  = nextFight;
         // CTRL-04: run allocateWorkers immediately in the same tick the command is issued.
         // alloc0.dig is 0 here under the two-role contract — auto-dig (Plan 02 step 10a)
         // overwrites colony.computedAllocation.dig later in this same tick when need.dig > 0.
@@ -623,37 +643,30 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // Mirrors auto-nurse (CLNY-09): demand-driven role outside the player ratio.
     //
     // Per D-02 ("third demand-driven check, BEFORE the forage/fight split"), the
-    // override carves a slot out of `computedAllocation.forage` so the canonical
-    // forage→dig→fight→nurse iteration below assigns one Idle ant to Digging
-    // instead of letting forage absorb the whole Idle pool. (Without the carve,
-    // `need.forage = computedAllocation.forage - actualForage` would saturate the
-    // eligibles loop and `need.dig > 0` would never fire even with 1 free worker.)
+    // override carves a slot out of the player's ratio-driven roles (forage
+    // first, then fight) so the canonical forage→dig→fight→nurse iteration
+    // below assigns one Idle ant to Digging instead of letting forage/fight
+    // absorb the whole Idle pool. The carve never touches `nurse`, which is
+    // demand-driven (CLNY-09) and must be preserved.
+    //
     // Strict 1-digger cap falls out for free: computeDigDemand returns 0 when any
     // ant of the colony is already Digging, so we don't double-carve.
     //
     // Scarcity policy (D-02 — wait, no preemption): if dig demand exists but no ant
     // is Idle, the eligibles loop simply has nothing to assign — Marked tiles wait
     // until an ant naturally goes Idle. Foragers/fighters mid-cycle are NOT preempted.
-    // The forage carve is bookkeeping only when no Idle ants are present.
+    // The carve is bookkeeping only when no Idle ants are present.
     //
-    // WR-06: dig is only honored when a forage slot exists to carve from. D-02
-    // LOCKED ties the carve specifically to `computedAllocation.forage`, so when
-    // forage is 0 we treat the situation as a scarcity-wait. Two reachable
-    // examples, both equally suppressed by the same gate:
-    //
-    //   (a) brood-heavy nurse cap (codex P1): {forage:0, fight:0, nurse:1, 1
-    //       worker}. Without the gate, the forage→dig→fight→nurse iteration
-    //       would steal the only Idle ant from nurse and break the CLNY-09
-    //       nurse carveout invariant.
-    //   (b) slider-to-fight (no brood): player sets {forage:0, fight:10},
-    //       allocation becomes {nurse:0, forage:0, dig:0, fight:N}. Without
-    //       the gate, dig would steal from the player's fight ratio. Per
-    //       D-02 ("carve from forage"), the Mark waits until the player
-    //       widens the forage band — symmetric with the no-Idle-ant case
-    //       described above.
-    //
-    // Both cases follow the same rule: auto-dig consumes from forage's slack;
-    // when forage has no slack, auto-dig waits.
+    // WR-06 / WR-08 (codex P1 series): the carve must protect nurse but must
+    // NOT block dig when only forage is empty. The earlier "forage > 0 only"
+    // gate fixed the nurse-starvation case at the cost of deadlocking dig
+    // whenever the player slid the slider all-fight (issue #13's promise:
+    // "auto-assign one digger when a Mark exists and an ant is Idle"). The
+    // current rule prefers carving from forage (per D-02 LOCKED), then falls
+    // back to fight, and finally suppresses dig only when the entire
+    // remaining ratio-driven budget is 0 (e.g., a 1-worker brood-heavy nurse
+    // cap pinning every worker to nurse). nurse is never carved — the
+    // CLNY-09 invariant.
     //
     // WR-07 (codex P1 v2): the dig slot must stay reserved while a digger is
     // actively excavating, not only on the activation tick. `computeDigDemand`
@@ -662,8 +675,8 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // forage→…→nurse iteration overbooks the remaining workforce — starving
     // nurse for the duration of every multi-tick dig. Holding `digDemand=1`
     // while a digger is active makes `need.dig = 1 - actualDig = 0` (no new
-    // assignment) but keeps the forage budget = N − 1, so a freshly-Idle
-    // worker reaches the nurse branch instead of being stolen by forage.
+    // assignment) but keeps the carve budget at N − 1, so a freshly-Idle
+    // worker reaches the nurse branch instead of being stolen by forage/fight.
     //
     // Wind-down semantics: `actualDig > 0` also fires for the single tick
     // between excavation completion (step 10b flips the tile Open and the
@@ -679,21 +692,32 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       ? computeDigDemand(colony, undergroundGrid10a, world.ants)
       : 0;
     const wantDigSlot = rawDigDemand > 0 || actualDig > 0;
-    const digDemand = (wantDigSlot && colony.computedAllocation.forage > 0) ? 1 : 0;
+    // Try to carve from forage first (D-02 preference), then fight. nurse is
+    // never carved (CLNY-09 invariant). digDemand is the canonical 0/1 flag
+    // both for `colony.computedAllocation.dig` and `need.dig` below.
+    let digDemand = 0;
+    let carvedForage = colony.computedAllocation.forage;
+    let carvedFight  = colony.computedAllocation.fight;
+    if (wantDigSlot) {
+      if (colony.computedAllocation.forage > 0) {
+        digDemand = 1;
+        carvedForage = colony.computedAllocation.forage - 1;
+      } else if (colony.computedAllocation.fight > 0) {
+        digDemand = 1;
+        carvedFight = colony.computedAllocation.fight - 1;
+      }
+      // else: ratio-driven budget is fully pinned by nurse (or workerCount
+      // is 0). Dig waits — same wait-no-preemption philosophy as the
+      // no-Idle-ant scarcity case.
+    }
     colony.computedAllocation.dig = digDemand;
-    // WR-02: carve a forage slot LOCALLY so need.forage budgets one fewer
-    // forager when a digger is needed, but DO NOT mutate
-    // `colony.computedAllocation.forage`. The persisted field is the
-    // step-8 / SetBehaviorRatio result (= targetRatio × workerCount); any
-    // mid-tick consumer (renderer, debug HUD, autosave snapshot) that reads
-    // it between tick boundaries sees the canonical allocation, not a
-    // post-carve value. Determinism is preserved: `need.forage` below is
-    // identical to the prior `computedAllocation.forage - actualForage`
-    // because the in-place decrement was an algebraic equivalent of this
-    // local subtraction.
-    const carvedForage = digDemand > 0
-      ? colony.computedAllocation.forage - 1
-      : colony.computedAllocation.forage;
+    // WR-02: the carve is LOCAL to the eligibles loop. We do NOT mutate
+    // `colony.computedAllocation.forage` or `.fight`. The persisted fields
+    // remain the step-8 / SetBehaviorRatio result (= targetRatio × worker
+    // budget); any mid-tick consumer (renderer, debug HUD, autosave snapshot)
+    // that reads them between tick boundaries sees the canonical allocation,
+    // not a post-carve value. Determinism is preserved: the need calculations
+    // below are algebraically equivalent to a hypothetical in-place decrement.
 
     // (b) Collect ants at PRD §7c idle checkpoints, sorted ascending by EntityId (SCEN-06 determinism).
     //     The eligibility predicate is `task === AntTask.Idle` — the single, uniform rule per §7c
@@ -716,7 +740,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     const need = {
       forage: carvedForage                     - actualForage,
       dig:    colony.computedAllocation.dig    - actualDig,
-      fight:  colony.computedAllocation.fight  - actualFight,
+      fight:  carvedFight                      - actualFight,
       nurse:  colony.computedAllocation.nurse  - actualNurse,
     };
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -189,8 +189,9 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
     }
 
     // Nested plain-object fields — field-by-field copy (NOT spread — preserves object identity)
+    // Phase 10 (CTRL-01'): targetRatio is two-field {forage, fight}. WorkerAllocation
+    // (computedAllocation, taskCensus) keeps its `dig` slot per D-03 — auto-dig writes it.
     d.targetRatio.forage           = s.targetRatio.forage;
-    d.targetRatio.dig              = s.targetRatio.dig;
     d.targetRatio.fight            = s.targetRatio.fight;
 
     d.computedAllocation.nurse     = s.computedAllocation.nurse;


### PR DESCRIPTION
## Summary

Closes #13 — assigning ants to digging is no longer strategic, so dig moves out of the player's behavior triangle and becomes demand-driven.

**What changed**
- The 3-vertex behavior triangle becomes a **1-D Forage↔Fight slider** in the same HUD slot.
- Digging is **auto-assigned**: when at least one Marked tile exists and an ant is Idle, the simulation assigns exactly one Idle ant to dig — mirroring the existing CLNY-09 nurse pattern.
- Strict 1-digger cap kills the tunnel-jam problem; scarcity-wait policy means foragers/fighters are never preempted mid-task.
- AI uses the same auto-dig path (no `if (isPlayer)` branching).
- Pre-Phase-10 saves load silently — `dig` field is dropped on load.
- **Issue #13 layout follow-up**: the slider zone shrank from 120×120 to 120×44, hugging the 1-D track instead of leaving the original triangle bounding box as an empty square (commits `f143674` + `9e1a94a`).

## Changes by plan

| Plan | What it built | Key files |
|------|---------------|-----------|
| 10-01 | Schema foundation: shrink `BehaviorRatio` to `{forage, fight}`; propagate through commands/types/tick/allocation/scenario; amend REQUIREMENTS.md | `src/sim/colony/colony-store.ts`, `src/sim/commands.ts`, `src/sim/types.ts`, `src/sim/tick.ts`, `src/sim/constants.ts`, `src/sim/behavior/allocation-system.ts`, `src/sim/scenario.ts` |
| 10-02 | Sim auto-dig: `computeDigDemand` helper + `tick.ts` step 10a override (strict 1-cap, scarcity-wait) | `src/sim/behavior/allocation-system.ts`, `src/sim/tick.ts`, sim test sweep |
| 10-03 | Silent save migration: `migrateBehaviorRatio` in `deserializeColony` (drops legacy `dig`; all-zero snaps to `{forage:10, fight:0}`) | `src/platform/save.ts` |
| 10-04 | AI parity: retune `AI_BEHAVIOR_RATIO` to `{forage:7, fight:3}` (preserves original 5:2 emphasis); CLNY-08 source-scan self-check; project-wide fixture sweep | `src/render/ai-controller.ts`, `src/input/surface-input.test.ts`, `src/render/minimap.test.ts` |
| 10-05 | UI slider rewrite: 1-D Forage↔Fight slider in same HUD slot; icons + text labels; dual current/target markers preserved (CTRL-05) | `src/render/triangle-widget.ts`, `src/render/ui-scene.ts` |
| **#13 follow-up** | **Shrink HUD.TRIANGLE zone from 120×120 to 120×44 (y: 456→532, bottom edge unchanged) to hug the 1-D slider instead of leaving an empty square. Stale-coordinate comments refreshed in lock-step.** | `src/render/sprites.ts`, `src/render/sprites.test.ts`, `src/render/triangle-widget.ts`, `src/render/ui-scene.ts` |

## Requirements addressed

- **CTRL-01** amended: "Triangle UI with three vertices: Forage, Dig, Fight" → "Behavior control widget with two roles: Forage and Fight (digging is auto-assigned per CLNY-09-style demand)"
- **CTRL-06** added: auto-dig spec — "When at least one Marked tile exists and any ant is Idle, the simulation auto-assigns exactly one Idle ant to dig until the queue empties or the ant dies"
- **CTRL-02, CTRL-03, CTRL-04, CTRL-05** preserved (slider remains draggable, always visible, dual current/target markers, allocation changes take effect within one tick)
- **CLNY-08** preserved (no `if (isPlayer)` branching; pinned by source-text scan in test)
- **HUD-05** preserved (Graphics + Text only; no new asset loading)
- **SCEN-06** preserved (determinism contract: `copyWorldState`, `SerializedWorldState`, `determinism.test.ts` updated in lock-step)

## Verification

**Automated checks: all green**

- `npm run typecheck` — exit 0
- `npm run lint` — exit 0
- `npm run test` — 1502/1502 ✓ (post-#13-follow-up)
- `npm run test:e2e` — 9/11 (2 pre-existing failures from issue #15 v1→v2 SAVE_KEY drift, not Phase 10 regressions)
- HUD-05 audit grep — zero forbidden matches
- CLNY-08 source-text scan — zero `PLAYER_COLONY_ID ===` matches
- Round-trip determinism on migrated saves — 30 ticks identical

**Local code review** (gsd-code-reviewer, standard depth, 23 files):
- 0 BLOCKER, 6 WARNING, 5 INFO
- 5/5 in-scope warnings fixed (NaN handling, mutation hygiene, slider denominator fallback, ratio clamping, zero-track-length guard); 1 pre-existing finding (`findOpenChamberSpot` BFS) deferred to a follow-up phase.
- Report: `.planning/phases/10-auto-assign-diggers/10-REVIEW-FIX.md`

**Issue #13 layout follow-up review** (3 fresh review rounds):
- Round 1: 1 P3 (stale coordinate comments) — fixed in `9e1a94a`.
- Round 2: 0 issues in slider-resize scope (2 P3 nits about pre-existing Phase 10 D-01 logic flagged but out of scope).
- Round 3: clean.

## UAT items (please run before merge)

The phase verifier returned `human_needed` (8/8 automated must-haves green; UAT visual checks remaining):

1. **Slider feel** — `npm run dev`, drag the new Forage↔Fight slider end-to-end. Verify icons (green forage / red fight), text labels at extremes, dual current/target markers behave the way the prior triangle did.
2. **Slider box footprint (issue #13 follow-up)** — confirm the dark slider background now hugs the slider track instead of a 120×120 empty square. Bottom edge sits at the same y as before, so neighbouring HUD anchors should look unchanged.
3. **Auto-dig behavior (issue #13 closure)** — start a game, place a Mark on an excavation target, observe **exactly one** ant assigned to dig. Confirm no tunnel pile-up. Mark more tiles; confirm the pattern continues at strict-1.
4. **Save migration smoke** — load a pre-Phase-10 save (if you have one). Confirm the slider position roughly matches your prior forage/fight balance with no errors.

## Key decisions

All locked in `.planning/phases/10-auto-assign-diggers/10-CONTEXT.md`:

- **D-01** — Slider is a fresh visual redesign (not a chopped-down triangle), 0–10 integer scale, dual markers preserved.
- **D-02** — Strict 1-digger cap; auto-dig waits silently when no Idle ants (no preemption); ant returns to Idle then `tick.ts` step 10a reassigns.
- **D-03** — `BehaviorRatio` shrinks to 2 fields; `WorkerAllocation` retains 4 fields (the `dig` slot is now demand-derived, not ratio-derived).
- **D-04** — Silent save migration (no schema bump): zero out legacy `dig`; all-zero saves snap to `{forage:10, fight:0}`.
- **D-05** — AI uses same auto-dig path as player (CLNY-08 parity); ratio retuned to `{forage:7, fight:3}` (Candidate A — preserves prior 5:2 forage:fight weighting).
- **D-06** — REQUIREMENTS.md amendment (CTRL-01 + new CTRL-06) committed atomically with the schema change in Plan 10-01.

## Test plan

- [ ] Run UAT items 1–4 above
- [ ] Confirm CI green
- [ ] Confirm second AI reviewer (server-side Codex review) approves
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
