### PR TITLE
fix(render): apply codex polish missing from PR #41 squash merge

### DIFF
--- a/src/render/minimap.ts
+++ b/src/render/minimap.ts
@@ -47,12 +47,13 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
   const surface = world.surface;
   if (surface !== undefined) {
     // Sparse darker-earth dapple — ~12% of tiles, deterministic per (tx, ty).
-    // Uses the same `spatialHash` salt domain as the surface terrain so the
-    // minimap stays in sync with the rendered world (the player can
-    // recognize patches they've seen up close).
+    // Codex P2 fix from PR #41 review (which got squash-merged before this
+    // commit landed): each dapple is a 1×1 pixel dot, NOT a `ceil(scale)+1`
+    // sized cell. With MINIMAP_SCALE_X = 1.25, drawing 3×3 cells caused
+    // each dapple to overlap ~2 neighboring cells, so 12% of tiles ended
+    // up covering ~50% of the minimap area — darkening the whole map and
+    // making colony / food markers harder to read.
     gfx.fillStyle(COLOR_BARREN_EARTH_DARK, 0.7);
-    const cellW = Math.ceil(MINIMAP_SCALE_X) + 1;
-    const cellH = Math.ceil(MINIMAP_SCALE_Y) + 1;
     const SALT_MINIMAP_DAPPLE = 901;
     for (let ty = 0; ty < surface.height; ty++) {
       for (let tx = 0; tx < surface.width; tx++) {
@@ -62,9 +63,11 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
         void sgGet(surface, tx, ty);
         const h = spatialHash(tx, ty, SALT_MINIMAP_DAPPLE);
         if ((h & 0xff) >= 32) continue; // ~12% coverage
-        const px = HUD.MINIMAP.x + tx * MINIMAP_SCALE_X;
-        const py = HUD.MINIMAP.y + ty * MINIMAP_SCALE_Y;
-        gfx.fillRect(px, py, cellW, cellH);
+        // Floor to integer pixel for crisp rendering — avoids sub-pixel
+        // sampling artifacts on Phaser's WebGL pipeline.
+        const px = (HUD.MINIMAP.x + tx * MINIMAP_SCALE_X) | 0;
+        const py = (HUD.MINIMAP.y + ty * MINIMAP_SCALE_Y) | 0;
+        gfx.fillRect(px, py, 1, 1);
       }
     }
   }

--- a/src/render/terrain-atlas.ts
+++ b/src/render/terrain-atlas.ts
@@ -272,12 +272,18 @@ function isAnchorSuppressed(
     const entry = LARGE_FEATURES[ei]!;
     const W = entry.variants[0]!.tilesWide;
     const H = entry.variants[0]!.tilesTall;
-    // (px, py) candidates where G's footprint at (px, py) overlaps own
-    // footprint at (ax, ay): px in [ax-W+1, ax+ownW-1] and similarly y.
     for (let py = ay - H + 1; py <= ay + ownH - 1; py++) {
       for (let px = ax - W + 1; px <= ax + ownW - 1; px++) {
         const ph = spatialHash(px, py, entry.salt);
-        if ((ph & 0xff) < entry.probability) return true;
+        if ((ph & 0xff) >= entry.probability) continue;
+        // Codex P3 fix from PR #41 review (which got squash-merged before
+        // this commit landed): only count (px, py) as a real suppressor if
+        // IT itself actually renders. A higher-priority anchor that's
+        // suppressed by an even-higher-priority one doesn't draw, so
+        // shouldn't block lower-priority anchors. Recursion terminates
+        // because every call strictly reduces either ownEntryIndex or
+        // (ay, ax) lex order.
+        if (!isAnchorSuppressed(px, py, ei)) return true;
       }
     }
   }
@@ -289,7 +295,10 @@ function isAnchorSuppressed(
       const px = ax - dx;
       const py = ay - dy;
       const ph = spatialHash(px, py, own.salt);
-      if ((ph & 0xff) < own.probability) return true;
+      if ((ph & 0xff) >= own.probability) continue;
+      // Same recursion-into-real-renders rule for own type. Termination:
+      // depth bounded by chain length.
+      if (!isAnchorSuppressed(px, py, ownEntryIndex)) return true;
     }
   }
   return false;


### PR DESCRIPTION
## Summary

Two codex P2/P3 fixes from PR #41's final review round were pushed to the branch but didn't make it into the squash merge — the GitHub merge picked up an earlier snapshot. Reapplying them as a small followup PR.

1. **Minimap dapple**: was drawn as a 3×3 cell at 1.25 px/tile, so the 12% sample rate covered ~50% of the minimap area, darkening the whole minimap and reducing colony/food marker legibility. Switched to a 1×1 dot per dapple-eligible tile so coverage actually matches the sample rate.

2. **Cross-type anchor suppression**: checked raw hash without verifying the higher-priority anchor itself rendered. A higher-priority anchor that's itself suppressed (by an even-higher-priority one) doesn't render but was still blocking lower-priority features. Recursive suppression check now only counts anchors that survive their own suppression rules; termination guaranteed by strictly-decreasing `(entryIndex, ay, ax)` lex on each recursive call.

## Test plan

- [x] `npx vitest run`: 1618/1618 green.
- [x] `npx tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)