### PR TITLE
fix: ceiling-strip dig + place rejected across player, sim, and AI paths (closes #30 #31)

### DIFF
--- a/src/input/underground-input.test.ts
+++ b/src/input/underground-input.test.ts
@@ -1031,6 +1031,22 @@ describe('underground-input — ceiling-strip row gate (issue #30)', () => {
     expect(state.isDragging).toBe(false);
   });
 
+  it('handleUndergroundLeftClick on the ceiling strip clears any stale isDragging flag (codex P2)', () => {
+    // Defensive: a prior gesture that didn't see a clean pointerup (focus-
+    // loss) could leave isDragging=true. The ceiling-row guard must also
+    // reset it so a subsequent pointermove doesn't resume the stale stroke
+    // from a stale lastMarkedTile and emit hidden marks — the exact
+    // pre-fix behavior this PR is supposed to eliminate.
+    const world = makeWorld();
+    ugSet(world.undergroundGrids[PLAYER_COLONY_ID]!, 10, 0, UndergroundTileState.Solid);
+    const vs = makeViewState('underground', 64, 32);
+    const state = makeState(/*isDragging*/ true, 4, 4);
+    const { x, y } = tileToScreen(10, 0, 64, 32);
+    handleUndergroundLeftClick(world, vs, x, y, state);
+    expect(world.commandQueue).toHaveLength(0);
+    expect(state.isDragging).toBe(false);
+  });
+
   it('handleUndergroundLeftClick on tileY=1 still emits MarkDigTile (sanity — only y=0 is gated)', () => {
     const world = makeWorld();
     const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;

--- a/src/input/underground-input.test.ts
+++ b/src/input/underground-input.test.ts
@@ -1007,3 +1007,112 @@ describe('underground-input read-only when activeUndergroundColonyId !== PLAYER_
     expect(world.commandQueue).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #30 — ceiling-strip click rejection
+// ---------------------------------------------------------------------------
+
+describe('underground-input — ceiling-strip row gate (issue #30)', () => {
+  it('handleUndergroundLeftClick on tileY=0 is a no-op (no MarkDigTile, no drag arm)', () => {
+    // The renderer paints the topmost underground row with the grass texture
+    // as a "this is the surface boundary, not a diggable wall" cue. Without
+    // this gate, a click on the visible grass dispatched MarkDigTile against
+    // the tile beneath, the renderer kept painting grass on top, and the
+    // mark was effectively invisible to the player. See draw-underground.ts
+    // (`ty === 0` branch) for the matching renderer logic.
+    const world = makeWorld();
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 10, 0, UndergroundTileState.Solid);
+    const vs = makeViewState('underground', 64, 32);
+    const state = makeState();
+    const { x, y } = tileToScreen(10, 0, 64, 32);
+    handleUndergroundLeftClick(world, vs, x, y, state);
+    expect(world.commandQueue).toHaveLength(0);
+    expect(state.isDragging).toBe(false);
+  });
+
+  it('handleUndergroundLeftClick on tileY=1 still emits MarkDigTile (sanity — only y=0 is gated)', () => {
+    const world = makeWorld();
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 10, 1, UndergroundTileState.Solid);
+    const vs = makeViewState('underground', 64, 32);
+    const state = makeState();
+    const { x, y } = tileToScreen(10, 1, 64, 32);
+    handleUndergroundLeftClick(world, vs, x, y, state);
+    expect(world.commandQueue).toHaveLength(1);
+    const cmd = world.commandQueue[0] as { type: string; tileY: number };
+    expect(cmd.type).toBe('MarkDigTile');
+    expect(cmd.tileY).toBe(1);
+  });
+
+  it('handleUndergroundDrag stroke that crosses tileY=0 skips the row-0 tiles but continues on row 1+', () => {
+    // Drag stroke from (10, 1) → (20, 0) → (20, 1) (synthesized via two
+    // emit calls). The row-0 tile must NOT emit a MarkDigTile; the row-1
+    // tiles bracketing it MUST emit. Bresenham continues across the gap.
+    const world = makeWorld();
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    // Solid corridor along the path so each tile would otherwise be markable.
+    for (let x = 10; x <= 20; x++) {
+      ugSet(grid, x, 0, UndergroundTileState.Solid);
+      ugSet(grid, x, 1, UndergroundTileState.Solid);
+    }
+    const vs = makeViewState('underground', 64, 32);
+    // Seed drag at (10, 1) with isDragging=true (sentinel-free path).
+    const state = makeState(/*isDragging*/ true, 10, 1);
+    // Drag to (20, 0) — Bresenham stroke runs along row 0 and row 1.
+    const { x, y } = tileToScreen(20, 0, 64, 32);
+    handleUndergroundDrag(world, vs, x, y, state);
+    // Every emitted command must have tileY > 0 — no ceiling-row marks.
+    const tileYsEmitted = world.commandQueue.map((c) => (c as { tileY: number }).tileY);
+    expect(tileYsEmitted.length).toBeGreaterThan(0); // sanity — some marks fired
+    expect(tileYsEmitted.every((ty) => ty > 0)).toBe(true);
+  });
+
+  it('handleUndergroundDrag stroke that grazes ty=0 mid-stroke still emits row-1+ tiles past the crossing', () => {
+    // Strengthens the prior "crosses ceiling" test by ending the stroke on
+    // a regular row, not on row 0. The Bresenham loop must keep emitting
+    // for tiles past the row-0 crossing — the row-0 gate must be a
+    // per-tile skip inside emitTile, not a stroke-level early return.
+    const world = makeWorld();
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    for (let x = 5; x <= 15; x++) {
+      for (let y = 0; y <= 2; y++) {
+        ugSet(grid, x, y, UndergroundTileState.Solid);
+      }
+    }
+    const vs = makeViewState('underground', 64, 32);
+    const state = makeState(/*isDragging*/ true, 5, 2);
+    // Drag end at (15, 2) — Bresenham line passes through tiles at multiple
+    // rows including y=0 if the stepper takes a diagonal turn through it.
+    // For our straight-row stroke (5,2)→(15,2), no row-0 tiles are touched,
+    // but we explicitly synthesize a stroke that does cross y=0 by routing
+    // through (10, 0).
+    let { x: x1, y: y1 } = tileToScreen(10, 0, 64, 32);
+    handleUndergroundDrag(world, vs, x1, y1, state); // first leg dips through row 0
+    ({ x: x1, y: y1 } = tileToScreen(15, 2, 64, 32));
+    handleUndergroundDrag(world, vs, x1, y1, state); // second leg returns to row 2
+    const tileYsEmitted = world.commandQueue.map((c) => (c as { tileY: number }).tileY);
+    expect(tileYsEmitted.length).toBeGreaterThan(0);
+    expect(tileYsEmitted.every((ty) => ty > 0)).toBe(true);
+    // Specifically: (15, 2) reached and emitted past the ceiling crossing.
+    expect(tileYsEmitted).toContain(2);
+  });
+
+  it('handleUndergroundDrag from sentinel (-1,-1) into tileY=0 is a no-op but rebases the cursor', () => {
+    // First-tick drag fall-back: when lastMarkedTile is the (-1,-1) sentinel
+    // and the pointer lands on the ceiling strip, we don't mark anything
+    // but we DO rebase the cursor so a subsequent drag onto a regular row
+    // can interpolate from a valid origin.
+    const world = makeWorld();
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 10, 0, UndergroundTileState.Solid);
+    const vs = makeViewState('underground', 64, 32);
+    const state = makeState(/*isDragging*/ true, -1, -1);
+    const { x, y } = tileToScreen(10, 0, 64, 32);
+    handleUndergroundDrag(world, vs, x, y, state);
+    expect(world.commandQueue).toHaveLength(0);
+    expect(state.lastMarkedTileX).toBe(10);
+    expect(state.lastMarkedTileY).toBe(0);
+    expect(state.isDragging).toBe(true);
+  });
+});

--- a/src/input/underground-input.ts
+++ b/src/input/underground-input.ts
@@ -170,10 +170,18 @@ export function handleUndergroundLeftClick(
   // `ty === 0` branch in draw-underground.ts:137-153). Without this gate a
   // click on the visible grass silently dispatches MarkDigTile against the
   // tile beneath, which the renderer keeps painting as grass — the player
-  // gets no visual feedback the click did anything. Drag is also armed to
-  // false here so a click-and-drag down from the ceiling strip cannot mark
-  // adjacent tiles via the Bresenham interpolation in handleUndergroundDrag.
-  if (tileY === UNDERGROUND_CEILING_ROW_Y) return;
+  // gets no visual feedback the click did anything.
+  //
+  // Codex P2 follow-up: also clear any stale drag state on this guard
+  // path. If a prior gesture left `isDragging=true` (focus-loss / missed
+  // pointerup), simply returning here without the reset would let the
+  // next pointermove resume the stale stroke from the old cursor — the
+  // exact "hidden marking" behavior this fix is supposed to eliminate.
+  // Symmetric with the enemy-view guard's defensive reset.
+  if (tileY === UNDERGROUND_CEILING_ROW_Y) {
+    state.isDragging = false;
+    return;
+  }
   // Arm drag state up front (before the tile-state branch) so a stroke that
   // begins on a Marked/BeingDug tile still marks subsequent Solid tiles. The
   // debounce cursor is seeded to the clicked tile so the first Bresenham

--- a/src/input/underground-input.ts
+++ b/src/input/underground-input.ts
@@ -23,7 +23,7 @@ import type { ViewState } from '../render/camera.js';
 import { screenToTile } from '../render/camera.js';
 import { ugGet, UndergroundTileState } from '../sim/terrain.js';
 import type { MarkDigTileCommand, CancelDigMarkCommand } from '../sim/commands.js';
-import { PLAYER_COLONY_ID } from '../sim/constants.js';
+import { PLAYER_COLONY_ID, UNDERGROUND_CEILING_ROW_Y } from '../sim/constants.js';
 import { isPointerOverHUD, panInputState } from './camera-input.js';
 import { contextMenuState, requestShowContextMenu } from '../render/context-menu-state.js';
 
@@ -165,6 +165,15 @@ export function handleUndergroundLeftClick(
   const grid = world.undergroundGrids[PLAYER_COLONY_ID];
   if (!grid) return;
   if (tileX < 0 || tileY < 0 || tileX >= grid.width || tileY >= grid.height) return;
+  // Issue #30: skip the ceiling-strip row. The renderer paints `tileY === 0`
+  // with the grass texture as a "this is the surface boundary" cue (see
+  // `ty === 0` branch in draw-underground.ts:137-153). Without this gate a
+  // click on the visible grass silently dispatches MarkDigTile against the
+  // tile beneath, which the renderer keeps painting as grass — the player
+  // gets no visual feedback the click did anything. Drag is also armed to
+  // false here so a click-and-drag down from the ceiling strip cannot mark
+  // adjacent tiles via the Bresenham interpolation in handleUndergroundDrag.
+  if (tileY === UNDERGROUND_CEILING_ROW_Y) return;
   // Arm drag state up front (before the tile-state branch) so a stroke that
   // begins on a Marked/BeingDug tile still marks subsequent Solid tiles. The
   // debounce cursor is seeded to the clicked tile so the first Bresenham
@@ -249,6 +258,13 @@ export function handleUndergroundDrag(
 
   if (x0 === -1 && y0 === -1) {
     if (x1 < 0 || y1 < 0 || x1 >= grid.width || y1 >= grid.height) return;
+    if (y1 === UNDERGROUND_CEILING_ROW_Y) {
+      // Issue #30: drag-into-ceiling-strip silently rebases the cursor without
+      // emitting a mark. The stroke can continue from here onto regular rows.
+      state.lastMarkedTileX = x1;
+      state.lastMarkedTileY = y1;
+      return;
+    }
     const tileStateSingle = ugGet(grid, x1, y1);
     if (tileStateSingle === UndergroundTileState.Solid || tileStateSingle === UndergroundTileState.Open) {
       const cmd: MarkDigTileCommand = {
@@ -281,6 +297,12 @@ export function handleUndergroundDrag(
     finalX = tx;
     finalY = ty;
     if (tx < 0 || ty < 0 || tx >= grid.width || ty >= grid.height) return;
+    // Issue #30: skip the ceiling-strip row inside the stroke — same gate as
+    // handleUndergroundLeftClick. The stroke cursor still advances (finalX/Y
+    // already updated above) so a drag that starts on a regular row, crosses
+    // the ceiling, and continues on the other side keeps interpolating; only
+    // the row-0 tiles themselves are skipped.
+    if (ty === UNDERGROUND_CEILING_ROW_Y) return;
     const ts = ugGet(grid, tx, ty);
     if (ts !== UndergroundTileState.Solid && ts !== UndergroundTileState.Open) return;
     const cmd: MarkDigTileCommand = {

--- a/src/render/ai-controller.test.ts
+++ b/src/render/ai-controller.test.ts
@@ -282,6 +282,28 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       expect(world.commandQueue).toHaveLength(0);
     });
 
+    it('Issue #30: chamber at chTileY=1 → AI must NOT mark row 0 (top border skips ceiling)', () => {
+      // The visible bug from PR #32 UAT: every chamber the AI placed at
+      // chTileY=1 had its top-border perimeter loop hit ty=0, marking the
+      // ceiling-strip tiles for digging. Once excavated, the chamber-edge
+      // network straddled the grass band. isDirtTileUnderground now
+      // rejects ty=0 so the AI never proposes those marks (the sim's
+      // MarkDigTile gate would reject them anyway, but pre-filtering
+      // saves AI_DIG_MARK_BUDGET on dead-on-arrival commands).
+      const world = makeWorld(AI_DIG_INTERVAL);
+      const colony = addColony(world, 2 as ColonyId, 0);
+      addUndergroundGrid(world, 2 as ColonyId);
+      // Single-tile chamber at (10, 1) — top border lands on ty=0 = ceiling.
+      colony.chambers.push(makeChamber(ChamberType.Queen, 10, 1, 1, 1));
+      aiDigHeuristic(world, colony);
+      const digCmds = world.commandQueue.filter((c) => c.type === 'MarkDigTile');
+      // Some marks fired (E/W/S neighbors are valid), but NONE on the ceiling row.
+      expect(digCmds.length).toBeGreaterThan(0);
+      for (const cmd of digCmds as Array<{ tileY: number }>) {
+        expect(cmd.tileY).not.toBe(0);
+      }
+    });
+
     it('every MarkDigTile command has issuedAtTick: world.tick and no zone field', () => {
       const world = makeWorld(AI_DIG_INTERVAL);
       const colony = addColony(world, 2 as ColonyId, 0);

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -16,6 +16,7 @@ import { ChamberType } from '../sim/enums.js';
 import { UndergroundTileState, ugGet } from '../sim/terrain.js';
 import { FP_SHIFT } from '../sim/fixed.js';
 import { CHAMBER_DIMENSIONS } from '../sim/colony/chamber.js';
+import { UNDERGROUND_CEILING_ROW_Y } from '../sim/constants.js';
 import { colonyFoodTotal } from '../sim/colony/colony-system.js';
 
 export const AI_DIG_INTERVAL = 40 as const;       // every 2 seconds @ 20Hz
@@ -321,6 +322,14 @@ function isDirtTileUnderground(
   const grid = world.undergroundGrids[colonyId];
   if (grid === undefined) return false;
   if (tx < 0 || ty < 0 || tx >= grid.width || ty >= grid.height) return false;
+  // Issue #30: the AI must never propose marks in the ceiling row. The
+  // sim-layer MarkDigTile gate would reject them anyway, but having the AI
+  // pre-filter avoids spamming AI_DIG_MARK_BUDGET on dead-on-arrival
+  // commands every AI_DIG_INTERVAL ticks. The screenshot from PR #32 UAT
+  // showed enemy chambers built straddling the grass strip because every
+  // chamber at chTileY=1 (the typical near-surface case) had its top-
+  // border perimeter loop hit ty=0 and excavate the ceiling.
+  if (ty === UNDERGROUND_CEILING_ROW_Y) return false;
   return ugGet(grid, tx, ty) === UndergroundTileState.Solid;
 }
 

--- a/src/sim/behavior/allocation-system.ts
+++ b/src/sim/behavior/allocation-system.ts
@@ -131,9 +131,19 @@ export function allocateWorkers(
 /**
  * Phase 10 / CTRL-06 — auto-dig demand check (D-02 LOCKED).
  *
- * Returns 1 if (a) at least one Marked tile exists in the colony's underground
- * grid AND (b) no ant in `colony.workers` currently has `task === AntTask.Digging`.
- * Returns 0 otherwise.
+ * Returns 1 if (a) at least one REACHABLE Marked tile exists in the colony's
+ * underground grid AND (b) no ant in `colony.workers` currently has
+ * `task === AntTask.Digging`. Returns 0 otherwise.
+ *
+ * "Reachable" (issue #31) — a Marked tile must have at least one 4-connected
+ * Open neighbor. Without this, isolated Marked islands (e.g., the player
+ * marked a column of tiles surrounded by Solid) generate dig demand the
+ * Digger can never satisfy: step 10a carves a forage slot for the digger
+ * each tick, the digger picks the unreachable Marked tile via a -2
+ * dig-flow-field reading, gets released back to Idle, and the cycle
+ * repeats — locking one worker out of forage/nurse work indefinitely. The
+ * adjacency check is one extra branch per Marked tile in the same single
+ * scan, deterministic, no allocation.
  *
  * Strict 1-digger cap (per CONTEXT.md D-02): if ANY ant of the colony is already
  * Digging, no new digger is auto-assigned this tick. This solves the tunnel-jam
@@ -155,7 +165,7 @@ export function allocateWorkers(
  * @param colony           - Colony record; iterated to detect any active digger.
  * @param undergroundGrid  - Colony's underground grid; scanned for Marked tiles.
  * @param ants             - Ant component store (alive + task arrays).
- * @returns 1 if Marked tiles exist and no ant is Digging in this colony, else 0.
+ * @returns 1 if a reachable Marked tile exists and no ant is Digging in this colony, else 0.
  */
 export function computeDigDemand(
   colony: ColonyRecord,
@@ -168,13 +178,37 @@ export function computeDigDemand(
     if (ants.alive[id] !== 1) continue;
     if (ants.task[id] === AntTask.Digging) return 0;
   }
-  // (a) Marked tile presence — single linear scan over the grid's Uint8Array.
-  // Direct data[] access (matches the Phase 07-04 decision for computeDigFlowField:
-  // direct array access, not ugGet, in inner BFS loop for performance). Same fixed
-  // iteration order as BFS (linear i from 0).
+  // (a) Reachable Marked tile presence — single linear scan over the grid's
+  // Uint8Array, plus a 4-neighbor Open adjacency check per Marked candidate.
+  // A digger excavates from an Open tile adjacent to the Marked target, so
+  // reachability ≡ "Marked tile has at least one Open 4-neighbor." This is
+  // the dig-flow-field's BFS-seed criterion in compact form (issue #31).
+  // Direct data[] access (matches the Phase 07-04 decision for
+  // computeDigFlowField: direct array access, not ugGet, in inner BFS loop
+  // for performance). Same fixed iteration order as BFS (linear i from 0).
   const data = undergroundGrid.data;
+  const w = undergroundGrid.width;
+  const h = undergroundGrid.height;
   for (let i = 0; i < data.length; i++) {
-    if (data[i] === UndergroundTileState.Marked) return 1;
+    if (data[i] !== UndergroundTileState.Marked) continue;
+    // Decode (x, y) from the linear index. Inline because ugGet adds a
+    // bounds check and a function-call frame per neighbor; the scan body
+    // is hot enough that the inlined math is the established pattern (see
+    // computeDigFlowField BFS in dig-system.ts).
+    // eslint-disable-next-line no-restricted-syntax -- integer division via `| 0` truncation; index-to-row conversion, not fixed-point math
+    const y = (i / w) | 0;
+    const x = i - y * w;
+    // 4-connected reachability: a neighbor counts as reachable if it's
+    // either Open OR BeingDug. Mirrors `computeDigFlowField`'s BFS in
+    // dig-system.ts which expands through both states. Without the
+    // BeingDug branch a Marked tile whose only Open path is currently
+    // mid-excavation would falsely report unreachable for one tick of
+    // the dig cycle, briefly suppressing demand and causing the
+    // forage-carve to wobble.
+    if (x > 0     && (data[i - 1] === UndergroundTileState.Open || data[i - 1] === UndergroundTileState.BeingDug)) return 1;
+    if (x < w - 1 && (data[i + 1] === UndergroundTileState.Open || data[i + 1] === UndergroundTileState.BeingDug)) return 1;
+    if (y > 0     && (data[i - w] === UndergroundTileState.Open || data[i - w] === UndergroundTileState.BeingDug)) return 1;
+    if (y < h - 1 && (data[i + w] === UndergroundTileState.Open || data[i + w] === UndergroundTileState.BeingDug)) return 1;
   }
   return 0;
 }

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -163,6 +163,17 @@ export const UNDERGROUND_GRID_WIDTH = 128;
 /** PRD §9c — Height of the underground pheromone grid in tiles. */
 export const UNDERGROUND_GRID_HEIGHT = 64;
 
+/**
+ * Issue #30 — y-coordinate of the underground "ceiling strip." Row 0 of the
+ * underground grid renders as the underside of the surface grass (see the
+ * `ty === 0` branch in `src/render/draw-underground.ts`); it's a visual cue
+ * communicating "this is the surface boundary, not a diggable wall." Both
+ * `handleUndergroundLeftClick` and `handleUndergroundDrag` reject clicks on
+ * this row so the input gate stays in lockstep with the renderer's
+ * ceiling-strip painting.
+ */
+export const UNDERGROUND_CEILING_ROW_Y = 0;
+
 // ---------------------------------------------------------------------------
 // Default behavior ratio (PRD §7, §2)
 // ---------------------------------------------------------------------------

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -1110,6 +1110,36 @@ describe('Phase 7: MarkDigTile command processing', () => {
     expect(ugGet(underground, 10, 10)).toBe(UndergroundTileState.Open);
   });
 
+  // Issue #30 (sim-side): ceiling-row reject regardless of dispatch source.
+  it('Issue #30: MarkDigTile on tileY=0 (ceiling row) → silent drop, tile stays Solid', () => {
+    const { world, colonyId } = makeWorldWithUnderground();
+    const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 30, tileY: 0, issuedAtTick: 0 };
+    tick(world, [cmd]);
+    const underground = world.undergroundGrids[colonyId]!;
+    // Tile stays Solid — the ceiling-row gate fires before the Marked write.
+    expect(ugGet(underground, 30, 0)).toBe(UndergroundTileState.Solid);
+  });
+
+  // Issue #30 (carve-out): DesignateEntrance must still mark row 0 at the
+  // entrance column. Entrance columns are exempt by design — the renderer
+  // paints them as the gold-tinted "way in" hole, not as the grass ceiling.
+  // The MarkDigTile gate above is scoped to the MarkDigTile dispatch path
+  // only; DesignateEntrance writes via direct ugSet to preserve this
+  // legitimate exemption. Regression guard so a future overreach of the
+  // ceiling-row rule doesn't break entrance shaft excavation.
+  it('Issue #30: DesignateEntrance still marks the row-0 shaft tile at the entrance column', () => {
+    const { world, colonyId } = makeWorldWithUnderground();
+    const cmd: SimCommand = {
+      type: 'DesignateEntrance', colonyId,
+      surfaceTileX: 40, surfaceTileY: 64, issuedAtTick: 0,
+    };
+    tick(world, [cmd]);
+    const underground = world.undergroundGrids[colonyId]!;
+    // Row-0 tile at the designated column is Marked — entrance columns
+    // are exempt from the ceiling-row prohibition.
+    expect(ugGet(underground, 40, 0)).toBe(UndergroundTileState.Marked);
+  });
+
   // Test P7-3: MarkDigTile out of bounds → silent drop
   it('Test P7-3: MarkDigTile out of bounds → silent drop, no throw', () => {
     const { world, colonyId } = makeWorldWithUnderground();
@@ -1239,6 +1269,21 @@ describe('Phase 7: MarkDigTile command processing', () => {
     tick(world, [cmd2]);
     // Overlapping chamber should NOT have been created
     expect(world.pendingChambers[`${colonyId}:12:10`]).toBeUndefined();
+  });
+
+  // Issue #30 (sim-side): PlaceChamber footprint must not include the
+  // ceiling row. Symmetric with the MarkDigTile gate.
+  it('Issue #30: PlaceChamber rejected when anchorTileY=0 (footprint overlaps ceiling)', () => {
+    const { world, colonyId } = makeWorldWithUnderground();
+    const underground = world.undergroundGrids[colonyId]!;
+    underground.data[0 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
+    const cmd: SimCommand = {
+      type: 'PlaceChamber', colonyId,
+      chamberType: ChamberType.Queen,
+      anchorTileX: 10, anchorTileY: 0, issuedAtTick: 0,
+    };
+    tick(world, [cmd]);
+    expect(world.pendingChambers[`${colonyId}:10:0`]).toBeUndefined();
   });
 
   // Test P7-9: PlaceChamber rejected if out of bounds

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -1055,7 +1055,7 @@ describe('PHER-02 two-grid integration', () => {
 // Phase 7: Command processing tests
 // ---------------------------------------------------------------------------
 
-import { createUndergroundGrid, UndergroundTileState, ugGet } from './terrain.js';
+import { createUndergroundGrid, UndergroundTileState, ugGet, ugSet } from './terrain.js';
 import { DiggingSubState } from './enums.js';
 import type { FoodPile } from './food.js';
 import {
@@ -2775,6 +2775,20 @@ describe('resetFlowFieldCaches — cross-world isolation', () => {
 // ---------------------------------------------------------------------------
 
 describe('Phase 10 / CTRL-06 auto-dig', () => {
+  // Reset the module-level dig flow-field cache between every test in this
+  // block. Without this, a test that mutates the underground grid via
+  // `ugSet` (rather than the MarkDigTileCommand handler that sets
+  // colony.digFlowFieldDirty=true) inherits the cached flow field from
+  // whichever test ran before — step 9 sees a falsy dirty flag AND a non-
+  // first-compute state, and skips recomputation. The flow field then
+  // doesn't reflect the tiles the test just marked, so tickDigExecution's
+  // unreachable-release path (-2 reading) misclassifies a freshly-assigned
+  // Digger and bounces it back to Idle. Caught while authoring Tests 11/12
+  // for issue #31 (computeDigDemand reachability fix).
+  beforeEach(() => {
+    resetFlowFieldCaches();
+  });
+
   /**
    * Build a single-colony world with an underground grid pre-shaped so that
    * (24, 1) is Open (mirrors the entrance shaft created by createScenario but
@@ -3222,6 +3236,93 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     }
     expect(diggingCount).toBe(1);
     expect(idleCount).toBe(2); // remaining Idle ants stay Idle (no other role demands)
+  });
+
+  it('Test 11 (issue #31): isolated Marked island (no Open neighbor) → dig demand = 0, Idle ants reassign to forage', () => {
+    // Repro of the user-visible "ant sitting at chamber doing nothing" bug
+    // captured in seed1521505688-tick2967. The player marked 4 tiles in the
+    // top row of the underground grid by clicking the grass-textured ceiling
+    // strip (issue #30); none of those tiles has an Open 4-neighbor. Pre-fix:
+    // computeDigDemand returns 1, step 10a carves a slot and assigns one
+    // Idle ant to Digging, the dig flow-field reports unreachable, the ant
+    // bounces back to Idle each tick — locked out of forage indefinitely.
+    // Post-fix (issue #31): Marked tiles without an Open neighbor don't
+    // count, demand=0, the Idle ant gets reassigned to Foraging normally.
+    const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    const colony = world.colonies[colonyId]!;
+    const underground = world.undergroundGrids[colonyId]!;
+
+    colony.workerCount = 2;
+    const widList: number[] = [];
+    for (let i = 0; i < 2; i++) {
+      const wid = allocateEntityId(world);
+      initAnt(world.ants, wid, {
+        colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
+        task: AntTask.Idle, subTask: 0,
+      });
+      world.ants.zone[wid] = 1;
+      colony.workers.push(wid);
+      widList.push(wid);
+    }
+
+    // Mark a 2-tile island far from the entrance shaft, with no Open
+    // 4-neighbor. The shaft Open tiles are at (24, 0) and (24, 1) per the
+    // helper; the marks at (50, 30)/(50, 31) sit in a sea of Solid. The
+    // describe-level `beforeEach(resetFlowFieldCaches)` ensures step 9's
+    // firstDigCompute gate fires this tick, so direct ugSet without
+    // dirty-flagging is safe here.
+    ugSet(underground, 50, 30, UndergroundTileState.Marked);
+    ugSet(underground, 50, 31, UndergroundTileState.Marked);
+
+    // t=0 preconditions — confirm the island is genuinely isolated.
+    expect(ugGet(underground, 50, 30)).toBe(UndergroundTileState.Marked);
+    expect(ugGet(underground, 50, 31)).toBe(UndergroundTileState.Marked);
+    expect(ugGet(underground, 49, 30)).toBe(UndergroundTileState.Solid);
+    expect(ugGet(underground, 51, 30)).toBe(UndergroundTileState.Solid);
+    expect(ugGet(underground, 50, 29)).toBe(UndergroundTileState.Solid);
+    expect(ugGet(underground, 50, 32)).toBe(UndergroundTileState.Solid);
+
+    tick(world, []);
+
+    // Dig demand suppressed — the Marked island is unreachable, so the
+    // forage-carve never fires. Both workers go to forage.
+    expect(colony.computedAllocation.dig).toBe(0);
+    let diggingCount = 0;
+    let foragingCount = 0;
+    for (const id of widList) {
+      if (world.ants.task[id] === AntTask.Digging)  diggingCount  += 1;
+      if (world.ants.task[id] === AntTask.Foraging) foragingCount += 1;
+    }
+    expect(diggingCount).toBe(0);
+    expect(foragingCount).toBe(2);
+  });
+
+  it('Test 12 (issue #31): one Marked tile with an Open neighbor + one isolated → dig demand = 1', () => {
+    // Mixed island scenario: prove the fix doesn't over-suppress. As long as
+    // ANY Marked tile has an Open 4-neighbor, dig demand fires — the
+    // unreachable marks are simply ignored.
+    const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    const colony = world.colonies[colonyId]!;
+    const underground = world.undergroundGrids[colonyId]!;
+
+    colony.workerCount = 1;
+    const wid = allocateEntityId(world);
+    initAnt(world.ants, wid, {
+      colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
+      task: AntTask.Idle, subTask: 0,
+    });
+    world.ants.zone[wid] = 1;
+    colony.workers.push(wid);
+
+    // (25, 1) is adjacent to the Open shaft at (24, 1) — reachable.
+    // (50, 30) is isolated — unreachable. beforeEach reset handles cache.
+    ugSet(underground, 25, 1, UndergroundTileState.Marked);
+    ugSet(underground, 50, 30, UndergroundTileState.Marked);
+
+    tick(world, []);
+
+    expect(colony.computedAllocation.dig).toBe(1);
+    expect(world.ants.task[wid]).toBe(AntTask.Digging);
   });
 
   it('Test 9 (WR-08): all-nurse colony (forage=fight=0) → auto-dig genuinely waits', () => {

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -21,6 +21,7 @@ import {
   ENTRANCE_SHAFT_DEPTH,
   UNDERGROUND_GRID_WIDTH,
   UNDERGROUND_GRID_HEIGHT,
+  UNDERGROUND_CEILING_ROW_Y,
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
 } from './constants.js';
@@ -239,6 +240,22 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         if (!underground) break;
         // T-07-10: bounds check (mitigate tamper — reject out-of-range silently)
         if (cmd.tileX < 0 || cmd.tileX >= UNDERGROUND_GRID_WIDTH || cmd.tileY < 0 || cmd.tileY >= UNDERGROUND_GRID_HEIGHT) break;
+        // Issue #30 (sim-side): reject ceiling-strip dispatches at the
+        // MarkDigTile boundary. The renderer paints `tileY === 0` as grass
+        // for non-entrance columns (entrance columns get the gold-tinted
+        // Open hole), so a Marked tile underneath would be invisible.
+        // Player clicks are also gated at the input layer; the AI
+        // controller pushes MarkDigTileCommand directly to the queue
+        // (every chamber's top-border perimeter mark hits ty=0 when
+        // chTileY=1). The sim-layer gate covers any current or future
+        // path that ends here — CLNY-08-compliant, no isPlayer branching.
+        //
+        // Out of scope for this gate: the DesignateEntrance handler
+        // writes Marked tiles in the entrance column from sy=0 down via
+        // direct `ugSet` and intentionally bypasses MarkDigTile. That's
+        // correct — entrance columns are exempt by design (the renderer
+        // paints them as the gold-tinted "way in" hole, not grass).
+        if (cmd.tileY === UNDERGROUND_CEILING_ROW_Y) break;
         if (ugGet(underground, cmd.tileX, cmd.tileY) !== UndergroundTileState.Solid) break;
         ugSet(underground, cmd.tileX, cmd.tileY, UndergroundTileState.Marked);
         const colony1 = world.colonies[cmd.colonyId];
@@ -286,6 +303,15 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         // (a)(b) Bounds check (T-07-11 first guard)
         if (cmd.anchorTileX < 0 || cmd.anchorTileX + dims.width > UNDERGROUND_GRID_WIDTH) break;
         if (cmd.anchorTileY < 0 || cmd.anchorTileY + dims.height > UNDERGROUND_GRID_HEIGHT) break;
+        // Issue #30 (sim-side): reject any chamber whose footprint overlaps
+        // the ceiling row. CHAMBER_DIMENSIONS extend DOWN from the anchor,
+        // so anchorTileY === UNDERGROUND_CEILING_ROW_Y is exactly the
+        // "footprint includes the ceiling row" case — no need to inspect
+        // the footprint range, the equality check is sufficient as long
+        // as the ceiling stays a single row. Mirrors the MarkDigTile
+        // gate above; same CLNY-08 rationale (player + AI use the same
+        // sim handler, so no isPlayer branching).
+        if (cmd.anchorTileY === UNDERGROUND_CEILING_ROW_Y) break;
         const colony3 = world.colonies[cmd.colonyId];
         if (!colony3) break;
         // Queen-uniqueness (09 backlog memo): reject if colony already has a


### PR DESCRIPTION
## Summary

Three layered gates prevent the underground "ceiling row" from being marked or placed-into, and `computeDigDemand` only counts marks that are actually reachable.

The PR started narrow (player input) and expanded to cover non-player paths after UAT showed the enemy AI was still building chambers straddling the grass strip — the AI bypasses the input layer entirely.

Closes #30. Closes #31.

## What changed

### #30 — ceiling row is undiggable across all dispatch paths

| Layer | File | Behavior |
|---|---|---|
| Input | `src/input/underground-input.ts` | `handleUndergroundLeftClick` and `handleUndergroundDrag` reject `tileY === UNDERGROUND_CEILING_ROW_Y` (clears stale `isDragging` per codex P2). |
| Sim | `src/sim/tick.ts` `MarkDigTile` handler | Rejects `cmd.tileY === UNDERGROUND_CEILING_ROW_Y` before the Solid-state read. |
| Sim | `src/sim/tick.ts` `PlaceChamber` handler | Rejects `cmd.anchorTileY === UNDERGROUND_CEILING_ROW_Y` (chambers extend DOWN; equality check covers all footprint overlaps while the ceiling is a single row). |
| AI | `src/render/ai-controller.ts` `isDirtTileUnderground` | Pre-filters `ty === UNDERGROUND_CEILING_ROW_Y` so the AI never queues dead-on-arrival ceiling commands. |

**Carve-out (intentional, regression-pinned):** `DesignateEntrance` writes Marked tiles at the entrance column from `sy=0` down via direct `ugSet` — entrance columns are exempt because the renderer paints them as the gold-tinted "way in" hole, not as the grass ceiling. A new test verifies entrance shaft excavation still works.

### #31 — `computeDigDemand` only counts reachable Marked tiles

`src/sim/behavior/allocation-system.ts` — a Marked tile contributes to dig demand only if at least one 4-connected neighbor is `Open` or `BeingDug` (mirrors the BFS expansion in `computeDigFlowField`). Without this, an isolated Marked island (e.g., the row-0 marks the player accidentally created via #30, or anything else stranded by future map changes) would lock one worker out of forage/nurse via repeated dig-then-bounce-back-to-Idle cycles.

## Verification

- `npm run verify` clean (lint, typecheck, sim-boundary, asset-path, all 1545 tests).
- 12 new regression tests covering all gates + the entrance-shaft carve-out.
- 6 internal review rounds total — 2 on the original input-layer fix, 2 on the codex P2 follow-up, 2 on the sim-layer expansion. Final exit was a clean confirmatory pass.
- 1 codex external review round (1 P2 finding addressed: ceiling-row guard now clears stale `isDragging`).

## Test plan

- [ ] `npm run dev`, switch to underground view.
- [ ] Click on the grass ceiling strip — no Marked overlay (was previously invisible-but-real).
- [ ] Mark a connected Solid tile — worker is assigned to dig (existing behavior).
- [ ] Mark an isolated Solid island (no Open neighbor) — no worker assigned; Idle workers go to Forage/Nurse normally.
- [ ] Watch the AI for ~3-5 minutes — no chambers built straddling the grass strip.
- [ ] Designate a new entrance — the shaft still excavates correctly from the surface down.
- [ ] Confirm CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)