### PR TITLE
fix: enable invading the enemy hive (closes #14)

### DIFF
--- a/src/input/camera-input.test.ts
+++ b/src/input/camera-input.test.ts
@@ -175,6 +175,38 @@ describe('isPointerOverHUD', () => {
     });
   });
 
+  describe('UNDERGROUND_COLONY_TOGGLE zone (issue #14)', () => {
+    // Helper: a minimal viewState fixture for the conditional-mask path.
+    function vs(activeView: 'surface' | 'underground'): import('../render/camera.js').ViewState {
+      return {
+        activeView,
+        surfaceCamera: { x: 0, y: 0, viewportWidth: 1, viewportHeight: 1 },
+        undergroundCamera: { x: 0, y: 0, viewportWidth: 1, viewportHeight: 1 },
+        undergroundVisited: true,
+        activeUndergroundColonyId: 1,
+      };
+    }
+
+    it('masks the colony-toggle zone ONLY when activeView === underground', () => {
+      const inside = [HUD.UNDERGROUND_COLONY_TOGGLE.x + 5, HUD.UNDERGROUND_COLONY_TOGGLE.y + 5] as const;
+      // Underground view → the toggle is rendered → click zone is masked.
+      expect(isPointerOverHUD(inside[0], inside[1], vs('underground'))).toBe(true);
+      // Surface view → the toggle is invisible → masking it would create a
+      // dead zone above the minimap. Click zone must NOT be masked.
+      expect(isPointerOverHUD(inside[0], inside[1], vs('surface'))).toBe(false);
+      // Legacy / no-viewState path stays unmasked too (safe default).
+      expect(isPointerOverHUD(inside[0], inside[1])).toBe(false);
+    });
+
+    it('returns false for a point above the colony-toggle button', () => {
+      expect(isPointerOverHUD(
+        HUD.UNDERGROUND_COLONY_TOGGLE.x + 5,
+        HUD.UNDERGROUND_COLONY_TOGGLE.y - 1,
+        vs('underground'),
+      )).toBe(false);
+    });
+  });
+
   describe('Phase 9 reservation zones (intentionally unmasked in Phase 8)', () => {
     it('does NOT mask SAVE_ICON — Phase 8 renders nothing there, so masking creates an invisible dead zone', () => {
       expect(isPointerOverHUD(HUD.SAVE_ICON.x + 5, HUD.SAVE_ICON.y + 5)).toBe(false);

--- a/src/input/camera-input.ts
+++ b/src/input/camera-input.ts
@@ -116,7 +116,7 @@ export function resetDragState(dragState: DragState): void {
  *
  * Inclusion rule: x in [rect.x, rect.x + rect.w) and y in [rect.y, rect.y + rect.h).
  */
-export function isPointerOverHUD(px: number, py: number): boolean {
+export function isPointerOverHUD(px: number, py: number, viewState?: ViewState): boolean {
   // Ant-activity popup full-canvas mask — while the panel is visible OR
   // already dismissing (pendingHide), treat every screen pixel as HUD.
   //
@@ -153,6 +153,17 @@ export function isPointerOverHUD(px: number, py: number): boolean {
     HUD.MINIMAP,
     HUD.VIEW_TOGGLE,
   ];
+  // Issue #14 — colony toggle is rendered ONLY on the underground view
+  // (ui-scene.ts gates `setVisible` on activeView === 'underground'). Mask
+  // the click zone only when it's actually visible — otherwise a 100×22
+  // pixel patch above the minimap on the surface view becomes a silent
+  // dead zone that swallows rally / food-mark / entrance-designation
+  // clicks. Callers that don't have a ViewState handy (legacy or test
+  // contexts) pass undefined and the toggle stays unmasked, which is
+  // strictly safer than the always-masked alternative.
+  if (viewState !== undefined && viewState.activeView === 'underground') {
+    zones.push(HUD.UNDERGROUND_COLONY_TOGGLE);
+  }
   for (const zone of zones) {
     if (
       px >= zone.x &&
@@ -341,7 +352,7 @@ export function registerDragPan(scene: Phaser.Scene, viewState: ViewState): Drag
 
   scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
     if (!isPanTriggerDown(pointer)) return;
-    if (isPointerOverHUD(pointer.x, pointer.y)) return;
+    if (isPointerOverHUD(pointer.x, pointer.y, viewState)) return;
     dragState.active = true;
     dragState.lastX = pointer.x;
     dragState.lastY = pointer.y;
@@ -353,7 +364,7 @@ export function registerDragPan(scene: Phaser.Scene, viewState: ViewState): Drag
     if (!dragState.active) return;
     // Continue pan only while the originating trigger is still held.
     if (!isPanTriggerDown(pointer)) return;
-    if (isPointerOverHUD(pointer.x, pointer.y)) return;
+    if (isPointerOverHUD(pointer.x, pointer.y, viewState)) return;
 
     const dx = (pointer.x - dragState.lastX) / TILE_SIZE_PX;
     const dy = (pointer.y - dragState.lastY) / TILE_SIZE_PX;

--- a/src/input/surface-input.test.ts
+++ b/src/input/surface-input.test.ts
@@ -16,6 +16,7 @@ import {
   handleSurfaceLeftClick,
   handleSurfaceRightClick,
   isEmptySurfaceTile,
+  isForeignColonyEntrance,
   handleSetRallyPoint,
   resetSurfaceInputState,
   type SurfaceInputState,
@@ -29,7 +30,7 @@ import type { WorldState } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
 import { VIEWPORT_WIDTH_TILES, VIEWPORT_HEIGHT_TILES } from '../render/camera.js';
 import { HUD, TILE_SIZE_PX } from '../render/sprites.js';
-import { PLAYER_COLONY_ID } from '../sim/constants.js';
+import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
 import type { SimCommand } from '../sim/commands.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
 
@@ -99,11 +100,12 @@ function makeWorld(overrides: {
 
 /** Build a minimal colony record stub with an optional rally point and entrances. */
 function makeColony(overrides: {
+  colonyId?: ColonyId;
   rallyPoint?: { tileX: number; tileY: number } | null;
   entrances?: Array<{ surfaceTileX: number; surfaceTileY: number }>;
 } = {}) {
   return {
-    colonyId: PLAYER_COLONY_ID as ColonyId,
+    colonyId: overrides.colonyId ?? (PLAYER_COLONY_ID as ColonyId),
     queenEntityId: 0,
     queenStarvationTimer: 0,
     foodStored: 0,
@@ -776,6 +778,96 @@ describe('surface-input rally-point fall-through (SURF-04)', () => {
     expect(cmd.tileX).toBe(7);
     expect(cmd.tileY).toBe(2);
     expect(cmd.issuedAtTick).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #14 — invade enemy hive: rally on enemy entrance
+// ---------------------------------------------------------------------------
+
+describe('isForeignColonyEntrance', () => {
+  it('returns true for an enemy entrance tile', () => {
+    const enemy = makeColony({
+      colonyId: ENEMY_COLONY_ID as ColonyId,
+      entrances: [{ surfaceTileX: 100, surfaceTileY: 0 }],
+    });
+    const world = makeWorld({
+      surfaceWidth: 128, surfaceHeight: 4,
+      colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
+    });
+    expect(isForeignColonyEntrance(world, 100, 0, PLAYER_COLONY_ID as ColonyId)).toBe(true);
+  });
+
+  it('returns false for the own-colony entrance tile (preserves designation flow)', () => {
+    const own = makeColony({ entrances: [{ surfaceTileX: 20, surfaceTileY: 0 }] });
+    const world = makeWorld({
+      surfaceWidth: 128, surfaceHeight: 4,
+      colonies: { [PLAYER_COLONY_ID]: own } as unknown as WorldState['colonies'],
+    });
+    expect(isForeignColonyEntrance(world, 20, 0, PLAYER_COLONY_ID as ColonyId)).toBe(false);
+  });
+
+  it('returns false for a tile with no entrance on it', () => {
+    const enemy = makeColony({
+      colonyId: ENEMY_COLONY_ID as ColonyId,
+      entrances: [{ surfaceTileX: 100, surfaceTileY: 0 }],
+    });
+    const world = makeWorld({
+      surfaceWidth: 128, surfaceHeight: 4,
+      colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
+    });
+    expect(isForeignColonyEntrance(world, 50, 1, PLAYER_COLONY_ID as ColonyId)).toBe(false);
+  });
+
+  it('returns false for out-of-bounds tile', () => {
+    const enemy = makeColony({
+      colonyId: ENEMY_COLONY_ID as ColonyId,
+      entrances: [{ surfaceTileX: 100, surfaceTileY: 0 }],
+    });
+    const world = makeWorld({
+      surfaceWidth: 128, surfaceHeight: 4,
+      colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
+    });
+    expect(isForeignColonyEntrance(world, -1, 0, PLAYER_COLONY_ID as ColonyId)).toBe(false);
+    expect(isForeignColonyEntrance(world, 200, 0, PLAYER_COLONY_ID as ColonyId)).toBe(false);
+  });
+});
+
+describe('handleSurfaceLeftClick — rally on enemy entrance (issue #14)', () => {
+  it('left-click on enemy entrance pushes SetRallyPointCommand for the player colony', () => {
+    const enemy = makeColony({
+      colonyId: ENEMY_COLONY_ID as ColonyId,
+      entrances: [{ surfaceTileX: 100, surfaceTileY: 0 }],
+    });
+    const world = makeWorld({
+      tick: 7,
+      surfaceWidth: 128, surfaceHeight: 4,
+      colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
+    });
+    const vs = makeViewState('surface', 64, 2);
+    const state = makeState();
+    const { x, y } = tileToScreen(100, 0, 64, 2);
+    handleSurfaceLeftClick(world, vs, x, y, state);
+    expect(world.commandQueue).toHaveLength(1);
+    const cmd = world.commandQueue[0] as { type: string; colonyId: number; tileX: number; tileY: number; issuedAtTick: number };
+    expect(cmd.type).toBe('SetRallyPoint');
+    expect(cmd.colonyId).toBe(PLAYER_COLONY_ID); // rally is the PLAYER's, not the enemy's
+    expect(cmd.tileX).toBe(100);
+    expect(cmd.tileY).toBe(0);
+    expect(cmd.issuedAtTick).toBe(7);
+  });
+
+  it('left-click on own entrance is still a no-op (entrance designation right-click flow undisturbed)', () => {
+    const own = makeColony({ entrances: [{ surfaceTileX: 20, surfaceTileY: 0 }] });
+    const world = makeWorld({
+      surfaceWidth: 128, surfaceHeight: 4,
+      colonies: { [PLAYER_COLONY_ID]: own } as unknown as WorldState['colonies'],
+    });
+    const vs = makeViewState('surface', 64, 2);
+    const state = makeState();
+    const { x, y } = tileToScreen(20, 0, 64, 2);
+    handleSurfaceLeftClick(world, vs, x, y, state);
+    expect(world.commandQueue).toHaveLength(0);
   });
 });
 

--- a/src/input/surface-input.ts
+++ b/src/input/surface-input.ts
@@ -94,6 +94,50 @@ export function isEmptySurfaceTile(world: WorldState, tileX: number, tileY: numb
 }
 
 // ---------------------------------------------------------------------------
+// isForeignColonyEntrance — issue #14 invasion enabler
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when (tileX, tileY) is the surface tile of an entrance owned
+ * by a colony OTHER than `ownColonyId`. Bounds and food-pile checks are not
+ * required here — handleSurfaceLeftClick has already evaluated those.
+ *
+ * Issue #14: enables the player to left-click an enemy entrance to rally
+ * Fighting ants there. The Phase 09.1 cross-grid descent + combat path is
+ * already wired (REQ-C3a, REQ-C4a); the rally input was the missing seam.
+ *
+ * Closed enemy entrances are intentionally still eligible — the rally-tile
+ * carve-out in updateFightAntTargets walks fighters onto the exact tile,
+ * but the descent-intent gate in tickAntMovement requires `isOpen` before
+ * crossing into the enemy grid. So a rally on a closed enemy entrance
+ * piles fighters at the door, ready to invade the moment the enemy AI
+ * opens it. That's the right read of "I want to attack here" — no need
+ * for the input layer to second-guess open/closed.
+ *
+ * ADR-0006: world.colonies is a PLAIN OBJECT. Uses Object.keys (per the
+ * existing isEmptySurfaceTile pattern).
+ */
+export function isForeignColonyEntrance(
+  world: WorldState,
+  tileX: number,
+  tileY: number,
+  ownColonyId: ColonyId,
+): boolean {
+  if (tileX < 0 || tileY < 0) return false;
+  if (tileX >= world.surface.width || tileY >= world.surface.height) return false;
+  for (const key of Object.keys(world.colonies)) {
+    const cid = Number(key) as ColonyId;
+    if (cid === ownColonyId) continue;
+    const colony = world.colonies[cid];
+    if (colony === undefined) continue;
+    for (const entrance of colony.entrances) {
+      if (entrance.surfaceTileX === tileX && entrance.surfaceTileY === tileY) return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 // findFoodPileAt — O(n) scan over world.foodPiles
 // ---------------------------------------------------------------------------
 
@@ -138,7 +182,7 @@ export function handleSurfaceLeftClick(
   state: SurfaceInputState,
 ): void {
   if (viewState.activeView !== 'surface') return;
-  if (isPointerOverHUD(screenX, screenY)) return;
+  if (isPointerOverHUD(screenX, screenY, viewState)) return;
   // Pan-mode guard: while Space is held or a pan gesture is already in flight,
   // the left-click is the pan trigger — not a world action.
   if (panInputState.spaceHeld || panInputState.isPanning) return;
@@ -180,7 +224,30 @@ export function handleSurfaceLeftClick(
     return;
   }
 
-  // Empty-tile fallthrough (priority 3): set rally point for player colony (SURF-04).
+  // Foreign-colony entrance rally (priority 3 — issue #14): left-click on an
+  // enemy colony's open entrance tile sets the player's rally point there.
+  // This is the input piece that unlocks Phase 09.1's invasion mechanic —
+  // Fighting ants rally to the tile, the rally-on-entrance carve-out in
+  // updateFightAntTargets keeps them walking onto it, and the descent-intent
+  // gate in tickAntMovement crosses them into the enemy underground grid.
+  // Own-colony entrance left-click stays a no-op so the right-click → left-
+  // click entrance designation flow is undisturbed.
+  //
+  // Ordering note: food-pile mark (priority 2) wins over foreign-entrance
+  // rally if a food pile and an enemy entrance somehow share a tile. The
+  // scenario seeder (createScenario) places enemy entrances at the colony
+  // start tile and food piles at distinct tiles, so this collision can't
+  // arise in practice today. If a future feature lets food piles spawn
+  // anywhere, prefer the food-mark — the player can always rally on an
+  // adjacent tile (the rally-on-entrance carve-out only requires the EXACT
+  // entrance tile, but a one-tile-off rally still routes fighters to the
+  // entrance via the existing path-to-rally walk).
+  if (isForeignColonyEntrance(world, tileX, tileY, PLAYER_COLONY_ID)) {
+    handleSetRallyPoint(world, tileX, tileY, PLAYER_COLONY_ID);
+    return;
+  }
+
+  // Empty-tile fallthrough (priority 4): set rally point for player colony (SURF-04).
   if (isEmptySurfaceTile(world, tileX, tileY)) {
     handleSetRallyPoint(world, tileX, tileY, PLAYER_COLONY_ID);
   }
@@ -239,7 +306,7 @@ export function handleSurfaceRightClick(
   playerColonyId: ColonyId = PLAYER_COLONY_ID,
 ): void {
   if (viewState.activeView !== 'surface') return;
-  if (isPointerOverHUD(screenX, screenY)) return;
+  if (isPointerOverHUD(screenX, screenY, viewState)) return;
   const { tileX, tileY } = screenToTile(screenX, screenY, viewState.surfaceCamera);
   if (tileX < 0 || tileY < 0) return;
 

--- a/src/input/underground-input.test.ts
+++ b/src/input/underground-input.test.ts
@@ -34,7 +34,7 @@ import type { WorldState } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
 import { VIEWPORT_WIDTH_TILES, VIEWPORT_HEIGHT_TILES } from '../render/camera.js';
 import { HUD, TILE_SIZE_PX } from '../render/sprites.js';
-import { PLAYER_COLONY_ID } from '../sim/constants.js';
+import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
 import type { SimCommand } from '../sim/commands.js';
 
 // ---------------------------------------------------------------------------
@@ -936,5 +936,74 @@ describe('resetUndergroundInputState', () => {
     expect(state.isDragging).toBe(true);
     expect(state.lastMarkedTileX).toBe(5);
     expect(state.lastMarkedTileY).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #14 — read-only when viewing enemy underground
+// ---------------------------------------------------------------------------
+
+describe('underground-input read-only when activeUndergroundColonyId !== PLAYER_COLONY_ID', () => {
+  // Helper: viewport pointing at the enemy underground.
+  function makeEnemyView(): ViewState {
+    return {
+      activeView: 'underground',
+      surfaceCamera: { x: 64, y: 32, viewportWidth: VIEWPORT_WIDTH_TILES, viewportHeight: VIEWPORT_HEIGHT_TILES },
+      undergroundCamera: { x: 64, y: 32, viewportWidth: VIEWPORT_WIDTH_TILES, viewportHeight: VIEWPORT_HEIGHT_TILES },
+      undergroundVisited: true,
+      activeUndergroundColonyId: ENEMY_COLONY_ID,
+    };
+  }
+
+  it('handleUndergroundLeftClick is a no-op while viewing the enemy hive', () => {
+    const world = makeWorld();
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 5, 5, UndergroundTileState.Solid);
+    const vs = makeEnemyView();
+    const state = makeState();
+    const { x, y } = tileToScreen(5, 5, 64, 32);
+    handleUndergroundLeftClick(world, vs, x, y, state);
+    // No command emitted, no drag armed. The click was rejected silently —
+    // dispatching a MarkDigTile against PLAYER_COLONY_ID at the same coords
+    // would silently scribble on the player's grid the player can't see.
+    expect(world.commandQueue).toHaveLength(0);
+    expect(state.isDragging).toBe(false);
+  });
+
+  it('handleUndergroundLeftClick on the enemy view clears any lingering isDragging flag', () => {
+    // Defensive: a prior gesture that didn't see a clean mouseup (e.g.,
+    // focus-loss) could leave isDragging=true. The enemy-view guard must
+    // also reset it so a subsequent flip back to the player view doesn't
+    // resume the stale stroke from a stale lastMarkedTile.
+    const world = makeWorld();
+    ugSet(world.undergroundGrids[PLAYER_COLONY_ID]!, 5, 5, UndergroundTileState.Solid);
+    const vs = makeEnemyView();
+    const state = makeState(/*isDragging*/ true, 4, 4);
+    const { x, y } = tileToScreen(5, 5, 64, 32);
+    handleUndergroundLeftClick(world, vs, x, y, state);
+    expect(state.isDragging).toBe(false);
+    expect(world.commandQueue).toHaveLength(0);
+  });
+
+  it('handleUndergroundDrag aborts and clears isDragging when activeUndergroundColonyId flips to enemy mid-drag', () => {
+    const world = makeWorld();
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 5, 5, UndergroundTileState.Solid);
+    const vs = makeEnemyView();
+    const state = makeState(/*isDragging*/ true, 4, 5);
+    const { x, y } = tileToScreen(5, 5, 64, 32);
+    handleUndergroundDrag(world, vs, x, y, state);
+    expect(world.commandQueue).toHaveLength(0);
+    expect(state.isDragging).toBe(false);
+  });
+
+  it('handleUndergroundRightClick is a no-op while viewing the enemy hive', () => {
+    const world = makeWorld();
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 5, 5, UndergroundTileState.Marked);
+    const vs = makeEnemyView();
+    const { x, y } = tileToScreen(5, 5, 64, 32);
+    handleUndergroundRightClick(world, vs, x, y);
+    expect(world.commandQueue).toHaveLength(0);
   });
 });

--- a/src/input/underground-input.ts
+++ b/src/input/underground-input.ts
@@ -134,7 +134,25 @@ export function handleUndergroundLeftClick(
   state: UndergroundInputState,
 ): void {
   if (viewState.activeView !== 'underground') return;
-  if (isPointerOverHUD(screenX, screenY)) return;
+  // Issue #14: when the player flips to view the enemy underground (X
+  // keybind), all underground commands target the PLAYER's grid (every
+  // dispatch below uses PLAYER_COLONY_ID as the colonyId). A click on the
+  // enemy view at screen coords (sx, sy) would silently mark a dig tile in
+  // the player's grid at the same world coords — the player can't see it,
+  // and replay would diverge from the visual state on screen. Treat the
+  // enemy view as read-only.
+  //
+  // Defensive: clear any lingering `isDragging` flag from a prior gesture
+  // that didn't get a clean mouseup (e.g., focus-loss). Without the
+  // explicit reset, a stale `isDragging=true` paired with a stale
+  // lastMarkedTile from the player view could resume scribbling dig
+  // marks if the player flips back via X. Symmetric with the abort path
+  // in handleUndergroundDrag.
+  if (viewState.activeUndergroundColonyId !== PLAYER_COLONY_ID) {
+    state.isDragging = false;
+    return;
+  }
+  if (isPointerOverHUD(screenX, screenY, viewState)) return;
   // Pan-mode guard: while Space is held or a pan gesture is already in flight,
   // the left-click/drag is the pan trigger — not a dig-mark.
   if (panInputState.spaceHeld || panInputState.isPanning) return;
@@ -200,7 +218,14 @@ export function handleUndergroundDrag(
 ): void {
   if (!state.isDragging) return;
   if (viewState.activeView !== 'underground') { state.isDragging = false; return; }
-  if (isPointerOverHUD(screenX, screenY)) return;
+  // Issue #14: same read-only guard as handleUndergroundLeftClick. If the
+  // player flipped to the enemy view mid-drag (X keybind), abort the stroke
+  // so it can't write through to the player's grid silently.
+  if (viewState.activeUndergroundColonyId !== PLAYER_COLONY_ID) {
+    state.isDragging = false;
+    return;
+  }
+  if (isPointerOverHUD(screenX, screenY, viewState)) return;
   // Pan-mode guard: if the player pressed Space mid-drag, treat it as a
   // clean cancel of the excavation drag so further pointer movement goes
   // through the pan handler exclusively.
@@ -331,7 +356,12 @@ export function handleUndergroundRightClick(
   screenY: number,
 ): void {
   if (viewState.activeView !== 'underground') return;
-  if (isPointerOverHUD(screenX, screenY)) return;
+  // Issue #14: read-only guard for the enemy underground view (X-toggle).
+  // Mirrors handleUndergroundLeftClick — every dispatch below targets
+  // PLAYER_COLONY_ID, so a right-click on the enemy view would silently
+  // hit the player's grid at the matching coords.
+  if (viewState.activeUndergroundColonyId !== PLAYER_COLONY_ID) return;
+  if (isPointerOverHUD(screenX, screenY, viewState)) return;
   const { tileX, tileY } = screenToTile(screenX, screenY, viewState.undergroundCamera);
   const grid = world.undergroundGrids[PLAYER_COLONY_ID];
   if (!grid) return;

--- a/src/render/draw-surface.test.ts
+++ b/src/render/draw-surface.test.ts
@@ -884,6 +884,91 @@ describe('drawSurfaceEntities — rally-point marker', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Issue #14 — enemy entrance border cue
+// ---------------------------------------------------------------------------
+
+describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
+  function makeWorldWithEnemyEntrance(tileX = 10, tileY = 0): WorldState {
+    const w = createWorldState(1);
+    const player = createColonyRecord(PLAYER_COLONY_ID, 99);
+    player.entrances = [{ entranceId: 1, surfaceTileX: 0, surfaceTileY: 0, isOpen: true }];
+    player.rallyPoint = null;
+    player.digFlowFieldDirty = false;
+    player.priorityFoodPileId = null;
+    const enemyId = PLAYER_COLONY_ID + 1;
+    const enemy = createColonyRecord(enemyId, 88);
+    enemy.entrances = [{ entranceId: 2, surfaceTileX: tileX, surfaceTileY: tileY, isOpen: true }];
+    enemy.rallyPoint = null;
+    enemy.digFlowFieldDirty = false;
+    enemy.priorityFoodPileId = null;
+    w.colonies[PLAYER_COLONY_ID] = player;
+    w.colonies[enemyId]         = enemy;
+    return w;
+  }
+
+  it('emits 4 thin COLOR_ENEMY_COLONY fillRects forming a perimeter ring around the enemy entrance tile', () => {
+    const gfx = new MockGfx();
+    const sprites = new MockAntSprites();
+    const tileX = 10;
+    const tileY = 0;
+    const world = makeWorldWithEnemyEntrance(tileX, tileY);
+    const cam = makeCamera(tileX, tileY, 10, 4);
+    drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
+
+    // Find every fillRect emitted under COLOR_ENEMY_COLONY style — the
+    // perimeter ring is exactly 4 strokes (top/bottom/left/right).
+    const enemyRects: Array<[number, number, number, number]> = [];
+    let style: number | undefined;
+    for (const c of gfx.calls) {
+      if (c.method === 'fillStyle') style = c.args[0] as number;
+      else if (c.method === 'fillRect' && style === COLOR_ENEMY_COLONY) {
+        enemyRects.push(c.args as [number, number, number, number]);
+      }
+    }
+    expect(enemyRects.length).toBe(4);
+
+    // Compute expected screen-space tile origin and assert a 1-pixel ring.
+    const left = Math.floor(cam.x - cam.viewportWidth  / 2);
+    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const sx = (tileX - left) * TILE_SIZE_PX;
+    const sy = (tileY - top)  * TILE_SIZE_PX;
+    const expected = new Set([
+      [sx,                  sy,                  TILE_SIZE_PX, 1].join(','),                 // top
+      [sx,                  sy + TILE_SIZE_PX-1, TILE_SIZE_PX, 1].join(','),                 // bottom
+      [sx,                  sy + 1,              1, TILE_SIZE_PX - 2].join(','),             // left
+      [sx + TILE_SIZE_PX-1, sy + 1,              1, TILE_SIZE_PX - 2].join(','),             // right
+    ]);
+    for (const r of enemyRects) {
+      expect(expected.has(r.join(','))).toBe(true);
+    }
+  });
+
+  it('player entrance does NOT receive the enemy-color border', () => {
+    const gfx = new MockGfx();
+    const sprites = new MockAntSprites();
+    // Setup: only the player colony, no enemy.
+    const w = createWorldState(1);
+    const player = createColonyRecord(PLAYER_COLONY_ID, 99);
+    player.entrances = [{ entranceId: 1, surfaceTileX: 0, surfaceTileY: 0, isOpen: true }];
+    player.rallyPoint = null;
+    player.digFlowFieldDirty = false;
+    player.priorityFoodPileId = null;
+    w.colonies[PLAYER_COLONY_ID] = player;
+    const cam = makeCamera(0, 0, 10, 4);
+    drawSurfaceEntities(gfx, sprites, w, w, 0, cam);
+
+    // No enemy-colored fillRects anywhere.
+    let style: number | undefined;
+    let enemyRectCount = 0;
+    for (const c of gfx.calls) {
+      if (c.method === 'fillStyle') style = c.args[0] as number;
+      else if (c.method === 'fillRect' && style === COLOR_ENEMY_COLONY) enemyRectCount += 1;
+    }
+    expect(enemyRectCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: drawSurface orchestrator
 // ---------------------------------------------------------------------------
 

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -163,8 +163,15 @@ export function drawSurfaceEntities(
   // Phase 8.5 readability: render a 2-px dirt rim around the dark hole interior
   // so the entrance reads as a dug-out hole with a piled-dirt mound, not an
   // arbitrary black square.
+  //
+  // Issue #14 cue: enemy entrances also get a 1-px enemy-colony perimeter
+  // overlaid on the dirt rim so the player reads them as "rally here to
+  // invade" targets rather than just neutral terrain features. Player
+  // entrances are unchanged — the existing brown-mound style still reads
+  // as "my entrance."
   for (const colony of Object.values(curr.colonies)) {
     if (!colony.entrances) continue;
+    const isEnemy = colony.colonyId !== PLAYER_COLONY_ID;
     for (const entrance of colony.entrances) {
       const sx = (entrance.surfaceTileX - left) * TILE_SIZE_PX;
       const sy = (entrance.surfaceTileY - top)  * TILE_SIZE_PX;
@@ -173,6 +180,16 @@ export function drawSurfaceEntities(
       gfx.fillRect(sx, sy, TILE_SIZE_PX, TILE_SIZE_PX);
       gfx.fillStyle(COLOR_SURFACE_ENTRANCE_HOLE, 1);
       gfx.fillRect(sx + 2, sy + 2, TILE_SIZE_PX - 4, TILE_SIZE_PX - 4);
+      if (isEnemy) {
+        // 1-px enemy-colony border. Four thin fillRects draw a perimeter
+        // ring inside the tile's outermost pixel (no GfxLike.strokeRect
+        // available; the four-rect pattern is the established alternative).
+        gfx.fillStyle(COLOR_ENEMY_COLONY, 1);
+        gfx.fillRect(sx,                  sy,                  TILE_SIZE_PX, 1); // top
+        gfx.fillRect(sx,                  sy + TILE_SIZE_PX-1, TILE_SIZE_PX, 1); // bottom
+        gfx.fillRect(sx,                  sy + 1,              1, TILE_SIZE_PX - 2); // left
+        gfx.fillRect(sx + TILE_SIZE_PX-1, sy + 1,              1, TILE_SIZE_PX - 2); // right
+      }
     }
   }
 

--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -106,6 +106,8 @@ describe('HUD zone layout', () => {
     expect(HUD.TRIANGLE).toMatchObject({ x: 8, y: 532, w: 120, h: 44 });
     expect(HUD.MINIMAP).toMatchObject({ x: 632, y: 424, w: 160, h: 160 });
     expect(HUD.VIEW_TOGGLE).toMatchObject({ x: 632, y: 396, w: 80, h: 24 });
+    // Issue #14: colony-toggle button stacked just above VIEW_TOGGLE.
+    expect(HUD.UNDERGROUND_COLONY_TOGGLE).toMatchObject({ x: 632, y: 372, w: 112, h: 22 });
     expect(HUD.SPEED).toMatchObject({ x: 320, y: 552, w: 160, h: 32 });
     expect(HUD.SAVE_ICON).toMatchObject({ x: 772, y: 8, w: 20, h: 20 });
   });
@@ -118,6 +120,12 @@ describe('HUD zone layout', () => {
   it('VIEW_TOGGLE is directly above MINIMAP', () => {
     expect(HUD.VIEW_TOGGLE.x).toBe(HUD.MINIMAP.x);
     expect(HUD.VIEW_TOGGLE.y + HUD.VIEW_TOGGLE.h).toBeLessThanOrEqual(HUD.MINIMAP.y);
+  });
+
+  it('UNDERGROUND_COLONY_TOGGLE sits directly above VIEW_TOGGLE without overlap (issue #14)', () => {
+    expect(HUD.UNDERGROUND_COLONY_TOGGLE.x).toBe(HUD.VIEW_TOGGLE.x);
+    expect(HUD.UNDERGROUND_COLONY_TOGGLE.y + HUD.UNDERGROUND_COLONY_TOGGLE.h)
+      .toBeLessThanOrEqual(HUD.VIEW_TOGGLE.y);
   });
 });
 

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -155,6 +155,19 @@ export const HUD = {
   /** View toggle button: switches between surface and underground views. */
   VIEW_TOGGLE: { x: 632, y: 396, w: 80,  h: 24  },
   /**
+   * Issue #14 — colony toggle button (underground view only). Flips the
+   * underground render between PLAYER and ENEMY grids; equivalent to the
+   * X keybind. Visible only while activeView === 'underground'. Sits just
+   * above VIEW_TOGGLE so the underground HUD chrome stacks vertically.
+   *
+   * Width 112 fits "Enemy Colony (X)" at fontSize 12 with breathing room
+   * (~6 px/char × 16 chars + 8 px padding ≈ 104 px). 100 px was the
+   * original sizing and clipped right against the rightmost glyph; 112
+   * gives a comfortable margin without crowding the canvas-right edge
+   * (canvas width 800; toggle right edge 744 leaves 56 px for SAVE_ICON).
+   */
+  UNDERGROUND_COLONY_TOGGLE: { x: 632, y: 372, w: 112, h: 22 },
+  /**
    * Save icon zone.
    * Phase 9 layout reservation — Phase 8 draws nothing here.
    * Phase 9 wires autosave indicator rendering.

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -21,7 +21,7 @@
 
 import * as Phaser from 'phaser';
 import type { ViewState } from './camera.js';
-import { toggleView } from './camera.js';
+import { toggleView, toggleUndergroundColony } from './camera.js';
 import type { WorldState } from '../sim/types.js';
 import { HUD } from './sprites.js';
 import { GameOutcome } from '../sim/game-over.js';
@@ -267,18 +267,23 @@ export class UIScene extends Phaser.Scene {
     this.viewToggleText.setPadding(4);
     this.viewToggleText.setScrollFactor(0);
 
-    // Phase 09.1 Chunk 2 — underground colony label. Placed above the
-    // view-toggle button (HUD.VIEW_TOGGLE at y=396) so both pieces of
-    // underground chrome live in the same corner. Visibility is bound to
-    // activeView === 'underground' in update(); text follows
-    // activeUndergroundColonyId (binary toggle via X keybind).
+    // Phase 09.1 Chunk 2 + issue #14 — underground colony toggle button.
+    // Sits above VIEW_TOGGLE (HUD.UNDERGROUND_COLONY_TOGGLE) so the two
+    // underground-only HUD elements stack vertically. Visibility is bound
+    // to activeView === 'underground' in update(); text follows
+    // activeUndergroundColonyId (binary toggle).
+    //
+    // Issue #14 made this a CLICKABLE button (was a passive label) — the
+    // X keybind alone left invasion undiscoverable. Click + key both
+    // dispatch toggleUndergroundColony. The "(X)" hint surfaces the key
+    // for keyboard players. Background matches VIEW_TOGGLE styling so the
+    // two read as a stacked pair of toggle buttons.
     this.undergroundLabelText = this.add.text(
-      HUD.VIEW_TOGGLE.x,
-      HUD.VIEW_TOGGLE.y - 18,
-      'Your Colony',
-      { color: '#ffffff', fontSize: '12px', backgroundColor: '#000000' },
+      HUD.UNDERGROUND_COLONY_TOGGLE.x + 4,
+      HUD.UNDERGROUND_COLONY_TOGGLE.y + 4,
+      'Your Colony (X)',
+      { color: '#ffffff', fontSize: '12px' },
     );
-    this.undergroundLabelText.setPadding(4);
     this.undergroundLabelText.setScrollFactor(0);
     this.undergroundLabelText.setVisible(false);
 
@@ -389,7 +394,12 @@ export class UIScene extends Phaser.Scene {
         const overHud =
              this.isInsideRect(pointer.x, pointer.y, HUD.TRIANGLE)
           || this.isInsideRect(pointer.x, pointer.y, HUD.MINIMAP)
-          || this.isInsideRect(pointer.x, pointer.y, HUD.VIEW_TOGGLE);
+          || this.isInsideRect(pointer.x, pointer.y, HUD.VIEW_TOGGLE)
+          // Issue #14 — colony-toggle button. Without this entry, a click
+          // on the new toggle while the ant-activity panel is up would
+          // be classified as "world click", dismissing the panel and
+          // dropping the toggle dispatch.
+          || this.isInsideRect(pointer.x, pointer.y, HUD.UNDERGROUND_COLONY_TOGGLE);
         if (!overHud) {
           // Click on the world — dismiss and consume. `return` prevents
           // any further UIScene handling; the deferred hide prevents the
@@ -407,6 +417,17 @@ export class UIScene extends Phaser.Scene {
       // View toggle button
       if (this.isInsideRect(pointer.x, pointer.y, HUD.VIEW_TOGGLE)) {
         toggleView(this.viewState);
+        return;
+      }
+      // Issue #14 — underground colony toggle button. Mirrors the X
+      // keybind in game-scene.ts. Gated on activeView === 'underground'
+      // so a stray click on the surface view (where the button is
+      // invisible) doesn't flip the underground colony invisibly.
+      if (
+        this.viewState.activeView === 'underground' &&
+        this.isInsideRect(pointer.x, pointer.y, HUD.UNDERGROUND_COLONY_TOGGLE)
+      ) {
+        toggleUndergroundColony(this.viewState);
         return;
       }
       // Minimap click
@@ -551,18 +572,30 @@ export class UIScene extends Phaser.Scene {
       this.viewState.activeView === 'surface' ? 'Underground >' : '< Surface',
     );
 
-    // Phase 09.1 Chunk 2 — underground colony label. Only visible in the
-    // underground view; driven by the binary toggle reducer in camera.ts.
-    // Published to window.__phase9_ui.activeUndergroundLabel every frame the
-    // label is visible so Playwright can poll it without OCR.
+    // Phase 09.1 Chunk 2 + issue #14 — underground colony toggle button.
+    // Only visible in the underground view; driven by the binary toggle
+    // reducer in camera.ts. The Playwright label feed
+    // (window.__phase9_ui.activeUndergroundLabel) keeps the bare data
+    // string ('Your Colony' / 'Enemy Colony') so existing tests don't have
+    // to know about the (X) hint affordance the button now renders.
     const undergroundLabel: ActiveUndergroundLabel =
       this.viewState.activeUndergroundColonyId === ENEMY_COLONY_ID
         ? 'Enemy Colony'
         : 'Your Colony';
-    this.undergroundLabelText.setText(undergroundLabel);
-    this.undergroundLabelText.setVisible(
-      this.viewState.activeView === 'underground',
-    );
+    const undergroundShowing = this.viewState.activeView === 'underground';
+    if (undergroundShowing) {
+      // Draw the toggle background as a Graphics fill (matches VIEW_TOGGLE
+      // pattern below) so the click zone reads as a button.
+      this.gfx.fillStyle(0x333333, 1);
+      this.gfx.fillRect(
+        HUD.UNDERGROUND_COLONY_TOGGLE.x,
+        HUD.UNDERGROUND_COLONY_TOGGLE.y,
+        HUD.UNDERGROUND_COLONY_TOGGLE.w,
+        HUD.UNDERGROUND_COLONY_TOGGLE.h,
+      );
+    }
+    this.undergroundLabelText.setText(`${undergroundLabel} (X)`);
+    this.undergroundLabelText.setVisible(undergroundShowing);
     // Expose regardless of visibility so tests can assert the underlying
     // toggle state even if the surface view is active. Cheap string write.
     setActiveUndergroundLabel(undergroundLabel);


### PR DESCRIPTION
## Summary

Phase 09.1 already shipped the cross-grid invasion sim path (REQ-C3a / REQ-C4a) — but the player had no UI to actually use it. This PR adds the four input + HUD seams that surface the mechanic:

- **Left-click on an enemy entrance** sets the player rally point there. Existing rally-on-entrance carve-out + descent-intent gate handle the rest (fighters walk to the tile, descend into the enemy grid, target the nearest hostile, kill the queen → Victory).
- **The X-keybind that flips between viewing your hive and the enemy's hive** is now also a clickable HUD button (it was always there but undiscoverable).
- **The enemy underground view is now read-only** — clicks during the enemy view used to silently dispatch dig-marks against the player grid at the matching coords (invisible scribbling). Now they no-op.
- **Enemy entrances on the surface view get a 1-pixel red perimeter ring** so the player reads them as "rally here to invade" targets.

Closes #14.

## What changed

| Subsystem | File | Change |
|---|---|---|
| Surface input | `src/input/surface-input.ts` | New `isForeignColonyEntrance` helper; new branch in `handleSurfaceLeftClick` between food-pile mark and empty-tile rally. |
| Underground input | `src/input/underground-input.ts` | All three handlers no-op when `viewState.activeUndergroundColonyId !== PLAYER_COLONY_ID`. Defensive `state.isDragging = false` on the new guard. |
| HUD layout | `src/render/sprites.ts` | New `HUD.UNDERGROUND_COLONY_TOGGLE` zone (112×22 above VIEW_TOGGLE). |
| HUD pointer block | `src/input/camera-input.ts` | `isPointerOverHUD` gains optional `viewState`; the toggle zone is masked only when `activeView === 'underground'`. |
| HUD render | `src/render/ui-scene.ts` | Existing colony label upgraded to a button (background rect + click handler dispatching `toggleUndergroundColony`). Added to ant-activity panel dismiss allowlist. |
| Surface render | `src/render/draw-surface.ts` | Enemy-only 4-fillRect perimeter ring overlaid on the entrance dirt rim. |

## Verification

- `npm run verify` — exit 0 (lint + typecheck + sim-boundary + asset-path + 1533/1533 tests).
- 14 new regression tests across `surface-input.test.ts`, `underground-input.test.ts`, `camera-input.test.ts`, `draw-surface.test.ts`, `sprites.test.ts`.
- 3 internal review rounds against the diff; clean exit.

## Test plan

- [ ] `npm run dev` and verify the new "Your Colony (X)" button is clickable from the underground view; it flips to "Enemy Colony (X)" and renders the enemy hive.
- [ ] On the surface view, the enemy entrance shows a thin red perimeter ring.
- [ ] Left-clicking the enemy entrance places a rally marker (the existing white crosshair) on that tile.
- [ ] Allocate fighters via the slider, watch them route to the enemy entrance, descend, and kill the enemy queen — Victory triggers.
- [ ] Right-clicking the rally tile clears it (existing flow, unchanged).
- [ ] Confirm CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)