### PR TITLE
fix(render): drop chamfer painting entirely (#48)

### DIFF
--- a/src/render/underground-autotile.test.ts
+++ b/src/render/underground-autotile.test.ts
@@ -1,24 +1,24 @@
-// underground-autotile.test.ts — issue #43 quarter-tile autotiling.
+// underground-autotile.test.ts — underground tile rendering tests.
 //
-// These tests verify the SHAPE produced by drawAutotiledUndergroundTile for
-// the canonical neighborhoods. The strategy is to render a tile to a
-// pixel-grid synthesized from the recorded fillRect calls, then assert the
-// expected silhouette pattern at quadrant-level granularity.
+// Issue #48 stripped the quarter-tile autotile masks (chamfer +
+// inner-corner bite) from drawAutotiledUndergroundTile because they read
+// as visible right-triangle teeth at every corner. The current contract
+// is "substrate-only": for any neighborhood, the tile renders only its
+// centerKind's dithered substrate. The rim-shading pass — covered by its
+// own describe block below — handles the wall-side carved-out feel as a
+// separate translucent overlay.
 //
-// We don't pin down exact pixel coordinates — that would over-fit the
-// implementation and would have to be rewritten when texture variants land
-// in Checkpoint 5. Instead we check shape invariants: which quadrants got
-// opposite-kind paint, where chamfer hypotenuses sit, and that the sacred
-// join contract holds across simulated adjacent tiles.
+// Tests render a tile via MockGfx into a pixel buffer (filtered to opaque
+// alpha=1 draws so translucent rim bands don't pollute the silhouette
+// assertions) and check that no opposite-kind paint appears regardless
+// of neighborhood configuration.
 
 import { describe, it, expect } from 'vitest';
 import { drawAutotiledUndergroundTile, drawUndergroundRim } from './underground-autotile.js';
 import type { Neighbors3x3, NeighborKind } from './underground-neighbors.js';
 import type { GfxLike } from './draw-surface.js';
-import { TILE_SIZE_PX, COLOR_QUEEN_OUTLINE } from './sprites.js';
+import { TILE_SIZE_PX } from './sprites.js';
 import { COLOR_ROCK_BASE, COLOR_FLOOR_BASE } from './terrain-atlas.js';
-
-void COLOR_QUEEN_OUTLINE; // silence unused — kept as a hook for future tests
 
 // ---------------------------------------------------------------------------
 // Pixel-buffer recorder. Re-plays MockGfx fillRect calls with their LAST
@@ -153,258 +153,87 @@ function countPixels(buf: PixelBuffer, kind: NeighborKind): number {
 // Tests — canonical quarter shapes
 // ---------------------------------------------------------------------------
 
-describe('drawAutotiledUndergroundTile — full quadrants', () => {
-  it('isolated open chamber tile (all 4 cardinals = wall) gets 4 chamfer cuts', () => {
-    // sameH=0, sameV=0 in every quadrant → chamfer everywhere.
-    // Canonical wall pixel count is 4 chamfers × 36 = 144. Per-tile chip
-    // variants (Phase E) cut 0..4 of those wall pixels back to open via a
-    // hashed 1-pixel chip per chamfer; the exact count for tile (5, 7) is
-    // 2 chips → 142 wall pixels. The range below is the variant envelope:
-    // anywhere from 140 (4 chips) to 144 (no chips) across the hash space.
-    const buf = renderTile(makeNeighbors('open'));
-    expect(countPixels(buf, 'wall')).toBeGreaterThanOrEqual(140);
-    expect(countPixels(buf, 'wall')).toBeLessThanOrEqual(144);
+describe('drawAutotiledUndergroundTile — substrate-only contract (issue #48)', () => {
+  // After issue #48, the autotile produces ONLY the dithered substrate
+  // for the center tile's kind. No chamfer, no inner-corner bite, no
+  // chip variants — those produced visible right-triangle "teeth" at
+  // every corner where the autotile fired. Corners now read as clean
+  // tile-aligned squares; rim shading (a separate translucent pass)
+  // gives wall-side edges their carved-out feel.
+
+  it('an open tile produces ONLY open substrate — no wall-color paint anywhere', () => {
+    // For a center=open tile with any neighborhood, the silhouette is
+    // entirely open substrate. The only wall pixels in the buffer would
+    // come from the (deleted) chamfer/bite painters.
+    const cases: Array<Partial<Neighbors3x3>> = [
+      // Isolated open pocket — used to fire 4 chamfers.
+      {},
+      // L-corner — used to fire 1 chamfer.
+      { n: 'wall', w: 'wall', s: 'open', e: 'open',
+        nw: 'wall', ne: 'wall', sw: 'wall', se: 'open' },
+      // Stair-step lead tile — used to fire 2 chamfers + 0 bites.
+      { nw: 'wall', n: 'wall', ne: 'wall',
+        w:  'wall',             e: 'open',
+        sw: 'wall', s: 'wall', se: 'open' },
+      // Saddle / inner-corner-only — used to fire 2 inner-corner bites.
+      { nw: 'wall',  n: 'open',  ne: 'open',
+        w:  'open',                e: 'open',
+        sw: 'open',  s: 'open',  se: 'wall' },
+    ];
+    for (const spec of cases) {
+      const buf = renderTile(makeNeighbors('open', spec));
+      expect(countPixels(buf, 'wall')).toBe(0);
+    }
   });
 
-  it('fully open tile (all 8 neighbors = open) leaves substrate intact — no opposite paint', () => {
-    const buf = renderTile(makeNeighbors('open', {
-      nw: 'open', n: 'open', ne: 'open',
-      w:  'open',             e: 'open',
-      sw: 'open', s: 'open', se: 'open',
-    }));
-    // Substrate is all open; no opposite-kind paint should appear.
-    expect(countPixels(buf, 'wall')).toBe(0);
+  it('a wall tile produces ONLY wall substrate — no floor-color paint anywhere', () => {
+    // Symmetric to the open case. With chamfers removed, a wall tile
+    // surrounded by open neighbors no longer has its corners cut to
+    // floor color (the dark-triangle artifact in the issue #48 screenshot).
+    const cases: Array<Partial<Neighbors3x3>> = [
+      // Isolated wall pillar — used to fire 4 floor-color chamfers.
+      { nw: 'open', n: 'open', ne: 'open',
+        w:  'open',             e:  'open',
+        sw: 'open', s: 'open', se: 'open' },
+      // Wall corner (open in NW, walls elsewhere) — used to fire 1 chamfer.
+      { nw: 'open', n: 'open',  ne: 'wall',
+        w:  'open',              e: 'wall',
+        sw: 'wall', s: 'wall',  se: 'wall' },
+      // Wall saddle (cardinals all wall, two opposite diagonals = open) —
+      // used to fire 2 floor-color inner-corner bites in the previous
+      // implementation. Now nothing.
+      { nw: 'open',  n: 'wall',  ne: 'wall',
+        w:  'wall',                e: 'wall',
+        sw: 'wall',  s: 'wall',  se: 'open' },
+    ];
+    for (const spec of cases) {
+      const buf = renderTile(makeNeighbors('wall', spec));
+      expect(countPixels(buf, 'open')).toBe(0);
+    }
   });
 
-  it('fully solid tile (all 8 neighbors = wall) leaves substrate intact — no opposite paint', () => {
-    const buf = renderTile(makeNeighbors('wall'));
-    expect(countPixels(buf, 'open')).toBe(0);
-  });
-
-  it('axis-aligned vertical corridor (open tile with W=wall, E=wall, N=open, S=open) draws no chamfers or bites', () => {
-    // sameH=0, sameV=1 in NW, NE, SW, SE — every quadrant is v-edge.
-    // No opposite-kind paint should appear; the substrate alone represents
-    // the open floor between two vertical walls.
+  it('axis-aligned vertical corridor renders fully open — every silhouette pixel is open substrate', () => {
+    // Tile in a 1-wide vertical corridor with walls L+R and corridor U+D.
+    // Stronger than the parameterized "no wall paint" check above: every
+    // pixel must positively be `open` (substrate filled the tile), proving
+    // the substrate path actually ran and didn't produce any gaps.
     const buf = renderTile(makeNeighbors('open', {
       nw: 'wall', n: 'open',  ne: 'wall',
       w:  'wall',              e: 'wall',
       sw: 'wall', s: 'open',  se: 'wall',
     }));
-    expect(countPixels(buf, 'wall')).toBe(0);
-  });
-
-  it('inner-corner only (all cardinals = open, NW diagonal = wall) produces a small wall bite at NW', () => {
-    // sameH=1, sameV=1 in every quadrant. Only NW has sameD=0; the others
-    // have sameD=1 → full → no paint.
-    const buf = renderTile(makeNeighbors('open', {
-      nw: 'wall',  n: 'open', ne: 'open',
-      w:  'open',              e:  'open',
-      sw: 'open',  s: 'open', se: 'open',
-    }));
-    // Inner-corner bite is a 4-row triangle at the NW corner: row 0 fills
-    // x=0..3 (4 px), row 1 fills x=0..2 (3 px), row 2: 2 px, row 3: 1 px.
-    // Total 4+3+2+1 = 10 pixels.
-    expect(countPixels(buf, 'wall')).toBe(10);
-    // The wall pixels must be in the NW quadrant (0..7, 0..7), not anywhere else.
     for (let y = 0; y < TILE_SIZE_PX; y++) {
       for (let x = 0; x < TILE_SIZE_PX; x++) {
-        if (buf.get(x, y) === 'wall') {
-          expect(x).toBeLessThan(8);
-          expect(y).toBeLessThan(8);
-        }
-      }
-    }
-    // Specifically: pixel (0,0) must be wall (the diagonal poke anchor).
-    expect(buf.get(0, 0)).toBe('wall');
-  });
-});
-
-describe('drawAutotiledUndergroundTile — chamfer anchor pixels', () => {
-  it('isolates a single NW chamfer and verifies the anchor pixels (8,0) and (0,8) are NOT painted', () => {
-    // Set up a neighborhood where ONLY the NW quadrant is chamfer:
-    //   - NW chamfer needs h(W)=wall AND v(N)=wall.
-    //   - NE NOT chamfer: h(E) must equal centerKind. Set E=open.
-    //   - SW NOT chamfer: h(W)=wall (sameH=0), so we need v(S)=open
-    //     (sameV=1) to demote SW to v-edge.
-    //   - SE NOT chamfer: h(E)=open, so SE is at most v-edge. Set S=open.
-    const buf = renderTile(makeNeighbors('open', {
-      nw: 'wall', n: 'wall',  ne: 'wall',  // NW chamfer fires; NE: h-edge
-      w:  'wall',              e:  'open',
-      sw: 'wall', s: 'open',  se: 'open',  // SW: v-edge; SE: full
-    }));
-    // The anchor pixels live on the BOUNDARY between quadrants. The NW
-    // chamfer mask covers (lx + ly < 8) in the NW quadrant. So:
-    //   - (8, 0) is in the NE quadrant → NOT painted by NW chamfer.
-    //   - (0, 8) is in the SW quadrant → NOT painted by NW chamfer.
-    //   - (7, 0) IS painted (last pixel of NW row 0).
-    //   - (0, 7) IS painted (last pixel of NW column 0).
-    expect(buf.get(7, 0)).toBe('wall');
-    expect(buf.get(0, 7)).toBe('wall');
-    expect(buf.get(8, 0)).not.toBe('wall'); // anchor — past NW chamfer end
-    expect(buf.get(0, 8)).not.toBe('wall');
-    // Hypotenuse interior pixel — (4, 3): 4 + 3 = 7 < 8 → wall.
-    expect(buf.get(4, 3)).toBe('wall');
-    // Just past the hypotenuse: (4, 4): 4 + 4 = 8 → NOT wall.
-    expect(buf.get(4, 4)).not.toBe('wall');
-  });
-
-  it('axis-aligned corridor (no chamfers fire along shared open-open boundary) — interior tile column is fully open', () => {
-    // 1-wide horizontal open corridor between two walls. The "join"
-    // between two open tiles in the corridor doesn't have either tile
-    // chamfering toward the other (chamfer needs a WALL on the cardinal,
-    // and the cardinal between two open tiles is the OTHER OPEN tile).
-    // So the shared boundary scanline is pure open substrate on both
-    // sides — the autotile silhouette is silent there by design.
-    const interior = renderTile(makeNeighbors('open', {
-      nw: 'wall', n: 'wall',  ne: 'wall',
-      w:  'open',              e:  'open',  // both cardinals open: corridor
-      sw: 'wall', s: 'wall',  se: 'wall',
-    }));
-    // Left and right columns should be pure open substrate (no chamfer or
-    // bite). The wall-side rim band (top / bottom, alpha < 1) does NOT
-    // contribute to the silhouette buffer (paintBuffer filters alpha < 1).
-    for (let y = 0; y < TILE_SIZE_PX; y++) {
-      expect(interior.get(0, y)).not.toBe('wall');
-      expect(interior.get(TILE_SIZE_PX - 1, y)).not.toBe('wall');
-    }
-  });
-});
-
-describe('drawAutotiledUndergroundTile — stair-step diagonal corridor', () => {
-  it('NW-leading open tile in a SW-NE stair-step shows wall chamfers on the NW corner', () => {
-    // Stair-step path: ..., (0,0)=O, (1,0)=O, (1,1)=O, (2,1)=O, ...
-    // For tile (0,0) in this layout (relative to surrounding wall fill):
-    //   N=W, S=W, E=O, W=W, NE=W, NW=W, SE=O, SW=W
-    const buf = renderTile(makeNeighbors('open', {
-      nw: 'wall', n: 'wall', ne: 'wall',
-      w:  'wall',             e: 'open',
-      sw: 'wall', s: 'wall', se: 'open',
-    }));
-    // NW quadrant: h(W)=W, v(N)=W → chamfer. Wall pixels in NW corner
-    // triangle.
-    for (let i = 0; i < 8; i++) {
-      // Row i, last wall pixel of NW chamfer is at x = 7 - i
-      // (chamfer condition: x + y < 8).
-      expect(buf.get(0, i)).toBe('wall');           // first column of chamfer
-      expect(buf.get(7 - i, i)).toBe('wall');       // hypotenuse pixel
-      // Just past the hypotenuse → NOT wall (open substrate)
-      // — except in row 0 where the NE chamfer also paints (x=8 wall).
-      if (i > 0) {
-        expect(buf.get(8 - i, i)).not.toBe('wall'); // open or untouched
-      }
-    }
-    // NE quadrant: h(E)=O, v(N)=W → h-edge → no paint. So the open
-    // substrate in the NE quadrant remains visible.
-    expect(buf.get(15, 7)).toBe('open');
-    // SW quadrant: h(W)=W, v(S)=W → chamfer.
-    expect(buf.get(0, 15)).toBe('wall');
-    // SE quadrant: h(E)=O, v(S)=W → h-edge → no paint.
-    expect(buf.get(15, 15)).toBe('open');
-  });
-
-  it('saddle case (cardinals all open, two opposing diagonals = wall) paints two opposite inner-corner bites and no chamfers', () => {
-    // sameH=1, sameV=1 in every quadrant. NW and SE diagonals are wall (sameD=0
-    // → inner-corner bite). NE and SW are open (sameD=1 → full → no paint).
-    const buf = renderTile(makeNeighbors('open', {
-      nw: 'wall',  n: 'open',  ne: 'open',
-      w:  'open',                e: 'open',
-      sw: 'open',  s: 'open',  se: 'wall',
-    }));
-    // 2 inner-corner bites = 20 wall pixels total.
-    expect(countPixels(buf, 'wall')).toBe(20);
-    // NW corner bite: pixel (0,0) is wall.
-    expect(buf.get(0, 0)).toBe('wall');
-    // SE corner bite: pixel (15,15) is wall.
-    expect(buf.get(15, 15)).toBe('wall');
-    // NE corner (would be wall if NE diagonal were wall) — open here.
-    expect(buf.get(15, 0)).not.toBe('wall');
-    // SW corner — open.
-    expect(buf.get(0, 15)).not.toBe('wall');
-  });
-});
-
-describe('drawAutotiledUndergroundTile — chip variants (Phase E)', () => {
-  function makeNeighbors(c: NeighborKind, spec: Partial<Neighbors3x3> = {}): Neighbors3x3 {
-    return {
-      nw: spec.nw ?? 'wall', n:  spec.n  ?? 'wall', ne: spec.ne ?? 'wall',
-      w:  spec.w  ?? 'wall', c,                       e:  spec.e  ?? 'wall',
-      sw: spec.sw ?? 'wall', s:  spec.s  ?? 'wall', se: spec.se ?? 'wall',
-    };
-  }
-
-  it('chip never violates anchor / corner sacred pixels under a hash sweep (single-quadrant chamfer)', () => {
-    // Use the single-NW-chamfer setup (only NW fires; other quadrants
-    // are h-edge / v-edge / full and paint nothing). Sweep tile
-    // coordinates so the chip hash varies across many values, and
-    // confirm:
-    //   - (8, 0) and (0, 8) anchors remain non-wall (NW chamfer never
-    //     reaches them; chips can only retreat further inward, not extend).
-    //   - (0, 0) — the OUTER NW corner — is always wall (chip's lx, ly
-    //     each ≥ 1, so chip never lands at (0, 0)).
-    const singleNW = makeNeighbors('open', {
-      nw: 'wall', n: 'wall',  ne: 'wall',
-      w:  'wall',              e:  'open',
-      sw: 'wall', s: 'open',  se: 'open',
-    });
-    for (let tx = 0; tx < 32; tx++) {
-      for (let ty = 0; ty < 32; ty++) {
-        const gfx = new MockGfx();
-        drawAutotiledUndergroundTile(gfx, 0, 0, tx, ty, 'open', singleNW);
-        const buf = new PixelBuffer(TILE_SIZE_PX, TILE_SIZE_PX);
-        gfx.paintBuffer(buf, 0, 0);
-
-        expect(buf.get(8, 0)).not.toBe('wall'); // top-edge midpoint anchor
-        expect(buf.get(0, 8)).not.toBe('wall'); // left-edge midpoint anchor
-        expect(buf.get(0, 0)).toBe('wall');     // outer NW corner — always wall
+        expect(buf.get(x, y)).toBe('open');
       }
     }
   });
 
-  it('chip output is deterministic per (tileX, tileY)', () => {
-    // Render the same tile twice and confirm draw call sequences match.
-    // Variant code paths are the densest part of the autotiler — chip
-    // determinism is what guarantees byte-identical replays across reloads.
+  it('output is deterministic per (tileX, tileY, neighbors)', () => {
     const a = new MockGfx();
     const b = new MockGfx();
-    drawAutotiledUndergroundTile(a, 0, 0, 11, 13, 'open', makeNeighbors('open'));
-    drawAutotiledUndergroundTile(b, 0, 0, 11, 13, 'open', makeNeighbors('open'));
-    expect(a.calls).toEqual(b.calls);
-  });
-
-  it('different tiles produce different chip placements (not a stamped triangle)', () => {
-    // Sample 16 distinct tiles and count how many produce a different
-    // wall-pixel pattern. Expect MOST tiles to differ — the whole point
-    // of variants is that long stair-step diagonals stop reading as a
-    // repeated stamp.
-    const fingerprints = new Set<string>();
-    for (let i = 0; i < 16; i++) {
-      const gfx = new MockGfx();
-      drawAutotiledUndergroundTile(gfx, 0, 0, i * 7, i * 11, 'open', makeNeighbors('open'));
-      const buf = new PixelBuffer(TILE_SIZE_PX, TILE_SIZE_PX);
-      gfx.paintBuffer(buf, 0, 0);
-      // Build a coarse fingerprint of wall positions inside the chamfer
-      // interior (exclude row 0 / col 0 which never vary).
-      const cells: string[] = [];
-      for (let y = 1; y < TILE_SIZE_PX - 1; y++) {
-        for (let x = 1; x < TILE_SIZE_PX - 1; x++) {
-          if (buf.get(x, y) === 'wall') cells.push(`${x},${y}`);
-        }
-      }
-      fingerprints.add(cells.join('|'));
-    }
-    // Want at least 4 distinct patterns from 16 tiles — otherwise the
-    // chip variation is too weak to break visual repetition.
-    expect(fingerprints.size).toBeGreaterThanOrEqual(4);
-  });
-});
-
-describe('drawAutotiledUndergroundTile — determinism', () => {
-  it('same neighborhood produces the same draw call sequence', () => {
-    const a = new MockGfx();
-    const b = new MockGfx();
-    const n = makeNeighbors('open', { ne: 'open', e: 'open', se: 'open' });
-    drawAutotiledUndergroundTile(a, 32, 48, 7, 11, 'open', n);
-    drawAutotiledUndergroundTile(b, 32, 48, 7, 11, 'open', n);
+    drawAutotiledUndergroundTile(a, 32, 48, 7, 11, 'open', makeNeighbors('open'));
+    drawAutotiledUndergroundTile(b, 32, 48, 7, 11, 'open', makeNeighbors('open'));
     expect(a.calls).toEqual(b.calls);
   });
 });
@@ -455,19 +284,41 @@ describe('drawUndergroundRim', () => {
 });
 
 describe('drawAutotiledUndergroundTile — draw-op budget', () => {
-  it('worst-case open tile (4 chamfers) emits ≤ 80 fillRects', () => {
-    const gfx = new MockGfx();
-    drawAutotiledUndergroundTile(gfx, 0, 0, 0, 0, 'open', makeNeighbors('open'));
-    expect(gfx.calls.filter(c => c.method === 'fillRect').length).toBeLessThanOrEqual(80);
+  // Issue #48 dropped the per-quadrant masks; tile cost is now just the
+  // dithered substrate (drawSolidRockTile / drawOpenFloorTile). Bounds
+  // measured across a 32x32 hash sweep at the time of writing:
+  //   OPEN tile fillRect count: 1..11
+  //   WALL tile fillRect count: 4..26
+  // Pin a slightly-loose ≤ 40 cap so legitimate substrate variation
+  // doesn't fail the test, but a regression re-introducing per-tile
+  // mask painting (~36 pixel chamfer × multiple quadrants = 80+) trips it.
+  it('open tile emits ≤ 40 fillRects (substrate-only after issue #48)', () => {
+    let max = 0;
+    for (let tx = 0; tx < 32; tx++) {
+      for (let ty = 0; ty < 32; ty++) {
+        const gfx = new MockGfx();
+        drawAutotiledUndergroundTile(gfx, 0, 0, tx, ty, 'open', makeNeighbors('open'));
+        const ops = gfx.calls.filter(c => c.method === 'fillRect').length;
+        if (ops > max) max = ops;
+      }
+    }
+    expect(max).toBeLessThanOrEqual(40);
   });
 
-  it('worst-case wall tile (4 chamfers) emits ≤ 80 fillRects', () => {
-    const gfx = new MockGfx();
-    drawAutotiledUndergroundTile(gfx, 0, 0, 0, 0, 'wall', makeNeighbors('wall', {
-      nw: 'open', n: 'open', ne: 'open',
-      w:  'open',             e:  'open',
-      sw: 'open', s: 'open', se: 'open',
-    }));
-    expect(gfx.calls.filter(c => c.method === 'fillRect').length).toBeLessThanOrEqual(80);
+  it('wall tile emits ≤ 40 fillRects (substrate-only after issue #48)', () => {
+    let max = 0;
+    for (let tx = 0; tx < 32; tx++) {
+      for (let ty = 0; ty < 32; ty++) {
+        const gfx = new MockGfx();
+        drawAutotiledUndergroundTile(gfx, 0, 0, tx, ty, 'wall', makeNeighbors('wall', {
+          nw: 'open', n: 'open', ne: 'open',
+          w:  'open',             e:  'open',
+          sw: 'open', s: 'open', se: 'open',
+        }));
+        const ops = gfx.calls.filter(c => c.method === 'fillRect').length;
+        if (ops > max) max = ops;
+      }
+    }
+    expect(max).toBeLessThanOrEqual(40);
   });
 });

--- a/src/render/underground-autotile.ts
+++ b/src/render/underground-autotile.ts
@@ -1,31 +1,22 @@
-// underground-autotile.ts — issue #43 Checkpoint 2.
+// underground-autotile.ts — underground tile rendering.
 //
-// Quarter-tile autotiling for the underground cross-section. Replaces the
-// per-corner overlay path (drawTunnelCornerOverlay + drawSolidConvexCornerOverlay)
-// with a quadrant-based approach where each tile's four 8×8 quadrants pick a
-// canonical shape from a 5-entry catalogue and paint OPPOSITE-kind pixels into
-// the quadrant when the silhouette demands it.
+// `drawAutotiledUndergroundTile` paints the dithered substrate for a tile
+// based on its centerKind ('wall' or 'open'). `drawUndergroundRim` adds
+// a translucent 2-pixel darker rim band on the open side of wall
+// boundaries (plus deterministic 1-pixel darker chip specks within the
+// band) for the carved-out feel.
 //
-// The five canonical quarter shapes (per quadrant):
-//
-//   sameH sameV sameD  shape          paints OPPOSITE kind?
-//   ─────────────────────────────────────────────────────────
-//     0     0     -    chamfer        yes — triangular fill at outer corner
-//     1     0     -    h-edge         no  — substrate is correct
-//     0     1     -    v-edge         no  — substrate is correct
-//     1     1     0    inner-corner   yes — small bite at diagonal corner
-//     1     1     1    full           no  — substrate is correct
-//
-// where sameH/V/D mean "this neighbor matches the center kind". h-edge/v-edge
-// represent straight cardinal walls; the rim shading that visually distinguishes
-// them from the open floor is added by a SEPARATE pass (Checkpoint 4) so the
-// shape logic stays orthogonal to the lighting/texture concerns.
-//
-// Sacred join contract — the chamfer hypotenuse passes through the edge
-// midpoints of the full tile (NW: (8,0)→(0,8); NE: (8,0)→(15,8); SE:
-// (15,8)→(8,15); SW: (0,8)→(8,15)). Variants may alter the jaggedness
-// between anchors but must NOT move them, so adjacent tiles' chamfers meet
-// exactly along their shared edge midpoint.
+// History — issue #43 originally introduced quarter-tile autotile masks
+// (chamfer + inner-corner-bite) at this function for "smooth stair-step
+// diagonal corridors." Issue #48 removed those masks: their opaque
+// opposite-kind triangles read as visible right-triangle "teeth" at every
+// corner where the autotile fired (chambers, L-corners, stair-step
+// diagonals). The hashed-wobble attempt (PR #50, closed) didn't fix the
+// silhouette read at high contrast. Corners now render as clean
+// tile-aligned squares; rim shading provides the only visual
+// differentiation along wall-side edges. The function name + signature
+// are preserved so any future re-introduction of a corner-softening pass
+// can land here without touching callers.
 //
 // Render-only — no sim mutation, no simVersion bump.
 
@@ -34,34 +25,36 @@ import { TILE_SIZE_PX } from './sprites.js';
 import {
   drawSolidRockTile,
   drawOpenFloorTile,
-  COLOR_ROCK_BASE,
   COLOR_ROCK_BASE_DARK,
-  COLOR_FLOOR_BASE,
 } from './terrain-atlas.js';
 import { spatialHash } from './terrain-noise.js';
 import type { Neighbors3x3, NeighborKind } from './underground-neighbors.js';
 
-// Per-quadrant salt namespaces for chamfer chip placement. Distinct so
-// adjacent quadrants on the same tile pick independent chip positions.
-const SALT_CHIP_NW = 401;
-const SALT_CHIP_NE = 402;
-const SALT_CHIP_SE = 403;
-const SALT_CHIP_SW = 404;
-// Rim chip salt (one channel — band-position derived from quadrant).
+// Rim chip salt — used by drawUndergroundRim for hashed 1-pixel darker
+// specks in the rim band.
 const SALT_RIM_CHIP = 411;
 
-const HALF = TILE_SIZE_PX / 2; // 8
-
-type Quadrant = 'NW' | 'NE' | 'SE' | 'SW';
-
 /**
- * Draw an autotiled underground tile: substrate by `centerKind`, then
- * quarter-tile masks driven by the 3×3 neighborhood. Tints / decoration
- * (Marked/BeingDug overlay, ceiling tint, etc.) are applied separately by
- * the caller.
+ * Draw an underground tile: dithered substrate by `centerKind`. Tints /
+ * decoration (Marked/BeingDug overlay, ceiling tint, etc.) and rim shading
+ * are applied separately by the caller.
  *
- * Total ops: ~30 (substrate) + up to 4 × 8 (chamfers) + up to 4 × 4
- * (inner-corner bites) ≈ 80 worst case for an isolated open pocket.
+ * Issue #48 follow-up: the chamfer + inner-corner-bite painting that PR
+ * #46 introduced has been REMOVED. Those opaque opposite-kind triangles
+ * read as visible right-triangle "teeth" at every corner where the
+ * autotile fired (chambers, L-corners, stair-step diagonals) and the
+ * hashed-wobble attempt (PR #50, closed) didn't fix the problem — the
+ * silhouette stayed triangular at high contrast even with ±1 boundary
+ * jaggedness. Corners now read as clean tile-aligned squares with the
+ * rim-shading pass (`drawUndergroundRim`) providing the carved-out feel
+ * along wall-side edges.
+ *
+ * The function name + signature are preserved so callers (draw-underground.ts)
+ * don't need to change. The `neighbors` parameter is unused at present but
+ * is retained for any future re-introduction of a corner-softening pass
+ * that doesn't paint hard triangles.
+ *
+ * Total ops: dominated by the substrate (~30); no per-quadrant work.
  */
 export function drawAutotiledUndergroundTile(
   gfx: GfxLike,
@@ -72,179 +65,12 @@ export function drawAutotiledUndergroundTile(
   centerKind: NeighborKind,
   neighbors: Neighbors3x3,
 ): void {
-  // 1. Substrate — same dithered base the existing code uses, so axis-aligned
-  //    corridors render byte-identical for substrate-level pixels.
   if (centerKind === 'wall') {
     drawSolidRockTile(gfx, screenX, screenY, tileX, tileY);
   } else {
     drawOpenFloorTile(gfx, screenX, screenY, tileX, tileY);
   }
-
-  // 2. Quarter-tile masks. We paint the OPPOSITE substrate's base color into
-  //    the quadrant region the autotile says belongs to the other kind. Solid
-  //    color (no dither) — the chamfer/bite reads as a clean "carved" region
-  //    against the dithered substrate behind it, which is the right contrast
-  //    for a hard-pixel-art look. Each helper sets its own fillStyle so the
-  //    chip / inner-corner / chamfer paints don't bleed into one another.
-  //
-  // For each quadrant, the (h, v, d) classification picks a shape. h is the
-  // cardinal-horizontal neighbor (W for NW/SW, E for NE/SE); v is the
-  // cardinal-vertical neighbor (N for NW/NE, S for SW/SE); d is the diagonal.
-  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'NW', neighbors.w, neighbors.n, neighbors.nw);
-  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'NE', neighbors.e, neighbors.n, neighbors.ne);
-  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'SE', neighbors.e, neighbors.s, neighbors.se);
-  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'SW', neighbors.w, neighbors.s, neighbors.sw);
-}
-
-function drawQuadrantMask(
-  gfx: GfxLike,
-  screenX: number,
-  screenY: number,
-  tileX: number,
-  tileY: number,
-  centerKind: NeighborKind,
-  quadrant: Quadrant,
-  horizKind: NeighborKind,
-  vertKind:  NeighborKind,
-  diagKind:  NeighborKind,
-): void {
-  const sameH = horizKind === centerKind;
-  const sameV = vertKind  === centerKind;
-  const sameD = diagKind  === centerKind;
-
-  const oppositeColor = centerKind === 'wall' ? COLOR_FLOOR_BASE : COLOR_ROCK_BASE;
-  if (!sameH && !sameV) {
-    // chamfer — the quadrant has two opposite-kind cardinals. Paint a
-    // hypotenuse-anchored triangle of OPPOSITE kind into the outer corner.
-    gfx.fillStyle(oppositeColor, 1);
-    fillChamferTriangle(gfx, screenX, screenY, quadrant);
-    // Per-tile chip variant — 1 deterministic pixel of CENTER-kind paint
-    // inside the chamfer interior, simulating a chip / crack / mineral
-    // inclusion. Strictly avoids the sacred edges (row 0 / col 0) and the
-    // hypotenuse boundary, so anchor and join contracts hold regardless.
-    maybeAddChamferChip(gfx, screenX, screenY, tileX, tileY, quadrant, centerKind);
-  } else if (sameH && sameV && !sameD) {
-    // inner-corner — only the diagonal differs. The opposite kind pokes in
-    // at the far corner of the quadrant. Paint a small bite there.
-    gfx.fillStyle(oppositeColor, 1);
-    fillInnerCornerBite(gfx, screenX, screenY, quadrant);
-  }
-  // else: full / h-edge / v-edge — substrate is correct, nothing to paint.
-}
-
-/**
- * Fill the hypotenuse-anchored triangle inside the named quadrant. The
- * triangle covers (lx, ly) where lx + ly ≤ 7 in quadrant-local coords; the
- * hypotenuse passes through the tile-edge midpoints, so adjacent tiles'
- * chamfers join cleanly on their shared edge.
- *
- * 8 fillRect scanline calls per chamfer.
- */
-function fillChamferTriangle(
-  gfx: GfxLike,
-  screenX: number,
-  screenY: number,
-  quadrant: Quadrant,
-): void {
-  // For each of the 8 scanlines, compute the row's (x, y) origin and width.
-  // The triangle's "right angle" sits at the outer corner of the quadrant
-  // (the corner of the full tile); the hypotenuse runs from the midpoint of
-  // one tile edge to the midpoint of the adjacent tile edge.
-  for (let i = 0; i < HALF; i++) {
-    const width = HALF - i;
-    let x = 0, y = 0;
-    switch (quadrant) {
-      case 'NW': x = 0;                        y = i;                              break;
-      case 'NE': x = HALF + i;                 y = i;                              break;
-      case 'SE': x = HALF + i;                 y = TILE_SIZE_PX - 1 - i;           break;
-      case 'SW': x = 0;                        y = TILE_SIZE_PX - 1 - i;           break;
-    }
-    gfx.fillRect(screenX + x, screenY + y, width, 1);
-  }
-}
-
-/**
- * Fill a 4×4 triangular bite at the diagonal corner of the named quadrant —
- * the opposite-kind diagonal neighbor "poking into" an otherwise same-kind
- * area. Smaller than a chamfer so it reads as a peninsula rather than a
- * full rounded corner.
- *
- * 4 fillRect scanline calls per inner-corner bite.
- */
-function fillInnerCornerBite(
-  gfx: GfxLike,
-  screenX: number,
-  screenY: number,
-  quadrant: Quadrant,
-): void {
-  const SIZE = 4;
-  for (let i = 0; i < SIZE; i++) {
-    const width = SIZE - i;
-    let x = 0, y = 0;
-    switch (quadrant) {
-      case 'NW': x = 0;                            y = i;                              break;
-      case 'NE': x = TILE_SIZE_PX - SIZE + i;      y = i;                              break;
-      case 'SE': x = TILE_SIZE_PX - SIZE + i;      y = TILE_SIZE_PX - 1 - i;           break;
-      case 'SW': x = 0;                            y = TILE_SIZE_PX - 1 - i;           break;
-    }
-    gfx.fillRect(screenX + x, screenY + y, width, 1);
-  }
-}
-
-/**
- * Place a 1-pixel "chip" of CENTER-kind paint inside a chamfer interior.
- *
- * Visual purpose: long stair-step diagonals look stamped if every chamfer
- * is pixel-identical. A single deterministic 1-pixel chip per chamfer
- * breaks the repetition without altering the silhouette.
- *
- * Sacred-edge protection: the chip's local (lx, ly) lives in [1..5] × [1..5]
- * with the additional constraint lx + ly ≤ 6 (strictly inside the canonical
- * chamfer hypotenuse, lx + ly < 8). So:
- *   - lx ≥ 1 → never on col 0 (sacred join with adjacent quadrant)
- *   - ly ≥ 1 → never on row 0 (same)
- *   - lx + ly ≤ 6 → never on or past the canonical hypotenuse pixels
- *
- * Approximate chip rate ~60% (h & 0xff < 154), so most chamfers carry one
- * but uniform stair-steps occasionally show a "boring" canonical mask too.
- */
-function maybeAddChamferChip(
-  gfx: GfxLike,
-  screenX: number,
-  screenY: number,
-  tileX: number,
-  tileY: number,
-  quadrant: Quadrant,
-  centerKind: NeighborKind,
-): void {
-  const salt = quadrant === 'NW' ? SALT_CHIP_NW
-             : quadrant === 'NE' ? SALT_CHIP_NE
-             : quadrant === 'SE' ? SALT_CHIP_SE
-             :                     SALT_CHIP_SW;
-  const h = spatialHash(tileX, tileY, salt);
-  if ((h & 0xff) >= 154) return; // ~60% emission rate
-
-  // Sample (lx, ly) inside the safe region. lx ∈ [1..5]; ly ∈ [1..(6 - lx)].
-  // The constraint lx + ly ≤ 6 keeps the chip strictly interior.
-  const lx = 1 + ((h >>> 8) & 0xf) % 5;
-  const ly = 1 + ((h >>> 12) & 0xf) % (6 - lx);
-
-  // Map quadrant-local (lx, ly) to tile-relative pixel.
-  let px = 0, py = 0;
-  switch (quadrant) {
-    case 'NW': px = lx;                          py = ly;                          break;
-    case 'NE': px = TILE_SIZE_PX - 1 - lx;       py = ly;                          break;
-    case 'SE': px = TILE_SIZE_PX - 1 - lx;       py = TILE_SIZE_PX - 1 - ly;       break;
-    case 'SW': px = lx;                          py = TILE_SIZE_PX - 1 - ly;       break;
-  }
-
-  // Chip color is the CENTER kind — i.e., a 1-pixel "cut" through the
-  // opposite-kind chamfer fill, revealing the substrate beneath. For an
-  // open tile this is a tiny floor-color crack in the rock chamfer; for
-  // a wall tile it's a tiny rock-color bump in the floor chamfer.
-  const chipColor = centerKind === 'wall' ? COLOR_ROCK_BASE : COLOR_FLOOR_BASE;
-  gfx.fillStyle(chipColor, 1);
-  gfx.fillRect(screenX + px, screenY + py, 1, 1);
+  void neighbors; // see docblock — kept for signature stability.
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Issue #48 v2 — option 3 from the original write-up: drop chamfer + inner-corner-bite + chip-variant painting entirely. `drawAutotiledUndergroundTile` now produces only the dithered substrate. Corners read as clean tile-aligned squares; the rim-shading pass provides the carved-out feel along wall-side edges.

Closes #48. Supersedes #50 (wobble approach, closed — didn't fix the silhouette read).

## Why the wobble didn't work

The hashed boundary wobble (PR #50) varied each chamfer's hypotenuse by ±1 pixel per row. Under UAT the dark/light triangles at corners were still clearly visible — the artifact is fundamental to the chamfer-painting *approach*, not the chamfer's *boundary*. Any 36-pixel opaque opposite-kind blob at high color contrast reads as a triangle regardless of how its hypotenuse is jagged.

## Trade-off

PR #46's stated goal was "smooth stair-step diagonal corridors" via the chamfers. The UAT screenshot in issue #48 showed that goal was never achieved anyway — stair-step diagonals always read as tile-aligned square cells with the triangle teeth bolted on. Removing the chamfers loses a fiction and gains clean corners. Net win.

## What changed

- **`src/render/underground-autotile.ts`**: deleted `fillChamferTriangle`, `fillInnerCornerBite`, `maybeAddChamferChip`, `drawQuadrantMask`, and the SALT_CHIP_* / SALT_WOBBLE_* / Quadrant / HALF constants. `drawAutotiledUndergroundTile` is now a 4-line function that just calls the substrate. Stale file-header docblock about the 5-shape catalogue / sacred-join contract replaced with the current contract + history. Function signature unchanged.

- **`src/render/underground-autotile.test.ts`**: 5 chamfer/bite/chip describe blocks (~250 lines) replaced with one "substrate-only contract" describe block (4 tests). Op budget tightened from ≤80 to ≤40 via a 32×32 hash sweep so any future regression re-adding per-tile mask painting trips it.

Net diff: 150 added, 473 deleted.

Render-only — no sim, save, replay, or simVersion impact.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 1639 tests pass (10 in this file, others unaffected)
- [x] 4 internal review rounds, clean final pass
- [ ] **UAT**: render an underground tunnel network with stair-step + L-corner + chamber. Confirm: NO dark-brown triangles outside tunnels, NO light/tan triangles inside tunnels. Corners are clean tile-aligned 90° boundaries with subtle rim shading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)