### PR TITLE
fix(render): remove stray bite triangles + clip rim at chamfered corners (#48)

### DIFF
--- a/src/render/underground-autotile.test.ts
+++ b/src/render/underground-autotile.test.ts
@@ -149,6 +149,23 @@ function countPixels(buf: PixelBuffer, kind: NeighborKind): number {
   return n;
 }
 
+function fillRectCalls(gfx: MockGfx): Array<[number, number, number, number, number, number]> {
+  return gfx.calls
+    .filter(c => c.method === 'fillRect')
+    .map(c => c.args as [number, number, number, number, number, number]);
+}
+
+function rectOverlaps(
+  rect: [number, number, number, number, number, number],
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): boolean {
+  const [rx, ry, rw, rh] = rect;
+  return rx < x + w && rx + rw > x && ry < y + h && ry + rh > y;
+}
+
 // ---------------------------------------------------------------------------
 // Tests — canonical quarter shapes
 // ---------------------------------------------------------------------------
@@ -193,29 +210,15 @@ describe('drawAutotiledUndergroundTile — full quadrants', () => {
     expect(countPixels(buf, 'wall')).toBe(0);
   });
 
-  it('inner-corner only (all cardinals = open, NW diagonal = wall) produces a small wall bite at NW', () => {
-    // sameH=1, sameV=1 in every quadrant. Only NW has sameD=0; the others
-    // have sameD=1 → full → no paint.
+  it('diagonal-only mismatch (all cardinals = open, NW diagonal = wall) leaves substrate intact', () => {
+    // Issue #48: diagonal-only opposite-kind bites read as stray wrong-side
+    // triangles. Only cardinal boundaries are allowed to change silhouette.
     const buf = renderTile(makeNeighbors('open', {
       nw: 'wall',  n: 'open', ne: 'open',
       w:  'open',              e:  'open',
       sw: 'open',  s: 'open', se: 'open',
     }));
-    // Inner-corner bite is a 4-row triangle at the NW corner: row 0 fills
-    // x=0..3 (4 px), row 1 fills x=0..2 (3 px), row 2: 2 px, row 3: 1 px.
-    // Total 4+3+2+1 = 10 pixels.
-    expect(countPixels(buf, 'wall')).toBe(10);
-    // The wall pixels must be in the NW quadrant (0..7, 0..7), not anywhere else.
-    for (let y = 0; y < TILE_SIZE_PX; y++) {
-      for (let x = 0; x < TILE_SIZE_PX; x++) {
-        if (buf.get(x, y) === 'wall') {
-          expect(x).toBeLessThan(8);
-          expect(y).toBeLessThan(8);
-        }
-      }
-    }
-    // Specifically: pixel (0,0) must be wall (the diagonal poke anchor).
-    expect(buf.get(0, 0)).toBe('wall');
+    expect(countPixels(buf, 'wall')).toBe(0);
   });
 });
 
@@ -302,24 +305,15 @@ describe('drawAutotiledUndergroundTile — stair-step diagonal corridor', () => 
     expect(buf.get(15, 15)).toBe('open');
   });
 
-  it('saddle case (cardinals all open, two opposing diagonals = wall) paints two opposite inner-corner bites and no chamfers', () => {
-    // sameH=1, sameV=1 in every quadrant. NW and SE diagonals are wall (sameD=0
-    // → inner-corner bite). NE and SW are open (sameD=1 → full → no paint).
+  it('saddle case (cardinals all open, two opposing diagonals = wall) paints no diagonal-only bites', () => {
+    // Diagonal-only mismatches do not represent a cardinal wall boundary, so
+    // they should not paint isolated opposite-kind triangles.
     const buf = renderTile(makeNeighbors('open', {
       nw: 'wall',  n: 'open',  ne: 'open',
       w:  'open',                e: 'open',
       sw: 'open',  s: 'open',  se: 'wall',
     }));
-    // 2 inner-corner bites = 20 wall pixels total.
-    expect(countPixels(buf, 'wall')).toBe(20);
-    // NW corner bite: pixel (0,0) is wall.
-    expect(buf.get(0, 0)).toBe('wall');
-    // SE corner bite: pixel (15,15) is wall.
-    expect(buf.get(15, 15)).toBe('wall');
-    // NE corner (would be wall if NE diagonal were wall) — open here.
-    expect(buf.get(15, 0)).not.toBe('wall');
-    // SW corner — open.
-    expect(buf.get(0, 15)).not.toBe('wall');
+    expect(countPixels(buf, 'wall')).toBe(0);
   });
 });
 
@@ -423,7 +417,7 @@ describe('drawUndergroundRim', () => {
   it('does nothing on a wall tile (rim only fires on open tiles)', () => {
     const gfx = gfxCalls();
     drawUndergroundRim(gfx, 0, 0, 0, 0, 'wall', makeNeighbors('wall'));
-    expect(gfx.calls.filter(c => c.method === 'fillRect')).toHaveLength(0);
+    expect(fillRectCalls(gfx)).toHaveLength(0);
   });
 
   it('does nothing on an open tile with no wall neighbors', () => {
@@ -433,7 +427,7 @@ describe('drawUndergroundRim', () => {
       w:  'open',             e: 'open',
       sw: 'open', s: 'open', se: 'open',
     }));
-    expect(gfx.calls.filter(c => c.method === 'fillRect')).toHaveLength(0);
+    expect(fillRectCalls(gfx)).toHaveLength(0);
   });
 
   it('emits 2 band fillRects + 1 chip per cardinal wall neighbor', () => {
@@ -444,13 +438,32 @@ describe('drawUndergroundRim', () => {
       ne: 'open', e: 'open', se: 'open', s: 'open', sw: 'open', w: 'open', nw: 'open',
     }));
     // 1 heavy band + 1 light band + 1 chip = 3 fillRects.
-    expect(gfx.calls.filter(c => c.method === 'fillRect')).toHaveLength(3);
+    expect(fillRectCalls(gfx)).toHaveLength(3);
   });
 
-  it('all four cardinal walls → 8 band fillRects + 4 chips = 12', () => {
+  it('clips rim bands away from chamfered corner halves', () => {
+    const gfx = gfxCalls();
+    // Open tile with N and W walls gets an NW chamfer. The north rim must
+    // skip its west half, and the west rim must skip its north half, so
+    // no grid-aligned rim stubs remain inside the chamfered corner.
+    drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
+      nw: 'wall', n: 'wall', ne: 'open',
+      w:  'wall',             e: 'open',
+      sw: 'open', s: 'open', se: 'open',
+    }));
+    const rects = fillRectCalls(gfx);
+    for (const rect of rects) {
+      expect(rectOverlaps(rect, 0, 0, 8, 2)).toBe(false); // clipped north rim half
+      expect(rectOverlaps(rect, 0, 0, 2, 8)).toBe(false); // clipped west rim half
+    }
+    expect(rects.some(rect => rectOverlaps(rect, 8, 0, 8, 2))).toBe(true);
+    expect(rects.some(rect => rectOverlaps(rect, 0, 8, 2, 8))).toBe(true);
+  });
+
+  it('all four cardinal walls clip all rim bands because every edge half is chamfered', () => {
     const gfx = gfxCalls();
     drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open'));
-    expect(gfx.calls.filter(c => c.method === 'fillRect')).toHaveLength(12);
+    expect(fillRectCalls(gfx)).toHaveLength(0);
   });
 });
 

--- a/src/render/underground-autotile.test.ts
+++ b/src/render/underground-autotile.test.ts
@@ -441,7 +441,7 @@ describe('drawUndergroundRim', () => {
     expect(fillRectCalls(gfx)).toHaveLength(3);
   });
 
-  it('clips rim bands away from chamfered corner halves', () => {
+  it('clips rim bands away from chamfered corner halves — NW chamfer', () => {
     const gfx = gfxCalls();
     // Open tile with N and W walls gets an NW chamfer. The north rim must
     // skip its west half, and the west rim must skip its north half, so
@@ -458,6 +458,60 @@ describe('drawUndergroundRim', () => {
     }
     expect(rects.some(rect => rectOverlaps(rect, 8, 0, 8, 2))).toBe(true);
     expect(rects.some(rect => rectOverlaps(rect, 0, 8, 2, 8))).toBe(true);
+  });
+
+  it('clips rim bands away from chamfered corner halves — NE chamfer', () => {
+    const gfx = gfxCalls();
+    // Open tile with N and E walls gets an NE chamfer. The north rim must
+    // skip its EAST half, and the east rim must skip its NORTH half.
+    drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
+      nw: 'open', n: 'wall', ne: 'wall',
+      w:  'open',             e: 'wall',
+      sw: 'open', s: 'open', se: 'open',
+    }));
+    const rects = fillRectCalls(gfx);
+    for (const rect of rects) {
+      expect(rectOverlaps(rect, 8, 0, 8, 2)).toBe(false);  // clipped north east half
+      expect(rectOverlaps(rect, 14, 0, 2, 8)).toBe(false); // clipped east north half
+    }
+    expect(rects.some(rect => rectOverlaps(rect, 0, 0, 8, 2))).toBe(true);  // unclipped north west half
+    expect(rects.some(rect => rectOverlaps(rect, 14, 8, 2, 8))).toBe(true); // unclipped east south half
+  });
+
+  it('clips rim bands away from chamfered corner halves — SE chamfer', () => {
+    const gfx = gfxCalls();
+    // Open tile with S and E walls gets an SE chamfer. The south rim must
+    // skip its EAST half, and the east rim must skip its SOUTH half.
+    drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
+      nw: 'open', n: 'open', ne: 'open',
+      w:  'open',             e: 'wall',
+      sw: 'open', s: 'wall', se: 'wall',
+    }));
+    const rects = fillRectCalls(gfx);
+    for (const rect of rects) {
+      expect(rectOverlaps(rect, 8, 14, 8, 2)).toBe(false); // clipped south east half
+      expect(rectOverlaps(rect, 14, 8, 2, 8)).toBe(false); // clipped east south half
+    }
+    expect(rects.some(rect => rectOverlaps(rect, 0, 14, 8, 2))).toBe(true); // unclipped south west half
+    expect(rects.some(rect => rectOverlaps(rect, 14, 0, 2, 8))).toBe(true); // unclipped east north half
+  });
+
+  it('clips rim bands away from chamfered corner halves — SW chamfer', () => {
+    const gfx = gfxCalls();
+    // Open tile with S and W walls gets an SW chamfer. The south rim must
+    // skip its WEST half, and the west rim must skip its SOUTH half.
+    drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
+      nw: 'open', n: 'open', ne: 'open',
+      w:  'wall',             e: 'open',
+      sw: 'wall', s: 'wall', se: 'open',
+    }));
+    const rects = fillRectCalls(gfx);
+    for (const rect of rects) {
+      expect(rectOverlaps(rect, 0, 14, 8, 2)).toBe(false); // clipped south west half
+      expect(rectOverlaps(rect, 0, 8, 2, 8)).toBe(false);  // clipped west south half
+    }
+    expect(rects.some(rect => rectOverlaps(rect, 8, 14, 8, 2))).toBe(true); // unclipped south east half
+    expect(rects.some(rect => rectOverlaps(rect, 0, 0, 2, 8))).toBe(true);  // unclipped west north half
   });
 
   it('all four cardinal walls clip all rim bands because every edge half is chamfered', () => {

--- a/src/render/underground-autotile.test.ts
+++ b/src/render/underground-autotile.test.ts
@@ -441,83 +441,124 @@ describe('drawUndergroundRim', () => {
     expect(fillRectCalls(gfx)).toHaveLength(3);
   });
 
+  // Rim-clip geometry post-codex-P2: the clip is depth-aware. The heavy
+  // band (rowFromEdge=0) clips a full half-edge (HALF=8 pixels) when an
+  // adjacent corner chamfers. The light band (rowFromEdge=1) clips only
+  // HALF-1=7 pixels because the chamfer's row 1 covers cols 0..6 (not
+  // 0..7). So row 1 col 7 keeps its rim shading even with a NW chamfer.
+
   it('clips rim bands away from chamfered corner halves — NW chamfer', () => {
     const gfx = gfxCalls();
-    // Open tile with N and W walls gets an NW chamfer. The north rim must
-    // skip its west half, and the west rim must skip its north half, so
-    // no grid-aligned rim stubs remain inside the chamfered corner.
     drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
       nw: 'wall', n: 'wall', ne: 'open',
       w:  'wall',             e: 'open',
       sw: 'open', s: 'open', se: 'open',
     }));
     const rects = fillRectCalls(gfx);
+    // Heavy band (row 0): NW chamfer covers cols 0..7 → clipped.
+    // Light band (row 1): NW chamfer covers cols 0..6 → cols 0..6 clipped.
     for (const rect of rects) {
-      expect(rectOverlaps(rect, 0, 0, 8, 2)).toBe(false); // clipped north rim half
-      expect(rectOverlaps(rect, 0, 0, 2, 8)).toBe(false); // clipped west rim half
+      expect(rectOverlaps(rect, 0, 0, 8, 1)).toBe(false); // clip heavy N row 0 cols 0..7
+      expect(rectOverlaps(rect, 0, 1, 7, 1)).toBe(false); // clip light N row 1 cols 0..6
+      expect(rectOverlaps(rect, 0, 0, 1, 8)).toBe(false); // clip heavy W col 0 rows 0..7
+      expect(rectOverlaps(rect, 1, 0, 1, 7)).toBe(false); // clip light W col 1 rows 0..6
     }
-    expect(rects.some(rect => rectOverlaps(rect, 8, 0, 8, 2))).toBe(true);
-    expect(rects.some(rect => rectOverlaps(rect, 0, 8, 2, 8))).toBe(true);
+    // Unclipped portions should be painted somewhere.
+    expect(rects.some(rect => rectOverlaps(rect, 8, 0, 8, 1))).toBe(true);  // heavy N E half
+    expect(rects.some(rect => rectOverlaps(rect, 7, 1, 9, 1))).toBe(true);  // light N from col 7
+    expect(rects.some(rect => rectOverlaps(rect, 0, 8, 1, 8))).toBe(true);  // heavy W S half
+    expect(rects.some(rect => rectOverlaps(rect, 1, 7, 1, 9))).toBe(true);  // light W from row 7
   });
 
   it('clips rim bands away from chamfered corner halves — NE chamfer', () => {
     const gfx = gfxCalls();
-    // Open tile with N and E walls gets an NE chamfer. The north rim must
-    // skip its EAST half, and the east rim must skip its NORTH half.
     drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
       nw: 'open', n: 'wall', ne: 'wall',
       w:  'open',             e: 'wall',
       sw: 'open', s: 'open', se: 'open',
     }));
     const rects = fillRectCalls(gfx);
+    // NE chamfer at row R covers cols (8+R)..15. So heavy (row 0): cols
+    // 8..15. Light (row 1): cols 9..15. NE on E edge col 15 row R covers
+    // similarly mirrored.
     for (const rect of rects) {
-      expect(rectOverlaps(rect, 8, 0, 8, 2)).toBe(false);  // clipped north east half
-      expect(rectOverlaps(rect, 14, 0, 2, 8)).toBe(false); // clipped east north half
+      expect(rectOverlaps(rect, 8, 0, 8, 1)).toBe(false);  // clip heavy N row 0 cols 8..15
+      expect(rectOverlaps(rect, 9, 1, 7, 1)).toBe(false);  // clip light N row 1 cols 9..15
+      expect(rectOverlaps(rect, 15, 0, 1, 8)).toBe(false); // clip heavy E col 15 rows 0..7
+      expect(rectOverlaps(rect, 14, 0, 1, 7)).toBe(false); // clip light E col 14 rows 0..6
     }
-    expect(rects.some(rect => rectOverlaps(rect, 0, 0, 8, 2))).toBe(true);  // unclipped north west half
-    expect(rects.some(rect => rectOverlaps(rect, 14, 8, 2, 8))).toBe(true); // unclipped east south half
+    expect(rects.some(rect => rectOverlaps(rect, 0, 0, 8, 1))).toBe(true);  // heavy N W half
+    expect(rects.some(rect => rectOverlaps(rect, 0, 1, 9, 1))).toBe(true);  // light N up to col 8
+    expect(rects.some(rect => rectOverlaps(rect, 15, 8, 1, 8))).toBe(true); // heavy E S half
+    expect(rects.some(rect => rectOverlaps(rect, 14, 7, 1, 9))).toBe(true); // light E from row 7
   });
 
   it('clips rim bands away from chamfered corner halves — SE chamfer', () => {
     const gfx = gfxCalls();
-    // Open tile with S and E walls gets an SE chamfer. The south rim must
-    // skip its EAST half, and the east rim must skip its SOUTH half.
     drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
       nw: 'open', n: 'open', ne: 'open',
       w:  'open',             e: 'wall',
       sw: 'open', s: 'wall', se: 'wall',
     }));
     const rects = fillRectCalls(gfx);
+    // SE chamfer at row R (R measured from south edge) covers cols
+    // (8+R)..15. On the S edge: heavy (S row 15, rowFromEdge=0): cols
+    // 8..15. Light (S row 14, rowFromEdge=1): cols 9..15.
     for (const rect of rects) {
-      expect(rectOverlaps(rect, 8, 14, 8, 2)).toBe(false); // clipped south east half
-      expect(rectOverlaps(rect, 14, 8, 2, 8)).toBe(false); // clipped east south half
+      expect(rectOverlaps(rect, 8, 15, 8, 1)).toBe(false);  // clip heavy S row 15 cols 8..15
+      expect(rectOverlaps(rect, 9, 14, 7, 1)).toBe(false);  // clip light S row 14 cols 9..15
+      expect(rectOverlaps(rect, 15, 8, 1, 8)).toBe(false);  // clip heavy E col 15 rows 8..15
+      expect(rectOverlaps(rect, 14, 9, 1, 7)).toBe(false);  // clip light E col 14 rows 9..15
     }
-    expect(rects.some(rect => rectOverlaps(rect, 0, 14, 8, 2))).toBe(true); // unclipped south west half
-    expect(rects.some(rect => rectOverlaps(rect, 14, 0, 2, 8))).toBe(true); // unclipped east north half
+    expect(rects.some(rect => rectOverlaps(rect, 0, 15, 8, 1))).toBe(true);  // heavy S W half
+    expect(rects.some(rect => rectOverlaps(rect, 0, 14, 9, 1))).toBe(true);  // light S up to col 8
+    expect(rects.some(rect => rectOverlaps(rect, 15, 0, 1, 8))).toBe(true);  // heavy E N half
+    expect(rects.some(rect => rectOverlaps(rect, 14, 0, 1, 9))).toBe(true);  // light E up to row 8
   });
 
   it('clips rim bands away from chamfered corner halves — SW chamfer', () => {
     const gfx = gfxCalls();
-    // Open tile with S and W walls gets an SW chamfer. The south rim must
-    // skip its WEST half, and the west rim must skip its SOUTH half.
     drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
       nw: 'open', n: 'open', ne: 'open',
       w:  'wall',             e: 'open',
       sw: 'wall', s: 'wall', se: 'open',
     }));
     const rects = fillRectCalls(gfx);
+    // SW chamfer at row R (from south edge) covers cols 0..(7-R). Heavy
+    // (S row 15): 0..7. Light (S row 14): 0..6. On the W edge, mirrored.
     for (const rect of rects) {
-      expect(rectOverlaps(rect, 0, 14, 8, 2)).toBe(false); // clipped south west half
-      expect(rectOverlaps(rect, 0, 8, 2, 8)).toBe(false);  // clipped west south half
+      expect(rectOverlaps(rect, 0, 15, 8, 1)).toBe(false); // clip heavy S row 15 cols 0..7
+      expect(rectOverlaps(rect, 0, 14, 7, 1)).toBe(false); // clip light S row 14 cols 0..6
+      expect(rectOverlaps(rect, 0, 8, 1, 8)).toBe(false);  // clip heavy W col 0 rows 8..15
+      expect(rectOverlaps(rect, 1, 9, 1, 7)).toBe(false);  // clip light W col 1 rows 9..15
     }
-    expect(rects.some(rect => rectOverlaps(rect, 8, 14, 8, 2))).toBe(true); // unclipped south east half
-    expect(rects.some(rect => rectOverlaps(rect, 0, 0, 2, 8))).toBe(true);  // unclipped west north half
+    expect(rects.some(rect => rectOverlaps(rect, 8, 15, 8, 1))).toBe(true); // heavy S E half
+    expect(rects.some(rect => rectOverlaps(rect, 7, 14, 9, 1))).toBe(true); // light S from col 7
+    expect(rects.some(rect => rectOverlaps(rect, 0, 0, 1, 8))).toBe(true);  // heavy W N half
+    expect(rects.some(rect => rectOverlaps(rect, 1, 0, 1, 9))).toBe(true);  // light W up to row 8
   });
 
-  it('all four cardinal walls clip all rim bands because every edge half is chamfered', () => {
+  it('all four cardinal walls — heavy bands fully clipped, light bands paint a 2-pixel center', () => {
+    // Heavy bands at clipPx=8 with both halves clipped → 0 paint per band.
+    // Light bands at clipPx=7 with both halves clipped → cols (or rows)
+    // 7..8 painted (center, 2 pixels). Codex P2 fix: previously the rim
+    // disappeared entirely in dense walls; now a 2-pixel rim line stays
+    // visible at each edge's center even when chamfers cover both halves.
     const gfx = gfxCalls();
     drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open'));
-    expect(fillRectCalls(gfx)).toHaveLength(0);
+    const rects = fillRectCalls(gfx);
+    // No heavy band at outermost rows/cols.
+    for (const rect of rects) {
+      expect(rectOverlaps(rect, 0, 0, 16, 1)).toBe(false);  // heavy N
+      expect(rectOverlaps(rect, 0, 15, 16, 1)).toBe(false); // heavy S
+      expect(rectOverlaps(rect, 0, 0, 1, 16)).toBe(false);  // heavy W
+      expect(rectOverlaps(rect, 15, 0, 1, 16)).toBe(false); // heavy E
+    }
+    // Light bands present in the 2-pixel center segments.
+    expect(rects.some(rect => rectOverlaps(rect, 7, 1, 2, 1))).toBe(true);  // light N center
+    expect(rects.some(rect => rectOverlaps(rect, 7, 14, 2, 1))).toBe(true); // light S center
+    expect(rects.some(rect => rectOverlaps(rect, 1, 7, 1, 2))).toBe(true);  // light W center
+    expect(rects.some(rect => rectOverlaps(rect, 14, 7, 1, 2))).toBe(true); // light E center
   });
 });
 

--- a/src/render/underground-autotile.ts
+++ b/src/render/underground-autotile.ts
@@ -81,10 +81,10 @@ export function drawAutotiledUndergroundTile(
 
   // 2. Quarter-tile masks. We paint the OPPOSITE substrate's base color into
   //    the quadrant region the autotile says belongs to the other kind. Solid
-  //    color (no dither) — the chamfer/bite reads as a clean "carved" region
+  //    color (no dither) — the chamfer reads as a clean "carved" region
   //    against the dithered substrate behind it, which is the right contrast
   //    for a hard-pixel-art look. Each helper sets its own fillStyle so the
-  //    chip / inner-corner / chamfer paints don't bleed into one another.
+  //    chip and chamfer paints don't bleed into one another.
   //
   // For each quadrant, the (h, v) classification picks a shape. h is the
   // cardinal-horizontal neighbor (W for NW/SW, E for NE/SE); v is the

--- a/src/render/underground-autotile.ts
+++ b/src/render/underground-autotile.ts
@@ -254,81 +254,132 @@ export function drawUndergroundRim(
   const last = TILE_SIZE_PX - 1;
 
   // Heavy band — outermost pixel row/column on each wall-facing edge.
-  // Clip away the half of an edge that belongs to an adjacent chamfer so the
-  // rim doesn't leave faint grid-aligned stubs through diagonal corners.
+  // Clip ONLY the chamfer-occupied portion of the half-edge (codex P2 pass —
+  // the previous "clip whole half" rule over-clipped: at row 1 of the N rim,
+  // the NW chamfer covers cols 0..6 only, so col 7 should still get rim
+  // shading. The depth-aware clip uses HALF - rowFromEdge so each band's
+  // clip width matches the chamfer's actual width at that row.
+  //
+  // rowFromEdge: distance into the tile from the band's outer edge.
+  //   - heavy band (outermost row/col): 0 → clip full HALF width (chamfer
+  //     row 0 covers 0..7).
+  //   - light band (1 inward): 1 → clip HALF-1 = 7 (chamfer row 1 covers
+  //     0..6); the edge pixel at 7 stays visible.
   gfx.fillStyle(COLOR_ROCK_BASE_DARK, 0.55);
-  if (wallN) drawHorizontalRimBand(gfx, screenX, screenY,        wallW, wallE);
-  if (wallS) drawHorizontalRimBand(gfx, screenX, screenY + last, wallW, wallE);
-  if (wallW) drawVerticalRimBand(gfx,   screenX, screenY,        wallN, wallS);
-  if (wallE) drawVerticalRimBand(gfx,   screenX + last, screenY, wallN, wallS);
+  if (wallN) drawHorizontalRimBand(gfx, screenX, screenY,        0, wallW, wallE);
+  if (wallS) drawHorizontalRimBand(gfx, screenX, screenY + last, 0, wallW, wallE);
+  if (wallW) drawVerticalRimBand(gfx,   screenX, screenY,        0, wallN, wallS);
+  if (wallE) drawVerticalRimBand(gfx,   screenX + last, screenY, 0, wallN, wallS);
 
-  // Light band — second pixel inward, lighter alpha for the fade transition.
+  // Light band — 1 pixel inward, lighter alpha for the fade transition.
   gfx.fillStyle(COLOR_ROCK_BASE_DARK, 0.30);
-  if (wallN) drawHorizontalRimBand(gfx, screenX, screenY + 1,        wallW, wallE);
-  if (wallS) drawHorizontalRimBand(gfx, screenX, screenY + last - 1, wallW, wallE);
-  if (wallW) drawVerticalRimBand(gfx,   screenX + 1, screenY,        wallN, wallS);
-  if (wallE) drawVerticalRimBand(gfx,   screenX + last - 1, screenY, wallN, wallS);
+  if (wallN) drawHorizontalRimBand(gfx, screenX, screenY + 1,        1, wallW, wallE);
+  if (wallS) drawHorizontalRimBand(gfx, screenX, screenY + last - 1, 1, wallW, wallE);
+  if (wallW) drawVerticalRimBand(gfx,   screenX + 1, screenY,        1, wallN, wallS);
+  if (wallE) drawVerticalRimBand(gfx,   screenX + last - 1, screenY, 1, wallN, wallS);
 
   // Per-tile rim chips — 1-pixel deterministic dark specks inside each
   // active rim band, breaking the rim's flat appearance. Same alpha as
   // the heavy band so chips read as small "packed soil" grains rather
-  // than sub-rim noise. Position is hash-driven within the band.
+  // than sub-rim noise. Chip lives on the LIGHT band (rowFromEdge=1).
   const h = spatialHash(tileX, tileY, SALT_RIM_CHIP);
   gfx.fillStyle(COLOR_ROCK_BASE_DARK, 0.55);
   if (wallN) {
     const x = (h >>> 0) & 0xf;        // 0..15
-    if (rimXVisible(x, wallW, wallE)) gfx.fillRect(screenX + x, screenY + 1, 1, 1);
+    if (rimXVisible(x, 1, wallW, wallE)) gfx.fillRect(screenX + x, screenY + 1, 1, 1);
   }
   if (wallS) {
     const x = (h >>> 4) & 0xf;
-    if (rimXVisible(x, wallW, wallE)) gfx.fillRect(screenX + x, screenY + last - 1, 1, 1);
+    if (rimXVisible(x, 1, wallW, wallE)) gfx.fillRect(screenX + x, screenY + last - 1, 1, 1);
   }
   if (wallW) {
     const y = (h >>> 8) & 0xf;
-    if (rimYVisible(y, wallN, wallS)) gfx.fillRect(screenX + 1, screenY + y, 1, 1);
+    if (rimYVisible(y, 1, wallN, wallS)) gfx.fillRect(screenX + 1, screenY + y, 1, 1);
   }
   if (wallE) {
     const y = (h >>> 12) & 0xf;
-    if (rimYVisible(y, wallN, wallS)) gfx.fillRect(screenX + last - 1, screenY + y, 1, 1);
+    if (rimYVisible(y, 1, wallN, wallS)) gfx.fillRect(screenX + last - 1, screenY + y, 1, 1);
   }
 }
 
+/**
+ * Paint a 1-pixel-tall rim band at row `y`, clipping the chamfer-occupied
+ * portion on either end. `rowFromEdge` is the band's depth into the tile
+ * from its outer edge (0 = outermost / heavy, 1 = inner / light). The
+ * clip width on each side matches the chamfer's width at that row, so
+ * pixels outside the chamfer remain visible.
+ */
 function drawHorizontalRimBand(
   gfx: GfxLike,
   screenX: number,
   y: number,
+  rowFromEdge: number,
   clipWestHalf: boolean,
   clipEastHalf: boolean,
 ): void {
-  if (!clipWestHalf && !clipEastHalf) {
+  const clipPx = HALF - rowFromEdge;
+  // Beyond the chamfer's reach — the row is fully outside any chamfer,
+  // so paint the full edge regardless of clip flags.
+  if (clipPx <= 0) {
     gfx.fillRect(screenX, y, TILE_SIZE_PX, 1);
     return;
   }
-  if (!clipWestHalf) gfx.fillRect(screenX,        y, HALF, 1);
-  if (!clipEastHalf) gfx.fillRect(screenX + HALF, y, HALF, 1);
+  const start  = clipWestHalf ? clipPx : 0;
+  const endExc = clipEastHalf ? (TILE_SIZE_PX - clipPx) : TILE_SIZE_PX;
+  if (endExc > start) {
+    gfx.fillRect(screenX + start, y, endExc - start, 1);
+  }
 }
 
+/** Vertical mirror of `drawHorizontalRimBand`. */
 function drawVerticalRimBand(
   gfx: GfxLike,
   x: number,
   screenY: number,
+  colFromEdge: number,
   clipNorthHalf: boolean,
   clipSouthHalf: boolean,
 ): void {
-  if (!clipNorthHalf && !clipSouthHalf) {
+  const clipPx = HALF - colFromEdge;
+  if (clipPx <= 0) {
     gfx.fillRect(x, screenY, 1, TILE_SIZE_PX);
     return;
   }
-  if (!clipNorthHalf) gfx.fillRect(x, screenY,        1, HALF);
-  if (!clipSouthHalf) gfx.fillRect(x, screenY + HALF, 1, HALF);
+  const start  = clipNorthHalf ? clipPx : 0;
+  const endExc = clipSouthHalf ? (TILE_SIZE_PX - clipPx) : TILE_SIZE_PX;
+  if (endExc > start) {
+    gfx.fillRect(x, screenY + start, 1, endExc - start);
+  }
 }
 
-function rimXVisible(x: number, clipWestHalf: boolean, clipEastHalf: boolean): boolean {
-  if (x < HALF) return !clipWestHalf;
-  return !clipEastHalf;
+/**
+ * True iff a chip at column `x` on a horizontal rim band at depth
+ * `rowFromEdge` is outside any chamfered area. Same depth-aware clip
+ * geometry as `drawHorizontalRimBand`.
+ */
+function rimXVisible(
+  x: number,
+  rowFromEdge: number,
+  clipWestHalf: boolean,
+  clipEastHalf: boolean,
+): boolean {
+  const clipPx = HALF - rowFromEdge;
+  if (clipPx <= 0) return true;
+  if (clipWestHalf && x < clipPx) return false;
+  if (clipEastHalf && x >= TILE_SIZE_PX - clipPx) return false;
+  return true;
 }
 
-function rimYVisible(y: number, clipNorthHalf: boolean, clipSouthHalf: boolean): boolean {
-  if (y < HALF) return !clipNorthHalf;
-  return !clipSouthHalf;
+/** Vertical mirror of `rimXVisible`. */
+function rimYVisible(
+  y: number,
+  colFromEdge: number,
+  clipNorthHalf: boolean,
+  clipSouthHalf: boolean,
+): boolean {
+  const clipPx = HALF - colFromEdge;
+  if (clipPx <= 0) return true;
+  if (clipNorthHalf && y < clipPx) return false;
+  if (clipSouthHalf && y >= TILE_SIZE_PX - clipPx) return false;
+  return true;
 }

--- a/src/render/underground-autotile.ts
+++ b/src/render/underground-autotile.ts
@@ -3,20 +3,19 @@
 // Quarter-tile autotiling for the underground cross-section. Replaces the
 // per-corner overlay path (drawTunnelCornerOverlay + drawSolidConvexCornerOverlay)
 // with a quadrant-based approach where each tile's four 8×8 quadrants pick a
-// canonical shape from a 5-entry catalogue and paint OPPOSITE-kind pixels into
+// canonical shape from a small catalogue and paint OPPOSITE-kind pixels into
 // the quadrant when the silhouette demands it.
 //
-// The five canonical quarter shapes (per quadrant):
+// The canonical quarter shapes (per quadrant):
 //
-//   sameH sameV sameD  shape          paints OPPOSITE kind?
-//   ─────────────────────────────────────────────────────────
-//     0     0     -    chamfer        yes — triangular fill at outer corner
-//     1     0     -    h-edge         no  — substrate is correct
-//     0     1     -    v-edge         no  — substrate is correct
-//     1     1     0    inner-corner   yes — small bite at diagonal corner
-//     1     1     1    full           no  — substrate is correct
+//   sameH sameV  shape          paints OPPOSITE kind?
+//   ───────────────────────────────────────────────────
+//     0     0    chamfer        yes — triangular fill at outer corner
+//     1     0    h-edge         no  — substrate is correct
+//     0     1    v-edge         no  — substrate is correct
+//     1     1    full           no  — substrate is correct
 //
-// where sameH/V/D mean "this neighbor matches the center kind". h-edge/v-edge
+// where sameH/V mean "this cardinal neighbor matches the center kind". h-edge/v-edge
 // represent straight cardinal walls; the rim shading that visually distinguishes
 // them from the open floor is added by a SEPARATE pass (Checkpoint 4) so the
 // shape logic stays orthogonal to the lighting/texture concerns.
@@ -60,8 +59,8 @@ type Quadrant = 'NW' | 'NE' | 'SE' | 'SW';
  * (Marked/BeingDug overlay, ceiling tint, etc.) are applied separately by
  * the caller.
  *
- * Total ops: ~30 (substrate) + up to 4 × 8 (chamfers) + up to 4 × 4
- * (inner-corner bites) ≈ 80 worst case for an isolated open pocket.
+ * Total ops: ~30 (substrate) + up to 4 × 8 (chamfers) ≈ 65 worst case for
+ * an isolated open pocket.
  */
 export function drawAutotiledUndergroundTile(
   gfx: GfxLike,
@@ -87,13 +86,14 @@ export function drawAutotiledUndergroundTile(
   //    for a hard-pixel-art look. Each helper sets its own fillStyle so the
   //    chip / inner-corner / chamfer paints don't bleed into one another.
   //
-  // For each quadrant, the (h, v, d) classification picks a shape. h is the
+  // For each quadrant, the (h, v) classification picks a shape. h is the
   // cardinal-horizontal neighbor (W for NW/SW, E for NE/SE); v is the
-  // cardinal-vertical neighbor (N for NW/NE, S for SW/SE); d is the diagonal.
-  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'NW', neighbors.w, neighbors.n, neighbors.nw);
-  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'NE', neighbors.e, neighbors.n, neighbors.ne);
-  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'SE', neighbors.e, neighbors.s, neighbors.se);
-  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'SW', neighbors.w, neighbors.s, neighbors.sw);
+  // cardinal-vertical neighbor (N for NW/NE, S for SW/SE). Diagonal-only
+  // mismatches are intentionally ignored after issue #48.
+  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'NW', neighbors.w, neighbors.n);
+  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'NE', neighbors.e, neighbors.n);
+  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'SE', neighbors.e, neighbors.s);
+  drawQuadrantMask(gfx, screenX, screenY, tileX, tileY, centerKind, 'SW', neighbors.w, neighbors.s);
 }
 
 function drawQuadrantMask(
@@ -106,11 +106,9 @@ function drawQuadrantMask(
   quadrant: Quadrant,
   horizKind: NeighborKind,
   vertKind:  NeighborKind,
-  diagKind:  NeighborKind,
 ): void {
   const sameH = horizKind === centerKind;
   const sameV = vertKind  === centerKind;
-  const sameD = diagKind  === centerKind;
 
   const oppositeColor = centerKind === 'wall' ? COLOR_FLOOR_BASE : COLOR_ROCK_BASE;
   if (!sameH && !sameV) {
@@ -123,13 +121,10 @@ function drawQuadrantMask(
     // inclusion. Strictly avoids the sacred edges (row 0 / col 0) and the
     // hypotenuse boundary, so anchor and join contracts hold regardless.
     maybeAddChamferChip(gfx, screenX, screenY, tileX, tileY, quadrant, centerKind);
-  } else if (sameH && sameV && !sameD) {
-    // inner-corner — only the diagonal differs. The opposite kind pokes in
-    // at the far corner of the quadrant. Paint a small bite there.
-    gfx.fillStyle(oppositeColor, 1);
-    fillInnerCornerBite(gfx, screenX, screenY, quadrant);
   }
   // else: full / h-edge / v-edge — substrate is correct, nothing to paint.
+  // Diagonal-only mismatches intentionally do not paint: issue #48 showed
+  // those tiny opposite-kind bites read as stray wrong-side triangles.
 }
 
 /**
@@ -158,34 +153,6 @@ function fillChamferTriangle(
       case 'NE': x = HALF + i;                 y = i;                              break;
       case 'SE': x = HALF + i;                 y = TILE_SIZE_PX - 1 - i;           break;
       case 'SW': x = 0;                        y = TILE_SIZE_PX - 1 - i;           break;
-    }
-    gfx.fillRect(screenX + x, screenY + y, width, 1);
-  }
-}
-
-/**
- * Fill a 4×4 triangular bite at the diagonal corner of the named quadrant —
- * the opposite-kind diagonal neighbor "poking into" an otherwise same-kind
- * area. Smaller than a chamfer so it reads as a peninsula rather than a
- * full rounded corner.
- *
- * 4 fillRect scanline calls per inner-corner bite.
- */
-function fillInnerCornerBite(
-  gfx: GfxLike,
-  screenX: number,
-  screenY: number,
-  quadrant: Quadrant,
-): void {
-  const SIZE = 4;
-  for (let i = 0; i < SIZE; i++) {
-    const width = SIZE - i;
-    let x = 0, y = 0;
-    switch (quadrant) {
-      case 'NW': x = 0;                            y = i;                              break;
-      case 'NE': x = TILE_SIZE_PX - SIZE + i;      y = i;                              break;
-      case 'SE': x = TILE_SIZE_PX - SIZE + i;      y = TILE_SIZE_PX - 1 - i;           break;
-      case 'SW': x = 0;                            y = TILE_SIZE_PX - 1 - i;           break;
     }
     gfx.fillRect(screenX + x, screenY + y, width, 1);
   }
@@ -287,18 +254,20 @@ export function drawUndergroundRim(
   const last = TILE_SIZE_PX - 1;
 
   // Heavy band — outermost pixel row/column on each wall-facing edge.
+  // Clip away the half of an edge that belongs to an adjacent chamfer so the
+  // rim doesn't leave faint grid-aligned stubs through diagonal corners.
   gfx.fillStyle(COLOR_ROCK_BASE_DARK, 0.55);
-  if (wallN) gfx.fillRect(screenX,            screenY,            TILE_SIZE_PX, 1);
-  if (wallS) gfx.fillRect(screenX,            screenY + last,     TILE_SIZE_PX, 1);
-  if (wallW) gfx.fillRect(screenX,            screenY,            1, TILE_SIZE_PX);
-  if (wallE) gfx.fillRect(screenX + last,     screenY,            1, TILE_SIZE_PX);
+  if (wallN) drawHorizontalRimBand(gfx, screenX, screenY,        wallW, wallE);
+  if (wallS) drawHorizontalRimBand(gfx, screenX, screenY + last, wallW, wallE);
+  if (wallW) drawVerticalRimBand(gfx,   screenX, screenY,        wallN, wallS);
+  if (wallE) drawVerticalRimBand(gfx,   screenX + last, screenY, wallN, wallS);
 
   // Light band — second pixel inward, lighter alpha for the fade transition.
   gfx.fillStyle(COLOR_ROCK_BASE_DARK, 0.30);
-  if (wallN) gfx.fillRect(screenX,            screenY + 1,        TILE_SIZE_PX, 1);
-  if (wallS) gfx.fillRect(screenX,            screenY + last - 1, TILE_SIZE_PX, 1);
-  if (wallW) gfx.fillRect(screenX + 1,        screenY,            1, TILE_SIZE_PX);
-  if (wallE) gfx.fillRect(screenX + last - 1, screenY,            1, TILE_SIZE_PX);
+  if (wallN) drawHorizontalRimBand(gfx, screenX, screenY + 1,        wallW, wallE);
+  if (wallS) drawHorizontalRimBand(gfx, screenX, screenY + last - 1, wallW, wallE);
+  if (wallW) drawVerticalRimBand(gfx,   screenX + 1, screenY,        wallN, wallS);
+  if (wallE) drawVerticalRimBand(gfx,   screenX + last - 1, screenY, wallN, wallS);
 
   // Per-tile rim chips — 1-pixel deterministic dark specks inside each
   // active rim band, breaking the rim's flat appearance. Same alpha as
@@ -308,18 +277,58 @@ export function drawUndergroundRim(
   gfx.fillStyle(COLOR_ROCK_BASE_DARK, 0.55);
   if (wallN) {
     const x = (h >>> 0) & 0xf;        // 0..15
-    gfx.fillRect(screenX + x, screenY + 1, 1, 1);
+    if (rimXVisible(x, wallW, wallE)) gfx.fillRect(screenX + x, screenY + 1, 1, 1);
   }
   if (wallS) {
     const x = (h >>> 4) & 0xf;
-    gfx.fillRect(screenX + x, screenY + last - 1, 1, 1);
+    if (rimXVisible(x, wallW, wallE)) gfx.fillRect(screenX + x, screenY + last - 1, 1, 1);
   }
   if (wallW) {
     const y = (h >>> 8) & 0xf;
-    gfx.fillRect(screenX + 1, screenY + y, 1, 1);
+    if (rimYVisible(y, wallN, wallS)) gfx.fillRect(screenX + 1, screenY + y, 1, 1);
   }
   if (wallE) {
     const y = (h >>> 12) & 0xf;
-    gfx.fillRect(screenX + last - 1, screenY + y, 1, 1);
+    if (rimYVisible(y, wallN, wallS)) gfx.fillRect(screenX + last - 1, screenY + y, 1, 1);
   }
+}
+
+function drawHorizontalRimBand(
+  gfx: GfxLike,
+  screenX: number,
+  y: number,
+  clipWestHalf: boolean,
+  clipEastHalf: boolean,
+): void {
+  if (!clipWestHalf && !clipEastHalf) {
+    gfx.fillRect(screenX, y, TILE_SIZE_PX, 1);
+    return;
+  }
+  if (!clipWestHalf) gfx.fillRect(screenX,        y, HALF, 1);
+  if (!clipEastHalf) gfx.fillRect(screenX + HALF, y, HALF, 1);
+}
+
+function drawVerticalRimBand(
+  gfx: GfxLike,
+  x: number,
+  screenY: number,
+  clipNorthHalf: boolean,
+  clipSouthHalf: boolean,
+): void {
+  if (!clipNorthHalf && !clipSouthHalf) {
+    gfx.fillRect(x, screenY, 1, TILE_SIZE_PX);
+    return;
+  }
+  if (!clipNorthHalf) gfx.fillRect(x, screenY,        1, HALF);
+  if (!clipSouthHalf) gfx.fillRect(x, screenY + HALF, 1, HALF);
+}
+
+function rimXVisible(x: number, clipWestHalf: boolean, clipEastHalf: boolean): boolean {
+  if (x < HALF) return !clipWestHalf;
+  return !clipEastHalf;
+}
+
+function rimYVisible(y: number, clipNorthHalf: boolean, clipSouthHalf: boolean): boolean {
+  if (y < HALF) return !clipNorthHalf;
+  return !clipSouthHalf;
 }


### PR DESCRIPTION
## Summary

Surgical fix for issue #48: the underground rendering produced stray small triangles at saddle cases (open tiles surrounded by all-open cardinals but a single wall diagonal — and the symmetric wall-tile case). User feedback called these out specifically as "tan triangles in the middle of the tunnels and dark triangles in the dirt next to the tunnels."

Codex designed and implemented this after my four failed attempts (PRs #50, #51, #52). I reviewed and ship with one cosmetic comment cleanup.

Closes #48.

## What changed

**1. Removed inner-corner bite painting entirely.**
- Deleted `fillInnerCornerBite` helper.
- Removed the `else if (sameH && sameV && !sameD)` branch in `drawQuadrantMask`.
- Removed the now-unused `diagKind` parameter from `drawQuadrantMask`.
- Diagonal-only mismatches (saddle cases) now produce no opposite-kind paint — the substrate alone represents them.

**2. Clipped rim bands at chamfered corner halves.**
- New helpers `drawHorizontalRimBand`, `drawVerticalRimBand`, `rimXVisible`, `rimYVisible`.
- When a chamfer fires in a corner (both adjoining cardinals are walls), the adjacent rim band skips its half-edge in that corner.
- Eliminates faint grid-aligned rim stubs that previously remained inside chamfered corner areas.

**Crucially, the L-corner chamfer triangles themselves are KEPT.** Those produce the rounded-corner / smooth-stair-step effect the user accepts as legitimate boundary detail.

## Why this is the right shape after 4 failed attempts

| Approach | Outcome |
|----------|---------|
| PR #50 (chamfer wobble) | Triangles still visible — wobble too subtle |
| PR #51 (drop chamfers entirely) | Square cell cutouts — too much removed |
| PR #52 (smooth boundary displacement) | Corner-ey/spiky — broad change to wrong target |
| **This PR (remove bites + rim cleanup)** | Surgically removes the stray triangles user complained about, keeps everything else from `main` |

The user's complaint was specifically about stray small triangles (saddle-case bites), not the L-corner chamfers. Codex correctly identified the precise artifact and removed it.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 1649 tests passed (saddle-case tests now assert no paint; new rim-clipping test added)
- [x] Independent code review — clean (one cosmetic comment drift fixed)
- [x] **UAT**: passed with flying colors (per user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)