### PR TITLE
feat(sim,input): chamber placement on Solid/Marked tiles with reachability gate (closes #38)

### DIFF
--- a/src/input/underground-input.test.ts
+++ b/src/input/underground-input.test.ts
@@ -31,6 +31,10 @@ import {
 import { panInputState, resetPanInputStateForTests } from './camera-input.js';
 import { UndergroundTileState, ugSet, createUndergroundGrid } from '../sim/terrain.js';
 import type { WorldState } from '../sim/types.js';
+import {
+  LEGACY_SIM_VERSION,
+  SIM_VERSION_V5_CHAMBER_ON_MARKED,
+} from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
 import { VIEWPORT_WIDTH_TILES, VIEWPORT_HEIGHT_TILES } from '../render/camera.js';
 import { HUD, TILE_SIZE_PX } from '../render/sprites.js';
@@ -83,6 +87,9 @@ function makeWorld(overrides: {
   const grid = createUndergroundGrid(w, h);
   return {
     tick: overrides.tick ?? 0,
+    // Default to LEGACY so existing right-click-on-Solid is-a-no-op tests
+    // pass. Issue #38 v5+ tests set simVersion explicitly.
+    simVersion: LEGACY_SIM_VERSION,
     rngState: 0,
     nextEntityId: 0,
     commandQueue: [] as SimCommand[],
@@ -875,6 +882,88 @@ describe('handleUndergroundRightClick', () => {
     ugSet(grid, 5, 5, UndergroundTileState.Marked);
     const vs = makeViewState('underground', 64, 32);
     handleUndergroundRightClick(world, vs, HUD.STATS.x + 5, HUD.STATS.y + 5);
+    expect(world.commandQueue).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #38 — v5+ right-click on Solid OR Open opens the chamber menu.
+  // -------------------------------------------------------------------------
+
+  it('v5+: right-click on a Solid tile opens the chamber-placement menu (issue #38)', () => {
+    const world = makeWorld();
+    world.simVersion = SIM_VERSION_V5_CHAMBER_ON_MARKED;
+    // (5,5) stays Solid by default. Pre-v5 this was a no-op; v5 should
+    // surface the menu so the player can plan a chamber in untouched dirt.
+    const vs = makeViewState('underground', 64, 32);
+    const { x, y } = tileToScreen(5, 5, 64, 32);
+    handleUndergroundRightClick(world, vs, x, y);
+    expect(contextMenuState.pendingShow).toBe(true);
+    expect(contextMenuState.anchorTileX).toBe(5);
+    expect(contextMenuState.anchorTileY).toBe(5);
+  });
+
+  it('v5+: right-click on an Open tile that is NOT a tunnel end opens the menu (issue #38)', () => {
+    const world = makeWorld();
+    world.simVersion = SIM_VERSION_V5_CHAMBER_ON_MARKED;
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    // 3×3 Open region — interior tile (5,5) has no Solid 4-neighbor, so
+    // pre-v5 isTunnelEnd would reject. v5 should still open the menu.
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        ugSet(grid, 5 + dx, 5 + dy, UndergroundTileState.Open);
+      }
+    }
+    const vs = makeViewState('underground', 64, 32);
+    const { x, y } = tileToScreen(5, 5, 64, 32);
+    handleUndergroundRightClick(world, vs, x, y);
+    expect(contextMenuState.pendingShow).toBe(true);
+  });
+
+  it('v5+: right-click on a Marked tile still pushes CancelDigMark (existing UX preserved)', () => {
+    const world = makeWorld();
+    world.simVersion = SIM_VERSION_V5_CHAMBER_ON_MARKED;
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 5, 5, UndergroundTileState.Marked);
+    const vs = makeViewState('underground', 64, 32);
+    const { x, y } = tileToScreen(5, 5, 64, 32);
+    handleUndergroundRightClick(world, vs, x, y);
+    // CancelDigMark wins over chamber-placement menu on Marked tiles —
+    // the existing right-click muscle memory is preserved.
+    const cancelCmd = world.commandQueue.find((c) => c.type === 'CancelDigMark');
+    expect(cancelCmd).toBeDefined();
+    expect(contextMenuState.pendingShow).toBe(false);
+  });
+
+  it('v5+: right-click on a BeingDug tile is still a no-op (sim would reject)', () => {
+    const world = makeWorld();
+    world.simVersion = SIM_VERSION_V5_CHAMBER_ON_MARKED;
+    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
+    ugSet(grid, 5, 5, UndergroundTileState.BeingDug);
+    const vs = makeViewState('underground', 64, 32);
+    const { x, y } = tileToScreen(5, 5, 64, 32);
+    handleUndergroundRightClick(world, vs, x, y);
+    expect(contextMenuState.pendingShow).toBe(false);
+    expect(world.commandQueue).toHaveLength(0);
+  });
+
+  it('v5+: right-click on the ceiling row is a no-op (sim ceiling guard mirrored)', () => {
+    const world = makeWorld();
+    world.simVersion = SIM_VERSION_V5_CHAMBER_ON_MARKED;
+    const vs = makeViewState('underground', 64, 32);
+    const { x, y } = tileToScreen(5, 0, 64, 32);
+    handleUndergroundRightClick(world, vs, x, y);
+    expect(contextMenuState.pendingShow).toBe(false);
+    expect(world.commandQueue).toHaveLength(0);
+  });
+
+  it('legacy (pre-v5): right-click on Solid is a no-op (replay determinism)', () => {
+    const world = makeWorld();
+    world.simVersion = LEGACY_SIM_VERSION;
+    // (5,5) stays Solid by default.
+    const vs = makeViewState('underground', 64, 32);
+    const { x, y } = tileToScreen(5, 5, 64, 32);
+    handleUndergroundRightClick(world, vs, x, y);
+    expect(contextMenuState.pendingShow).toBe(false);
     expect(world.commandQueue).toHaveLength(0);
   });
 });

--- a/src/input/underground-input.ts
+++ b/src/input/underground-input.ts
@@ -19,6 +19,7 @@
 
 import * as Phaser from 'phaser';
 import type { WorldState } from '../sim/types.js';
+import { SIM_VERSION_V5_CHAMBER_ON_MARKED } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
 import { screenToTile } from '../render/camera.js';
 import { ugGet, UndergroundTileState } from '../sim/terrain.js';
@@ -372,10 +373,23 @@ export function handleUndergroundDrag(
 /**
  * Handles a right-click on the underground view.
  *
- * Dispatch:
- *   - Marked tile → push CancelDigMarkCommand (CTRL-04: BeingDug is NOT cancellable).
- *   - Open tile that is a tunnel end → open context menu (UNDR-04).
- *   - All other tiles (Solid, BeingDug, non-tunnel-end Open) → no-op.
+ * Dispatch (v4 / pre-v5):
+ *   - Marked tile → push CancelDigMarkCommand.
+ *   - Open tunnel-end tile → open chamber-placement context menu.
+ *   - Solid / BeingDug / non-tunnel-end Open → no-op.
+ *
+ * Dispatch (v5+, issue #38):
+ *   - Marked tile → push CancelDigMarkCommand (unchanged — preserves the
+ *     existing "right-click cancels a queued dig" muscle memory).
+ *   - Solid OR Open tile → open chamber-placement context menu. The sim
+ *     layer's reachability gate decides whether the placement actually
+ *     lands; the UI just needs to surface the option. Tunnel-end check
+ *     dropped because v5 chambers can be planned in untouched dirt.
+ *   - BeingDug → no-op (active excavation conflict; sim would reject).
+ *
+ * The pre-v5 strict path is preserved so legacy saves keep their UX
+ * contract (right-click on Solid does nothing). simVersion is sticky on
+ * load, so a player who loads a v3/v4 save sees the legacy gate.
  *
  * No-ops if: activeView !== 'underground', pointer over HUD, or out of bounds.
  */
@@ -396,7 +410,12 @@ export function handleUndergroundRightClick(
   const grid = world.undergroundGrids[PLAYER_COLONY_ID];
   if (!grid) return;
   if (tileX < 0 || tileY < 0 || tileX >= grid.width || tileY >= grid.height) return;
+  // Reject ceiling-row right-clicks symmetric with the sim's ceiling guard
+  // (issue #30): the chamber-placement command would always be rejected
+  // anyway, so don't open a menu the player can't act on.
+  if (tileY === UNDERGROUND_CEILING_ROW_Y) return;
   const tileState = ugGet(grid, tileX, tileY);
+  const v5OrLater = world.simVersion >= SIM_VERSION_V5_CHAMBER_ON_MARKED;
 
   if (tileState === UndergroundTileState.Marked) {
     // CancelDigMark — only on Marked tiles (CTRL-04: BeingDug finish-then-switch).
@@ -411,8 +430,21 @@ export function handleUndergroundRightClick(
     return;
   }
 
+  // BeingDug: no-op on either path (sim would reject the placement
+  // anyway via gate (e); avoid surfacing a doomed menu).
+  if (tileState === UndergroundTileState.BeingDug) return;
+
+  if (v5OrLater) {
+    // Issue #38 — Solid OR Open. The sim handles reachability rejection
+    // post-selection. Pre-flight check: bounds were already validated above,
+    // ceiling row excluded above. Defer the actual show by a frame to keep
+    // the UIScene pointerdown SHOW-race defense (see below).
+    requestShowContextMenu(screenX, screenY, tileX, tileY);
+    return;
+  }
+
+  // Pre-v5 legacy path — Open tunnel end only.
   if (tileState === UndergroundTileState.Open && isTunnelEnd(world, tileX, tileY, PLAYER_COLONY_ID)) {
-    // Open tunnel end → request context menu for next frame (UNDR-04).
     // Deferred show: UIScene's pointerdown handler runs in the same dispatch as
     // this one and would otherwise see visible=true and mis-interpret this same
     // right-click as a menu-item selection (the menu is anchored at the click).
@@ -422,7 +454,7 @@ export function handleUndergroundRightClick(
     // already defends against.
     requestShowContextMenu(screenX, screenY, tileX, tileY);
   }
-  // Solid / BeingDug / non-tunnel-end Open → no-op (including no context menu).
+  // Solid / non-tunnel-end Open → no-op (legacy behavior).
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -6,7 +6,12 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { tick, resetFlowFieldCaches } from './tick.js';
-import { createWorldState, allocateEntityId } from './types.js';
+import {
+  createWorldState,
+  allocateEntityId,
+  LEGACY_SIM_VERSION,
+  SIM_VERSION_V5_CHAMBER_ON_MARKED,
+} from './types.js';
 import { GameOutcome } from './game-over.js';
 import type { SimCommand } from './commands.js';
 import { initAnt } from './ant/ant-store.js';
@@ -1217,6 +1222,11 @@ describe('Phase 7: MarkDigTile command processing', () => {
   it('Test P7-7: PlaceChamber creates PendingChamber with correct dims; tiles marked', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     // PRD §3c tunnel-end: anchor tile must be Open; surrounding Solid tiles give adjacency.
+    // Issue #38: this test exercises the LEGACY pre-v5 gate — pin simVersion
+    // so the v5 reachability BFS doesn't reject the placement (the test
+    // colony has no entrance, which is fine for the legacy gate but
+    // trivially fails the new reachability check).
+    world.simVersion = LEGACY_SIM_VERSION;
     const underground = world.undergroundGrids[colonyId]!;
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
     const cmd: SimCommand = {
@@ -1249,6 +1259,8 @@ describe('Phase 7: MarkDigTile command processing', () => {
   // Test P7-8: PlaceChamber rejected if overlapping existing pendingChamber
   it('Test P7-8: PlaceChamber rejected if overlapping existing pendingChamber', () => {
     const { world, colonyId } = makeWorldWithUnderground();
+    // Issue #38: legacy gate (no entrance set up — fails v5 reachability).
+    world.simVersion = LEGACY_SIM_VERSION;
     // PRD §3c tunnel-end: open the anchor tile for each placement attempt.
     const underground = world.undergroundGrids[colonyId]!;
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
@@ -1648,6 +1660,11 @@ describe('Phase 7: Integration tests', () => {
   // SC 6: PlaceChamber + manually open footprint → ChamberRecord created; overlap rejected
   it('SC 6: PlaceChamber + open footprint → ChamberRecord; overlapping chamber rejected', () => {
     const world = createScenario(42);
+    // Issue #38: this test directly mutates underground state to set up a
+    // chamber-anchor scenario without digging an entrance shaft to it. Pin
+    // simVersion to LEGACY so the v5 reachability BFS doesn't reject the
+    // synthetic placement.
+    world.simVersion = LEGACY_SIM_VERSION;
     const colonyId = PLAYER_COLONY_ID as ColonyId;
     const colony = world.colonies[colonyId]!;
 
@@ -1792,6 +1809,12 @@ describe('Regression: reviewer P1 fixes', () => {
   // --- PlaceChamber tunnel-end validation (PRD §3c) ---
   it('PlaceChamber rejected: anchor tile is Solid (not a tunnel end)', () => {
     const { world, colonyId } = makeWorldWithUnderground();
+    // Issue #38: this test verifies the LEGACY pre-v5 anchor-must-be-Open
+    // gate. Under v5 the gate disappears (Solid anchors are accepted with
+    // reachability), so pin simVersion explicitly. Without the pin, the
+    // test would still pass under v5 — but for the wrong reason (no
+    // entrance → reachability rejects every placement).
+    world.simVersion = LEGACY_SIM_VERSION;
     // Everything is Solid by default — anchor (10,10) is Solid
     const cmd: SimCommand = {
       type: 'PlaceChamber', colonyId,
@@ -1803,6 +1826,9 @@ describe('Regression: reviewer P1 fixes', () => {
 
   it('PlaceChamber rejected: no adjacent Solid (anchor in wide-open cavern)', () => {
     const { world, colonyId } = makeWorldWithUnderground();
+    // Issue #38: legacy gate (the v5 path drops the Solid-4-neighbor
+    // requirement entirely). See note on the previous test.
+    world.simVersion = LEGACY_SIM_VERSION;
     const underground = world.undergroundGrids[colonyId]!;
     // Open a 3×3 region around (10,10) — no adjacent Solid
     for (let dy = -1; dy <= 1; dy++) {
@@ -1833,6 +1859,8 @@ describe('Regression: reviewer P1 fixes', () => {
 
   it('PlaceChamber rejected: pendingChambers key already exists at anchor', () => {
     const { world, colonyId } = makeWorldWithUnderground();
+    // Issue #38: legacy gate (no entrance — fails v5 reachability).
+    world.simVersion = LEGACY_SIM_VERSION;
     const underground = world.undergroundGrids[colonyId]!;
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
     const cmd: SimCommand = {
@@ -1850,6 +1878,8 @@ describe('Regression: reviewer P1 fixes', () => {
   // --- 09 backlog memo — Queen uniqueness + FoodStorage multiplicity ---
   it('PlaceChamber rejected: second Queen attempt while a Queen pending', () => {
     const { world, colonyId } = makeWorldWithUnderground();
+    // Issue #38: legacy gate (no entrance — fails v5 reachability).
+    world.simVersion = LEGACY_SIM_VERSION;
     const underground = world.undergroundGrids[colonyId]!;
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
     underground.data[20 * UNDERGROUND_GRID_WIDTH + 30] = UndergroundTileState.Open;
@@ -1888,6 +1918,8 @@ describe('Regression: reviewer P1 fixes', () => {
 
   it('PlaceChamber allows multiple FoodStorage placements on the same colony', () => {
     const { world, colonyId } = makeWorldWithUnderground();
+    // Issue #38: legacy gate (no entrance — fails v5 reachability).
+    world.simVersion = LEGACY_SIM_VERSION;
     const underground = world.undergroundGrids[colonyId]!;
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
     underground.data[20 * UNDERGROUND_GRID_WIDTH + 30] = UndergroundTileState.Open;
@@ -2056,6 +2088,194 @@ describe('Regression: reviewer P1 fixes', () => {
     };
     tick(world, [cmd]);
     expect(world.colonies[colonyId]!.entrances.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #38 — PlaceChamber on Solid/Marked tiles with reachability gate (v5+).
+// ---------------------------------------------------------------------------
+
+describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
+  /** Build a world with one entrance at column ENTRANCE_X and the entrance
+   *  shaft auto-Marked rows 0..ENTRANCE_SHAFT_DEPTH-1. Mirrors what a real
+   *  DesignateEntrance command would produce (without going through the
+   *  command path so the test can directly inspect the gate behavior).
+   *  simVersion is left at LATEST (= V5+) so the new gate is exercised. */
+  function makeWorldWithEntrance(seed = 42, entranceX = 10) {
+    const world = createWorldState(seed);
+    const queenId = allocateEntityId(world);
+    initAnt(world.ants, queenId, { colonyId: 1, posX: 1024, posY: 1024, task: AntTask.Idle, subTask: 0 });
+    world.colonies[1] = createColonyRecord(1, queenId);
+    world.colonies[1]!.foodStored = 10000;
+    world.colonies[1]!.entrances = [{
+      entranceId: 999, surfaceTileX: entranceX, surfaceTileY: 0, isOpen: true,
+    }];
+    world.colonies[1]!.rallyPoint = null;
+    world.colonies[1]!.digFlowFieldDirty = false;
+    const ug = createUndergroundGrid(UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
+    world.undergroundGrids[1] = ug;
+    return { world, colonyId: 1 as ColonyId, ug, entranceX };
+  }
+
+  it('accepts anchor on Solid when reachable via Marked tunnel from entrance', () => {
+    const { world, colonyId, ug, entranceX } = makeWorldWithEntrance();
+    // Mark a column from row 0 to row 9 — this becomes the "tunnel" the
+    // chamber will sit at the bottom of.
+    for (let y = 0; y < 10; y++) {
+      ug.data[y * UNDERGROUND_GRID_WIDTH + entranceX] = UndergroundTileState.Marked;
+    }
+    // Anchor on a SOLID tile two columns over from the marked tunnel,
+    // adjacent to the marked column. Reachable via the marked column +
+    // own footprint expansion.
+    const cmd: SimCommand = {
+      type: 'PlaceChamber', colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: entranceX, anchorTileY: 10, issuedAtTick: 0,
+    };
+    tick(world, [cmd]);
+    const pcKey = `${colonyId}:${entranceX}:10`;
+    expect(world.pendingChambers[pcKey]).toBeDefined();
+  });
+
+  it('rejects anchor on Solid in unreachable dirt (no Marked path)', () => {
+    const { world, colonyId, ug, entranceX } = makeWorldWithEntrance();
+    // The helper does NOT auto-mark the entrance shaft (DesignateEntrance
+    // does that in production but we bypass the command path here for
+    // test isolation). So the entrance source tile (entranceX, 0) is
+    // Solid, not in the new footprint, and NOT traversable — BFS
+    // terminates with an empty visited set and the placement is rejected.
+    // That's the test we want: a far-away Solid anchor with no path
+    // through Marked tiles to it must be refused.
+    void ug;
+    void entranceX;
+    const cmd: SimCommand = {
+      type: 'PlaceChamber', colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: 50, anchorTileY: 30, issuedAtTick: 0,
+    };
+    tick(world, [cmd]);
+    expect(world.pendingChambers[`${colonyId}:50:30`]).toBeUndefined();
+  });
+
+  it('rejects when colony has no entrance (BFS source set is empty)', () => {
+    const { world, colonyId } = makeWorldWithEntrance();
+    // Drop the entrance.
+    world.colonies[colonyId]!.entrances = [];
+    const cmd: SimCommand = {
+      type: 'PlaceChamber', colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: 5, anchorTileY: 5, issuedAtTick: 0,
+    };
+    tick(world, [cmd]);
+    expect(world.pendingChambers[`${colonyId}:5:5`]).toBeUndefined();
+  });
+
+  it('auto-marks Solid footprint tiles after acceptance', () => {
+    const { world, colonyId, ug, entranceX } = makeWorldWithEntrance();
+    for (let y = 0; y < 10; y++) {
+      ug.data[y * UNDERGROUND_GRID_WIDTH + entranceX] = UndergroundTileState.Marked;
+    }
+    // Place 4×3 FoodStorage at (entranceX, 10). All footprint tiles start Solid.
+    const cmd: SimCommand = {
+      type: 'PlaceChamber', colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: entranceX, anchorTileY: 10, issuedAtTick: 0,
+    };
+    tick(world, [cmd]);
+    // Every Solid footprint tile should be Marked now.
+    const dims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage]!;
+    for (let dy = 0; dy < dims.height; dy++) {
+      for (let dx = 0; dx < dims.width; dx++) {
+        const state = ugGet(ug, entranceX + dx, 10 + dy);
+        expect(state).toBe(UndergroundTileState.Marked);
+      }
+    }
+  });
+
+  it('accepts anchor on a Marked tile (chamber along an in-progress tunnel)', () => {
+    const { world, colonyId, ug, entranceX } = makeWorldWithEntrance();
+    // Mark column entranceX rows 0..15 — long tunnel being dug.
+    for (let y = 0; y < 16; y++) {
+      ug.data[y * UNDERGROUND_GRID_WIDTH + entranceX] = UndergroundTileState.Marked;
+    }
+    // Anchor on a Marked tile at row 10 (mid-tunnel).
+    const cmd: SimCommand = {
+      type: 'PlaceChamber', colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: entranceX, anchorTileY: 10, issuedAtTick: 0,
+    };
+    tick(world, [cmd]);
+    expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeDefined();
+  });
+
+  it('rejects anchor on a BeingDug tile (active excavation conflict)', () => {
+    const { world, colonyId, ug, entranceX } = makeWorldWithEntrance();
+    for (let y = 0; y < 10; y++) {
+      ug.data[y * UNDERGROUND_GRID_WIDTH + entranceX] = UndergroundTileState.Marked;
+    }
+    // Set the proposed anchor tile to BeingDug.
+    ug.data[10 * UNDERGROUND_GRID_WIDTH + entranceX] = UndergroundTileState.BeingDug;
+    const cmd: SimCommand = {
+      type: 'PlaceChamber', colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: entranceX, anchorTileY: 10, issuedAtTick: 0,
+    };
+    tick(world, [cmd]);
+    expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeUndefined();
+  });
+
+  it('promotes a v5-placed chamber once all footprint tiles are dug Open', () => {
+    const { world, colonyId, ug, entranceX } = makeWorldWithEntrance();
+    for (let y = 0; y < 10; y++) {
+      ug.data[y * UNDERGROUND_GRID_WIDTH + entranceX] = UndergroundTileState.Marked;
+    }
+    // Place chamber on Solid; should enter PendingChamber state.
+    const cmd: SimCommand = {
+      type: 'PlaceChamber', colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: entranceX, anchorTileY: 10, issuedAtTick: 0,
+    };
+    tick(world, [cmd]);
+    expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeDefined();
+    // Manually open the footprint (simulating excavation complete) and tick.
+    const dims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage]!;
+    for (let dy = 0; dy < dims.height; dy++) {
+      for (let dx = 0; dx < dims.width; dx++) {
+        ug.data[(10 + dy) * UNDERGROUND_GRID_WIDTH + (entranceX + dx)] = UndergroundTileState.Open;
+      }
+    }
+    tick(world, []);
+    // ChamberRecord should exist; PendingChamber is gone.
+    const colony = world.colonies[colonyId]!;
+    const chamber = colony.chambers.find(
+      (ch) => (ch.posX >> FP_SHIFT) === entranceX && (ch.posY >> FP_SHIFT) === 10,
+    );
+    expect(chamber).toBeDefined();
+    expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeUndefined();
+  });
+
+  it('legacy v4 still rejects Solid-anchor placements (replay determinism)', () => {
+    const { world, colonyId, ug, entranceX } = makeWorldWithEntrance();
+    // Roll back to a pre-v5 version. Pre-v5 saves with Solid-anchor commands
+    // in their inputLog must keep getting rejected so replay stays
+    // byte-identical.
+    world.simVersion = LEGACY_SIM_VERSION;
+    for (let y = 0; y < 10; y++) {
+      ug.data[y * UNDERGROUND_GRID_WIDTH + entranceX] = UndergroundTileState.Marked;
+    }
+    const cmd: SimCommand = {
+      type: 'PlaceChamber', colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: entranceX, anchorTileY: 10, issuedAtTick: 0,
+    };
+    tick(world, [cmd]);
+    expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeUndefined();
+  });
+
+  it('SIM_VERSION_V5_CHAMBER_ON_MARKED is the LATEST_SIM_VERSION', () => {
+    // Sanity: new worlds run on v5 by default.
+    const world = createWorldState(42);
+    expect(world.simVersion).toBe(SIM_VERSION_V5_CHAMBER_ON_MARKED);
   });
 });
 

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1,6 +1,6 @@
 // src/sim/tick.ts — Phase 9 19-step tick dispatcher.
 import type { WorldState } from './types.js';
-import { allocateEntityId } from './types.js';
+import { allocateEntityId, SIM_VERSION_V5_CHAMBER_ON_MARKED } from './types.js';
 import { MAX_COMMANDS_PER_TICK, type SimCommand } from './commands.js';
 import { GameOutcome, checkQueenDeath } from './game-over.js';
 import { detectAndResolveCombat } from './combat.js';
@@ -78,7 +78,7 @@ import type { ChamberFlowFields } from './chamber-flow.js';
 import { ugGet, ugSet, UndergroundTileState } from './terrain.js';
 import { CHAMBER_DIMENSIONS } from './colony/chamber.js';
 import type { PendingChamber } from './colony/chamber.js';
-import type { ColonyId } from './colony/colony-store.js';
+import type { ColonyId, ColonyRecord } from './colony/colony-store.js';
 import type { FoodPileId } from './food.js';
 
 // ---------------------------------------------------------------------------
@@ -334,10 +334,15 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
           }
           if (hasQueen) break;
         }
-        // (c) Anchor tile must be Open (tunnel-end check, UNDR-04)
-        if (ugGet(underground, cmd.anchorTileX, cmd.anchorTileY) !== UndergroundTileState.Open) break;
-        // (d) At least one 4-connected neighbor of the anchor must be Solid (tunnel-end check)
-        {
+        // (c) Anchor tile state.
+        //   pre-v5: must be Open (the legacy tunnel-end gate).
+        //   v5+: Open OR Solid OR Marked. BeingDug remains rejected by gate
+        //        (e) below so an in-flight excavation can't be re-anchored.
+        // (d) Solid 4-neighbor "tunnel-end" check (pre-v5 only). v5 drops it
+        //     because chambers can now be planned in untouched dirt; the
+        //     v5 reachability BFS below subsumes the connectivity intent.
+        if (world.simVersion < SIM_VERSION_V5_CHAMBER_ON_MARKED) {
+          if (ugGet(underground, cmd.anchorTileX, cmd.anchorTileY) !== UndergroundTileState.Open) break;
           let hasAdjacentSolid = false;
           const ax = cmd.anchorTileX;
           const ay = cmd.anchorTileY;
@@ -347,6 +352,12 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
           if (!hasAdjacentSolid && ay + 1 < UNDERGROUND_GRID_HEIGHT && ugGet(underground, ax,     ay + 1) === UndergroundTileState.Solid) hasAdjacentSolid = true;
           if (!hasAdjacentSolid) break;
         }
+        // v5: gates (c)+(d) are dropped entirely. Solid / Marked / Open
+        // anchors are all accepted; BeingDug is rejected by the
+        // footprint scan in gate (e) below (anchor is at offset (0,0),
+        // so it's covered). Auto-mark at the end of the handler
+        // converts any Solid footprint tile to Marked. Reachability
+        // is enforced by gate (i) below.
         // (e) No footprint tile may be BeingDug (conflict with active excavation)
         {
           let conflictsBeingDug = false;
@@ -385,6 +396,27 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
           }
         }
         if (overlaps) break;
+        // (i) v5+ reachability gate (issue #38). Once the strict
+        // tunnel-end gate is gone, a player could in principle drop a
+        // chamber in completely untouched dirt with no path to it. The
+        // BFS below verifies that — assuming every currently-Marked /
+        // BeingDug tile gets dug to Open AND the new footprint's Solid
+        // tiles get auto-Marked-and-dug — at least one footprint tile
+        // would be reachable from at least one of the colony's
+        // entrances. Not run pre-v5 because pre-v5 saves' inputLogs
+        // never include unreachable placements (the old gates (c)+(d)
+        // required anchor=Open + adjacent Solid, which is naturally
+        // tunnel-network-adjacent for any entrance-rooted dig). Strictly
+        // speaking the old gates didn't PROVE reachability — a
+        // disconnected pre-existing Open cavern could pass them — but
+        // those edge cases are unchanged by this PR (pre-v5 replays use
+        // the legacy gates verbatim).
+        if (world.simVersion >= SIM_VERSION_V5_CHAMBER_ON_MARKED) {
+          if (!isFootprintReachableAfterDigs(
+                world, colony3, cmd.anchorTileX, cmd.anchorTileY,
+                dims.width, dims.height,
+              )) break;
+        }
         // All checks passed — mark footprint Solid tiles and create PendingChamber
         for (let dy = 0; dy < dims.height; dy++) {
           for (let dx = 0; dx < dims.width; dx++) {
@@ -934,4 +966,114 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   world.tick += 1;
 
   return outcome;
+}
+
+// ---------------------------------------------------------------------------
+// isFootprintReachableAfterDigs — issue #38 (v5+) PlaceChamber gate.
+//
+// Verifies that a proposed chamber footprint will be connected to at least
+// one of the colony's entrances after every currently-Marked / BeingDug
+// tile is dug to Open AND the new footprint's Solid tiles are auto-Marked
+// and dug.
+//
+// The BFS treats as traversable:
+//   - Open tiles (already excavated; chamber footprints land here today)
+//   - Marked tiles (queued for excavation)
+//   - BeingDug tiles (excavation in progress)
+//   - Tiles inside the proposed new footprint (will be Marked by this same
+//     handler if the placement is accepted)
+//
+// Non-traversable: Solid tiles outside the new footprint. Out-of-bounds
+// tiles are also rejected by the bounds check.
+//
+// BFS sources are each entrance's underground entry tile (surfaceTileX, 0).
+// DesignateEntrance auto-marks the shaft column down to ENTRANCE_SHAFT_DEPTH,
+// so the source tile is at least Marked even before the entrance dig
+// completes — the BFS still reaches outward through the shaft regardless.
+//
+// Determinism: pure read-only over the underground grid + entrances. No
+// PRNG, no float math, no allocation beyond a single fixed-size visited
+// `Uint8Array` and a Number[] queue (PlaceChamber commands are rare —
+// once per click — so per-call allocation is acceptable).
+//
+// Performance: O(grid.width × grid.height) worst case = 8192 ops at
+// default scenario dimensions. PlaceChamber is a low-frequency command
+// (player click cadence + AI bursts every AI_DIG_INTERVAL=40 ticks), so
+// the cost is amortized to near-zero.
+// ---------------------------------------------------------------------------
+
+function isFootprintReachableAfterDigs(
+  world: WorldState,
+  colony: ColonyRecord,
+  anchorTileX: number,
+  anchorTileY: number,
+  width: number,
+  height: number,
+): boolean {
+  const underground = world.undergroundGrids[colony.colonyId];
+  if (!underground) return false;
+  // No entrance → no path can exist. Trivially reject the placement so a
+  // pre-entrance chamber drop doesn't silently sit in PendingChamber
+  // forever.
+  if (colony.entrances.length === 0) return false;
+
+  const w = underground.width;
+  const h = underground.height;
+
+  const inFootprint = (x: number, y: number): boolean =>
+    x >= anchorTileX && x < anchorTileX + width &&
+    y >= anchorTileY && y < anchorTileY + height;
+
+  const isTraversable = (x: number, y: number): boolean => {
+    if (x < 0 || y < 0 || x >= w || y >= h) return false;
+    const state = ugGet(underground, x, y);
+    if (state !== UndergroundTileState.Solid) return true; // Open / Marked / BeingDug
+    return inFootprint(x, y);
+  };
+
+  // Visited bitmap. Uint8Array per call — PlaceChamber is rare (player
+  // click cadence + AI bursts), so per-command allocation is fine and
+  // avoids any cross-tick state.
+  const visited = new Uint8Array(w * h);
+  // Index-based queue (Number[]) avoids the O(n) shift cost a JS array
+  // queue would otherwise pay. Tile keys are interleaved as (x, y) pairs.
+  const queue: number[] = [];
+
+  for (let e = 0; e < colony.entrances.length; e++) {
+    const ent = colony.entrances[e]!;
+    const sx = ent.surfaceTileX;
+    const sy = 0; // underground row 0 is the entrance's underground side
+    if (sx < 0 || sx >= w) continue;
+    if (!isTraversable(sx, sy)) continue;
+    const k = sy * w + sx;
+    if (visited[k]) continue;
+    visited[k] = 1;
+    queue.push(sx, sy);
+  }
+
+  let head = 0;
+  while (head < queue.length) {
+    const x = queue[head]!;
+    const y = queue[head + 1]!;
+    head += 2;
+    if (inFootprint(x, y)) return true;
+    // 4-cardinal expansion. Order is N/E/S/W for determinism (same
+    // ordering used by aiDigHeuristic and the dig flow-field).
+    const neighbors: ReadonlyArray<readonly [number, number]> = [
+      [x, y - 1],
+      [x + 1, y],
+      [x, y + 1],
+      [x - 1, y],
+    ];
+    for (let i = 0; i < neighbors.length; i++) {
+      const [nx, ny] = neighbors[i]!;
+      if (nx < 0 || ny < 0 || nx >= w || ny >= h) continue;
+      const nk = ny * w + nx;
+      if (visited[nk]) continue;
+      if (!isTraversable(nx, ny)) continue;
+      visited[nk] = 1;
+      queue.push(nx, ny);
+    }
+  }
+  return false;
 }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -34,7 +34,7 @@ export type EntityId = number; // incrementing counter from 0, no recycling per 
  * first (array-index tie-break); carriers enter WaitingToDeposit when
  * storage is fully saturated. Movement remains 4-connected.
  *
- * v4 (LATEST_SIM_VERSION) — issue #34 follow-up. 8-connected ant movement:
+ * v4 — issue #34 follow-up. 8-connected ant movement:
  * pickStep can return diagonal cardinals when both axes have remaining
  * work, with corner-cut prevention requiring at least one of the two
  * intermediate cardinal tiles to be passable. Underground flow-field
@@ -42,6 +42,15 @@ export type EntityId = number; // incrementing counter from 0, no recycling per 
  * diagonal step when the next-tile flow is perpendicular. Diagonal moves
  * traverse √2× cardinal Manhattan distance per tick — standard 8-connected
  * speed semantics.
+ *
+ * v5 (LATEST_SIM_VERSION) — issue #38. PlaceChamber accepts anchors on
+ * Solid or Marked tiles in addition to Open. The handler auto-marks any
+ * Solid tile in the chamber footprint and runs a reachability BFS from
+ * the colony's entrances through Open + Marked + BeingDug + the new
+ * footprint; placements that wouldn't be reachable after all current
+ * digs complete are rejected. Pre-v5 saves keep the strict-Open anchor
+ * + Solid-4-neighbor-required gates so SCEN-06 replays of recorded
+ * commands stay byte-identical.
  *
  * Saves missing the `simVersion` field load with LEGACY_SIM_VERSION (sticky).
  * New worlds (createWorldState) start at LATEST_SIM_VERSION. Sticky on load
@@ -51,7 +60,8 @@ export type EntityId = number; // incrementing counter from 0, no recycling per 
 export const LEGACY_SIM_VERSION = 2 as const;
 export const SIM_VERSION_V3 = 3 as const;
 export const SIM_VERSION_V4_DIAGONAL_MOTION = 4 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V4_DIAGONAL_MOTION;
+export const SIM_VERSION_V5_CHAMBER_ON_MARKED = 5 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V5_CHAMBER_ON_MARKED;
 
 export interface WorldState {
   tick: number;             // 0 at creation; incremented once per tick
@@ -74,6 +84,10 @@ export interface WorldState {
    *       SearchingFood pause cadence (issue #35). The pause block consumes
    *       additional RNG pulls per tick, so v3 saves stay on the no-pause
    *       path forever to keep replay byte-identical.
+   *   5 = PlaceChamber accepts Solid/Marked anchors with reachability check
+   *       and auto-marks Solid footprint tiles (issue #38). Pre-v5 saves keep
+   *       the strict-Open-anchor + Solid-4-neighbor gates so any v5-only
+   *       commands that may sit in their inputLog stay rejected on replay.
    *
    * Round-trips through copyWorldState and save/load.
    */


### PR DESCRIPTION
## Summary

Closes [#38](https://github.com/LightAxe/subterrans/issues/38). Pre-fix the player had to mark a tunnel, wait for a digger to arrive, wait for the digger to finish + leave the tile, and only THEN could they place a chamber on the now-Open tunnel-end. The natural workflow ('I want a chamber HERE at the end of THIS tunnel') was broken in two.

Under v5 the player right-clicks ANY tile (except BeingDug / ceiling row), picks a chamber type, and the placement queues immediately. The sim auto-marks Solid footprint tiles, ants excavate, and the existing `checkPendingChambers` step promotes PendingChamber → ChamberRecord once every footprint tile is Open. A reachability BFS rejects placements that wouldn't connect to the colony's tunnel network even after every currently-Marked / BeingDug tile finishes.

## What changed

### Sim layer

- New `SIM_VERSION_V5_CHAMBER_ON_MARKED = 5` (new `LATEST_SIM_VERSION`). Pre-v5 saves keep strict gates for replay determinism.
- `PlaceChamber` gates (c)+(d) (anchor=Open + Solid-4-neighbor) drop under v5. Anchor can be any state except BeingDug.
- New gate (i) — `isFootprintReachableAfterDigs`. BFS from each entrance's underground entry tile (`surfaceTileX, 0`) through `Open ∪ Marked ∪ BeingDug ∪ new-footprint`. Reject if no footprint tile is reachable. Pure integer arithmetic, fixed-size `Uint8Array` visited bitmap, index-based queue (no `shift()`), N/E/S/W expansion order. No PRNG.

### UI layer

- Right-click on Solid OR Open under v5 opens the chamber-placement menu.
- Right-click on Marked still cancels the dig (existing UX preserved).
- Right-click on BeingDug / ceiling row is a no-op (mirrors sim guards).
- Pre-v5 right-click behavior unchanged (Open + tunnel-end → menu).

## Determinism

- Both behavior changes (sim gate relaxation + UI surfacing) are gated behind `simVersion >= V5`.
- Pre-v5 saves replay byte-identically — the legacy gates are preserved verbatim and the legacy UI still requires Open + tunnel-end.
- BFS is deterministic: integer arithmetic, fixed iteration order, no PRNG/`Date.now`/`Math.random`, no platform-dependent iteration.

## Test plan

- [x] 9 new sim tests (`tick.test.ts`): all v5 gate transitions + the legacy regression check.
- [x] 6 new UI tests (`underground-input.test.ts`): right-click matrix (Solid/Open/Marked/BeingDug/ceiling) under v5 + a legacy regression test.
- [x] 8 existing sim tests pinned to `LEGACY_SIM_VERSION` to keep them honest about which gate they verify.
- [x] `npx vitest run`: 1594/1594 green.
- [x] `npx tsc --noEmit`: clean.
- [x] 2 internal review rounds — final pass clean.
- [ ] UAT: load a fresh game; right-click a patch of dirt; pick a chamber; verify the chamber footprint becomes Marked, ants excavate it, and the chamber materialises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)