### PR TITLE
feat(sim): visible brood carry — issue #17 Phase 1

### DIFF
--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -202,6 +202,38 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(w2.ants.searchWave[0]).toBe(0);
       expect(w2.ants.searchWave[10]).toBe(0);
     });
+    it('Issue #17 Phase 1: round-trips ants.carryingBroodId and carriedBy through serialize → deserialize', () => {
+      // Regression guard: if either field is dropped, an autosaved snapshot
+      // mid-carry would land all carries at the carrier's last position
+      // (because the renderer position-syncs the brood to the carrier each
+      // tick) but with the carry slot cleared — the brood would teleport
+      // back to its idle position on the next tick. SCEN-06 byte-identity
+      // would also break across reload.
+      const w = createScenario(42);
+      w.ants.carryingBroodId[0] = 7;
+      w.ants.carriedBy[7] = 0;
+      w.ants.carryingBroodId[1] = -1;
+      w.ants.carriedBy[1] = -1;
+      const w2 = deserializeWorldState(serializeWorldState(w));
+      expect(w2.ants.carryingBroodId[0]).toBe(7);
+      expect(w2.ants.carriedBy[7]).toBe(0);
+      expect(w2.ants.carryingBroodId[1]).toBe(-1);
+      expect(w2.ants.carriedBy[1]).toBe(-1);
+    });
+    it('pre-#17-Phase-1 saves (carry slots absent) deserialize to all-(-1)', () => {
+      // Backward compatibility: a pre-v10 save omits carryingBroodId/carriedBy.
+      // Loading defaults the fields to all-(-1), which is the correct "no
+      // carries in flight" state for both pre-v10 (never read) and v10+.
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      delete (s.ants as { carryingBroodId?: number[] }).carryingBroodId;
+      delete (s.ants as { carriedBy?: number[] }).carriedBy;
+      const w2 = deserializeWorldState(s);
+      expect(w2.ants.carryingBroodId[0]).toBe(-1);
+      expect(w2.ants.carriedBy[0]).toBe(-1);
+      expect(w2.ants.carryingBroodId[100]).toBe(-1);
+      expect(w2.ants.carriedBy[100]).toBe(-1);
+    });
     it('round-trips ants.currentGridColonyId through serialize → deserialize (Phase 09.1 Chunk 0 grid-of-occupancy)', () => {
       // Regression guard for the phase 09.1 verification gap: if
       // currentGridColonyId is dropped from the save envelope, every loaded
@@ -238,12 +270,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(w2.ants.currentGridColonyId[enemyQueen]).toBe(ENEMY_COLONY_ID);
       expect(w2.ants.currentGridColonyId[playerInvader]).toBe(ENEMY_COLONY_ID);
     });
-    it('round-trips simVersion (LATEST: v9 cancel-drops-pending)', async () => {
+    it('round-trips simVersion (LATEST: v10 visible brood carry)', async () => {
       const { LATEST_SIM_VERSION, SIM_VERSION_V7_SURFACE_PASSABILITY } = await import('../sim/types.js');
       // New worlds default to LATEST_SIM_VERSION. Save/load must preserve
       // it so any LATEST replay continues to apply the gated behaviour
-      // (currently surface passability, soft cost, leash hysteresis, and
-      // cancel-drops-pending) on resume.
+      // (currently surface passability, soft cost, leash hysteresis,
+      // cancel-drops-pending, and visible brood carry) on resume.
       const w = createScenario(42);
       expect(w.simVersion).toBe(LATEST_SIM_VERSION);
       // Sanity-check that LATEST is at least v7 — anything lower would

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -122,6 +122,16 @@ interface SerializedAnts {
   recentTilesX?: number[];
   recentTilesY?: number[];
   recentTilesHead?: number[];
+  /**
+   * Issue #17 Phase 1 — visible brood carry. carryingBroodId[i] = entity id
+   * of the brood ant `i` is carrying (or -1 if none); carriedBy[j] = entity
+   * id of the nurse carrying brood `j` (or -1 if uncarried). Optional;
+   * absent → all-(-1) default, which also matches a v10+ "no carries in
+   * flight" snapshot. Pre-v10 saves never read these fields (gated on
+   * simVersion).
+   */
+  carryingBroodId?: number[];
+  carriedBy?: number[];
 }
 
 interface SerializedColony {
@@ -236,6 +246,9 @@ function serializeAnts(a: AntComponents): SerializedAnts {
     recentTilesX:    Array.from(a.recentTilesX),
     recentTilesY:    Array.from(a.recentTilesY),
     recentTilesHead: Array.from(a.recentTilesHead),
+    // Issue #17 Phase 1 — visible brood carry slot + reverse pointer.
+    carryingBroodId: Array.from(a.carryingBroodId),
+    carriedBy:       Array.from(a.carriedBy),
   };
 }
 
@@ -461,6 +474,16 @@ function deserializeAnts(saved: SerializedAnts, capacity: number): AntComponents
   }
   if (saved.recentTilesHead !== undefined) {
     copyIntoUint8(a.recentTilesHead, saved.recentTilesHead);
+  }
+  // Issue #17 Phase 1 — brood carry slot + reverse pointer. Pre-v10 saves
+  // omit; createAntComponents fills both with -1 (no carries), which is
+  // correct for both pre-v10 (never read) and a fresh v10 load (no carries
+  // in flight at that snapshot).
+  if (saved.carryingBroodId !== undefined) {
+    copyIntoInt32(a.carryingBroodId, saved.carryingBroodId);
+  }
+  if (saved.carriedBy !== undefined) {
+    copyIntoInt32(a.carriedBy, saved.carriedBy);
   }
   return a;
 }

--- a/src/render/draw-underground.test.ts
+++ b/src/render/draw-underground.test.ts
@@ -415,6 +415,67 @@ describe('drawUndergroundEntities', () => {
     expect(eggCall.y).toBe((5 - top)  * TILE_SIZE_PX + TILE_SIZE_PX / 2);
   });
 
+  // Issue #17 Phase 1.6 — visible carry render offset.
+  it('carried egg renders ~1/4 tile above center (carrier alive, carriedBy set)', () => {
+    const eggId = 5;
+    const carrierId = 6;
+    world.colonies[PLAYER_COLONY_ID]!.queenEntityId = 999;
+    initAnt(world.ants, eggId, {
+      colonyId: PLAYER_COLONY_ID,
+      posX: 4 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      zone: 1,
+    });
+    initAnt(world.ants, carrierId, {
+      colonyId: PLAYER_COLONY_ID,
+      posX: 4 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      zone: 1,
+    });
+    world.ants.carriedBy[eggId] = carrierId;
+    world.colonies[PLAYER_COLONY_ID]!.eggs = [eggId];
+
+    const cam = makeCamera(5, 5, 20, 20);
+    drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
+
+    const left = Math.floor(cam.x - cam.viewportWidth  / 2);
+    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const eggCall = sprites.staticOfKind('egg')[0]!;
+    expect(eggCall.x).toBe((4 - left) * TILE_SIZE_PX + TILE_SIZE_PX / 2);
+    // y is shifted upward (smaller value) by ~1/4 tile vs. the un-carried baseline.
+    const baseline = (5 - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    expect(eggCall.y).toBeLessThan(baseline);
+    expect(baseline - eggCall.y).toBe(Math.round(TILE_SIZE_PX / 4));
+  });
+
+  it('carried egg with DEAD carrier renders WITHOUT offset (orphaned brood is reclaimable but rendered as idle)', () => {
+    const eggId = 5;
+    const carrierId = 6;
+    world.colonies[PLAYER_COLONY_ID]!.queenEntityId = 999;
+    initAnt(world.ants, eggId, {
+      colonyId: PLAYER_COLONY_ID,
+      posX: 4 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 1,
+    });
+    initAnt(world.ants, carrierId, {
+      colonyId: PLAYER_COLONY_ID,
+      posX: 4 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 1,
+    });
+    // Dead carrier: alive flips to 0; carriedBy still points at it (this is
+    // the dead-carrier orphan state — sim treats the brood as reclaimable,
+    // and the renderer treats it as not-being-carried).
+    world.ants.alive[carrierId] = 0;
+    world.ants.carriedBy[eggId] = carrierId;
+    world.colonies[PLAYER_COLONY_ID]!.eggs = [eggId];
+
+    const cam = makeCamera(5, 5, 20, 20);
+    drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
+
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
+    const eggCall = sprites.staticOfKind('egg')[0]!;
+    // No offset — sits at tile center exactly.
+    expect(eggCall.y).toBe((5 - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2);
+  });
+
   it('does NOT draw enemy-colony ants even when underground in view (PRD §7b)', () => {
     // Regression guard: prior revision rendered all zone=1 ants and just
     // colored them by colony, which leaked enemy positions into the player's

--- a/src/render/draw-underground.ts
+++ b/src/render/draw-underground.ts
@@ -417,6 +417,16 @@ export function drawUndergroundEntities(
   drawBrood(sprites, curr, colony.larvae, 'larva', left, top, canvasW, canvasH);
 }
 
+/**
+ * Issue #17 Phase 1.6 — visible carry render offset. When a brood entity
+ * is being carried by an alive nurse (carriedBy !== -1 and the carrier is
+ * alive), nudge the sprite up by ~1/4 tile so it sits "in arms" above the
+ * carrier instead of perfectly stacked on the carrier's body. Under v10+
+ * only — pre-v10 saves never set carriedBy to a non-(-1) value, so this
+ * is a no-op for them by construction.
+ */
+const CARRY_RENDER_DY_PX = -Math.round(TILE_SIZE_PX / 4);
+
 /** Shared loop for rendering a list of brood entity IDs as static sprites. */
 function drawBrood(
   sprites: AntSpriteLayer,
@@ -428,17 +438,23 @@ function drawBrood(
   canvasW: number,
   canvasH: number,
 ): void {
+  const ants = curr.ants;
   for (const id of entityIds) {
-    if (!isAlive(curr.ants, id)) continue;
-    const tileX = curr.ants.posX[id]! >> FP_SHIFT;
-    const tileY = curr.ants.posY[id]! >> FP_SHIFT;
+    if (!isAlive(ants, id)) continue;
+    const tileX = ants.posX[id]! >> FP_SHIFT;
+    const tileY = ants.posY[id]! >> FP_SHIFT;
     const screenX = (tileX - left) * TILE_SIZE_PX;
     const screenY = (tileY - top)  * TILE_SIZE_PX;
     if (screenX < -TILE_SIZE_PX || screenX > canvasW || screenY < -TILE_SIZE_PX || screenY > canvasH) continue;
+    // Visible-carry offset: when this brood is on a carrier's tile and
+    // the carrier is alive, lift it ~1/4 tile so it visually sits
+    // above the carrier instead of being hidden under the ant sprite.
+    const carrierId = ants.carriedBy[id]!;
+    const carryDy = carrierId !== -1 && isAlive(ants, carrierId) ? CARRY_RENDER_DY_PX : 0;
     sprites.drawStatic({
       kind,
       x: screenX + TILE_SIZE_PX / 2,
-      y: screenY + TILE_SIZE_PX / 2,
+      y: screenY + TILE_SIZE_PX / 2 + carryDy,
     });
   }
 }

--- a/src/sim/ant/ant-store.test.ts
+++ b/src/sim/ant/ant-store.test.ts
@@ -339,4 +339,39 @@ describe('ant-store', () => {
 
     expect(ants.currentGridColonyId[id]).toBe(0);
   });
+
+  // Issue #17 Phase 1 — visible brood carry slot fields.
+  it('createAntComponents fills carryingBroodId and carriedBy with -1', () => {
+    const ants = createAntComponents(16);
+    for (let i = 0; i < 16; i++) {
+      expect(ants.carryingBroodId[i]).toBe(-1);
+      expect(ants.carriedBy[i]).toBe(-1);
+    }
+  });
+
+  it('initAnt resets carryingBroodId and carriedBy to -1', () => {
+    const ants = createAntComponents(16);
+    const id = 5;
+    // Pre-pollute both slots so the reset is observable.
+    ants.carryingBroodId[id] = 7;
+    ants.carriedBy[id] = 3;
+    initAnt(ants, id, { colonyId: 1, posX: 0, posY: 0 });
+    expect(ants.carryingBroodId[id]).toBe(-1);
+    expect(ants.carriedBy[id]).toBe(-1);
+  });
+
+  it('killAnt does NOT clear carryingBroodId or carriedBy (death-drop behaviour: brood stays carried-by-id until next nurse claim)', () => {
+    const ants = createAntComponents(16);
+    const nurseId = 4;
+    const broodId = 7;
+    initAnt(ants, nurseId, { colonyId: 1, posX: 0, posY: 0 });
+    initAnt(ants, broodId, { colonyId: 1, posX: 0, posY: 0 });
+    ants.carryingBroodId[nurseId] = broodId;
+    ants.carriedBy[broodId] = nurseId;
+    killAnt(ants, nurseId);
+    // Death cleanup is up to the runtime (tickNurseActions / death sweep) —
+    // killAnt itself is O(1) and only zeroes `alive`.
+    expect(ants.carryingBroodId[nurseId]).toBe(broodId);
+    expect(ants.carriedBy[broodId]).toBe(nurseId);
+  });
 });

--- a/src/sim/ant/ant-store.ts
+++ b/src/sim/ant/ant-store.ts
@@ -201,6 +201,38 @@ export interface AntComponents {
   readonly recentTilesX: Int32Array;
   readonly recentTilesY: Int32Array;
   readonly recentTilesHead: Uint8Array;
+  /**
+   * Issue #17 Phase 1 — visible brood carry. For nurses (task=Nursing) under
+   * simVersion >= 10, the entity ID of the brood (egg or larva) currently
+   * being carried, or -1 if not carrying. The brood's posX/posY are synced
+   * to the carrier each tick while carried; on Nursery-tile arrival the
+   * carry slot clears and the brood is deposited via the same `pickId %
+   * openCount` spread that pre-v10 `transportBroodToNursery` used.
+   *
+   * Reset to -1 in initAnt. NOT cleared by killAnt — death cleanup leaves
+   * the brood at the carrier's last-synced tile so the next nurse picks it
+   * up via the v10 `nursing` flow-field (which seeds from Queen Open tiles
+   * AND any uncarried-brood tile outside Nursery).
+   *
+   * Round-trips through copyWorldState and save/load (optional field;
+   * defaults to all-(-1) on pre-v10 saves, which matches the v10+
+   * "no carries in flight" load default).
+   */
+  readonly carryingBroodId: Int32Array;
+  /**
+   * Issue #17 Phase 1 — reverse pointer for the carry. For brood entities
+   * (eggs and larvae) under simVersion >= 10, the entity ID of the nurse
+   * currently carrying this brood, or -1 if uncarried. Set on pickup,
+   * cleared on deposit OR when the carrier's `alive` flips to 0.
+   *
+   * Used by tickNurseActions to detect "brood already claimed this tick"
+   * during pickup — replay-deterministic because nurse iteration order is
+   * by ant id.
+   *
+   * Reset to -1 in initAnt. Round-trips through copyWorldState and
+   * save/load (optional; defaults to all-(-1) on pre-v10 saves).
+   */
+  readonly carriedBy: Int32Array;
 }
 
 /**
@@ -248,6 +280,11 @@ export function createAntComponents(maxEntities: number = MAX_ENTITIES): AntComp
   recentTilesX.fill(RECENT_TILES_SENTINEL);
   const recentTilesY = new Int32Array(maxEntities * RECENT_TILES_LEN);
   recentTilesY.fill(RECENT_TILES_SENTINEL);
+  // Issue #17 Phase 1 — visible brood carry. -1 = not carrying / not carried.
+  const carryingBroodId = new Int32Array(maxEntities);
+  carryingBroodId.fill(-1);
+  const carriedBy = new Int32Array(maxEntities);
+  carriedBy.fill(-1);
 
   return {
     posX:            new Int32Array(maxEntities),
@@ -291,6 +328,9 @@ export function createAntComponents(maxEntities: number = MAX_ENTITIES): AntComp
     recentTilesX,
     recentTilesY,
     recentTilesHead: new Uint8Array(maxEntities),
+    // Issue #17 Phase 1 — visible brood carry. -1 = not carrying / not carried.
+    carryingBroodId,
+    carriedBy,
   };
 }
 
@@ -375,6 +415,9 @@ export function initAnt(ants: AntComponents, id: EntityId, spec: InitAntSpec): v
     ants.recentTilesY[base + s] = RECENT_TILES_SENTINEL;
   }
   ants.recentTilesHead[id]   = 0;
+  // Issue #17 Phase 1 — fresh ant is not carrying / not carried.
+  ants.carryingBroodId[id]   = -1;
+  ants.carriedBy[id]         = -1;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sim/ant/ant-store.ts
+++ b/src/sim/ant/ant-store.ts
@@ -480,6 +480,21 @@ export function killAnt(ants: AntComponents, id: EntityId): void {
 }
 
 /**
+ * Issue #17 Phase 1 — predicate: is brood `bid` available for a v10 nurse to
+ * claim? Returns true iff the brood is alive AND either uncarried OR carried
+ * by a dead ant (orphan from a mid-carry death).
+ *
+ * Shared by `findUncarriedBroodOnTile` (per-tile pickup match) and
+ * `computeNursingPickupField` (chamber-flow seeding). Keeping the predicate
+ * single-sourced avoids drift between the two consumers.
+ */
+export function isBroodReclaimable(ants: AntComponents, bid: EntityId): boolean {
+  if (ants.alive[bid] !== 1) return false;
+  const cby = ants.carriedBy[bid]!;
+  return cby === -1 || ants.alive[cby] !== 1;
+}
+
+/**
  * Returns true if the entity at `id` is currently alive.
  * Returns false for never-initialized slots (alive[id] === 0 by default).
  */

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -77,6 +77,7 @@ import {
   createChamberFlowFields,
   ensureChamberFlowFields,
   computeChamberFlowField,
+  computeNursingPickupField,
   FOOD_CHAMBER_TYPES,
   NURSING_CHAMBER_TYPES,
   NURSERY_CHAMBER_TYPES,
@@ -4115,6 +4116,143 @@ describe('chamber-flow nurseDeposit field (#17 phase 1)', () => {
     for (let y = 5; y < 8; y++) {
       for (let x = 5; x < 8; x++) {
         expect(bufs.nurseDeposit[y * W + x]).toBe(-2);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #17 Phase 1 — nursing PICKUP field. Seeds from uncarried-brood
+// entity tiles outside Nursery only. The chamber-flow recompute under v10+
+// runs this every tick (brood positions move with carriers).
+// ---------------------------------------------------------------------------
+
+describe('chamber-flow nursing pickup field (#17 phase 1)', () => {
+  it('UAT regression: routes to brood tiles only, NOT to non-egg Queen tiles', () => {
+    // The original Phase 1.3 implementation seeded EVERY Queen-chamber Open
+    // tile as a source. A 5×3 Queen chamber with 2 eggs would have 15
+    // sources, not 2. The BFS routed nurses to whichever Queen tile was
+    // geographically closest, often a NON-egg tile — the nurse arrived,
+    // found no brood, and finite-nursing-released. She never reached the
+    // egg. This test pins the post-fix contract: only brood-entity tiles
+    // are sources, so the BFS routes nurses directly to eggs.
+    const { world, underground, colony, colonyId } = setupWorldWithUnderground(40, 30);
+    // Excavate a Queen chamber at (30..34, 8..10) — 5×3, matching the
+    // F9-debug case from UAT.
+    for (let dy = 0; dy < 3; dy++) {
+      for (let dx = 0; dx < 5; dx++) {
+        ugSet(underground, 30 + dx, 8 + dy, UndergroundTileState.Open);
+      }
+    }
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.Queen, foodStored: 0,
+      posX: 30 << FP_SHIFT, posY: 8 << FP_SHIFT, width: 5, height: 3,
+    });
+    // Two eggs in only 2 of the 15 Queen tiles.
+    const eggA = allocateEntityId(world);
+    initAnt(world.ants, eggA, {
+      colonyId,
+      posX: (33 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (8 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle, speed: 0, zone: Zone.Underground,
+    });
+    colony.eggs.push(eggA);
+    const eggB = allocateEntityId(world);
+    initAnt(world.ants, eggB, {
+      colonyId,
+      posX: (30 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (9 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle, speed: 0, zone: Zone.Underground,
+    });
+    colony.eggs.push(eggB);
+
+    const cache = createChamberFlowFields();
+    const gridSize = underground.width * underground.height;
+    const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
+    computeNursingPickupField(
+      underground, colony.chambers, world.ants,
+      colony.eggs, colony.larvae,
+      bufs.nursing, bufs.queue,
+    );
+
+    const W = underground.width;
+    // The two egg tiles ARE sources (-1).
+    expect(bufs.nursing[8 * W + 33]).toBe(-1); // eggA
+    expect(bufs.nursing[9 * W + 30]).toBe(-1); // eggB
+    // Other Queen tiles are NOT sources — they carry a step direction
+    // (0..3) routing them toward the nearest egg, never -1.
+    const otherQueenTiles: Array<[number, number]> = [
+      [30, 8], [31, 8], [32, 8],         [34, 8], // row 8 minus eggA
+      [31, 9], [32, 9], [33, 9], [34, 9],         // row 9 minus eggB
+      [30, 10], [31, 10], [32, 10], [33, 10], [34, 10], // row 10
+    ];
+    for (const [tx, ty] of otherQueenTiles) {
+      const v = bufs.nursing[ty * W + tx]!;
+      expect(v).not.toBe(-1);
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it('orphan brood outside any chamber is also seeded (carrier-death reclaim path)', () => {
+    // Brood dropped at a tunnel tile after a carrier death must still be
+    // reachable. The seed loop's "outside Nursery" exclusion covers that.
+    const { world, underground, colony, colonyId } = setupWorldWithUnderground(20, 20);
+    // Tunnel at (5, 5).
+    ugSet(underground, 5, 5, UndergroundTileState.Open);
+    // Orphan brood at the tunnel tile.
+    const orphan = allocateEntityId(world);
+    initAnt(world.ants, orphan, {
+      colonyId,
+      posX: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle, speed: 0, zone: Zone.Underground,
+    });
+    colony.eggs.push(orphan);
+
+    const cache = createChamberFlowFields();
+    const gridSize = underground.width * underground.height;
+    const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
+    computeNursingPickupField(
+      underground, colony.chambers, world.ants,
+      colony.eggs, colony.larvae,
+      bufs.nursing, bufs.queue,
+    );
+    expect(bufs.nursing[5 * underground.width + 5]).toBe(-1);
+  });
+
+  it('no uncarried brood: field has no sources (all -2)', () => {
+    // No brood at all → no seeds → field is all-(-2). Nurses with no work
+    // get nowhere; the finite-nursing release fires when they happen to
+    // be on a Queen/Nursery tile (allocateWorkers should produce
+    // nurseCount=0 in this case, so it's only a defensive concern).
+    const { world, underground, colony, colonyId } = setupWorldWithUnderground(16, 16);
+    void world;
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.Queen, foodStored: 0,
+      posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, width: 2, height: 2,
+    });
+    for (let dy = 0; dy < 2; dy++) {
+      for (let dx = 0; dx < 2; dx++) {
+        ugSet(underground, 5 + dx, 5 + dy, UndergroundTileState.Open);
+      }
+    }
+
+    const cache = createChamberFlowFields();
+    const gridSize = underground.width * underground.height;
+    const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
+    computeNursingPickupField(
+      underground, colony.chambers, world.ants,
+      colony.eggs, colony.larvae,
+      bufs.nursing, bufs.queue,
+    );
+    const W = underground.width;
+    // Queen tiles previously seeded as -1 by the dropped Seed (1) are
+    // now -2 (no sources at all). This is the regression test that
+    // would have failed pre-fix.
+    for (let dy = 0; dy < 2; dy++) {
+      for (let dx = 0; dx < 2; dx++) {
+        expect(bufs.nursing[(5 + dy) * W + (5 + dx)]).toBe(-2);
       }
     }
   });

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -6793,17 +6793,21 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     expect(world.ants.subTask[nurse2]).toBe(NursingSubState.MovingToBrood);
   });
 
-  it('already-carried brood is not claimed by another nurse on the same tile', () => {
-    const { world, broodId, colony } = setupV10NurseAndBroodOnTile({ sameTile: true });
-    // Mark the brood as already carried by some other nurse (not in this
-    // test's iteration loop) — simulates a race that resolved on a prior tick.
-    world.ants.carriedBy[broodId] = 99;
-    void colony;
+  it('already-carried brood (carrier ALIVE) is not claimed by another nurse', () => {
+    const { world, broodId } = setupV10NurseAndBroodOnTile({ sameTile: true });
+    // Allocate a separate ALIVE ant to be the existing carrier — the
+    // dead-carrier exception in findUncarriedBroodOnTile would let the
+    // claim through if the carrier weren't alive.
+    const otherCarrier = allocateEntityId(world);
+    initAnt(world.ants, otherCarrier, {
+      colonyId: COLONY_ID, posX: 0, posY: 0, task: AntTask.Nursing,
+    });
+    world.ants.carriedBy[broodId] = otherCarrier;
     tickNurseActions(world);
-    // Original nurse (id 2) is still on the brood tile but the brood was
-    // already claimed; nurse stays in MovingToBrood and does not steal.
+    // Original nurse (id 2) is on the brood tile but the brood was
+    // already claimed by an alive carrier; nurse stays in MovingToBrood.
     expect(world.ants.carryingBroodId[2]).toBe(-1);
-    expect(world.ants.carriedBy[broodId]).toBe(99);
+    expect(world.ants.carriedBy[broodId]).toBe(otherCarrier);
     expect(world.ants.subTask[2]).toBe(NursingSubState.MovingToBrood);
   });
 
@@ -7029,5 +7033,160 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
     expect(world.ants.posX[broodId]! >> FP_SHIFT).toBe(14);
     expect(world.ants.posY[broodId]! >> FP_SHIFT).toBe(14);
+  });
+
+  // ----- Issue #17 Phase 1.5 — death + maturation handling -----
+
+  it('carrier dies mid-carry: brood stays at carrier last-synced tile and is reclaimable', () => {
+    const { world, nurseId, broodId, colony } = setupV10CarryWorld({
+      nurseTileX: 5, nurseTileY: 5,
+      broodTileX: 5, broodTileY: 5,
+      nurseryTileX: 12, nurseryTileY: 12,
+    });
+    tickNurseActions(world); // claim
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
+    // Move the carrier (simulate one tick of motion) and kill it mid-carry.
+    world.ants.posX[nurseId] = (8 << FP_SHIFT) + (FP_ONE >> 1);
+    world.ants.posY[nurseId] = (8 << FP_SHIFT) + (FP_ONE >> 1);
+    tickNurseActions(world); // sync brood pos to carrier — brood now at (8, 8)
+    expect(world.ants.posX[broodId]).toBe(world.ants.posX[nurseId]);
+    world.ants.alive[nurseId] = 0;
+    // Spawn a second nurse on the same tile (8, 8) — should be able to claim.
+    const nurse2 = allocateEntityId(world);
+    initAnt(world.ants, nurse2, {
+      colonyId: COLONY_ID,
+      posX:     (8 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (8 << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Nursing, subTask: NursingSubState.MovingToBrood,
+      zone:     Zone.Underground,
+    });
+    void colony;
+    tickNurseActions(world);
+    // The new nurse claims the orphaned brood (dead-carrier exception).
+    expect(world.ants.carryingBroodId[nurse2]).toBe(broodId);
+    expect(world.ants.carriedBy[broodId]).toBe(nurse2);
+    expect(world.ants.subTask[nurse2]).toBe(NursingSubState.Feeding);
+  });
+
+  it('brood dies mid-carry: carrier drops the carry and returns to Idle', () => {
+    const { world, nurseId, broodId } = setupV10CarryWorld({
+      nurseTileX: 5, nurseTileY: 5,
+      broodTileX: 5, broodTileY: 5,
+      nurseryTileX: 12, nurseryTileY: 12,
+    });
+    tickNurseActions(world); // claim
+    expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
+    // Brood dies (combat, starvation, anything).
+    world.ants.alive[broodId] = 0;
+    tickNurseActions(world);
+    expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
+    expect(world.ants.subTask[nurseId]).toBe(0);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #17 Phase 1.5 — larva→worker maturation while carried.
+//
+// Driven by tickLifecycleTransitions, not tickNurseActions — the lifecycle
+// step promotes the larva to worker and (under v10+) drops the carry.
+// ---------------------------------------------------------------------------
+
+describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase 1.5)', () => {
+  it('larva matures while being carried: carrier drops, returns to Idle, new worker stays put', async () => {
+    const { tickLifecycleTransitions } = await import('../colony/lifecycle-system.js');
+    const { LARVA_MATURE_TICKS } = await import('../constants.js');
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = SIM_VERSION_V10_VISIBLE_BROOD_CARRY;
+    // Queen + Nursery so brood-aging gate is satisfied.
+    const queenId = allocateEntityId(world);
+    initAnt(world.ants, queenId, { colonyId: COLONY_ID, posX: 0, posY: 0, speed: 0 });
+    const colony = createColonyRecord(COLONY_ID, queenId);
+    world.colonies[COLONY_ID] = colony;
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.Nursery, foodStored: 0,
+      posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT, width: 2, height: 2,
+    });
+
+    // Larva at age = LARVA_MATURE_TICKS - 1 so a single tick promotes it.
+    const larvaId = allocateEntityId(world);
+    initAnt(world.ants, larvaId, {
+      colonyId: COLONY_ID,
+      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Idle, speed: 0, zone: Zone.Underground,
+    });
+    world.ants.age[larvaId] = LARVA_MATURE_TICKS - 1;
+    colony.larvae.push(larvaId);
+    colony.larvaeCount += 1;
+
+    // Carrier holding the larva.
+    const nurseId = allocateEntityId(world);
+    initAnt(world.ants, nurseId, {
+      colonyId: COLONY_ID,
+      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Nursing, subTask: NursingSubState.Feeding,
+      zone:     Zone.Underground,
+    });
+    world.ants.carryingBroodId[nurseId] = larvaId;
+    world.ants.carriedBy[larvaId]       = nurseId;
+
+    tickLifecycleTransitions(world, colony);
+    // Larva promoted to worker; entity id preserved.
+    expect(world.colonies[COLONY_ID]!.workers).toContain(larvaId);
+    expect(world.colonies[COLONY_ID]!.larvae).not.toContain(larvaId);
+    // Carry slot dropped on both ends.
+    expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
+    expect(world.ants.carriedBy[larvaId]).toBe(-1);
+    // Carrier returned to Idle.
+    expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
+    expect(world.ants.subTask[nurseId]).toBe(0);
+    // New worker stays at the carrier's tile (position-sync was the
+    // last write; lifecycle promotion doesn't move the entity).
+    expect(world.ants.posX[larvaId]! >> FP_SHIFT).toBe(5);
+    expect(world.ants.posY[larvaId]! >> FP_SHIFT).toBe(5);
+  });
+
+  it('egg→larva mid-carry: carry stays attached (entity id preserved)', async () => {
+    const { tickLifecycleTransitions } = await import('../colony/lifecycle-system.js');
+    const { EGG_HATCH_TICKS } = await import('../constants.js');
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = SIM_VERSION_V10_VISIBLE_BROOD_CARRY;
+    const queenId = allocateEntityId(world);
+    initAnt(world.ants, queenId, { colonyId: COLONY_ID, posX: 0, posY: 0, speed: 0 });
+    const colony = createColonyRecord(COLONY_ID, queenId);
+    world.colonies[COLONY_ID] = colony;
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.Nursery, foodStored: 0,
+      posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT, width: 2, height: 2,
+    });
+    const eggId = allocateEntityId(world);
+    initAnt(world.ants, eggId, {
+      colonyId: COLONY_ID,
+      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Idle, speed: 0, zone: Zone.Underground,
+    });
+    world.ants.age[eggId] = EGG_HATCH_TICKS - 1;
+    colony.eggs.push(eggId);
+    colony.eggCount += 1;
+    const nurseId = allocateEntityId(world);
+    initAnt(world.ants, nurseId, {
+      colonyId: COLONY_ID,
+      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Nursing, subTask: NursingSubState.Feeding,
+      zone:     Zone.Underground,
+    });
+    world.ants.carryingBroodId[nurseId] = eggId;
+    world.ants.carriedBy[eggId]         = nurseId;
+
+    tickLifecycleTransitions(world, colony);
+    // Promoted to larva; carry preserved.
+    expect(colony.larvae).toContain(eggId);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(eggId);
+    expect(world.ants.carriedBy[eggId]).toBe(nurseId);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
   });
 });

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -6993,20 +6993,24 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
   });
 
   it('on Nursery-tile arrival: deposits brood, clears carry, returns to Idle', () => {
-    // Two-tick natural flow: tick 1 = claim (MovingToBrood→Feeding),
-    // tick 2 = deposit (Feeding + on Nursery → Idle). Carrier and brood
-    // start on a tile that IS a Nursery tile so the second tick deposits
-    // immediately without needing inter-tick movement.
+    // Brood starts OUTSIDE the Nursery (Phase-1.5 W-03: brood inside a
+    // Nursery is excluded from pickup). Pickup happens at tile (5, 5);
+    // we then pre-position the carrier on a Nursery tile and run a
+    // second tick to trigger the deposit branch.
     const { world, nurseId, broodId } = setupV10CarryWorld({
-      nurseTileX: 12, nurseTileY: 12, // Inside the Nursery 2x2 at (12, 12).
-      broodTileX: 12, broodTileY: 12, // Same tile so claim happens.
+      nurseTileX: 5, nurseTileY: 5,
+      broodTileX: 5, broodTileY: 5,
       nurseryTileX: 12, nurseryTileY: 12,
     });
     // Tick 1 — claim.
     tickNurseActions(world);
     expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
     expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
-    // Tick 2 — deposit (carrier is on a Nursery tile, no movement needed).
+    // Move the carrier onto a Nursery Open tile (simulating one tick of
+    // movement). The next tickNurseActions will sync the brood and deposit.
+    world.ants.posX[nurseId] = (12 << FP_SHIFT) + (FP_ONE >> 1);
+    world.ants.posY[nurseId] = (12 << FP_SHIFT) + (FP_ONE >> 1);
+    // Tick 2 — deposit.
     tickNurseActions(world);
     expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
     expect(world.ants.subTask[nurseId]).toBe(0);
@@ -7024,37 +7028,44 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
   it('multiple deposits spread across Nursery Open tiles, not stacked at one corner', () => {
     // Two carriers each holding a different brood, both arriving at Nursery
     // on the same tick. broodId differs → spread index differs → tiles differ.
-    const { world } = setupV10CarryWorld({
-      nurseTileX: 12, nurseTileY: 12,
-      broodTileX: 12, broodTileY: 12,
+    const { world, nurseId, broodId } = setupV10CarryWorld({
+      nurseTileX: 5, nurseTileY: 5,
+      broodTileX: 5, broodTileY: 5,
       nurseryTileX: 12, nurseryTileY: 12,
     });
-    // Add a second brood + nurse pair.
+    // Add a second brood + nurse pair at a second non-Nursery tile.
     const colony = world.colonies[COLONY_ID]!;
     const brood2 = allocateEntityId(world);
     initAnt(world.ants, brood2, {
       colonyId: COLONY_ID,
-      posX:     (13 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (12 << FP_SHIFT) + (FP_ONE >> 1),
+      posX:     (6 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
       task:     AntTask.Idle, speed: 0, zone: Zone.Underground,
     });
     colony.eggs.push(brood2);
     const nurse2 = allocateEntityId(world);
     initAnt(world.ants, nurse2, {
       colonyId: COLONY_ID,
-      posX:     (13 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (12 << FP_SHIFT) + (FP_ONE >> 1),
+      posX:     (6 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
       task:     AntTask.Nursing,
       subTask:  NursingSubState.MovingToBrood,
       zone:     Zone.Underground,
     });
-    void nurse2;
     // Tick 1 — both nurses claim their respective brood.
     tickNurseActions(world);
+    // Move both carriers onto Nursery Open tiles (one per tile so deposit
+    // branches converge in the same tick).
+    world.ants.posX[nurseId] = (12 << FP_SHIFT) + (FP_ONE >> 1);
+    world.ants.posY[nurseId] = (12 << FP_SHIFT) + (FP_ONE >> 1);
+    world.ants.posX[nurse2]  = (12 << FP_SHIFT) + (FP_ONE >> 1);
+    world.ants.posY[nurse2]  = (12 << FP_SHIFT) + (FP_ONE >> 1);
     // Tick 2 — both deposit.
     tickNurseActions(world);
     const allBroodIds = colony.eggs.slice();
     expect(allBroodIds.length).toBe(2);
+    expect(allBroodIds).toContain(broodId);
+    expect(allBroodIds).toContain(brood2);
     const tilesUsed = new Set<string>();
     for (const bid of allBroodIds) {
       const bx = world.ants.posX[bid]! >> FP_SHIFT;
@@ -7087,26 +7098,52 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
 
   it('1×1 Nursery: deposit collapses to the single Open tile (broodId % 1 === 0)', () => {
     const { world, nurseId, broodId } = setupV10CarryWorld({
-      nurseTileX: 14, nurseTileY: 14,
-      broodTileX: 14, broodTileY: 14,
+      nurseTileX: 5, nurseTileY: 5,
+      broodTileX: 5, broodTileY: 5,
       nurseryTileX: 14, nurseryTileY: 14,
       nurseryWidth: 1, nurseryHeight: 1,
     });
-    tickNurseActions(world); // claim
+    tickNurseActions(world); // claim at (5, 5)
+    // Move carrier onto the 1×1 Nursery tile.
+    world.ants.posX[nurseId] = (14 << FP_SHIFT) + (FP_ONE >> 1);
+    world.ants.posY[nurseId] = (14 << FP_SHIFT) + (FP_ONE >> 1);
     tickNurseActions(world); // deposit
     expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
     expect(world.ants.posX[broodId]! >> FP_SHIFT).toBe(14);
     expect(world.ants.posY[broodId]! >> FP_SHIFT).toBe(14);
   });
 
+  it('brood already inside Nursery is NOT re-claimed (W-03 — pre-v10 selection invariant)', () => {
+    // A nurse incidentally walks onto a Nursery tile that holds a deposited
+    // brood (e.g. immediately after Idle→Nursing re-allocation, before the
+    // chamber-flow re-routes her elsewhere). The pre-v10 transport gate
+    // skips brood-inside-Nursery in its selection; v10 must too. Without
+    // this skip, the brood would be re-picked-up and re-shuffled via
+    // broodId%openCount on the next deposit, visible as a brood teleport.
+    const { world, nurseId, broodId } = setupV10CarryWorld({
+      nurseTileX: 12, nurseTileY: 12, // Inside the Nursery 2x2 at (12,12).
+      broodTileX: 12, broodTileY: 12, // Brood already deposited there.
+      nurseryTileX: 12, nurseryTileY: 12,
+    });
+    tickNurseActions(world);
+    // No claim — brood-inside-Nursery is excluded from pickup selection.
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
+    expect(world.ants.carriedBy[broodId]).toBe(-1);
+  });
+
   it('integration: carrier + brood share a tile after tickAntMovement (resolveSameColonyOccupancy must not displace carried brood)', () => {
     // Regression for the resolveSameColonyOccupancy interaction: under v10
     // both carrier and brood end at the same tile each tick. The occupancy
     // resolver iterates all alive entities and bumps higher-id same-tile
-    // ants to a neighbour. Without the v10 carry-aware exemption added in
-    // resolveSameColonyOccupancy, the brood (higher entity id by allocation
-    // order) would jitter off the carrier tile every tick and the next 16c
-    // sync would snap it back — visible as a 1-tile flicker.
+    // ants to a neighbour. In setupV10CarryWorld the brood is allocated
+    // BEFORE the nurse, so brood is the lower id — the resolver would
+    // claim the tile for the brood and bump the higher-id NURSE off the
+    // tile. Either way the carry-render contract breaks (brood + carrier
+    // diverge on a tile every tick of in-tunnel transit until the next
+    // 16c sync re-places the brood under the now-displaced carrier).
+    // The carry-aware exemption skips both ends of the carry pointer so
+    // the resolver never contests the shared tile.
     const { world, nurseId, broodId } = setupV10CarryWorld({
       nurseTileX: 5, nurseTileY: 5,
       broodTileX: 5, broodTileY: 5,

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -6792,11 +6792,16 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     });
     expect(nurse2).toBeGreaterThan(nurseId); // entity ids are monotonic
     tickNurseActions(world);
-    // The lower-id nurse claims; the second stays MovingToBrood.
+    // The lower-id nurse claims; the second is on a Queen-chamber source
+    // tile with no claimable brood — releases via Feeding-without-carry
+    // (pre-v10 cadence), which the next tick will flip to Idle.
     expect(world.ants.carriedBy[broodId]).toBe(nurseId);
     expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
     expect(world.ants.carryingBroodId[nurse2]).toBe(-1);
-    expect(world.ants.subTask[nurse2]).toBe(NursingSubState.MovingToBrood);
+    expect(world.ants.subTask[nurse2]).toBe(NursingSubState.Feeding);
+    // Next tick — defensive Feeding-no-carry guard fires → Idle.
+    tickNurseActions(world);
+    expect(world.ants.task[nurse2]).toBe(AntTask.Idle);
   });
 
   it('already-carried brood (carrier ALIVE) is not claimed by another nurse', () => {
@@ -6810,11 +6815,12 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     });
     world.ants.carriedBy[broodId] = otherCarrier;
     tickNurseActions(world);
-    // Original nurse is on the brood tile but the brood was already claimed
-    // by an alive carrier; nurse stays in MovingToBrood.
+    // Original nurse is on a Queen-chamber tile with no claimable brood
+    // (other carrier is alive). Per finite-nursing: release via Feeding-
+    // without-carry (next tick flips to Idle).
     expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
     expect(world.ants.carriedBy[broodId]).toBe(otherCarrier);
-    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
   });
 
   it('dead brood is skipped — even on the same tile, no claim happens', () => {
@@ -6823,12 +6829,15 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     tickNurseActions(world);
     expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
     expect(world.ants.carriedBy[broodId]).toBe(-1);
-    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
+    // Nurse on a Queen-chamber tile with only a dead brood → finite-
+    // nursing release via Feeding-without-carry.
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
   });
 
   it('Feeding nurse with no carry slot drops back to Idle (defensive guard)', () => {
-    // Reachable only via state corruption — under normal v10 flow the carry
-    // slot is always set when subTask=Feeding. Guard against it.
+    // Reachable via the finite-nursing release path (#56 codex P1) when a
+    // nurse arrives at a source tile with no claimable brood — also via
+    // state corruption.
     const { world, nurseId } = setupV10NurseAndBroodOnTile({ sameTile: false });
     // Manually force the nurse into Feeding without a carry slot.
     world.ants.subTask[nurseId] = NursingSubState.Feeding;
@@ -6836,6 +6845,44 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     tickNurseActions(world);
     expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
     expect(world.ants.subTask[nurseId]).toBe(0);
+  });
+
+  it('finite-nursing release: nurse on Queen tile with no claimable brood completes 2-tick MovingToBrood→Feeding→Idle (#56 codex P1)', () => {
+    // The release path covers two real-world cases:
+    //   (1) No brood anywhere in the colony (brood pool exhausted).
+    //   (2) Another nurse claimed the only brood this tick.
+    // Without the release, a v10 nurse would strand in MovingToBrood
+    // permanently because step 10a only re-allocates Idle workers.
+    const { world, nurseId, broodId } = setupV10NurseAndBroodOnTile({ sameTile: true });
+    // Mark the brood as already-carried by an alive carrier — the nurse
+    // can't claim, so findUncarriedBroodOnTile returns -1.
+    const otherCarrier = allocateEntityId(world);
+    initAnt(world.ants, otherCarrier, {
+      colonyId: COLONY_ID, posX: 0, posY: 0, task: AntTask.Nursing,
+    });
+    world.ants.carriedBy[broodId] = otherCarrier;
+    // Tick 1: MovingToBrood → Feeding (release-pending, no carry).
+    tickNurseActions(world);
+    expect(world.ants.task[nurseId]).toBe(AntTask.Nursing);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
+    // Tick 2: Feeding-no-carry guard → Idle.
+    tickNurseActions(world);
+    expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
+    expect(world.ants.subTask[nurseId]).toBe(0);
+  });
+
+  it('finite-nursing: nurse OFF source tile (in tunnel, no brood here) stays in MovingToBrood', () => {
+    // Defensive: the release ONLY fires when the nurse is on a Queen-chamber
+    // OR Nursery footprint tile — i.e., she has actually arrived at a
+    // pickup source. A nurse mid-walk should keep walking.
+    const { world, nurseId } = setupV10NurseAndBroodOnTile({ sameTile: false });
+    // Helper sets nurse at (8, 8) — far from Queen chamber at (5, 5) and
+    // Nursery at (12, 12). Brood sits at (5, 5).
+    tickNurseActions(world);
+    // No release — nurse keeps walking next tick.
+    expect(world.ants.task[nurseId]).toBe(AntTask.Nursing);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
   });
 
   it('pre-v10 boundary (simVersion=v9): legacy teleport still fires, no carry slot is set', () => {
@@ -7127,9 +7174,11 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     });
     tickNurseActions(world);
     // No claim — brood-inside-Nursery is excluded from pickup selection.
-    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
+    // Nurse releases via finite-nursing (Feeding-without-carry → Idle
+    // next tick) since she's on a Nursery source tile.
     expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
     expect(world.ants.carriedBy[broodId]).toBe(-1);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
   });
 
   it('integration: carrier + brood share a tile after tickAntMovement (resolveSameColonyOccupancy must not displace carried brood)', () => {

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -6728,6 +6728,13 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
       chamberId: 1, chamberType: ChamberType.Queen, foodStored: 0,
       posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, width: 2, height: 2,
     });
+    // Nursery chamber — required for v10 pickup gate. Empty space (no
+    // Open tiles needed for these unit tests; the gate just requires
+    // hasCompletedChamber to return true).
+    colony.chambers.push({
+      chamberId: 2, chamberType: ChamberType.Nursery, foodStored: 0,
+      posX: 12 << FP_SHIFT, posY: 12 << FP_SHIFT, width: 2, height: 2,
+    });
     // Brood entity (egg) at tile (5, 5).
     const broodId = allocateEntityId(world);
     initAnt(world.ants, broodId, {
@@ -6771,7 +6778,7 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
   });
 
   it('two nurses on the same brood tile: only the lower-id nurse claims', () => {
-    const { world, broodId } = setupV10NurseAndBroodOnTile({ sameTile: true });
+    const { world, nurseId, broodId } = setupV10NurseAndBroodOnTile({ sameTile: true });
     // Add a second nurse on the same tile (higher id than the first by
     // construction — entity ids are monotonic).
     const nurse2 = allocateEntityId(world);
@@ -6783,18 +6790,17 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
       subTask:  NursingSubState.MovingToBrood,
       zone:     Zone.Underground,
     });
-    // The first nurse from setup is the queen+brood-1 = entity id 2.
-    // (queen=0, brood=1, nurse=2). nurse2 is entity id 3.
+    expect(nurse2).toBeGreaterThan(nurseId); // entity ids are monotonic
     tickNurseActions(world);
     // The lower-id nurse claims; the second stays MovingToBrood.
-    expect(world.ants.carriedBy[broodId]).toBe(2);
-    expect(world.ants.carryingBroodId[2]).toBe(broodId);
+    expect(world.ants.carriedBy[broodId]).toBe(nurseId);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
     expect(world.ants.carryingBroodId[nurse2]).toBe(-1);
     expect(world.ants.subTask[nurse2]).toBe(NursingSubState.MovingToBrood);
   });
 
   it('already-carried brood (carrier ALIVE) is not claimed by another nurse', () => {
-    const { world, broodId } = setupV10NurseAndBroodOnTile({ sameTile: true });
+    const { world, nurseId, broodId } = setupV10NurseAndBroodOnTile({ sameTile: true });
     // Allocate a separate ALIVE ant to be the existing carrier — the
     // dead-carrier exception in findUncarriedBroodOnTile would let the
     // claim through if the carrier weren't alive.
@@ -6804,32 +6810,32 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     });
     world.ants.carriedBy[broodId] = otherCarrier;
     tickNurseActions(world);
-    // Original nurse (id 2) is on the brood tile but the brood was
-    // already claimed by an alive carrier; nurse stays in MovingToBrood.
-    expect(world.ants.carryingBroodId[2]).toBe(-1);
+    // Original nurse is on the brood tile but the brood was already claimed
+    // by an alive carrier; nurse stays in MovingToBrood.
+    expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
     expect(world.ants.carriedBy[broodId]).toBe(otherCarrier);
-    expect(world.ants.subTask[2]).toBe(NursingSubState.MovingToBrood);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
   });
 
   it('dead brood is skipped — even on the same tile, no claim happens', () => {
-    const { world, broodId } = setupV10NurseAndBroodOnTile({ sameTile: true });
+    const { world, nurseId, broodId } = setupV10NurseAndBroodOnTile({ sameTile: true });
     world.ants.alive[broodId] = 0;
     tickNurseActions(world);
-    expect(world.ants.carryingBroodId[2]).toBe(-1);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
     expect(world.ants.carriedBy[broodId]).toBe(-1);
-    expect(world.ants.subTask[2]).toBe(NursingSubState.MovingToBrood);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
   });
 
   it('Feeding nurse with no carry slot drops back to Idle (defensive guard)', () => {
     // Reachable only via state corruption — under normal v10 flow the carry
     // slot is always set when subTask=Feeding. Guard against it.
-    const { world } = setupV10NurseAndBroodOnTile({ sameTile: false });
+    const { world, nurseId } = setupV10NurseAndBroodOnTile({ sameTile: false });
     // Manually force the nurse into Feeding without a carry slot.
-    world.ants.subTask[2] = NursingSubState.Feeding;
-    world.ants.carryingBroodId[2] = -1;
+    world.ants.subTask[nurseId] = NursingSubState.Feeding;
+    world.ants.carryingBroodId[nurseId] = -1;
     tickNurseActions(world);
-    expect(world.ants.task[2]).toBe(AntTask.Idle);
-    expect(world.ants.subTask[2]).toBe(0);
+    expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
+    expect(world.ants.subTask[nurseId]).toBe(0);
   });
 
   it('pre-v10 boundary (simVersion=v9): legacy teleport still fires, no carry slot is set', () => {
@@ -7059,11 +7065,14 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     expect(tilesUsed.size).toBe(2);
   });
 
-  it('no Nursery: nurse on a Queen-chamber tile claims but never deposits (Feeding holds)', () => {
-    // Without a Nursery footprint, isInsideNursery returns false everywhere
-    // — the carrier stays in Feeding, brood follows along, no deposit.
-    // Matches Rob's Phase-1 contract: with no Nursery, no carry happens
-    // (effectively — claim still happens but never resolves).
+  it('no Nursery: pickup is gated, nurse stays in MovingToBrood (no claim, no carry)', () => {
+    // Phase-1 contract: with no Nursery, no carry happens. The v10 pickup
+    // path is gated on hasCompletedChamber(Nursery) — without one, the
+    // nurse remains in MovingToBrood and the brood remains uncarried.
+    // Matches the pre-v10 P2 transport gate (transportBroodToNursery is
+    // also only called when a Nursery exists). Without this gate, a
+    // pre-Nursery colony's nurses would claim brood and softlock in
+    // Feeding forever (no nurseDeposit field, no isInsideNursery match).
     const { world, nurseId, broodId } = setupV10CarryWorld({
       nurseTileX: 5, nurseTileY: 5,
       broodTileX: 5, broodTileY: 5,
@@ -7071,13 +7080,9 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
       omitNursery: true,
     });
     tickNurseActions(world);
-    // Claimed, but no deposit → still in Feeding.
-    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
-    expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
-    // Run another tick: brood still attached, no deposit.
-    tickNurseActions(world);
-    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
-    expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
+    expect(world.ants.carriedBy[broodId]).toBe(-1);
   });
 
   it('1×1 Nursery: deposit collapses to the single Open tile (broodId % 1 === 0)', () => {
@@ -7092,6 +7097,35 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
     expect(world.ants.posX[broodId]! >> FP_SHIFT).toBe(14);
     expect(world.ants.posY[broodId]! >> FP_SHIFT).toBe(14);
+  });
+
+  it('integration: carrier + brood share a tile after tickAntMovement (resolveSameColonyOccupancy must not displace carried brood)', () => {
+    // Regression for the resolveSameColonyOccupancy interaction: under v10
+    // both carrier and brood end at the same tile each tick. The occupancy
+    // resolver iterates all alive entities and bumps higher-id same-tile
+    // ants to a neighbour. Without the v10 carry-aware exemption added in
+    // resolveSameColonyOccupancy, the brood (higher entity id by allocation
+    // order) would jitter off the carrier tile every tick and the next 16c
+    // sync would snap it back — visible as a 1-tile flicker.
+    const { world, nurseId, broodId } = setupV10CarryWorld({
+      nurseTileX: 5, nurseTileY: 5,
+      broodTileX: 5, broodTileY: 5,
+      nurseryTileX: 12, nurseryTileY: 12,
+    });
+    tickNurseActions(world); // claim — both at (5, 5), broodId carriedBy nurseId
+    expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
+    expect(broodId).toBeLessThan(nurseId); // brood allocated before nurse in helper
+    // Direct invocation of tickAntMovement runs resolveSameColonyOccupancy
+    // at its tail. The carry-aware exemption must keep the brood at the
+    // carrier's tile, not bump it sideways.
+    const rng = new Rng(0);
+    const digFlowFields = createDigFlowFields();
+    // Speed=0 carrier so movement doesn't stretch the tile distance during
+    // this tick — the only mutation we care about is the occupancy resolver.
+    world.ants.speed[nurseId] = 0;
+    tickAntMovement(world, rng, digFlowFields);
+    expect(world.ants.posX[broodId]).toBe(world.ants.posX[nurseId]);
+    expect(world.ants.posY[broodId]).toBe(world.ants.posY[nurseId]);
   });
 
   // ----- Issue #17 Phase 1.5 — death + maturation handling -----
@@ -7168,6 +7202,7 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
     });
 
     // Larva at age = LARVA_MATURE_TICKS - 1 so a single tick promotes it.
+    // Spawn the larva at (5, 5) — its initial pre-carry tile.
     const larvaId = allocateEntityId(world);
     initAnt(world.ants, larvaId, {
       colonyId: COLONY_ID,
@@ -7179,17 +7214,25 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
     colony.larvae.push(larvaId);
     colony.larvaeCount += 1;
 
-    // Carrier holding the larva.
+    // Carrier holding the larva — at a DIFFERENT tile (8, 7) so the test
+    // can prove the new worker stays at the carrier's tile, not the
+    // larva's pre-carry tile. (In normal v10 flow tickNurseActions
+    // step 16c keeps brood synced to carrier each tick, so by the time
+    // promotion fires both are at the carrier's tile.)
     const nurseId = allocateEntityId(world);
     initAnt(world.ants, nurseId, {
       colonyId: COLONY_ID,
-      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posX:     (8 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (7 << FP_SHIFT) + (FP_ONE >> 1),
       task:     AntTask.Nursing, subTask: NursingSubState.Feeding,
       zone:     Zone.Underground,
     });
     world.ants.carryingBroodId[nurseId] = larvaId;
     world.ants.carriedBy[larvaId]       = nurseId;
+    // Manually pre-sync the larva's position to the carrier (mirrors what
+    // tickNurseActions Feeding branch does each tick).
+    world.ants.posX[larvaId] = world.ants.posX[nurseId]!;
+    world.ants.posY[larvaId] = world.ants.posY[nurseId]!;
 
     tickLifecycleTransitions(world, colony);
     // Larva promoted to worker; entity id preserved.
@@ -7201,10 +7244,11 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
     // Carrier returned to Idle.
     expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
     expect(world.ants.subTask[nurseId]).toBe(0);
-    // New worker stays at the carrier's tile (position-sync was the
-    // last write; lifecycle promotion doesn't move the entity).
-    expect(world.ants.posX[larvaId]! >> FP_SHIFT).toBe(5);
-    expect(world.ants.posY[larvaId]! >> FP_SHIFT).toBe(5);
+    // New worker stays at the carrier's tile (8, 7), NOT the larva's
+    // pre-carry tile (5, 5). This proves lifecycle promotion does not
+    // teleport the new worker.
+    expect(world.ants.posX[larvaId]! >> FP_SHIFT).toBe(8);
+    expect(world.ants.posY[larvaId]! >> FP_SHIFT).toBe(7);
   });
 
   it('egg→larva mid-carry: carry stays attached (entity id preserved)', async () => {

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -3840,7 +3840,11 @@ describe('tickNurseActions', () => {
   });
 
   it('colony with zero chambers: nursing ant unchanged', () => {
+    // Pre-v10 path — under v10 the new finite-nursing colony-level
+    // release fires when there's no claimable brood. This test exercises
+    // the legacy on-chamber-tile flip behaviour, so pin to v9.
     const world = createWorldState(42, 64);
+    world.simVersion = SIM_VERSION_V9_CANCEL_DROPS_PENDING;
     const queenId = allocateEntityId(world);
     initAnt(world.ants, queenId, { colonyId: COLONY_ID, posX: 0, posY: 0, speed: 0 });
     const colony = createColonyRecord(COLONY_ID, queenId);
@@ -7021,6 +7025,55 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     // No release — nurse keeps walking next tick.
     expect(world.ants.task[nurseId]).toBe(AntTask.Nursing);
     expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
+  });
+
+  it('finite-nursing colony-level release: nurse mid-tunnel with no claimable brood releases (#56 codex P1 round 2)', () => {
+    // The pickup field has zero seeds when no claimable brood exists,
+    // so a mid-tunnel nurse can\'t pathfind anywhere. Without the colony-
+    // level release, she\'d strand in MovingToBrood forever. The release
+    // fires regardless of source-tile status because there\'s no work
+    // anywhere — no point in waiting for her to arrive somewhere.
+    const { world, nurseId, broodId } = setupV10NurseAndBroodOnTile({ sameTile: false });
+    // Kill the only brood so the colony has no claimable brood.
+    world.ants.alive[broodId] = 0;
+    // Tick 1: colony-level check fires → Feeding (release-pending).
+    tickNurseActions(world);
+    expect(world.ants.task[nurseId]).toBe(AntTask.Nursing);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
+    // Tick 2: Feeding-no-carry guard → Idle.
+    tickNurseActions(world);
+    expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
+  });
+
+  it('finite-nursing colony-level release: nurse mid-tunnel WITH brood elsewhere keeps walking', () => {
+    // Defensive: if brood exists somewhere in the colony, the colony-level
+    // release does NOT fire — the nurse keeps walking toward the brood.
+    // Only the on-source-tile release applies in that case.
+    const { world, nurseId } = setupV10NurseAndBroodOnTile({ sameTile: false });
+    tickNurseActions(world);
+    expect(world.ants.task[nurseId]).toBe(AntTask.Nursing);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
+  });
+
+  it('finite-nursing colony-level release: brood ALL inside Nursery counts as no-claim (#56 round 3 edge)', () => {
+    // colonyHasClaimableBrood must mirror the pickup field's source set —
+    // brood inside Nursery is excluded by the seed loop AND by
+    // findUncarriedBroodOnTile, so it must also be excluded here.
+    // Without the inside-Nursery filter, a queen-dead colony whose brood
+    // sits in the Nursery un-matured would still claim "has brood,"
+    // pickup field has no sources (brood is inside Nursery), and the
+    // mid-tunnel nurse strands.
+    const { world, nurseId, broodId } = setupV10NurseAndBroodOnTile({ sameTile: false });
+    // Move the brood inside the Nursery footprint (12, 12 — 2x2).
+    world.ants.posX[broodId] = (12 << FP_SHIFT) + (FP_ONE >> 1);
+    world.ants.posY[broodId] = (12 << FP_SHIFT) + (FP_ONE >> 1);
+    // Now colonyHasClaimableBrood should return false (brood inside
+    // Nursery filtered out), so the colony-level release fires.
+    tickNurseActions(world);
+    expect(world.ants.task[nurseId]).toBe(AntTask.Nursing);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
+    tickNurseActions(world);
+    expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
   });
 
   it('pre-v10 boundary (simVersion=v9): legacy teleport still fires, no carry slot is set', () => {

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -6831,6 +6831,65 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     expect(world.ants.task[2]).toBe(AntTask.Idle);
     expect(world.ants.subTask[2]).toBe(0);
   });
+
+  it('pre-v10 boundary (simVersion=v9): legacy teleport still fires, no carry slot is set', () => {
+    // Boundary regression — guards against an off-by-one slip in the gate.
+    // simVersion=v9 must keep the pre-v10 MovingToBrood→Feeding-on-chamber-
+    // tile flip + transportBroodToNursery teleport. carryingBroodId must
+    // stay at the -1 default (never read pre-v10).
+    const world = createWorldState(42, 64);
+    world.simVersion = SIM_VERSION_V9_CANCEL_DROPS_PENDING;
+    const queenId = allocateEntityId(world);
+    initAnt(world.ants, queenId, { colonyId: COLONY_ID, posX: 0, posY: 0, speed: 0 });
+    const colony = createColonyRecord(COLONY_ID, queenId);
+    world.colonies[COLONY_ID] = colony;
+    // Queen + Nursery so the legacy teleport has a destination.
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.Queen, foodStored: 0,
+      posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, width: 2, height: 2,
+    });
+    colony.chambers.push({
+      chamberId: 2, chamberType: ChamberType.Nursery, foodStored: 0,
+      posX: 12 << FP_SHIFT, posY: 12 << FP_SHIFT, width: 2, height: 2,
+    });
+    // Underground grid with the Nursery footprint Open.
+    const ug = createUndergroundGrid(16, 16);
+    for (let dy = 0; dy < 2; dy++) {
+      for (let dx = 0; dx < 2; dx++) {
+        ugSet(ug, 12 + dx, 12 + dy, UndergroundTileState.Open);
+      }
+    }
+    world.undergroundGrids[COLONY_ID] = ug;
+    // Brood on a Queen tile.
+    const broodId = allocateEntityId(world);
+    initAnt(world.ants, broodId, {
+      colonyId: COLONY_ID,
+      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Idle, speed: 0, zone: Zone.Underground,
+    });
+    colony.eggs.push(broodId);
+    // Nurse on the same Queen tile — pre-v10 path requires only "on a
+    // Queen/Nursery footprint tile" to flip Feeding and teleport ONE brood.
+    const nurseId = allocateEntityId(world);
+    initAnt(world.ants, nurseId, {
+      colonyId: COLONY_ID,
+      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Nursing,
+      subTask:  NursingSubState.MovingToBrood,
+      zone:     Zone.Underground,
+    });
+    tickNurseActions(world);
+    // Pre-v10: subTask flipped to Feeding (legacy on-chamber-tile flip);
+    // brood teleported into Nursery footprint.
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
+    expect(world.ants.posX[broodId]! >> FP_SHIFT).toBeGreaterThanOrEqual(12);
+    expect(world.ants.posX[broodId]! >> FP_SHIFT).toBeLessThan(14);
+    // Carry slot stays at the -1 default — pre-v10 never touches it.
+    expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
+    expect(world.ants.carriedBy[broodId]).toBe(-1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -77,6 +77,7 @@ import {
   computeChamberFlowField,
   FOOD_CHAMBER_TYPES,
   NURSING_CHAMBER_TYPES,
+  NURSERY_CHAMBER_TYPES,
 } from '../chamber-flow.js';
 import type { WorldState } from '../types.js';
 import type { ColonyRecord } from '../colony/colony-store.js';
@@ -4011,6 +4012,102 @@ describe('tickAntMovement — underground entrance routing (tunnel-aware)', () =
     // Held position — no phantom movement into dirt.
     expect(world.ants.posX[antId]).toBe(posXBefore);
     expect(world.ants.posY[antId]).toBe(posYBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #17 Phase 1 — nurseDeposit chamber-flow field. Pure-additive: the
+// field is allocated alongside food/nursing/queen and seeded from Nursery
+// Open tiles only. Consumed by v10+ carrying nurses (subTask=Feeding with
+// carryingBroodId set).
+// ---------------------------------------------------------------------------
+
+describe('chamber-flow nurseDeposit field (#17 phase 1)', () => {
+  /**
+   * Build a 16x16 grid with one Nursery (2x2 Open at 6,6) and one Queen
+   * chamber (2x2 Open at 10,3), connected by a tunnel. Compute nurseDeposit
+   * with NURSERY_CHAMBER_TYPES and assert that Queen tiles do NOT carry a
+   * source/-1 marker — only Nursery tiles do.
+   */
+  it('seeds from Nursery Open tiles only — Queen Open tiles are NOT sources', () => {
+    const { underground, colony, colonyId } = setupWorldWithUnderground(16, 16);
+    // Nursery (2x2) at (6,6).
+    for (let dy = 0; dy < 2; dy++) {
+      for (let dx = 0; dx < 2; dx++) {
+        ugSet(underground, 6 + dx, 6 + dy, UndergroundTileState.Open);
+      }
+    }
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.Nursery, foodStored: 0,
+      posX: 6 << FP_SHIFT, posY: 6 << FP_SHIFT, width: 2, height: 2,
+    });
+    // Queen chamber (2x2) at (10,3).
+    for (let dy = 0; dy < 2; dy++) {
+      for (let dx = 0; dx < 2; dx++) {
+        ugSet(underground, 10 + dx, 3 + dy, UndergroundTileState.Open);
+      }
+    }
+    colony.chambers.push({
+      chamberId: 2, chamberType: ChamberType.Queen, foodStored: 0,
+      posX: 10 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 2, height: 2,
+    });
+    // Tunnel connecting them so BFS can reach Queen tiles.
+    for (let y = 4; y <= 6; y++) ugSet(underground, 8, y, UndergroundTileState.Open);
+    for (let x = 7; x <= 10; x++) ugSet(underground, x, 4, UndergroundTileState.Open);
+
+    const cache = createChamberFlowFields();
+    const gridSize = underground.width * underground.height;
+    const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
+    computeChamberFlowField(
+      underground, colony.chambers, NURSERY_CHAMBER_TYPES,
+      bufs.nurseDeposit, bufs.queue,
+    );
+
+    const W = underground.width;
+    // Nursery footprint tiles ARE sources (-1).
+    expect(bufs.nurseDeposit[6 * W + 6]).toBe(-1);
+    expect(bufs.nurseDeposit[6 * W + 7]).toBe(-1);
+    expect(bufs.nurseDeposit[7 * W + 6]).toBe(-1);
+    expect(bufs.nurseDeposit[7 * W + 7]).toBe(-1);
+    // Queen footprint tiles are NOT sources — they're reachable, so they
+    // carry a step direction (0..3), but never -1.
+    for (const [qx, qy] of [[10, 3], [11, 3], [10, 4], [11, 4]] as const) {
+      const v = bufs.nurseDeposit[qy * W + qx]!;
+      expect(v).not.toBe(-1);
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it('with no Nursery chamber, every reachable tile is unreachable (-2) — there is nothing to seed', () => {
+    const { underground, colony, colonyId } = setupWorldWithUnderground(16, 16);
+    // Open a small region but NO Nursery chamber.
+    for (let dy = 0; dy < 3; dy++) {
+      for (let dx = 0; dx < 3; dx++) {
+        ugSet(underground, 5 + dx, 5 + dy, UndergroundTileState.Open);
+      }
+    }
+    // Push a Queen chamber so we prove only the type filter matters.
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.Queen, foodStored: 0,
+      posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, width: 2, height: 2,
+    });
+
+    const cache = createChamberFlowFields();
+    const gridSize = underground.width * underground.height;
+    const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
+    computeChamberFlowField(
+      underground, colony.chambers, NURSERY_CHAMBER_TYPES,
+      bufs.nurseDeposit, bufs.queue,
+    );
+
+    // No seeds → every tile stays at -2.
+    const W = underground.width;
+    for (let y = 5; y < 8; y++) {
+      for (let x = 5; x < 8; x++) {
+        expect(bufs.nurseDeposit[y * W + x]).toBe(-2);
+      }
+    }
   });
 });
 

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -7055,6 +7055,39 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
   });
 
+  it('finite-nursing: orphan brood on BeingDug tile DOES count as claimable (#56 codex P1 r3)', () => {
+    // Codex round 3 P1: a carrier can die on a BeingDug tile, leaving
+    // its orphan brood there. The pickup field's seed-tile guard now
+    // allows BeingDug (BFS expansion already traverses it). The
+    // colonyHasClaimableBrood predicate must agree — otherwise the
+    // colony-level release would incorrectly fire even though the
+    // pickup field DOES have a source for that orphan, sending a
+    // walking nurse back to Idle prematurely.
+    const { world, nurseId, broodId } = setupV10NurseAndBroodOnTile({ sameTile: false });
+    // Set up an underground grid the predicate will read. Mark the
+    // brood's tile (5, 5) as BeingDug.
+    const ug = createUndergroundGrid(64, 64);
+    for (let y = 0; y < 64; y++) {
+      for (let x = 0; x < 64; x++) {
+        ugSet(ug, x, y, UndergroundTileState.Open);
+      }
+    }
+    ugSet(ug, 5, 5, UndergroundTileState.BeingDug);
+    world.undergroundGrids[COLONY_ID] = ug;
+    // Mark the brood as orphaned (carriedBy points at a dead nurse).
+    const deadCarrier = allocateEntityId(world);
+    initAnt(world.ants, deadCarrier, {
+      colonyId: COLONY_ID, posX: 0, posY: 0, task: AntTask.Nursing,
+    });
+    world.ants.alive[deadCarrier] = 0;
+    world.ants.carriedBy[broodId] = deadCarrier;
+    tickNurseActions(world);
+    // Nurse keeps walking — colony-level release does NOT fire because
+    // the BeingDug-tile orphan is a valid pickup source.
+    expect(world.ants.task[nurseId]).toBe(AntTask.Nursing);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
+  });
+
   it('finite-nursing colony-level release: brood ALL inside Nursery counts as no-claim (#56 round 3 edge)', () => {
     // colonyHasClaimableBrood must mirror the pickup field's source set —
     // brood inside Nursery is excluded by the seed loop AND by

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -37,6 +37,8 @@ import {
   SIM_VERSION_V4_DIAGONAL_MOTION,
   SIM_VERSION_V5_CHAMBER_ON_MARKED,
   SIM_VERSION_V8_LEASH_HYSTERESIS,
+  SIM_VERSION_V9_CANCEL_DROPS_PENDING,
+  SIM_VERSION_V10_VISIBLE_BROOD_CARRY,
 } from '../types.js';
 import { createColonyRecord } from '../colony/colony-store.js';
 import { initAnt, createAntComponents, RECENT_TILES_LEN } from './ant-store.js';
@@ -3701,6 +3703,13 @@ describe('tickNurseActions', () => {
     subTask?: number;
   }): { world: WorldState; antId: number; colony: ColonyRecord } {
     const world = createWorldState(42, 64);
+    // Pin to pre-v10 — these tests exercise the legacy
+    // MovingToBrood→Feeding-on-chamber-tile flip + teleport. Phase 1.3
+    // (#17) replaced that flip under v10+ with a brood-tile pickup, so
+    // tests that expect the legacy flip must explicitly run on a pre-v10
+    // sim version. v10-specific tests live in their own describe block
+    // below and bump simVersion back to LATEST.
+    world.simVersion = SIM_VERSION_V9_CANCEL_DROPS_PENDING;
     // Queen (entity 0) — required for createColonyRecord.
     const queenId = allocateEntityId(world);
     initAnt(world.ants, queenId, { colonyId: COLONY_ID, posX: 0, posY: 0, speed: 0 });
@@ -5621,6 +5630,11 @@ describe('tickNurseActions — P2 brood transport to Nursery', () => {
     const ugWidth  = params.ugWidth  ?? 16;
     const ugHeight = params.ugHeight ?? 16;
     const world = createWorldState(42, MAX_TEST_ENTITIES);
+    // Pin to pre-v10 — these tests assert the legacy teleport behaviour
+    // of `transportBroodToNursery` on the MovingToBrood→Feeding flip.
+    // Under v10+ that path is replaced by visible carry; v10 tests live
+    // in their own describe block and bump simVersion back to LATEST.
+    world.simVersion = SIM_VERSION_V9_CANCEL_DROPS_PENDING;
     const colony = createColonyRecord(COLONY_ID, 0);
     colony.entrances = [];
     colony.rallyPoint = null;
@@ -6685,5 +6699,133 @@ describe('issue #42 — surface SearchingFood no-revisit rule (v6)', () => {
       expect(world.ants.recentTilesY[antId * RECENT_TILES_LEN + s]).toBe(-1);
     }
     expect(world.ants.recentTilesHead[antId]).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #17 Phase 1.3 — v10+ tickNurseActions pickup branch.
+//
+// Under simVersion >= V10, MovingToBrood → Feeding only flips when the nurse
+// is standing on a tile with an alive uncarried brood entity. On the flip
+// we set carryingBroodId on the nurse and carriedBy on the brood (the
+// reverse pointer keeps a second nurse from racing the same brood).
+// ---------------------------------------------------------------------------
+
+describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
+  function setupV10NurseAndBroodOnTile(opts: {
+    sameTile: boolean;
+  }): { world: WorldState; nurseId: number; broodId: number; colony: ColonyRecord } {
+    const world = createWorldState(42, 64);
+    // LATEST already includes v10; pin explicitly so the test name describes
+    // what's under test even when LATEST advances.
+    world.simVersion = SIM_VERSION_V10_VISIBLE_BROOD_CARRY;
+    const queenId = allocateEntityId(world);
+    initAnt(world.ants, queenId, { colonyId: COLONY_ID, posX: 0, posY: 0, speed: 0 });
+    const colony = createColonyRecord(COLONY_ID, queenId);
+    world.colonies[COLONY_ID] = colony;
+    // Queen chamber so the brood is in a "natural" location.
+    colony.chambers.push({
+      chamberId: 1, chamberType: ChamberType.Queen, foodStored: 0,
+      posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, width: 2, height: 2,
+    });
+    // Brood entity (egg) at tile (5, 5).
+    const broodId = allocateEntityId(world);
+    initAnt(world.ants, broodId, {
+      colonyId: COLONY_ID,
+      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Idle,
+      speed:    0,
+      zone:     Zone.Underground,
+    });
+    colony.eggs.push(broodId);
+    // Nurse — same tile as brood, OR offset depending on sameTile flag.
+    const nurseTileX = opts.sameTile ? 5 : 8;
+    const nurseTileY = opts.sameTile ? 5 : 8;
+    const nurseId = allocateEntityId(world);
+    initAnt(world.ants, nurseId, {
+      colonyId: COLONY_ID,
+      posX:     (nurseTileX << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (nurseTileY << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Nursing,
+      subTask:  NursingSubState.MovingToBrood,
+      zone:     Zone.Underground,
+    });
+    return { world, nurseId, broodId, colony };
+  }
+
+  it('on brood tile: claims the brood and flips to Feeding (carry pointer set both ways)', () => {
+    const { world, nurseId, broodId } = setupV10NurseAndBroodOnTile({ sameTile: true });
+    tickNurseActions(world);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
+    expect(world.ants.carriedBy[broodId]).toBe(nurseId);
+  });
+
+  it('off brood tile: stays in MovingToBrood, no carry claimed', () => {
+    const { world, nurseId, broodId } = setupV10NurseAndBroodOnTile({ sameTile: false });
+    tickNurseActions(world);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
+    expect(world.ants.carriedBy[broodId]).toBe(-1);
+  });
+
+  it('two nurses on the same brood tile: only the lower-id nurse claims', () => {
+    const { world, broodId } = setupV10NurseAndBroodOnTile({ sameTile: true });
+    // Add a second nurse on the same tile (higher id than the first by
+    // construction — entity ids are monotonic).
+    const nurse2 = allocateEntityId(world);
+    initAnt(world.ants, nurse2, {
+      colonyId: COLONY_ID,
+      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Nursing,
+      subTask:  NursingSubState.MovingToBrood,
+      zone:     Zone.Underground,
+    });
+    // The first nurse from setup is the queen+brood-1 = entity id 2.
+    // (queen=0, brood=1, nurse=2). nurse2 is entity id 3.
+    tickNurseActions(world);
+    // The lower-id nurse claims; the second stays MovingToBrood.
+    expect(world.ants.carriedBy[broodId]).toBe(2);
+    expect(world.ants.carryingBroodId[2]).toBe(broodId);
+    expect(world.ants.carryingBroodId[nurse2]).toBe(-1);
+    expect(world.ants.subTask[nurse2]).toBe(NursingSubState.MovingToBrood);
+  });
+
+  it('already-carried brood is not claimed by another nurse on the same tile', () => {
+    const { world, broodId, colony } = setupV10NurseAndBroodOnTile({ sameTile: true });
+    // Mark the brood as already carried by some other nurse (not in this
+    // test's iteration loop) — simulates a race that resolved on a prior tick.
+    world.ants.carriedBy[broodId] = 99;
+    void colony;
+    tickNurseActions(world);
+    // Original nurse (id 2) is still on the brood tile but the brood was
+    // already claimed; nurse stays in MovingToBrood and does not steal.
+    expect(world.ants.carryingBroodId[2]).toBe(-1);
+    expect(world.ants.carriedBy[broodId]).toBe(99);
+    expect(world.ants.subTask[2]).toBe(NursingSubState.MovingToBrood);
+  });
+
+  it('dead brood is skipped — even on the same tile, no claim happens', () => {
+    const { world, broodId } = setupV10NurseAndBroodOnTile({ sameTile: true });
+    world.ants.alive[broodId] = 0;
+    tickNurseActions(world);
+    expect(world.ants.carryingBroodId[2]).toBe(-1);
+    expect(world.ants.carriedBy[broodId]).toBe(-1);
+    expect(world.ants.subTask[2]).toBe(NursingSubState.MovingToBrood);
+  });
+
+  it('Feeding nurse with no carry slot drops back to Idle (Phase 1.3 partial-state guard)', () => {
+    // Phase 1.4 will populate Feeding=carrying; until then, a Feeding nurse
+    // with carryingBroodId === -1 should release back to Idle so a half-
+    // implemented v10 build doesn't strand nurses in Feeding forever.
+    const { world } = setupV10NurseAndBroodOnTile({ sameTile: false });
+    // Manually force the nurse into Feeding without a carry slot.
+    world.ants.subTask[2] = NursingSubState.Feeding;
+    world.ants.carryingBroodId[2] = -1;
+    tickNurseActions(world);
+    expect(world.ants.task[2]).toBe(AntTask.Idle);
+    expect(world.ants.subTask[2]).toBe(0);
   });
 });

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -6984,6 +6984,16 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     }
     world.undergroundGrids[COLONY_ID] = underground;
 
+    // Queen chamber sized to cover the brood tile — eggs are laid in the
+    // queen's chamber per the design, so the test setup needs one for
+    // pickup-source tile detection (isInsideQueenChamber). 2×2 anchored at
+    // (broodTileX, broodTileY) so the brood always sits inside.
+    colony.chambers.push({
+      chamberId: 0, chamberType: ChamberType.Queen, foodStored: 0,
+      posX: opts.broodTileX << FP_SHIFT, posY: opts.broodTileY << FP_SHIFT,
+      width: 2, height: 2,
+    });
+
     if (!opts.omitNursery) {
       colony.chambers.push({
         chamberId: 1, chamberType: ChamberType.Nursery, foodStored: 0,
@@ -7123,24 +7133,47 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     expect(tilesUsed.size).toBe(2);
   });
 
-  it('no Nursery: pickup is gated, nurse stays in MovingToBrood (no claim, no carry)', () => {
-    // Phase-1 contract: with no Nursery, no carry happens. The v10 pickup
-    // path is gated on hasCompletedChamber(Nursery) — without one, the
-    // nurse remains in MovingToBrood and the brood remains uncarried.
-    // Matches the pre-v10 P2 transport gate (transportBroodToNursery is
-    // also only called when a Nursery exists). Without this gate, a
-    // pre-Nursery colony's nurses would claim brood and softlock in
-    // Feeding forever (no nurseDeposit field, no isInsideNursery match).
+  it('no Nursery: pickup is gated; nurse on a Queen tile releases via Feeding (#56 codex P2)', () => {
+    // Phase-1 contract: with no Nursery, no carry happens. The v10
+    // pickup path is gated on hasCompletedChamber(Nursery) — without one
+    // the gate fires before any claim. Defensive: if a Nursing ant
+    // somehow exists pre-Nursery (migrated/corrupted/scripted state),
+    // she still needs to release back to Idle so step 10a can reallocate.
+    // The release path mirrors the pre-v10 finite-nursing cadence
+    // (MovingToBrood→Feeding→Idle two ticks).
+    //
+    // Test setup: Queen chamber at (5,5) is created by setupV10CarryWorld
+    // unconditionally; Nursery is omitted via `omitNursery: true`. The
+    // nurse stands on the Queen tile, so onSourceTile=true → release.
     const { world, nurseId, broodId } = setupV10CarryWorld({
       nurseTileX: 5, nurseTileY: 5,
       broodTileX: 5, broodTileY: 5,
       nurseryTileX: 0, nurseryTileY: 0, // ignored
       omitNursery: true,
     });
-    tickNurseActions(world);
-    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
+    tickNurseActions(world); // tick 1 — release-pending
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
     expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
     expect(world.ants.carriedBy[broodId]).toBe(-1);
+    tickNurseActions(world); // tick 2 — Idle
+    expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
+  });
+
+  it('no Nursery: pickup gated, nurse OFF source tile keeps walking (no premature release)', () => {
+    // Defensive: the release ONLY fires when the nurse is on a source
+    // tile. A nurse mid-walk to a Queen tile with no Nursery yet should
+    // continue walking — she may reach the source on a future tick and
+    // THEN release.
+    const { world, nurseId } = setupV10CarryWorld({
+      nurseTileX: 0, nurseTileY: 0, // far from any chamber
+      broodTileX: 5, broodTileY: 5,
+      nurseryTileX: 0, nurseryTileY: 0, // ignored
+      omitNursery: true,
+    });
+    tickNurseActions(world);
+    // No release — nurse keeps walking next tick.
+    expect(world.ants.task[nurseId]).toBe(AntTask.Nursing);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.MovingToBrood);
   });
 
   it('1×1 Nursery: deposit collapses to the single Open tile (broodId % 1 === 0)', () => {

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -6816,10 +6816,9 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     expect(world.ants.subTask[2]).toBe(NursingSubState.MovingToBrood);
   });
 
-  it('Feeding nurse with no carry slot drops back to Idle (Phase 1.3 partial-state guard)', () => {
-    // Phase 1.4 will populate Feeding=carrying; until then, a Feeding nurse
-    // with carryingBroodId === -1 should release back to Idle so a half-
-    // implemented v10 build doesn't strand nurses in Feeding forever.
+  it('Feeding nurse with no carry slot drops back to Idle (defensive guard)', () => {
+    // Reachable only via state corruption — under normal v10 flow the carry
+    // slot is always set when subTask=Feeding. Guard against it.
     const { world } = setupV10NurseAndBroodOnTile({ sameTile: false });
     // Manually force the nurse into Feeding without a carry slot.
     world.ants.subTask[2] = NursingSubState.Feeding;
@@ -6827,5 +6826,208 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     tickNurseActions(world);
     expect(world.ants.task[2]).toBe(AntTask.Idle);
     expect(world.ants.subTask[2]).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #17 Phase 1.4 — v10+ carry + deposit.
+//
+// Once a nurse claims a brood (Phase 1.3), it walks to a Nursery tile while
+// syncing the brood's position to its own each tick. On Nursery arrival the
+// brood is deposited at a Nursery Open tile (spread by broodId%openCount,
+// matching the pre-v10 teleport's distribution), the carry slot clears,
+// and the nurse returns to Idle.
+// ---------------------------------------------------------------------------
+
+describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
+  function setupV10CarryWorld(opts: {
+    nurseTileX: number; nurseTileY: number;
+    broodTileX: number; broodTileY: number;
+    nurseryTileX: number; nurseryTileY: number;
+    nurseryWidth?: number; nurseryHeight?: number;
+    omitNursery?: boolean;
+  }): { world: WorldState; nurseId: number; broodId: number; colony: ColonyRecord } {
+    const ugWidth = 16, ugHeight = 16;
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = SIM_VERSION_V10_VISIBLE_BROOD_CARRY;
+    const queenId = allocateEntityId(world);
+    initAnt(world.ants, queenId, { colonyId: COLONY_ID, posX: 0, posY: 0, speed: 0 });
+    const colony = createColonyRecord(COLONY_ID, queenId);
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
+    world.colonies[COLONY_ID] = colony;
+
+    // Open the entire grid so the Nursery footprint tiles are Open without
+    // any extra dig wiring.
+    const underground = createUndergroundGrid(ugWidth, ugHeight);
+    for (let y = 0; y < ugHeight; y++) {
+      for (let x = 0; x < ugWidth; x++) {
+        ugSet(underground, x, y, UndergroundTileState.Open);
+      }
+    }
+    world.undergroundGrids[COLONY_ID] = underground;
+
+    if (!opts.omitNursery) {
+      colony.chambers.push({
+        chamberId: 1, chamberType: ChamberType.Nursery, foodStored: 0,
+        posX: opts.nurseryTileX << FP_SHIFT, posY: opts.nurseryTileY << FP_SHIFT,
+        width: opts.nurseryWidth ?? 2, height: opts.nurseryHeight ?? 2,
+      });
+    }
+
+    const broodId = allocateEntityId(world);
+    initAnt(world.ants, broodId, {
+      colonyId: COLONY_ID,
+      posX:     (opts.broodTileX << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (opts.broodTileY << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Idle, speed: 0, zone: Zone.Underground,
+    });
+    colony.eggs.push(broodId);
+
+    const nurseId = allocateEntityId(world);
+    initAnt(world.ants, nurseId, {
+      colonyId: COLONY_ID,
+      posX:     (opts.nurseTileX << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (opts.nurseTileY << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Nursing,
+      subTask:  NursingSubState.MovingToBrood,
+      zone:     Zone.Underground,
+    });
+    return { world, nurseId, broodId, colony };
+  }
+
+  it('after claim, brood position syncs to carrier each tick (in-flight, NOT yet at Nursery)', () => {
+    // Carrier on brood tile (claim happens) but Nursery is far away —
+    // after the tick, brood position equals carrier position; nurse is
+    // still in Feeding (not yet at Nursery) and not back to Idle.
+    const { world, nurseId, broodId } = setupV10CarryWorld({
+      nurseTileX: 5, nurseTileY: 5,
+      broodTileX: 5, broodTileY: 5,
+      nurseryTileX: 12, nurseryTileY: 12,
+    });
+    tickNurseActions(world);
+    // Sub-state flipped to Feeding (claim succeeded), brood follows carrier.
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
+    expect(world.ants.posX[broodId]).toBe(world.ants.posX[nurseId]);
+    expect(world.ants.posY[broodId]).toBe(world.ants.posY[nurseId]);
+    // Now move the carrier manually (simulating one tick of movement) and
+    // re-run tickNurseActions: brood follows.
+    world.ants.posX[nurseId] = (7 << FP_SHIFT) + (FP_ONE >> 1);
+    world.ants.posY[nurseId] = (8 << FP_SHIFT) + (FP_ONE >> 1);
+    tickNurseActions(world);
+    expect(world.ants.posX[broodId]).toBe(world.ants.posX[nurseId]);
+    expect(world.ants.posY[broodId]).toBe(world.ants.posY[nurseId]);
+    // Still in Feeding (not at Nursery yet).
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
+  });
+
+  it('on Nursery-tile arrival: deposits brood, clears carry, returns to Idle', () => {
+    // Two-tick natural flow: tick 1 = claim (MovingToBrood→Feeding),
+    // tick 2 = deposit (Feeding + on Nursery → Idle). Carrier and brood
+    // start on a tile that IS a Nursery tile so the second tick deposits
+    // immediately without needing inter-tick movement.
+    const { world, nurseId, broodId } = setupV10CarryWorld({
+      nurseTileX: 12, nurseTileY: 12, // Inside the Nursery 2x2 at (12, 12).
+      broodTileX: 12, broodTileY: 12, // Same tile so claim happens.
+      nurseryTileX: 12, nurseryTileY: 12,
+    });
+    // Tick 1 — claim.
+    tickNurseActions(world);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
+    // Tick 2 — deposit (carrier is on a Nursery tile, no movement needed).
+    tickNurseActions(world);
+    expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
+    expect(world.ants.subTask[nurseId]).toBe(0);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
+    expect(world.ants.carriedBy[broodId]).toBe(-1);
+    // Brood landed at a Nursery Open tile (broodId % openCount spread).
+    const bx = world.ants.posX[broodId]! >> FP_SHIFT;
+    const by = world.ants.posY[broodId]! >> FP_SHIFT;
+    expect(bx).toBeGreaterThanOrEqual(12);
+    expect(bx).toBeLessThan(14);
+    expect(by).toBeGreaterThanOrEqual(12);
+    expect(by).toBeLessThan(14);
+  });
+
+  it('multiple deposits spread across Nursery Open tiles, not stacked at one corner', () => {
+    // Two carriers each holding a different brood, both arriving at Nursery
+    // on the same tick. broodId differs → spread index differs → tiles differ.
+    const { world } = setupV10CarryWorld({
+      nurseTileX: 12, nurseTileY: 12,
+      broodTileX: 12, broodTileY: 12,
+      nurseryTileX: 12, nurseryTileY: 12,
+    });
+    // Add a second brood + nurse pair.
+    const colony = world.colonies[COLONY_ID]!;
+    const brood2 = allocateEntityId(world);
+    initAnt(world.ants, brood2, {
+      colonyId: COLONY_ID,
+      posX:     (13 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (12 << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Idle, speed: 0, zone: Zone.Underground,
+    });
+    colony.eggs.push(brood2);
+    const nurse2 = allocateEntityId(world);
+    initAnt(world.ants, nurse2, {
+      colonyId: COLONY_ID,
+      posX:     (13 << FP_SHIFT) + (FP_ONE >> 1),
+      posY:     (12 << FP_SHIFT) + (FP_ONE >> 1),
+      task:     AntTask.Nursing,
+      subTask:  NursingSubState.MovingToBrood,
+      zone:     Zone.Underground,
+    });
+    void nurse2;
+    // Tick 1 — both nurses claim their respective brood.
+    tickNurseActions(world);
+    // Tick 2 — both deposit.
+    tickNurseActions(world);
+    const allBroodIds = colony.eggs.slice();
+    expect(allBroodIds.length).toBe(2);
+    const tilesUsed = new Set<string>();
+    for (const bid of allBroodIds) {
+      const bx = world.ants.posX[bid]! >> FP_SHIFT;
+      const by = world.ants.posY[bid]! >> FP_SHIFT;
+      tilesUsed.add(`${bx},${by}`);
+    }
+    // Two distinct deposit tiles within the 2×2 Nursery footprint.
+    expect(tilesUsed.size).toBe(2);
+  });
+
+  it('no Nursery: nurse on a Queen-chamber tile claims but never deposits (Feeding holds)', () => {
+    // Without a Nursery footprint, isInsideNursery returns false everywhere
+    // — the carrier stays in Feeding, brood follows along, no deposit.
+    // Matches Rob's Phase-1 contract: with no Nursery, no carry happens
+    // (effectively — claim still happens but never resolves).
+    const { world, nurseId, broodId } = setupV10CarryWorld({
+      nurseTileX: 5, nurseTileY: 5,
+      broodTileX: 5, broodTileY: 5,
+      nurseryTileX: 0, nurseryTileY: 0, // ignored
+      omitNursery: true,
+    });
+    tickNurseActions(world);
+    // Claimed, but no deposit → still in Feeding.
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
+    // Run another tick: brood still attached, no deposit.
+    tickNurseActions(world);
+    expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
+    expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
+  });
+
+  it('1×1 Nursery: deposit collapses to the single Open tile (broodId % 1 === 0)', () => {
+    const { world, nurseId, broodId } = setupV10CarryWorld({
+      nurseTileX: 14, nurseTileY: 14,
+      broodTileX: 14, broodTileY: 14,
+      nurseryTileX: 14, nurseryTileY: 14,
+      nurseryWidth: 1, nurseryHeight: 1,
+    });
+    tickNurseActions(world); // claim
+    tickNurseActions(world); // deposit
+    expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
+    expect(world.ants.posX[broodId]! >> FP_SHIFT).toBe(14);
+    expect(world.ants.posY[broodId]! >> FP_SHIFT).toBe(14);
   });
 });

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -861,7 +861,25 @@ export function tickNurseActions(world: WorldState): void {
       // determinism (matches the pre-v10 transportBroodToNursery
       // selection order).
       const broodId = findUncarriedBroodOnTile(ants, colony, tileX, tileY);
-      if (broodId < 0) continue;
+      if (broodId < 0) {
+        // Finite-nursing release (PR #56 codex P1). A nurse that has
+        // arrived at a source tile (Queen-chamber footprint, or —
+        // defensively — a Nursery footprint) but found no claimable
+        // brood is done with this trip. Mirror the pre-v10 cadence:
+        // flip to Feeding WITHOUT setting a carry slot. Next tick the
+        // Feeding branch's defensive guard (carryingBroodId === -1)
+        // releases to Idle, matching the pre-v10
+        // MovingToBrood→Feeding→Idle two-tick path. Without this,
+        // nurses with no available brood would strand in MovingToBrood
+        // forever, permanently removed from the forage/dig/fight pool.
+        if (
+          isInsideQueenChamber(colony, tileX, tileY) ||
+          isInsideNursery(colony, tileX, tileY)
+        ) {
+          ants.subTask[id] = NursingSubState.Feeding;
+        }
+        continue;
+      }
 
       // Defensive: if the brood was carried by a now-dead carrier
       // (orphan reclaim path), null out the dead carrier's carryingBroodId

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -810,6 +810,17 @@ export function tickNurseActions(world: WorldState): void {
           ants.subTask[id] = 0;
           continue;
         }
+        // Brood died mid-carry (combat, starvation, etc.). Drop the carry
+        // and return to Idle. The dead brood will be swap-removed from
+        // colony.eggs/larvae at step 5 (tickDeathCleanup) on the next tick.
+        if (ants.alive[broodId] !== 1) {
+          ants.carryingBroodId[id]    = -1;
+          // carriedBy[broodId] is left as-is (the brood is dead — it
+          // doesn't matter, and the entity slot may be recycled later).
+          ants.task[id]    = AntTask.Idle;
+          ants.subTask[id] = 0;
+          continue;
+        }
         // Sync brood position to carrier (every tick — the renderer reads
         // posX/posY directly).
         ants.posX[broodId] = ants.posX[id]!;
@@ -917,10 +928,14 @@ function findUncarriedBroodOnTile(
 ): number {
   const ants = world.ants;
   let pickId = -1;
+  // "Uncarried" means carriedBy === -1 OR the carrier is dead (orphan
+  // case — carrier died mid-carry and the brood needs reclaiming).
+  // Mirrors the same dead-carrier exception in computeNursingPickupField.
   for (let i = 0; i < colony.eggs.length; i++) {
     const bid = colony.eggs[i]!;
     if (ants.alive[bid] !== 1) continue;
-    if (ants.carriedBy[bid] !== -1) continue;
+    const cby = ants.carriedBy[bid]!;
+    if (cby !== -1 && ants.alive[cby] === 1) continue;
     const bx = ants.posX[bid]! >> FP_SHIFT;
     const by = ants.posY[bid]! >> FP_SHIFT;
     if (bx !== tileX || by !== tileY) continue;
@@ -929,7 +944,8 @@ function findUncarriedBroodOnTile(
   for (let i = 0; i < colony.larvae.length; i++) {
     const bid = colony.larvae[i]!;
     if (ants.alive[bid] !== 1) continue;
-    if (ants.carriedBy[bid] !== -1) continue;
+    const cby = ants.carriedBy[bid]!;
+    if (cby !== -1 && ants.alive[cby] === 1) continue;
     const bx = ants.posX[bid]! >> FP_SHIFT;
     const by = ants.posY[bid]! >> FP_SHIFT;
     if (bx !== tileX || by !== tileY) continue;

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -846,29 +846,39 @@ export function tickNurseActions(world: WorldState): void {
       const colony = world.colonies[colonyId];
       if (!colony) continue;
 
+      // Finite-nursing release — three cases (PR #56 codex P1 + P2).
+      // Any "no claim possible" path flips subTask to Feeding without a
+      // carry slot. Next tick the Feeding branch's defensive guard
+      // (carryingBroodId === -1) releases to Idle, mirroring the
+      // pre-v10 MovingToBrood→Feeding→Idle two-tick cadence. Without
+      // these releases, nurses without claimable brood would strand in
+      // MovingToBrood forever — step 10a only reallocates Idle ants.
+      //
+      // Case 1 (colony-level): no claimable brood exists anywhere in
+      // the colony — pickup field has no sources at all. The nurse may
+      // be mid-tunnel and never reach a source tile, so the release
+      // must fire regardless of her current tile. Covers brood
+      // matured/died/all-claimed mid-walk.
+      if (!colonyHasClaimableBrood(colony, ants)) {
+        ants.subTask[id] = NursingSubState.Feeding;
+        continue;
+      }
+
       const tileX = ants.posX[id]! >> FP_SHIFT;
       const tileY = ants.posY[id]! >> FP_SHIFT;
 
-      // Finite-nursing release (PR #56 codex P1 + P2). Any "no claim
-      // possible" path below routes through this helper: if the nurse
-      // has arrived at a source tile (Queen-chamber footprint, or —
-      // defensively — a Nursery footprint) flip to Feeding without
-      // setting a carry slot. Next tick the Feeding branch's defensive
-      // guard (carryingBroodId === -1) releases to Idle, mirroring the
-      // pre-v10 MovingToBrood→Feeding→Idle two-tick cadence. Without
-      // this, nurses without claimable brood would strand in
-      // MovingToBrood forever — step 10a only reallocates Idle ants.
+      // Cases 2 + 3 (tile-level): brood exists somewhere but pickup is
+      // gated for THIS nurse on THIS tile. Release only when she's on
+      // a source tile (i.e., she has actually arrived). An in-transit
+      // off-source nurse keeps walking — she'll reach a brood tile.
       const onSourceTile =
         isInsideQueenChamber(colony, tileX, tileY) ||
         isInsideNursery(colony, tileX, tileY);
 
-      // Symmetric with the pre-v10 P2 transport gate (the legacy path
-      // checks the same condition before calling transportBroodToNursery).
-      // Without a completed Nursery there is no destination — skip pickup.
-      // Defensive: allocateWorkers gates nurseCount on hasNursery, so a
-      // Nursing ant should never exist before a completed Nursery in
-      // normal flow. The release branch fires for migrated/corrupted/
-      // scripted state where a Nursing ant appears anyway.
+      // Case 2: no completed Nursery → no destination for the carry.
+      // Symmetric with the pre-v10 transport gate. Defensive — allocator
+      // gates nurseCount on hasNursery, so a Nursing ant should never
+      // exist before a completed Nursery in normal flow.
       if (!hasCompletedChamber(colony, ChamberType.Nursery)) {
         if (onSourceTile) ants.subTask[id] = NursingSubState.Feeding;
         continue;
@@ -880,6 +890,9 @@ export function tickNurseActions(world: WorldState): void {
       // selection order).
       const broodId = findUncarriedBroodOnTile(ants, colony, tileX, tileY);
       if (broodId < 0) {
+        // Case 3: brood exists in colony but not on this tile (lower-id
+        // nurse claimed first, brood inside Nursery, or arrived at a
+        // stale source tile). Release if on-source; keep walking otherwise.
         if (onSourceTile) ants.subTask[id] = NursingSubState.Feeding;
         continue;
       }
@@ -961,6 +974,41 @@ export function tickNurseActions(world: WorldState): void {
  * larvae and picks the lowest entity id for determinism (matches the pre-
  * v10 transportBroodToNursery selection order).
  */
+/**
+ * Issue #17 Phase 1 — true iff `colony` owns at least one alive,
+ * reclaimable, OUTSIDE-Nursery brood entity (egg or larva). Equivalent
+ * to "the v10 nursing pickup field has at least one source." Both
+ * `computeNursingPickupField` (BFS seeding) and `findUncarriedBroodOnTile`
+ * (per-tile pickup match) apply the same filter: alive AND
+ * (uncarried OR carrier-dead) AND outside any Nursery footprint.
+ *
+ * Used by tickNurseActions to release MovingToBrood nurses to Idle when
+ * the pickup pool is empty — without this the nurse would strand mid-
+ * tunnel forever (no field source → can't pathfind anywhere → never
+ * reaches a source tile → finite-nursing release never fires). Brood
+ * already inside the Nursery footprint is intentionally excluded
+ * because it has already been delivered — no carry needed.
+ */
+function colonyHasClaimableBrood(colony: ColonyRecord, ants: AntComponents): boolean {
+  for (let i = 0; i < colony.eggs.length; i++) {
+    const bid = colony.eggs[i]!;
+    if (!isBroodReclaimable(ants, bid)) continue;
+    const tx = ants.posX[bid]! >> FP_SHIFT;
+    const ty = ants.posY[bid]! >> FP_SHIFT;
+    if (isInsideNursery(colony, tx, ty)) continue;
+    return true;
+  }
+  for (let i = 0; i < colony.larvae.length; i++) {
+    const bid = colony.larvae[i]!;
+    if (!isBroodReclaimable(ants, bid)) continue;
+    const tx = ants.posX[bid]! >> FP_SHIFT;
+    const ty = ants.posY[bid]! >> FP_SHIFT;
+    if (isInsideNursery(colony, tx, ty)) continue;
+    return true;
+  }
+  return false;
+}
+
 function findUncarriedBroodOnTile(
   ants: AntComponents,
   colony: ColonyRecord,

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -48,7 +48,7 @@ import {
   type SurfaceMovementCache,
 } from '../surface-features.js';
 import type { AntComponents } from './ant-store.js';
-import { isRecentTile, pushRecentTile, clearRecentTiles } from './ant-store.js';
+import { isRecentTile, pushRecentTile, clearRecentTiles, isBroodReclaimable } from './ant-store.js';
 import type { ColonyRecord, ChamberRecord } from '../colony/colony-store.js';
 import { hasCompletedChamber, isFoodChamberDepositable } from '../colony/colony-system.js';
 import { AntTask, ForagingSubState, DiggingSubState, NursingSubState, ChamberType, PheromoneType } from '../enums.js';
@@ -815,8 +815,10 @@ export function tickNurseActions(world: WorldState): void {
         // colony.eggs/larvae at step 5 (tickDeathCleanup) on the next tick.
         if (ants.alive[broodId] !== 1) {
           ants.carryingBroodId[id]    = -1;
-          // carriedBy[broodId] is left as-is (the brood is dead — it
-          // doesn't matter, and the entity slot may be recycled later).
+          // carriedBy[broodId] is left as-is — the brood is dead and will
+          // be swap-removed from colony.eggs/larvae at the next step 5
+          // tickDeathCleanup. Entity ids are not recycled (PRD §3), so
+          // the stale carriedBy is harmless.
           ants.task[id]    = AntTask.Idle;
           ants.subTask[id] = 0;
           continue;
@@ -843,6 +845,13 @@ export function tickNurseActions(world: WorldState): void {
       const colonyId = ants.colonyId[id]!;
       const colony = world.colonies[colonyId];
       if (!colony) continue;
+      // Symmetric with the pre-v10 P2 transport gate (the legacy path
+      // checks the same condition before calling transportBroodToNursery).
+      // Without a completed Nursery, there is no destination, so a v10
+      // pickup would strand the carrier in Feeding forever holding the
+      // brood. Skip pickup so nurses cycle Idle harmlessly until a
+      // Nursery exists.
+      if (!hasCompletedChamber(colony, ChamberType.Nursery)) continue;
 
       const tileX = ants.posX[id]! >> FP_SHIFT;
       const tileY = ants.posY[id]! >> FP_SHIFT;
@@ -928,14 +937,12 @@ function findUncarriedBroodOnTile(
 ): number {
   const ants = world.ants;
   let pickId = -1;
-  // "Uncarried" means carriedBy === -1 OR the carrier is dead (orphan
-  // case — carrier died mid-carry and the brood needs reclaiming).
-  // Mirrors the same dead-carrier exception in computeNursingPickupField.
+  // Reclaimable = alive AND (uncarried OR carrier is dead). Shared with
+  // computeNursingPickupField via `isBroodReclaimable` so the two consumers
+  // can never drift.
   for (let i = 0; i < colony.eggs.length; i++) {
     const bid = colony.eggs[i]!;
-    if (ants.alive[bid] !== 1) continue;
-    const cby = ants.carriedBy[bid]!;
-    if (cby !== -1 && ants.alive[cby] === 1) continue;
+    if (!isBroodReclaimable(ants, bid)) continue;
     const bx = ants.posX[bid]! >> FP_SHIFT;
     const by = ants.posY[bid]! >> FP_SHIFT;
     if (bx !== tileX || by !== tileY) continue;
@@ -943,9 +950,7 @@ function findUncarriedBroodOnTile(
   }
   for (let i = 0; i < colony.larvae.length; i++) {
     const bid = colony.larvae[i]!;
-    if (ants.alive[bid] !== 1) continue;
-    const cby = ants.carriedBy[bid]!;
-    if (cby !== -1 && ants.alive[cby] === 1) continue;
+    if (!isBroodReclaimable(ants, bid)) continue;
     const bx = ants.posX[bid]! >> FP_SHIFT;
     const by = ants.posY[bid]! >> FP_SHIFT;
     if (bx !== tileX || by !== tileY) continue;
@@ -955,15 +960,69 @@ function findUncarriedBroodOnTile(
 }
 
 /**
+ * Issue #17 Phase 1 — compute the fixed-point Nursery deposit position for
+ * brood `broodId`, spread across all Open tiles in the colony's Nursery
+ * chambers via `broodId % openCount` in row-major order. Returns `null` if
+ * no underground grid OR no Open Nursery tile exists. Shared by the v10
+ * `depositCarriedBrood` (visible-carry deposit) and the pre-v10
+ * `transportBroodToNursery` (legacy teleport) so both produce byte-
+ * identical deposit positions for the same inputs.
+ */
+function computeNurseryDepositPosition(
+  world: WorldState,
+  colony: ColonyRecord,
+  broodId: number,
+): { x: number; y: number } | null {
+  const underground = world.undergroundGrids[colony.colonyId];
+  if (!underground) return null;
+
+  let openCount = 0;
+  for (let c = 0; c < colony.chambers.length; c++) {
+    const ch = colony.chambers[c]!;
+    if (ch.chamberType !== ChamberType.Nursery) continue;
+    const bx = ch.posX >> FP_SHIFT;
+    const by = ch.posY >> FP_SHIFT;
+    for (let ty = 0; ty < ch.height; ty++) {
+      for (let tx = 0; tx < ch.width; tx++) {
+        if (ugGet(underground, bx + tx, by + ty) === UndergroundTileState.Open) openCount++;
+      }
+    }
+  }
+  if (openCount === 0) return null;
+
+  // broodId is a non-negative entity ID, so the modulo is always in
+  // [0, openCount) without the negative-fold guard moveQueens needs.
+  const targetIndex = broodId % openCount;
+  let cursor = 0;
+  for (let c = 0; c < colony.chambers.length; c++) {
+    const ch = colony.chambers[c]!;
+    if (ch.chamberType !== ChamberType.Nursery) continue;
+    const bx = ch.posX >> FP_SHIFT;
+    const by = ch.posY >> FP_SHIFT;
+    for (let ty = 0; ty < ch.height; ty++) {
+      for (let tx = 0; tx < ch.width; tx++) {
+        const cx = bx + tx;
+        const cy = by + ty;
+        if (ugGet(underground, cx, cy) !== UndergroundTileState.Open) continue;
+        if (cursor === targetIndex) {
+          return {
+            x: (cx << FP_SHIFT) + (FP_ONE >> 1),
+            y: (cy << FP_SHIFT) + (FP_ONE >> 1),
+          };
+        }
+        cursor++;
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Issue #17 Phase 1 — v10 deposit. The carrier (`nurseId`) has just arrived
  * at a tile inside a Nursery footprint while carrying brood `broodId`.
  * Place the brood at a Nursery Open tile (spread by `broodId % openCount`,
  * matching the pre-v10 `transportBroodToNursery` distribution), then clear
  * the carry slot on both ends and return the carrier to Idle.
- *
- * The spread index intentionally re-uses the brood's own entity id so
- * successive deposits fan out across Nursery tiles instead of stacking on
- * the first one (issue #21 contract — same as the legacy teleport).
  *
  * No allocations, no RNG.
  */
@@ -974,59 +1033,13 @@ function depositCarriedBrood(
   broodId: number,
 ): void {
   const ants = world.ants;
-  const underground = world.undergroundGrids[colony.colonyId];
-
-  // Count Open tiles across every Nursery chamber, then pick
-  // `broodId % openCount` in row-major order. Symmetric with the pre-v10
-  // teleport so sim-version-agnostic deposit positions match.
-  let openCount = 0;
-  if (underground) {
-    for (let c = 0; c < colony.chambers.length; c++) {
-      const ch = colony.chambers[c]!;
-      if (ch.chamberType !== ChamberType.Nursery) continue;
-      const bx = ch.posX >> FP_SHIFT;
-      const by = ch.posY >> FP_SHIFT;
-      for (let ty = 0; ty < ch.height; ty++) {
-        for (let tx = 0; tx < ch.width; tx++) {
-          if (ugGet(underground, bx + tx, by + ty) === UndergroundTileState.Open) openCount++;
-        }
-      }
-    }
-  }
-
-  // Default deposit coordinates: the carrier's own tile (which is already
-  // inside the Nursery — caller checked isInsideNursery). Used when no
-  // Open tile is enumerable (test harness without a grid, or every
-  // Nursery tile somehow non-Open).
-  let depositX = ants.posX[nurseId]!;
-  let depositY = ants.posY[nurseId]!;
-
-  if (underground && openCount > 0) {
-    const targetIndex = broodId % openCount;
-    let cursor = 0;
-    outer: for (let c = 0; c < colony.chambers.length; c++) {
-      const ch = colony.chambers[c]!;
-      if (ch.chamberType !== ChamberType.Nursery) continue;
-      const bx = ch.posX >> FP_SHIFT;
-      const by = ch.posY >> FP_SHIFT;
-      for (let ty = 0; ty < ch.height; ty++) {
-        for (let tx = 0; tx < ch.width; tx++) {
-          const cx = bx + tx;
-          const cy = by + ty;
-          if (ugGet(underground, cx, cy) !== UndergroundTileState.Open) continue;
-          if (cursor === targetIndex) {
-            depositX = (cx << FP_SHIFT) + (FP_ONE >> 1);
-            depositY = (cy << FP_SHIFT) + (FP_ONE >> 1);
-            break outer;
-          }
-          cursor++;
-        }
-      }
-    }
-  }
-
-  ants.posX[broodId] = depositX;
-  ants.posY[broodId] = depositY;
+  const pos = computeNurseryDepositPosition(world, colony, broodId);
+  // Fallback: if the helper returns null (no grid, no Open Nursery tile —
+  // test-harness or pathological state), keep the brood at the carrier's
+  // current tile. Never reachable in production because the v10 path only
+  // runs when nurseDeposit routed the carrier onto a Nursery tile.
+  ants.posX[broodId] = pos !== null ? pos.x : ants.posX[nurseId]!;
+  ants.posY[broodId] = pos !== null ? pos.y : ants.posY[nurseId]!;
   ants.zone[broodId] = Zone.Underground;
   ants.currentGridColonyId[broodId] = colony.colonyId;
   // Clear both ends of the carry pointer.
@@ -1076,66 +1089,27 @@ function transportBroodToNursery(world: WorldState, colony: ColonyRecord): void 
   }
   if (pickId < 0) return;
 
-  // 2. Distribute across all Nursery Open tiles (issue #21). Pre-fix the
-  //    transport always picked the first Open tile in row-major order across
-  //    the first Nursery chamber, so successive brood stacked at one corner.
-  //    Now: count Open tiles across every Nursery chamber the colony owns,
-  //    then deposit at index `pickId % openCount` in row-major order. Using
-  //    pickId (the brood's own entity ID) gives a deterministic, replay-safe
-  //    spread that fans out as new brood is transported — different IDs land
-  //    on different tiles. Same two-pass count/find pattern as moveQueens.
+  // 2. Compute the deposit position via the shared helper — issue #21
+  //    spread across all Nursery Open tiles by `pickId % openCount` in
+  //    row-major order. Same source as the v10 `depositCarriedBrood` so
+  //    legacy teleport and visible carry produce byte-identical deposit
+  //    positions for the same inputs.
   //
   // Phase 09.1 Chunk 0 disposition: own-colony chamber membership — brood
   // is transported into its own colony's Nursery chamber, never into an
   // enemy grid. Keeping colony.colonyId here is safe-by-construction (brood
   // never invades). Parallel to colony-system.ts:376/431 dispositions.
-  const underground = world.undergroundGrids[colony.colonyId];
-  if (!underground) return;
-
-  let openCount = 0;
-  for (let c = 0; c < colony.chambers.length; c++) {
-    const ch = colony.chambers[c]!;
-    if (ch.chamberType !== ChamberType.Nursery) continue;
-    const bx = ch.posX >> FP_SHIFT;
-    const by = ch.posY >> FP_SHIFT;
-    for (let ty = 0; ty < ch.height; ty++) {
-      for (let tx = 0; tx < ch.width; tx++) {
-        if (ugGet(underground, bx + tx, by + ty) === UndergroundTileState.Open) openCount++;
-      }
-    }
-  }
-  if (openCount === 0) return;
-
-  // pickId is a non-negative entity ID, so the modulo is always in
-  // [0, openCount) without the negative-fold guard moveQueens needs.
-  const targetIndex = pickId % openCount;
-  let cursor = 0;
-  for (let c = 0; c < colony.chambers.length; c++) {
-    const ch = colony.chambers[c]!;
-    if (ch.chamberType !== ChamberType.Nursery) continue;
-    const bx = ch.posX >> FP_SHIFT;
-    const by = ch.posY >> FP_SHIFT;
-    for (let ty = 0; ty < ch.height; ty++) {
-      for (let tx = 0; tx < ch.width; tx++) {
-        const cx = bx + tx;
-        const cy = by + ty;
-        if (ugGet(underground, cx, cy) !== UndergroundTileState.Open) continue;
-        if (cursor === targetIndex) {
-          // Fixed-point tile-center position.
-          ants.posX[pickId] = (cx << FP_SHIFT) + (FP_ONE >> 1);
-          ants.posY[pickId] = (cy << FP_SHIFT) + (FP_ONE >> 1);
-          ants.zone[pickId] = Zone.Underground;
-          // Phase 09.1 Chunk 0 — descent invariant. Brood teleported into
-          // nursery now occupies that colony's grid. Today brood is in its
-          // OWN colony so colony.colonyId === ants.colonyId[pickId] and this
-          // is a byte-identical no-op.
-          ants.currentGridColonyId[pickId] = colony.colonyId;
-          return;
-        }
-        cursor++;
-      }
-    }
-  }
+  const pos = computeNurseryDepositPosition(world, colony, pickId);
+  if (pos === null) return; // no grid OR no Open Nursery tile — skip teleport
+  // Fixed-point tile-center position.
+  ants.posX[pickId] = pos.x;
+  ants.posY[pickId] = pos.y;
+  ants.zone[pickId] = Zone.Underground;
+  // Phase 09.1 Chunk 0 — descent invariant. Brood teleported into nursery
+  // now occupies that colony's grid. Today brood is in its OWN colony so
+  // colony.colonyId === ants.colonyId[pickId] and this is a byte-identical
+  // no-op.
+  ants.currentGridColonyId[pickId] = colony.colonyId;
 }
 
 function isInsideNursery(colony: ColonyRecord, tileX: number, tileY: number): boolean {
@@ -4250,6 +4224,16 @@ function resolveSameColonyOccupancy(world: WorldState): void {
 
   for (let id = 0; id < world.nextEntityId; id++) {
     if (ants.alive[id] !== 1) continue;
+
+    // Issue #17 Phase 1 — brood entities currently being carried by an alive
+    // nurse follow the nurse's position via `tickNurseActions` step 16c sync,
+    // so they MUST NOT participate in occupancy displacement. Otherwise the
+    // resolver would bump the brood off the carrier's tile every tick of in-
+    // tunnel transit, the next 16c sync would snap it back, and the player
+    // would see a 1-tile-jitter visual artifact + the carry render offset
+    // would briefly appear above an empty tile.
+    const carrierId = ants.carriedBy[id]!;
+    if (carrierId !== -1 && ants.alive[carrierId] === 1) continue;
 
     const colonyId = ants.colonyId[id]!;
     const zone = ants.zone[id]!;

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -37,6 +37,7 @@ import {
   SIM_VERSION_V6_FORAGER_NO_REVISIT,
   SIM_VERSION_V7_SURFACE_PASSABILITY,
   SIM_VERSION_V8_LEASH_HYSTERESIS,
+  SIM_VERSION_V10_VISIBLE_BROOD_CARRY,
   type WorldState,
 } from '../types.js';
 import {
@@ -774,12 +775,72 @@ export function tickForagerActions(world: WorldState): void {
  */
 export function tickNurseActions(world: WorldState): void {
   const ants = world.ants;
+  const v10 = world.simVersion >= SIM_VERSION_V10_VISIBLE_BROOD_CARRY;
 
   for (let id = 0; id < world.nextEntityId; id++) {
     if (ants.alive[id] !== 1) continue;
     if (ants.task[id] !== AntTask.Nursing) continue;
 
     const subTask = ants.subTask[id]!;
+
+    if (v10) {
+      // -----------------------------------------------------------------
+      // Issue #17 Phase 1 (v10+): visible brood carry.
+      //
+      // Substate semantics under v10:
+      //   MovingToBrood (0) — heading toward a brood pickup tile via the
+      //     `nursing` chamber-flow field (re-seeded each tick from Queen
+      //     Open tiles AND uncarried-brood-entity tiles outside Nursery).
+      //     On arrival at a tile that holds an alive uncarried brood,
+      //     claim it: set carryingBroodId/carriedBy, flip to Feeding.
+      //   Feeding (1) — Phase 1.4 will use this state for "carrying";
+      //     this commit only handles pickup. Carry/deposit logic lands
+      //     in the next commit so this commit's diff is reviewable in
+      //     isolation. Until then, a Feeding nurse with no carry slot
+      //     drops back to Idle (matches pre-v10 Feeding→Idle release).
+      // -----------------------------------------------------------------
+      if (subTask === NursingSubState.Feeding) {
+        // No carry slot set yet (Phase 1.3 only attaches it on pickup;
+        // the deposit-arrival branch lands in Phase 1.4). For now, mirror
+        // the pre-v10 Feeding→Idle release so a half-implemented v10
+        // build doesn't strand nurses in Feeding.
+        if (ants.carryingBroodId[id] === -1) {
+          ants.task[id]    = AntTask.Idle;
+          ants.subTask[id] = 0;
+        }
+        continue;
+      }
+      if (subTask !== NursingSubState.MovingToBrood) continue;
+
+      const colonyId = ants.colonyId[id]!;
+      const colony = world.colonies[colonyId];
+      if (!colony) continue;
+
+      const tileX = ants.posX[id]! >> FP_SHIFT;
+      const tileY = ants.posY[id]! >> FP_SHIFT;
+
+      // Find an alive uncarried brood entity standing on this tile.
+      // Iterate eggs first then larvae; pick the lowest entity id for
+      // determinism (matches the pre-v10 transportBroodToNursery
+      // selection order).
+      const broodId = findUncarriedBroodOnTile(world, colony, tileX, tileY);
+      if (broodId < 0) continue;
+
+      // Claim the brood. Set both ends of the carry pointer atomically.
+      ants.carryingBroodId[id]    = broodId;
+      ants.carriedBy[broodId]     = id;
+      ants.subTask[id]            = NursingSubState.Feeding;
+      // Carried brood is no longer a pickup seed — the next per-tick
+      // recompute of the `nursing` field in tick.ts step 9 will exclude
+      // it because `carriedBy[broodId] !== -1`. No dirty flag needed.
+      continue;
+    }
+
+    // -------------------------------------------------------------------
+    // Pre-v10 path (legacy teleport). Unchanged — Feeding→Idle release,
+    // MovingToBrood→Feeding flip on Queen/Nursery tile, then the
+    // transportBroodToNursery teleport.
+    // -------------------------------------------------------------------
 
     // Feeding → Idle: the dwell tick is already spent; release the ant.
     // Step 10a on the next tick sees an Idle ant and routes per allocation.
@@ -823,6 +884,41 @@ export function tickNurseActions(world: WorldState): void {
       transportBroodToNursery(world, colony);
     }
   }
+}
+
+/**
+ * Return the entity ID of an alive uncarried brood (egg or larva) standing
+ * on tile (tileX, tileY) for `colony`, or -1 if none. Iterates eggs then
+ * larvae and picks the lowest entity id for determinism (matches the pre-
+ * v10 transportBroodToNursery selection order).
+ */
+function findUncarriedBroodOnTile(
+  world: WorldState,
+  colony: ColonyRecord,
+  tileX: number,
+  tileY: number,
+): number {
+  const ants = world.ants;
+  let pickId = -1;
+  for (let i = 0; i < colony.eggs.length; i++) {
+    const bid = colony.eggs[i]!;
+    if (ants.alive[bid] !== 1) continue;
+    if (ants.carriedBy[bid] !== -1) continue;
+    const bx = ants.posX[bid]! >> FP_SHIFT;
+    const by = ants.posY[bid]! >> FP_SHIFT;
+    if (bx !== tileX || by !== tileY) continue;
+    if (pickId < 0 || bid < pickId) pickId = bid;
+  }
+  for (let i = 0; i < colony.larvae.length; i++) {
+    const bid = colony.larvae[i]!;
+    if (ants.alive[bid] !== 1) continue;
+    if (ants.carriedBy[bid] !== -1) continue;
+    const bx = ants.posX[bid]! >> FP_SHIFT;
+    const by = ants.posY[bid]! >> FP_SHIFT;
+    if (bx !== tileX || by !== tileY) continue;
+    if (pickId < 0 || bid < pickId) pickId = bid;
+  }
+  return pickId;
 }
 
 /**

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -859,7 +859,7 @@ export function tickNurseActions(world: WorldState): void {
       // be mid-tunnel and never reach a source tile, so the release
       // must fire regardless of her current tile. Covers brood
       // matured/died/all-claimed mid-walk.
-      if (!colonyHasClaimableBrood(colony, ants)) {
+      if (!colonyHasClaimableBrood(world, colony)) {
         ants.subTask[id] = NursingSubState.Feeding;
         continue;
       }
@@ -976,37 +976,62 @@ export function tickNurseActions(world: WorldState): void {
  */
 /**
  * Issue #17 Phase 1 — true iff `colony` owns at least one alive,
- * reclaimable, OUTSIDE-Nursery brood entity (egg or larva). Equivalent
- * to "the v10 nursing pickup field has at least one source." Both
- * `computeNursingPickupField` (BFS seeding) and `findUncarriedBroodOnTile`
- * (per-tile pickup match) apply the same filter: alive AND
- * (uncarried OR carrier-dead) AND outside any Nursery footprint.
+ * reclaimable, OUTSIDE-Nursery brood entity (egg or larva) on a tile
+ * that the pickup field would actually seed. Equivalent to "the v10
+ * nursing pickup field has at least one source." Filters mirror
+ * `computeNursingPickupField` exactly:
+ *   - alive AND (uncarried OR carrier-dead)            (isBroodReclaimable)
+ *   - outside any Nursery footprint                    (isInsideNursery)
+ *   - on an Open OR BeingDug tile                      (tile state)
  *
  * Used by tickNurseActions to release MovingToBrood nurses to Idle when
  * the pickup pool is empty — without this the nurse would strand mid-
  * tunnel forever (no field source → can't pathfind anywhere → never
- * reaches a source tile → finite-nursing release never fires). Brood
- * already inside the Nursery footprint is intentionally excluded
- * because it has already been delivered — no carry needed.
+ * reaches a source tile → finite-nursing release never fires).
+ *
+ * Tile-state filter parity (PR #56 codex P1 round 3): a carrier can die
+ * on a BeingDug tile, leaving the orphan brood there. The field seeds
+ * such tiles (BeingDug is reachable per canEnterUndergroundTile and the
+ * BFS expansion traverses it). Without the matching filter here, a
+ * brood on a Solid/Marked tile (theoretically impossible — defensive
+ * only) would be counted as claimable but never seeded → strand.
  */
-function colonyHasClaimableBrood(colony: ColonyRecord, ants: AntComponents): boolean {
+function colonyHasClaimableBrood(
+  world: WorldState,
+  colony: ColonyRecord,
+): boolean {
+  const ants = world.ants;
+  const underground = world.undergroundGrids[colony.colonyId];
   for (let i = 0; i < colony.eggs.length; i++) {
-    const bid = colony.eggs[i]!;
-    if (!isBroodReclaimable(ants, bid)) continue;
-    const tx = ants.posX[bid]! >> FP_SHIFT;
-    const ty = ants.posY[bid]! >> FP_SHIFT;
-    if (isInsideNursery(colony, tx, ty)) continue;
-    return true;
+    if (isReclaimableBroodSeedable(ants, colony, underground, colony.eggs[i]!)) return true;
   }
   for (let i = 0; i < colony.larvae.length; i++) {
-    const bid = colony.larvae[i]!;
-    if (!isBroodReclaimable(ants, bid)) continue;
-    const tx = ants.posX[bid]! >> FP_SHIFT;
-    const ty = ants.posY[bid]! >> FP_SHIFT;
-    if (isInsideNursery(colony, tx, ty)) continue;
-    return true;
+    if (isReclaimableBroodSeedable(ants, colony, underground, colony.larvae[i]!)) return true;
   }
   return false;
+}
+
+/** Shared predicate: brood `bid` is reclaimable AND would seed the pickup field. */
+function isReclaimableBroodSeedable(
+  ants: AntComponents,
+  colony: ColonyRecord,
+  underground: UndergroundGrid | undefined,
+  bid: number,
+): boolean {
+  if (!isBroodReclaimable(ants, bid)) return false;
+  const tx = ants.posX[bid]! >> FP_SHIFT;
+  const ty = ants.posY[bid]! >> FP_SHIFT;
+  if (isInsideNursery(colony, tx, ty)) return false;
+  // Tile-state filter — must match computeNursingPickupField. Without an
+  // underground grid (test harness), assume the brood is on an Open
+  // tile so the predicate stays inclusive (matches the legacy behaviour
+  // where the field couldn't be computed anyway).
+  if (underground !== undefined) {
+    if (tx < 0 || tx >= underground.width || ty < 0 || ty >= underground.height) return false;
+    const state = ugGet(underground, tx, ty);
+    if (state !== UndergroundTileState.Open && state !== UndergroundTileState.BeingDug) return false;
+  }
+  return true;
 }
 
 function findUncarriedBroodOnTile(

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -845,16 +845,34 @@ export function tickNurseActions(world: WorldState): void {
       const colonyId = ants.colonyId[id]!;
       const colony = world.colonies[colonyId];
       if (!colony) continue;
-      // Symmetric with the pre-v10 P2 transport gate (the legacy path
-      // checks the same condition before calling transportBroodToNursery).
-      // Without a completed Nursery, there is no destination, so a v10
-      // pickup would strand the carrier in Feeding forever holding the
-      // brood. Skip pickup so nurses cycle Idle harmlessly until a
-      // Nursery exists.
-      if (!hasCompletedChamber(colony, ChamberType.Nursery)) continue;
 
       const tileX = ants.posX[id]! >> FP_SHIFT;
       const tileY = ants.posY[id]! >> FP_SHIFT;
+
+      // Finite-nursing release (PR #56 codex P1 + P2). Any "no claim
+      // possible" path below routes through this helper: if the nurse
+      // has arrived at a source tile (Queen-chamber footprint, or —
+      // defensively — a Nursery footprint) flip to Feeding without
+      // setting a carry slot. Next tick the Feeding branch's defensive
+      // guard (carryingBroodId === -1) releases to Idle, mirroring the
+      // pre-v10 MovingToBrood→Feeding→Idle two-tick cadence. Without
+      // this, nurses without claimable brood would strand in
+      // MovingToBrood forever — step 10a only reallocates Idle ants.
+      const onSourceTile =
+        isInsideQueenChamber(colony, tileX, tileY) ||
+        isInsideNursery(colony, tileX, tileY);
+
+      // Symmetric with the pre-v10 P2 transport gate (the legacy path
+      // checks the same condition before calling transportBroodToNursery).
+      // Without a completed Nursery there is no destination — skip pickup.
+      // Defensive: allocateWorkers gates nurseCount on hasNursery, so a
+      // Nursing ant should never exist before a completed Nursery in
+      // normal flow. The release branch fires for migrated/corrupted/
+      // scripted state where a Nursing ant appears anyway.
+      if (!hasCompletedChamber(colony, ChamberType.Nursery)) {
+        if (onSourceTile) ants.subTask[id] = NursingSubState.Feeding;
+        continue;
+      }
 
       // Find an alive uncarried brood entity standing on this tile.
       // Iterate eggs first then larvae; pick the lowest entity id for
@@ -862,22 +880,7 @@ export function tickNurseActions(world: WorldState): void {
       // selection order).
       const broodId = findUncarriedBroodOnTile(ants, colony, tileX, tileY);
       if (broodId < 0) {
-        // Finite-nursing release (PR #56 codex P1). A nurse that has
-        // arrived at a source tile (Queen-chamber footprint, or —
-        // defensively — a Nursery footprint) but found no claimable
-        // brood is done with this trip. Mirror the pre-v10 cadence:
-        // flip to Feeding WITHOUT setting a carry slot. Next tick the
-        // Feeding branch's defensive guard (carryingBroodId === -1)
-        // releases to Idle, matching the pre-v10
-        // MovingToBrood→Feeding→Idle two-tick path. Without this,
-        // nurses with no available brood would strand in MovingToBrood
-        // forever, permanently removed from the forage/dig/fight pool.
-        if (
-          isInsideQueenChamber(colony, tileX, tileY) ||
-          isInsideNursery(colony, tileX, tileY)
-        ) {
-          ants.subTask[id] = NursingSubState.Feeding;
-        }
+        if (onSourceTile) ants.subTask[id] = NursingSubState.Feeding;
         continue;
       }
 

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -793,20 +793,37 @@ export function tickNurseActions(world: WorldState): void {
       //     Open tiles AND uncarried-brood-entity tiles outside Nursery).
       //     On arrival at a tile that holds an alive uncarried brood,
       //     claim it: set carryingBroodId/carriedBy, flip to Feeding.
-      //   Feeding (1) — Phase 1.4 will use this state for "carrying";
-      //     this commit only handles pickup. Carry/deposit logic lands
-      //     in the next commit so this commit's diff is reviewable in
-      //     isolation. Until then, a Feeding nurse with no carry slot
-      //     drops back to Idle (matches pre-v10 Feeding→Idle release).
+      //   Feeding (1) — "carrying brood." The carrier syncs the brood's
+      //     position to its own each tick (so the renderer just draws the
+      //     brood at its own posX/posY). Movement step routes via
+      //     `nurseDeposit` (Nursery-only flow-field). On arrival at a
+      //     Nursery Open tile, deposit the brood and return to Idle.
       // -----------------------------------------------------------------
       if (subTask === NursingSubState.Feeding) {
-        // No carry slot set yet (Phase 1.3 only attaches it on pickup;
-        // the deposit-arrival branch lands in Phase 1.4). For now, mirror
-        // the pre-v10 Feeding→Idle release so a half-implemented v10
-        // build doesn't strand nurses in Feeding.
-        if (ants.carryingBroodId[id] === -1) {
+        const broodId = ants.carryingBroodId[id]!;
+        if (broodId === -1) {
+          // Defensive guard — Feeding without a carry slot is unreachable
+          // under normal v10 flow (pickup always sets the slot). If we
+          // hit it (state corruption, manual mutation), release back to
+          // Idle so the nurse doesn't strand.
           ants.task[id]    = AntTask.Idle;
           ants.subTask[id] = 0;
+          continue;
+        }
+        // Sync brood position to carrier (every tick — the renderer reads
+        // posX/posY directly).
+        ants.posX[broodId] = ants.posX[id]!;
+        ants.posY[broodId] = ants.posY[id]!;
+        ants.zone[broodId] = ants.zone[id]!;
+        ants.currentGridColonyId[broodId] = ants.currentGridColonyId[id]!;
+        // Check for Nursery-tile arrival → deposit.
+        const colonyId = ants.colonyId[id]!;
+        const colony = world.colonies[colonyId];
+        if (!colony) continue;
+        const tileX = ants.posX[id]! >> FP_SHIFT;
+        const tileY = ants.posY[id]! >> FP_SHIFT;
+        if (isInsideNursery(colony, tileX, tileY)) {
+          depositCarriedBrood(world, colony, id, broodId);
         }
         continue;
       }
@@ -919,6 +936,89 @@ function findUncarriedBroodOnTile(
     if (pickId < 0 || bid < pickId) pickId = bid;
   }
   return pickId;
+}
+
+/**
+ * Issue #17 Phase 1 — v10 deposit. The carrier (`nurseId`) has just arrived
+ * at a tile inside a Nursery footprint while carrying brood `broodId`.
+ * Place the brood at a Nursery Open tile (spread by `broodId % openCount`,
+ * matching the pre-v10 `transportBroodToNursery` distribution), then clear
+ * the carry slot on both ends and return the carrier to Idle.
+ *
+ * The spread index intentionally re-uses the brood's own entity id so
+ * successive deposits fan out across Nursery tiles instead of stacking on
+ * the first one (issue #21 contract — same as the legacy teleport).
+ *
+ * No allocations, no RNG.
+ */
+function depositCarriedBrood(
+  world: WorldState,
+  colony: ColonyRecord,
+  nurseId: number,
+  broodId: number,
+): void {
+  const ants = world.ants;
+  const underground = world.undergroundGrids[colony.colonyId];
+
+  // Count Open tiles across every Nursery chamber, then pick
+  // `broodId % openCount` in row-major order. Symmetric with the pre-v10
+  // teleport so sim-version-agnostic deposit positions match.
+  let openCount = 0;
+  if (underground) {
+    for (let c = 0; c < colony.chambers.length; c++) {
+      const ch = colony.chambers[c]!;
+      if (ch.chamberType !== ChamberType.Nursery) continue;
+      const bx = ch.posX >> FP_SHIFT;
+      const by = ch.posY >> FP_SHIFT;
+      for (let ty = 0; ty < ch.height; ty++) {
+        for (let tx = 0; tx < ch.width; tx++) {
+          if (ugGet(underground, bx + tx, by + ty) === UndergroundTileState.Open) openCount++;
+        }
+      }
+    }
+  }
+
+  // Default deposit coordinates: the carrier's own tile (which is already
+  // inside the Nursery — caller checked isInsideNursery). Used when no
+  // Open tile is enumerable (test harness without a grid, or every
+  // Nursery tile somehow non-Open).
+  let depositX = ants.posX[nurseId]!;
+  let depositY = ants.posY[nurseId]!;
+
+  if (underground && openCount > 0) {
+    const targetIndex = broodId % openCount;
+    let cursor = 0;
+    outer: for (let c = 0; c < colony.chambers.length; c++) {
+      const ch = colony.chambers[c]!;
+      if (ch.chamberType !== ChamberType.Nursery) continue;
+      const bx = ch.posX >> FP_SHIFT;
+      const by = ch.posY >> FP_SHIFT;
+      for (let ty = 0; ty < ch.height; ty++) {
+        for (let tx = 0; tx < ch.width; tx++) {
+          const cx = bx + tx;
+          const cy = by + ty;
+          if (ugGet(underground, cx, cy) !== UndergroundTileState.Open) continue;
+          if (cursor === targetIndex) {
+            depositX = (cx << FP_SHIFT) + (FP_ONE >> 1);
+            depositY = (cy << FP_SHIFT) + (FP_ONE >> 1);
+            break outer;
+          }
+          cursor++;
+        }
+      }
+    }
+  }
+
+  ants.posX[broodId] = depositX;
+  ants.posY[broodId] = depositY;
+  ants.zone[broodId] = Zone.Underground;
+  ants.currentGridColonyId[broodId] = colony.colonyId;
+  // Clear both ends of the carry pointer.
+  ants.carryingBroodId[nurseId] = -1;
+  ants.carriedBy[broodId]       = -1;
+  // Carrier returns to Idle; step 10a next tick re-allocates per ratio.
+  ants.task[nurseId]    = AntTask.Idle;
+  ants.subTask[nurseId] = 0;
 }
 
 /**
@@ -1131,8 +1231,20 @@ export function getTaskDirection(
     // instead of straight-line stepping into Solid dirt on bends. See the
     // seed-920076605 debug snapshot: ant 19 at (14,16) targeted Nursery
     // (13,9) and straight-line steering picked (14,15) = Solid every tick.
+    //
+    // Issue #17 Phase 1 (v10+): a nurse currently carrying a brood routes
+    // via the Nursery-only `nurseDeposit` field instead. Detection: subTask
+    // === Feeding AND carryingBroodId set. The empty-handed pickup phase
+    // (subTask = MovingToBrood) keeps using the `nursing` field, which v10
+    // re-seeds to Queen tiles + uncarried-brood tiles outside Nursery.
     if (chamberFlowFields !== undefined) {
-      const flowField = chamberFlowFields.nursing[colonyId];
+      const v10Carrying =
+        world.simVersion >= SIM_VERSION_V10_VISIBLE_BROOD_CARRY &&
+        ants.subTask[antId] === NursingSubState.Feeding &&
+        ants.carryingBroodId[antId] !== -1;
+      const flowField = v10Carrying
+        ? chamberFlowFields.nurseDeposit[colonyId]
+        : chamberFlowFields.nursing[colonyId];
       const underground = world.undergroundGrids[gridColonyId];
       if (flowField && underground) {
         const tileX = ants.posX[antId]! >> FP_SHIFT;

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -860,8 +860,19 @@ export function tickNurseActions(world: WorldState): void {
       // Iterate eggs first then larvae; pick the lowest entity id for
       // determinism (matches the pre-v10 transportBroodToNursery
       // selection order).
-      const broodId = findUncarriedBroodOnTile(world, colony, tileX, tileY);
+      const broodId = findUncarriedBroodOnTile(ants, colony, tileX, tileY);
       if (broodId < 0) continue;
+
+      // Defensive: if the brood was carried by a now-dead carrier
+      // (orphan reclaim path), null out the dead carrier's carryingBroodId
+      // slot so the both-ends-of-the-pointer invariant holds. killAnt
+      // intentionally leaves carry slots set so the brood stays at the
+      // death tile until reclaim; the cleanup happens here when we
+      // overwrite the brood's carriedBy below.
+      const oldCarrier = ants.carriedBy[broodId]!;
+      if (oldCarrier !== -1 && ants.alive[oldCarrier] !== 1) {
+        ants.carryingBroodId[oldCarrier] = -1;
+      }
 
       // Claim the brood. Set both ends of the carry pointer atomically.
       ants.carryingBroodId[id]    = broodId;
@@ -930,12 +941,20 @@ export function tickNurseActions(world: WorldState): void {
  * v10 transportBroodToNursery selection order).
  */
 function findUncarriedBroodOnTile(
-  world: WorldState,
+  ants: AntComponents,
   colony: ColonyRecord,
   tileX: number,
   tileY: number,
 ): number {
-  const ants = world.ants;
+  // The pickup gate already excluded the inside-Nursery case (the v10
+  // `nursing` chamber-flow field skips brood-inside-Nursery as seeds, so
+  // a nurse should never be routed here). Defensive guard mirrors the
+  // pre-v10 transportBroodToNursery selection invariant — without this,
+  // a v10 nurse who incidentally walks onto a Nursery tile holding a
+  // deposited brood (e.g. immediately after Idle→Nursing re-allocation)
+  // would re-pick-up the brood and re-shuffle it via broodId%openCount,
+  // visible as occasional brood teleports inside the Nursery.
+  if (isInsideNursery(colony, tileX, tileY)) return -1;
   let pickId = -1;
   // Reclaimable = alive AND (uncarried OR carrier is dead). Shared with
   // computeNursingPickupField via `isBroodReclaimable` so the two consumers

--- a/src/sim/chamber-flow.ts
+++ b/src/sim/chamber-flow.ts
@@ -96,6 +96,57 @@ export function ensureChamberFlowFields(
 }
 
 /**
+ * Shared BFS expansion for chamber-style flow-fields. Caller seeds `out`
+ * with -1 at every source tile (and fills the rest with -2 first), pushes
+ * each source's flat index into `queue`, and passes the resulting tail
+ * pointer. This function expands outward through Open and BeingDug tiles,
+ * writing the step direction (0=N, 1=E, 2=S, 3=W) to `out[idx]` for each
+ * reached tile.
+ *
+ * Single-sourced so the integer-division `(idx / width) | 0` BFS row
+ * extraction lives in ONE place — extracted from the previously
+ * duplicated implementations in `computeChamberFlowField` and
+ * `computeNursingPickupField` (PR #56 codex P2).
+ */
+function bfsExpandSeededField(
+  out:        Int32Array,
+  queue:      Int32Array,
+  initialTail: number,
+  data:       Uint8Array,
+  width:      number,
+  height:     number,
+): void {
+  let head = 0;
+  let tail = initialTail;
+  while (head < tail) {
+    const idx = queue[head++]!;
+    // eslint-disable-next-line no-restricted-syntax -- integer division via `| 0`; BFS index→row conversion, not fixed-point math
+    const row = (idx / width) | 0;
+    const col = idx % width;
+
+    for (let d = 0; d < 4; d++) {
+      const nRow = row + NEIGHBOR_DR[d]!;
+      const nCol = col + NEIGHBOR_DC[d]!;
+      if (nRow < 0 || nRow >= height || nCol < 0 || nCol >= width) continue;
+
+      const nIdx = nRow * width + nCol;
+      if (out[nIdx] !== -2) continue;
+
+      const tileState = data[nIdx]!;
+      if (
+        tileState !== UndergroundTileState.Open &&
+        tileState !== UndergroundTileState.BeingDug
+      ) {
+        continue;
+      }
+
+      out[nIdx] = REVERSE[d]!;
+      queue[tail++] = nIdx;
+    }
+  }
+}
+
+/**
  * Multi-source BFS from every Open tile inside any chamber whose type is
  * present in `chamberTypes` AND (optionally) passes `chamberFilter`.
  * Expands through Open and BeingDug tiles. Marked and Solid are walls
@@ -130,7 +181,6 @@ export function computeChamberFlowField(
 
   out.fill(-2);
 
-  let head = 0;
   let tail = 0;
 
   // Seed every Open tile inside any matching chamber footprint.
@@ -159,33 +209,7 @@ export function computeChamberFlowField(
     }
   }
 
-  // BFS expansion through Open and BeingDug only.
-  while (head < tail) {
-    const idx = queue[head++]!;
-    // eslint-disable-next-line no-restricted-syntax -- integer division via `| 0`; BFS index→row conversion, not fixed-point math
-    const row = (idx / width) | 0;
-    const col = idx % width;
-
-    for (let d = 0; d < 4; d++) {
-      const nRow = row + NEIGHBOR_DR[d]!;
-      const nCol = col + NEIGHBOR_DC[d]!;
-      if (nRow < 0 || nRow >= height || nCol < 0 || nCol >= width) continue;
-
-      const nIdx = nRow * width + nCol;
-      if (out[nIdx] !== -2) continue;
-
-      const tileState = data[nIdx]!;
-      if (
-        tileState !== UndergroundTileState.Open &&
-        tileState !== UndergroundTileState.BeingDug
-      ) {
-        continue;
-      }
-
-      out[nIdx] = REVERSE[d]!;
-      queue[tail++] = nIdx;
-    }
-  }
+  bfsExpandSeededField(out, queue, tail, data, width, height);
 }
 
 /** Chamber type lists exported so callers don't hard-code the arrays. */
@@ -246,7 +270,6 @@ export function computeNursingPickupField(
 
   out.fill(-2);
 
-  let head = 0;
   let tail = 0;
 
   // Seed (1): Queen chamber Open tiles.
@@ -315,32 +338,5 @@ export function computeNursingPickupField(
     }
   }
 
-  // BFS expansion through Open and BeingDug only — same contract as
-  // computeChamberFlowField.
-  while (head < tail) {
-    const idx = queue[head++]!;
-    // eslint-disable-next-line no-restricted-syntax -- integer division via `| 0`; BFS index→row conversion, not fixed-point math
-    const row = (idx / width) | 0;
-    const col = idx % width;
-
-    for (let d = 0; d < 4; d++) {
-      const nRow = row + NEIGHBOR_DR[d]!;
-      const nCol = col + NEIGHBOR_DC[d]!;
-      if (nRow < 0 || nRow >= height || nCol < 0 || nCol >= width) continue;
-
-      const nIdx = nRow * width + nCol;
-      if (out[nIdx] !== -2) continue;
-
-      const tileState = data[nIdx]!;
-      if (
-        tileState !== UndergroundTileState.Open &&
-        tileState !== UndergroundTileState.BeingDug
-      ) {
-        continue;
-      }
-
-      out[nIdx] = REVERSE[d]!;
-      queue[tail++] = nIdx;
-    }
-  }
+  bfsExpandSeededField(out, queue, tail, data, width, height);
 }

--- a/src/sim/chamber-flow.ts
+++ b/src/sim/chamber-flow.ts
@@ -218,17 +218,18 @@ export const NURSERY_CHAMBER_TYPES: ReadonlyArray<ChamberType> = [ChamberType.Nu
  * (-1 = source, -2 = unreachable, 0..3 = step N/E/S/W).
  *
  * Deterministic: chamber seed order is chamber array order × row-major
- * footprint; brood seed order is `broodIds` array order. Duplicate sources
- * are idempotent (the `out[idx] !== -2` guard skips re-seeding).
+ * footprint; brood seed order is eggIds first then larvaeIds, each in
+ * array order. Duplicate sources are idempotent (the `out[idx] !== -2`
+ * guard skips re-seeding).
  *
  * @param underground Colony underground grid (read-only).
  * @param chambers    Colony chambers (used for Queen seeds and Nursery
  *                    footprints — the Nursery footprints are read to
  *                    exclude brood already deposited).
- * @param posX/posY/alive/carriedBy The same SoA arrays from `world.ants`.
- * @param broodIds    Concatenation of `colony.eggs` and `colony.larvae`
- *                    for the colony being computed. The function does NOT
- *                    care about order beyond determinism.
+ * @param ants        The world.ants AntComponents struct (reads
+ *                    posX/posY/alive/carriedBy via isBroodReclaimable).
+ * @param eggIds      colony.eggs for the colony being computed.
+ * @param larvaeIds   colony.larvae for the colony being computed.
  * @param out         Pre-allocated Int32Array of length W*H. Filled in-place.
  * @param queue       Pre-allocated Int32Array of length W*H for BFS queue.
  */

--- a/src/sim/chamber-flow.ts
+++ b/src/sim/chamber-flow.ts
@@ -2,15 +2,23 @@
 //
 // Analogue of src/sim/entrance-flow.ts, but seeded from every Open tile
 // inside a chamber footprint instead of from entrance shaft tops. Maintains
-// three per-colony flow-fields:
-//   - food    : seeded from Open tiles inside FoodStorage chambers.
-//               Consumed by Underground carrying foragers routing to deposit.
-//   - nursing : seeded from Open tiles inside Queen OR Nursery chambers.
-//               Consumed by Nursing ants routing to tend brood.
-//   - queen   : seeded from Open tiles inside Queen chambers only.
-//               Consumed by the queen entity when routing from her current
-//               underground tile to the Queen chamber footprint (PRD §4b —
-//               queen relocates once a Queen chamber is completed).
+// four per-colony flow-fields:
+//   - food         : seeded from Open tiles inside FoodStorage chambers.
+//                    Consumed by Underground carrying foragers routing to deposit.
+//   - nursing      : pre-v10: seeded from Open tiles inside Queen OR Nursery
+//                    chambers. v10+: re-seeded from Queen Open tiles AND any
+//                    uncarried-brood-entity tile outside Nursery (the
+//                    "pickup" field; tickNurseActions handles the v10
+//                    re-seed via the same compute function).
+//                    Consumed by Nursing ants routing to brood pickup.
+//   - queen        : seeded from Open tiles inside Queen chambers only.
+//                    Consumed by the queen entity when routing from her current
+//                    underground tile to the Queen chamber footprint (PRD §4b —
+//                    queen relocates once a Queen chamber is completed).
+//   - nurseDeposit : seeded from Open tiles inside Nursery chambers only.
+//                    Consumed by v10+ nurses currently carrying a brood
+//                    (subTask=Feeding under simVersion >= 10) routing to
+//                    deposit. Issue #17 Phase 1.
 //
 // Why a dedicated field per target class rather than one shared field:
 // each consumer targets a different set of chamber types. Sharing a single
@@ -41,20 +49,22 @@ const NEIGHBOR_DC = [0, 1, 0, -1] as const;
 /**
  * Per-colony flow-field cache for chamber-targeted routing.
  *
- * `food`, `nursing`, and `queen` are parallel Int32Arrays of length W*H
- * indexed by tileY * width + tileX. `queues` is a single BFS scratch queue
- * per colony reused across the compute calls (BFS is sequential, never
- * concurrent).
+ * `food`, `nursing`, `queen`, and `nurseDeposit` are parallel Int32Arrays of
+ * length W*H indexed by tileY * width + tileX. `queues` is a single BFS
+ * scratch queue per colony reused across the compute calls (BFS is
+ * sequential, never concurrent).
  */
 export interface ChamberFlowFields {
   food: Record<ColonyId, Int32Array>;
   nursing: Record<ColonyId, Int32Array>;
   queen: Record<ColonyId, Int32Array>;
+  /** Issue #17 Phase 1 — Nursery-only deposit field for v10 carrying nurses. */
+  nurseDeposit: Record<ColonyId, Int32Array>;
   queues: Record<ColonyId, Int32Array>;
 }
 
 export function createChamberFlowFields(): ChamberFlowFields {
-  return { food: {}, nursing: {}, queen: {}, queues: {} };
+  return { food: {}, nursing: {}, queen: {}, nurseDeposit: {}, queues: {} };
 }
 
 /**
@@ -68,16 +78,18 @@ export function ensureChamberFlowFields(
   cache: ChamberFlowFields,
   colonyId: ColonyId,
   gridSize: number,
-): { food: Int32Array; nursing: Int32Array; queen: Int32Array; queue: Int32Array } {
-  if (!(colonyId in cache.food))    cache.food[colonyId]    = new Int32Array(gridSize);
-  if (!(colonyId in cache.nursing)) cache.nursing[colonyId] = new Int32Array(gridSize);
-  if (!(colonyId in cache.queen))   cache.queen[colonyId]   = new Int32Array(gridSize);
-  if (!(colonyId in cache.queues))  cache.queues[colonyId]  = new Int32Array(gridSize);
+): { food: Int32Array; nursing: Int32Array; queen: Int32Array; nurseDeposit: Int32Array; queue: Int32Array } {
+  if (!(colonyId in cache.food))         cache.food[colonyId]         = new Int32Array(gridSize);
+  if (!(colonyId in cache.nursing))      cache.nursing[colonyId]      = new Int32Array(gridSize);
+  if (!(colonyId in cache.queen))        cache.queen[colonyId]        = new Int32Array(gridSize);
+  if (!(colonyId in cache.nurseDeposit)) cache.nurseDeposit[colonyId] = new Int32Array(gridSize);
+  if (!(colonyId in cache.queues))       cache.queues[colonyId]       = new Int32Array(gridSize);
   return {
-    food:    cache.food[colonyId]!,
-    nursing: cache.nursing[colonyId]!,
-    queen:   cache.queen[colonyId]!,
-    queue:   cache.queues[colonyId]!,
+    food:         cache.food[colonyId]!,
+    nursing:      cache.nursing[colonyId]!,
+    queen:        cache.queen[colonyId]!,
+    nurseDeposit: cache.nurseDeposit[colonyId]!,
+    queue:        cache.queues[colonyId]!,
   };
 }
 
@@ -181,3 +193,5 @@ export const NURSING_CHAMBER_TYPES: ReadonlyArray<ChamberType> = [
   ChamberType.Nursery,
 ];
 export const QUEEN_CHAMBER_TYPES: ReadonlyArray<ChamberType> = [ChamberType.Queen];
+/** Issue #17 Phase 1 — Nursery-only seeds for the v10 nurseDeposit field. */
+export const NURSERY_CHAMBER_TYPES: ReadonlyArray<ChamberType> = [ChamberType.Nursery];

--- a/src/sim/chamber-flow.ts
+++ b/src/sim/chamber-flow.ts
@@ -226,30 +226,27 @@ export const NURSERY_CHAMBER_TYPES: ReadonlyArray<ChamberType> = [ChamberType.Nu
  * Issue #17 Phase 1 — multi-source BFS toward brood pickup tiles for v10+
  * Nursing ants in the MovingToBrood substate.
  *
- * Seeded from:
- *   1. Every Open tile inside any Queen chamber (where new eggs spawn).
- *   2. Every alive uncarried brood entity (egg or larva) tile that is NOT
- *      inside any Nursery footprint — covers brood dropped at a carrier's
- *      death tile that needs to be re-claimed.
+ * Seeded from every alive uncarried brood entity (egg or larva) tile
+ * that is NOT inside any Nursery footprint. Brood inside the Queen
+ * chamber, brood orphaned at a tunnel tile after a carrier death, and
+ * any other uncarried brood outside a Nursery are all included.
  *
  * Brood already inside a Nursery is excluded — it has reached its
- * destination and shouldn't lure pickups. Carried brood (carriedBy >= 0)
- * is excluded — a second nurse must not race onto an already-claimed
- * brood (race resolution lives in tickNurseActions; this just keeps the
- * field from advertising a stale pickup target).
+ * destination and shouldn't lure pickups. Carried brood (carriedBy >= 0
+ * with an alive carrier) is excluded — a second nurse must not race onto
+ * an already-claimed brood (race resolution lives in tickNurseActions;
+ * this just keeps the field from advertising a stale pickup target).
  *
  * Output is a step-direction grid identical to computeChamberFlowField
  * (-1 = source, -2 = unreachable, 0..3 = step N/E/S/W).
  *
- * Deterministic: chamber seed order is chamber array order × row-major
- * footprint; brood seed order is eggIds first then larvaeIds, each in
- * array order. Duplicate sources are idempotent (the `out[idx] !== -2`
+ * Deterministic: brood seed order is eggIds first then larvaeIds, each
+ * in array order. Duplicate sources are idempotent (the `out[idx] !== -2`
  * guard skips re-seeding).
  *
  * @param underground Colony underground grid (read-only).
- * @param chambers    Colony chambers (used for Queen seeds and Nursery
- *                    footprints — the Nursery footprints are read to
- *                    exclude brood already deposited).
+ * @param chambers    Colony chambers (used to exclude brood already
+ *                    deposited inside a Nursery footprint).
  * @param ants        The world.ants AntComponents struct (reads
  *                    posX/posY/alive/carriedBy via isBroodReclaimable).
  * @param eggIds      colony.eggs for the colony being computed.
@@ -272,27 +269,18 @@ export function computeNursingPickupField(
 
   let tail = 0;
 
-  // Seed (1): Queen chamber Open tiles.
-  for (let c = 0; c < chambers.length; c++) {
-    const chamber = chambers[c]!;
-    if (chamber.chamberType !== ChamberType.Queen) continue;
-    const baseX = chamber.posX >> FP_SHIFT;
-    const baseY = chamber.posY >> FP_SHIFT;
-    for (let ty = 0; ty < chamber.height; ty++) {
-      for (let tx = 0; tx < chamber.width; tx++) {
-        const cx = baseX + tx;
-        const cy = baseY + ty;
-        if (cx < 0 || cx >= width || cy < 0 || cy >= height) continue;
-        const idx = cy * width + cx;
-        if (data[idx] !== UndergroundTileState.Open) continue;
-        if (out[idx] !== -2) continue;
-        out[idx] = -1;
-        queue[tail++] = idx;
-      }
-    }
-  }
-
-  // Seed (2): uncarried brood entities outside Nursery, on Open tiles.
+  // Seed: uncarried brood entities outside Nursery, on Open tiles.
+  //
+  // Earlier this function ALSO seeded every Queen-chamber Open tile
+  // (the now-removed "Seed (1)"). That over-seeded — a Queen chamber is
+  // typically 5×3 with at most a handful of eggs at any time, so most
+  // Queen tiles have no brood. The BFS routed nurses to the geographically
+  // nearest Queen tile, which often was NOT one of the egg-bearing tiles.
+  // When the nurse arrived at a non-egg Queen tile, the pickup gate found
+  // no brood there and the finite-nursing release fired — the nurse was
+  // sent back to Idle without ever reaching an egg. Brood-tile-only
+  // seeding routes nurses directly to the egg tile via BFS, so the
+  // first-arrival pickup gate succeeds.
   // Brood inside Nursery doesn't seed (already deposited); carried brood
   // doesn't seed (a second nurse mustn't race onto it). Dead-carrier
   // exception: if `carriedBy[bid]` points to an ant whose `alive` is 0,

--- a/src/sim/chamber-flow.ts
+++ b/src/sim/chamber-flow.ts
@@ -195,3 +195,142 @@ export const NURSING_CHAMBER_TYPES: ReadonlyArray<ChamberType> = [
 export const QUEEN_CHAMBER_TYPES: ReadonlyArray<ChamberType> = [ChamberType.Queen];
 /** Issue #17 Phase 1 — Nursery-only seeds for the v10 nurseDeposit field. */
 export const NURSERY_CHAMBER_TYPES: ReadonlyArray<ChamberType> = [ChamberType.Nursery];
+
+/**
+ * Issue #17 Phase 1 — multi-source BFS toward brood pickup tiles for v10+
+ * Nursing ants in the MovingToBrood substate.
+ *
+ * Seeded from:
+ *   1. Every Open tile inside any Queen chamber (where new eggs spawn).
+ *   2. Every alive uncarried brood entity (egg or larva) tile that is NOT
+ *      inside any Nursery footprint — covers brood dropped at a carrier's
+ *      death tile that needs to be re-claimed.
+ *
+ * Brood already inside a Nursery is excluded — it has reached its
+ * destination and shouldn't lure pickups. Carried brood (carriedBy >= 0)
+ * is excluded — a second nurse must not race onto an already-claimed
+ * brood (race resolution lives in tickNurseActions; this just keeps the
+ * field from advertising a stale pickup target).
+ *
+ * Output is a step-direction grid identical to computeChamberFlowField
+ * (-1 = source, -2 = unreachable, 0..3 = step N/E/S/W).
+ *
+ * Deterministic: chamber seed order is chamber array order × row-major
+ * footprint; brood seed order is `broodIds` array order. Duplicate sources
+ * are idempotent (the `out[idx] !== -2` guard skips re-seeding).
+ *
+ * @param underground Colony underground grid (read-only).
+ * @param chambers    Colony chambers (used for Queen seeds and Nursery
+ *                    footprints — the Nursery footprints are read to
+ *                    exclude brood already deposited).
+ * @param posX/posY/alive/carriedBy The same SoA arrays from `world.ants`.
+ * @param broodIds    Concatenation of `colony.eggs` and `colony.larvae`
+ *                    for the colony being computed. The function does NOT
+ *                    care about order beyond determinism.
+ * @param out         Pre-allocated Int32Array of length W*H. Filled in-place.
+ * @param queue       Pre-allocated Int32Array of length W*H for BFS queue.
+ */
+export function computeNursingPickupField(
+  underground: UndergroundGrid,
+  chambers: ReadonlyArray<ChamberRecord>,
+  posX:      Int32Array,
+  posY:      Int32Array,
+  alive:     Int32Array,
+  carriedBy: Int32Array,
+  broodIds:  ReadonlyArray<number>,
+  out:       Int32Array,
+  queue:     Int32Array,
+): void {
+  const { data, width, height } = underground;
+
+  out.fill(-2);
+
+  let head = 0;
+  let tail = 0;
+
+  // Seed (1): Queen chamber Open tiles.
+  for (let c = 0; c < chambers.length; c++) {
+    const chamber = chambers[c]!;
+    if (chamber.chamberType !== ChamberType.Queen) continue;
+    const baseX = chamber.posX >> FP_SHIFT;
+    const baseY = chamber.posY >> FP_SHIFT;
+    for (let ty = 0; ty < chamber.height; ty++) {
+      for (let tx = 0; tx < chamber.width; tx++) {
+        const cx = baseX + tx;
+        const cy = baseY + ty;
+        if (cx < 0 || cx >= width || cy < 0 || cy >= height) continue;
+        const idx = cy * width + cx;
+        if (data[idx] !== UndergroundTileState.Open) continue;
+        if (out[idx] !== -2) continue;
+        out[idx] = -1;
+        queue[tail++] = idx;
+      }
+    }
+  }
+
+  // Seed (2): uncarried brood entities outside Nursery, on Open tiles.
+  // Brood inside Nursery doesn't seed (already deposited); carried brood
+  // doesn't seed (a second nurse mustn't race onto it).
+  for (let i = 0; i < broodIds.length; i++) {
+    const bid = broodIds[i]!;
+    if (alive[bid] !== 1) continue;
+    if (carriedBy[bid] !== -1) continue;
+    const tx = posX[bid]! >> FP_SHIFT;
+    const ty = posY[bid]! >> FP_SHIFT;
+    if (tx < 0 || tx >= width || ty < 0 || ty >= height) continue;
+    // Skip brood inside any Nursery footprint.
+    let insideNursery = false;
+    for (let c = 0; c < chambers.length; c++) {
+      const chamber = chambers[c]!;
+      if (chamber.chamberType !== ChamberType.Nursery) continue;
+      const bx = chamber.posX >> FP_SHIFT;
+      const by = chamber.posY >> FP_SHIFT;
+      if (
+        tx >= bx && tx < bx + chamber.width &&
+        ty >= by && ty < by + chamber.height
+      ) {
+        insideNursery = true;
+        break;
+      }
+    }
+    if (insideNursery) continue;
+    const idx = ty * width + tx;
+    // Brood entities should always be on Open tiles in normal play (the
+    // queen-laying code drops them on Open Queen-chamber tiles, and the
+    // carry code drops them on Open Nursery tiles). Defensive guard so a
+    // mid-transition edge case doesn't seed a non-traversable cell.
+    if (data[idx] !== UndergroundTileState.Open) continue;
+    if (out[idx] !== -2) continue;
+    out[idx] = -1;
+    queue[tail++] = idx;
+  }
+
+  // BFS expansion through Open and BeingDug only — same contract as
+  // computeChamberFlowField.
+  while (head < tail) {
+    const idx = queue[head++]!;
+    // eslint-disable-next-line no-restricted-syntax -- integer division via `| 0`; BFS index→row conversion, not fixed-point math
+    const row = (idx / width) | 0;
+    const col = idx % width;
+
+    for (let d = 0; d < 4; d++) {
+      const nRow = row + NEIGHBOR_DR[d]!;
+      const nCol = col + NEIGHBOR_DC[d]!;
+      if (nRow < 0 || nRow >= height || nCol < 0 || nCol >= width) continue;
+
+      const nIdx = nRow * width + nCol;
+      if (out[nIdx] !== -2) continue;
+
+      const tileState = data[nIdx]!;
+      if (
+        tileState !== UndergroundTileState.Open &&
+        tileState !== UndergroundTileState.BeingDug
+      ) {
+        continue;
+      }
+
+      out[nIdx] = REVERSE[d]!;
+      queue[tail++] = nIdx;
+    }
+  }
+}

--- a/src/sim/chamber-flow.ts
+++ b/src/sim/chamber-flow.ts
@@ -270,11 +270,16 @@ export function computeNursingPickupField(
 
   // Seed (2): uncarried brood entities outside Nursery, on Open tiles.
   // Brood inside Nursery doesn't seed (already deposited); carried brood
-  // doesn't seed (a second nurse mustn't race onto it).
+  // doesn't seed (a second nurse mustn't race onto it). Dead-carrier
+  // exception: if `carriedBy[bid]` points to an ant whose `alive` is 0,
+  // the brood is effectively orphaned (carrier died mid-carry) and is
+  // reclaimable — seed it as uncarried. tickNurseActions Feeding branch
+  // also drops dead-brood carries on the carrier side.
   for (let i = 0; i < broodIds.length; i++) {
     const bid = broodIds[i]!;
     if (alive[bid] !== 1) continue;
-    if (carriedBy[bid] !== -1) continue;
+    const cby = carriedBy[bid]!;
+    if (cby !== -1 && alive[cby] === 1) continue;
     const tx = posX[bid]! >> FP_SHIFT;
     const ty = posY[bid]! >> FP_SHIFT;
     if (tx < 0 || tx >= width || ty < 0 || ty >= height) continue;

--- a/src/sim/chamber-flow.ts
+++ b/src/sim/chamber-flow.ts
@@ -315,11 +315,21 @@ export function computeNursingPickupField(
       }
       if (insideNursery) continue;
       const idx = ty * width + tx;
-      // Brood entities should always be on Open tiles in normal play (the
-      // queen-laying code drops them on Open Queen-chamber tiles, and the
-      // carry code drops them on Open Nursery tiles). Defensive guard so a
-      // mid-transition edge case doesn't seed a non-traversable cell.
-      if (data[idx] !== UndergroundTileState.Open) continue;
+      // Allow seeds on Open OR BeingDug tiles. BeingDug is reachable per
+      // canEnterUndergroundTile, and the BFS expansion below traverses
+      // both states, so a seed on a BeingDug tile propagates correctly.
+      // PR #56 codex P1 round 3 fix: a carrier can die on a BeingDug
+      // tile (e.g. mid-combat next to an active dig), dropping its brood
+      // there. Pre-fix, the Open-only guard skipped that seed, the
+      // pickup field had no source for the orphan, and mid-tunnel nurses
+      // stranded indefinitely. The colonyHasClaimableBrood predicate in
+      // ant-system.ts applies the same Open-or-BeingDug filter so the
+      // field-seed-set and the release predicate agree exactly.
+      const tileState = data[idx]!;
+      if (
+        tileState !== UndergroundTileState.Open &&
+        tileState !== UndergroundTileState.BeingDug
+      ) continue;
       if (out[idx] !== -2) continue;
       out[idx] = -1;
       queue[tail++] = idx;

--- a/src/sim/chamber-flow.ts
+++ b/src/sim/chamber-flow.ts
@@ -39,6 +39,8 @@ import type { ColonyId, ChamberRecord } from './colony/colony-store.js';
 import { UndergroundTileState } from './terrain.js';
 import type { UndergroundGrid } from './terrain.js';
 import { FP_SHIFT } from './fixed.js';
+import type { AntComponents } from './ant/ant-store.js';
+import { isBroodReclaimable } from './ant/ant-store.js';
 
 // Direction constants — identical encoding to entrance-flow.ts / dig-system.ts.
 //   0=N, 1=E, 2=S, 3=W, -1=source, -2=unreachable.
@@ -233,11 +235,9 @@ export const NURSERY_CHAMBER_TYPES: ReadonlyArray<ChamberType> = [ChamberType.Nu
 export function computeNursingPickupField(
   underground: UndergroundGrid,
   chambers: ReadonlyArray<ChamberRecord>,
-  posX:      Int32Array,
-  posY:      Int32Array,
-  alive:     Int32Array,
-  carriedBy: Int32Array,
-  broodIds:  ReadonlyArray<number>,
+  ants:      AntComponents,
+  eggIds:    ReadonlyArray<number>,
+  larvaeIds: ReadonlyArray<number>,
   out:       Int32Array,
   queue:     Int32Array,
 ): void {
@@ -275,39 +275,43 @@ export function computeNursingPickupField(
   // the brood is effectively orphaned (carrier died mid-carry) and is
   // reclaimable — seed it as uncarried. tickNurseActions Feeding branch
   // also drops dead-brood carries on the carrier side.
-  for (let i = 0; i < broodIds.length; i++) {
-    const bid = broodIds[i]!;
-    if (alive[bid] !== 1) continue;
-    const cby = carriedBy[bid]!;
-    if (cby !== -1 && alive[cby] === 1) continue;
-    const tx = posX[bid]! >> FP_SHIFT;
-    const ty = posY[bid]! >> FP_SHIFT;
-    if (tx < 0 || tx >= width || ty < 0 || ty >= height) continue;
-    // Skip brood inside any Nursery footprint.
-    let insideNursery = false;
-    for (let c = 0; c < chambers.length; c++) {
-      const chamber = chambers[c]!;
-      if (chamber.chamberType !== ChamberType.Nursery) continue;
-      const bx = chamber.posX >> FP_SHIFT;
-      const by = chamber.posY >> FP_SHIFT;
-      if (
-        tx >= bx && tx < bx + chamber.width &&
-        ty >= by && ty < by + chamber.height
-      ) {
-        insideNursery = true;
-        break;
+  //
+  // Iterate eggs then larvae as two separate arrays to avoid per-tick
+  // `concat()` allocation (this BFS runs every tick under v10+).
+  for (let pass = 0; pass < 2; pass++) {
+    const broodIds = pass === 0 ? eggIds : larvaeIds;
+    for (let i = 0; i < broodIds.length; i++) {
+      const bid = broodIds[i]!;
+      if (!isBroodReclaimable(ants, bid)) continue;
+      const tx = ants.posX[bid]! >> FP_SHIFT;
+      const ty = ants.posY[bid]! >> FP_SHIFT;
+      if (tx < 0 || tx >= width || ty < 0 || ty >= height) continue;
+      // Skip brood inside any Nursery footprint.
+      let insideNursery = false;
+      for (let c = 0; c < chambers.length; c++) {
+        const chamber = chambers[c]!;
+        if (chamber.chamberType !== ChamberType.Nursery) continue;
+        const bx = chamber.posX >> FP_SHIFT;
+        const by = chamber.posY >> FP_SHIFT;
+        if (
+          tx >= bx && tx < bx + chamber.width &&
+          ty >= by && ty < by + chamber.height
+        ) {
+          insideNursery = true;
+          break;
+        }
       }
+      if (insideNursery) continue;
+      const idx = ty * width + tx;
+      // Brood entities should always be on Open tiles in normal play (the
+      // queen-laying code drops them on Open Queen-chamber tiles, and the
+      // carry code drops them on Open Nursery tiles). Defensive guard so a
+      // mid-transition edge case doesn't seed a non-traversable cell.
+      if (data[idx] !== UndergroundTileState.Open) continue;
+      if (out[idx] !== -2) continue;
+      out[idx] = -1;
+      queue[tail++] = idx;
     }
-    if (insideNursery) continue;
-    const idx = ty * width + tx;
-    // Brood entities should always be on Open tiles in normal play (the
-    // queen-laying code drops them on Open Queen-chamber tiles, and the
-    // carry code drops them on Open Nursery tiles). Defensive guard so a
-    // mid-transition edge case doesn't seed a non-traversable cell.
-    if (data[idx] !== UndergroundTileState.Open) continue;
-    if (out[idx] !== -2) continue;
-    out[idx] = -1;
-    queue[tail++] = idx;
   }
 
   // BFS expansion through Open and BeingDug only — same contract as

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -17,7 +17,7 @@
 // array.length > 0, so array[length-1] is always defined.
 
 import type { WorldState } from '../types.js';
-import { allocateEntityId } from '../types.js';
+import { allocateEntityId, SIM_VERSION_V10_VISIBLE_BROOD_CARRY } from '../types.js';
 import { initAnt } from '../ant/ant-store.js';
 import type { ColonyRecord } from './colony-store.js';
 import { AntTask, ChamberType } from '../enums.js';
@@ -302,6 +302,21 @@ export function tickLifecycleTransitions(world: WorldState, colony: ColonyRecord
       ants.speed[id] = WORKER_BASE_SPEED;
       colony.workers.push(id);
       colony.workerCount += 1;
+      // Issue #17 Phase 1 — if a v10+ nurse was carrying this larva when
+      // it matured, drop the carry. The new worker stays at the carrier's
+      // current tile (posX/posY were synced last tick); the carrier
+      // returns to Idle so step 10a re-allocates per ratio.
+      if (world.simVersion >= SIM_VERSION_V10_VISIBLE_BROOD_CARRY) {
+        const carrierId = ants.carriedBy[id]!;
+        if (carrierId !== -1) {
+          if (ants.alive[carrierId] === 1 && ants.carryingBroodId[carrierId] === id) {
+            ants.carryingBroodId[carrierId] = -1;
+            ants.task[carrierId]    = AntTask.Idle;
+            ants.subTask[carrierId] = 0;
+          }
+          ants.carriedBy[id] = -1;
+        }
+      }
     }
   }
 

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -309,11 +309,18 @@ export function tickLifecycleTransitions(world: WorldState, colony: ColonyRecord
       if (world.simVersion >= SIM_VERSION_V10_VISIBLE_BROOD_CARRY) {
         const carrierId = ants.carriedBy[id]!;
         if (carrierId !== -1) {
+          // Carrier-side cleanup is gated on the carrier still being alive
+          // AND still carrying THIS entity — guards against state desync
+          // (e.g. carrier already started carrying a different brood).
           if (ants.alive[carrierId] === 1 && ants.carryingBroodId[carrierId] === id) {
             ants.carryingBroodId[carrierId] = -1;
             ants.task[carrierId]    = AntTask.Idle;
             ants.subTask[carrierId] = 0;
           }
+          // Always clear the matured worker's `carriedBy` so the new
+          // worker is not flagged as carried, regardless of carrier-side
+          // state. The new worker is now in colony.workers (no longer
+          // brood) and will not be referenced by carry-aware code.
           ants.carriedBy[id] = -1;
         }
       }

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -3605,7 +3605,15 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     // The load-bearing setup here is brood + Nursery + workerCount=1 (driving the
     // cap); targetRatio is irrelevant (the cap saturates first and forage_share
     // would be 0 even with forage=10).
+    //
+    // Pinned to v9 — the test's contrived brood-in-Nursery layout (30 larvae
+    // all stacked at tile (0,0) inside the Nursery footprint) hits the v10
+    // colony-level finite-nursing release and flips subTask from
+    // MovingToBrood to Feeding. The allocator behavior under test is
+    // unchanged either way, but the post-tick subTask assertion specifically
+    // checks the pre-v10 freshly-assigned MovingToBrood state.
     const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    world.simVersion = SIM_VERSION_V9_CANCEL_DROPS_PENDING;
     const colony = world.colonies[colonyId]!;
     const underground = world.undergroundGrids[colonyId]!;
 
@@ -3895,7 +3903,14 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     // under the 1-cap) and the forage→…→nurse iteration assigns the Idle
     // ant to Foraging — starving nurse for the entire dig duration. WR-07
     // holds digDemand=1 while actualDig>0, preserving the carve.
+    //
+    // Pinned to v9 — same reason as Test 6 above: the contrived
+    // brood-stacked-in-Nursery setup hits the v10 colony-level finite-
+    // nursing release and flips subTask to Feeding, breaking the
+    // post-tick subTask=MovingToBrood assertion. Allocator behavior
+    // under test is unaffected.
     const { world, colonyId } = makeWorldWithUndergroundForAutoDig();
+    world.simVersion = SIM_VERSION_V9_CANCEL_DROPS_PENDING;
     const colony = world.colonies[colonyId]!;
     const underground = world.undergroundGrids[colonyId]!;
 

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -14,6 +14,7 @@ import {
   SIM_VERSION_V7_SURFACE_PASSABILITY,
   SIM_VERSION_V8_LEASH_HYSTERESIS,
   SIM_VERSION_V9_CANCEL_DROPS_PENDING,
+  SIM_VERSION_V10_VISIBLE_BROOD_CARRY,
   LATEST_SIM_VERSION,
 } from './types.js';
 import { GameOutcome } from './game-over.js';
@@ -2495,16 +2496,20 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeUndefined();
   });
 
-  it('new worlds run at LATEST_SIM_VERSION (== V9_CANCEL_DROPS_PENDING after #54)', () => {
+  it('new worlds run at LATEST_SIM_VERSION (== V10_VISIBLE_BROOD_CARRY after #17 phase 1)', () => {
     // Verify createWorldState uses the LATEST_SIM_VERSION constant exactly.
     // Tracks the constant rather than a hard-coded number so future bumps
     // don't have to update this assertion, while still proving the factory
     // is wired to the latest version (not stuck on a stale literal). Also
-    // pins the explicit v9 sentinel so a downgrade (e.g. accidental revert
-    // of the #54 cancel-drops-pending fix) trips here.
+    // pins the explicit v10 sentinel so a downgrade (e.g. accidental revert
+    // of the #17 visible-brood-carry phase 1) trips here.
     const world = createWorldState(42);
     expect(world.simVersion).toBe(LATEST_SIM_VERSION);
-    expect(world.simVersion).toBe(SIM_VERSION_V9_CANCEL_DROPS_PENDING);
+    expect(world.simVersion).toBe(SIM_VERSION_V10_VISIBLE_BROOD_CARRY);
+    // The v9 cancel-drops-pending floor still belongs to LATEST as well —
+    // an accidental drop below v9 would silently re-enable the #54 Queen
+    // chamber soft-lock.
+    expect(world.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V9_CANCEL_DROPS_PENDING);
     // The v8 leash-hysteresis ceiling still belongs to LATEST as well — an
     // accidental drop below v8 would silently re-enable the #44 UAT round 3
     // bugs (flip-flop at leash boundary, detour deadlocks in one-way

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -691,8 +691,8 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       chamberBufs.queue,
     );
     // Issue #17 Phase 1 — Nursery-only deposit field for v10+ carrying nurses.
-    // Pre-v10 the field is allocated but unread; cheap to keep it in sync so
-    // a v10 sim version flip on a loaded save lands on a populated buffer.
+    // Pre-v10 the field is allocated but unread; computed alongside the other
+    // chamber fields for code symmetry — no measurable cost.
     computeChamberFlowField(
       underground,
       colony.chambers,
@@ -720,18 +720,12 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       if (!underground) continue;
       const gridSize = underground.width * underground.height;
       const chamberBufs = ensureChamberFlowFields(chamberFlowFields, colony.colonyId, gridSize);
-      // Concatenate eggs ∪ larvae into the brood seed list. Allocation-
-      // sensitive: re-uses no scratch buffer, but eggs/larvae are tiny
-      // arrays (typically O(10)).
-      const broodIds = colony.eggs.concat(colony.larvae);
       computeNursingPickupField(
         underground,
         colony.chambers,
-        world.ants.posX,
-        world.ants.posY,
-        world.ants.alive,
-        world.ants.carriedBy,
-        broodIds,
+        world.ants,
+        colony.eggs,
+        colony.larvae,
         chamberBufs.nursing,
         chamberBufs.queue,
       );

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1,6 +1,6 @@
 // src/sim/tick.ts — Phase 9 19-step tick dispatcher.
 import type { WorldState } from './types.js';
-import { allocateEntityId, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING } from './types.js';
+import { allocateEntityId, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY } from './types.js';
 import { MAX_COMMANDS_PER_TICK, type SimCommand } from './commands.js';
 import { GameOutcome, checkQueenDeath } from './game-over.js';
 import { detectAndResolveCombat } from './combat.js';
@@ -68,6 +68,7 @@ import {
 import type { EntranceFlowFields } from './entrance-flow.js';
 import {
   computeChamberFlowField,
+  computeNursingPickupField,
   ensureChamberFlowFields,
   createChamberFlowFields,
   FOOD_CHAMBER_TYPES,
@@ -702,6 +703,39 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
 
     colony.digFlowFieldDirty = false;
     colony.foodFlowFieldDirty = false;
+  }
+
+  // Issue #17 Phase 1 — under v10+, the `nursing` chamber-flow field is
+  // re-seeded from Queen Open tiles AND any uncarried-brood-entity tile
+  // outside Nursery (the v10 pickup field). Brood positions move with their
+  // carriers each tick, so the field MUST recompute every tick (not just
+  // on dirty signal) to stay in sync. Overwrites the buffer that the
+  // dirty-gated block above filled with the legacy NURSING_CHAMBER_TYPES
+  // seeding — pre-v10 worlds keep the legacy seeding (Queen+Nursery).
+  if (world.simVersion >= SIM_VERSION_V10_VISIBLE_BROOD_CARRY) {
+    for (const key in world.colonies) {
+      if (!Object.hasOwn(world.colonies, key)) continue;
+      const colony = world.colonies[key as unknown as ColonyId]!;
+      const underground = world.undergroundGrids[colony.colonyId];
+      if (!underground) continue;
+      const gridSize = underground.width * underground.height;
+      const chamberBufs = ensureChamberFlowFields(chamberFlowFields, colony.colonyId, gridSize);
+      // Concatenate eggs ∪ larvae into the brood seed list. Allocation-
+      // sensitive: re-uses no scratch buffer, but eggs/larvae are tiny
+      // arrays (typically O(10)).
+      const broodIds = colony.eggs.concat(colony.larvae);
+      computeNursingPickupField(
+        underground,
+        colony.chambers,
+        world.ants.posX,
+        world.ants.posY,
+        world.ants.alive,
+        world.ants.carriedBy,
+        broodIds,
+        chamberBufs.nursing,
+        chamberBufs.queue,
+      );
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -72,6 +72,7 @@ import {
   createChamberFlowFields,
   FOOD_CHAMBER_TYPES,
   NURSING_CHAMBER_TYPES,
+  NURSERY_CHAMBER_TYPES,
   QUEEN_CHAMBER_TYPES,
 } from './chamber-flow.js';
 import type { ChamberFlowFields } from './chamber-flow.js';
@@ -115,10 +116,11 @@ export function resetFlowFieldCaches(): void {
   for (const k in digFlowFields.queues)       delete digFlowFields.queues[k as unknown as ColonyId];
   for (const k in entranceFlowFields.fields)  delete entranceFlowFields.fields[k as unknown as ColonyId];
   for (const k in entranceFlowFields.queues)  delete entranceFlowFields.queues[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.food)     delete chamberFlowFields.food[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.nursing)  delete chamberFlowFields.nursing[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.queen)    delete chamberFlowFields.queen[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.queues)   delete chamberFlowFields.queues[k as unknown as ColonyId];
+  for (const k in chamberFlowFields.food)         delete chamberFlowFields.food[k as unknown as ColonyId];
+  for (const k in chamberFlowFields.nursing)      delete chamberFlowFields.nursing[k as unknown as ColonyId];
+  for (const k in chamberFlowFields.queen)        delete chamberFlowFields.queen[k as unknown as ColonyId];
+  for (const k in chamberFlowFields.nurseDeposit) delete chamberFlowFields.nurseDeposit[k as unknown as ColonyId];
+  for (const k in chamberFlowFields.queues)       delete chamberFlowFields.queues[k as unknown as ColonyId];
 }
 
 // Suppress unused-import TS error for PendingChamber (used in PlaceChamber case shape)
@@ -685,6 +687,16 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       colony.chambers,
       QUEEN_CHAMBER_TYPES,
       chamberBufs.queen,
+      chamberBufs.queue,
+    );
+    // Issue #17 Phase 1 — Nursery-only deposit field for v10+ carrying nurses.
+    // Pre-v10 the field is allocated but unread; cheap to keep it in sync so
+    // a v10 sim version flip on a loaded save lands on a populated buffer.
+    computeChamberFlowField(
+      underground,
+      colony.chambers,
+      NURSERY_CHAMBER_TYPES,
+      chamberBufs.nurseDeposit,
       chamberBufs.queue,
     );
 

--- a/src/sim/types.test.ts
+++ b/src/sim/types.test.ts
@@ -260,6 +260,27 @@ describe('WorldState', () => {
         expect(dst.ants.searchPrevTileX[0]).toBe(11);
         expect(dst.ants.searchPrevTileY[0]).toBe(22);
       });
+
+      it('Issue #17 Phase 1: carryingBroodId and carriedBy round-trip through copyWorldState', () => {
+        // The render snapshot reads brood positions through prevState; if the
+        // carry slot doesn't round-trip, the carrier sprite would track on
+        // the current frame but the brood would visually lag (or vice-versa
+        // depending on which side dropped). Both fields must round-trip.
+        src.ants.carryingBroodId[0] = 7;
+        src.ants.carriedBy[7] = 0;
+        src.ants.carryingBroodId[1] = -1; // sentinel round-trips unchanged
+        src.ants.carriedBy[1] = -1;
+        copyWorldState(src, dst);
+        expect(dst.ants.carryingBroodId[0]).toBe(7);
+        expect(dst.ants.carriedBy[7]).toBe(0);
+        expect(dst.ants.carryingBroodId[1]).toBe(-1);
+        expect(dst.ants.carriedBy[1]).toBe(-1);
+        // Independence: mutating src after copy must NOT propagate to dst.
+        src.ants.carryingBroodId[0] = 99;
+        src.ants.carriedBy[7] = 42;
+        expect(dst.ants.carryingBroodId[0]).toBe(7);
+        expect(dst.ants.carriedBy[7]).toBe(0);
+      });
     });
 
     describe('colonies', () => {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -111,7 +111,8 @@ export const SIM_VERSION_V7_SURFACE_PASSABILITY = 7 as const;
  */
 export const SIM_VERSION_V8_LEASH_HYSTERESIS = 8 as const;
 export const SIM_VERSION_V9_CANCEL_DROPS_PENDING = 9 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V9_CANCEL_DROPS_PENDING;
+export const SIM_VERSION_V10_VISIBLE_BROOD_CARRY = 10 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V10_VISIBLE_BROOD_CARRY;
 
 export interface WorldState {
   tick: number;             // 0 at creation; incremented once per tick
@@ -175,6 +176,15 @@ export interface WorldState {
    *       PlaceChamber Queen-uniqueness rule in `tick.ts`) stayed
    *       tripped, soft-locking re-placement. Pre-v9 saves replay
    *       byte-identical with the orphan-on-cancel behaviour.
+   *  10 = Issue #17 Phase 1 — visible brood carry. Nurses pathfind to
+   *       a brood entity (egg or larva) inside a Queen chamber, pick
+   *       it up (sets `carryingBroodId` on the nurse and `carriedBy`
+   *       on the brood), walk it to a Nursery Open tile, and deposit.
+   *       Pre-v10 the `Feeding` substate ran the instant teleport in
+   *       `transportBroodToNursery`. Pre-v10 saves replay byte-
+   *       identically with the teleport behaviour. With no Nursery,
+   *       no carry happens and brood sits where laid (matches pre-v10
+   *       teleport-gate behaviour).
    *
    * Round-trips through copyWorldState and save/load.
    */
@@ -313,6 +323,10 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   dst.ants.recentTilesX.set(src.ants.recentTilesX);
   dst.ants.recentTilesY.set(src.ants.recentTilesY);
   dst.ants.recentTilesHead.set(src.ants.recentTilesHead);
+  // Issue #17 Phase 1 — brood carry slot + reverse pointer. Both round-trip
+  // because the v10 nurse state machine reads them every tick.
+  dst.ants.carryingBroodId.set(src.ants.carryingBroodId);
+  dst.ants.carriedBy.set(src.ants.carriedBy);
 
   // --- colonies: delete stale dst keys; upsert each src colony ---
   // Remove dst colonies that no longer exist in src


### PR DESCRIPTION
## Summary

Phase 1 of issue #17 — replaces the instant `transportBroodToNursery` teleport with a visible nurse-carries-brood mechanic:

- **Pickup**: a Nursing ant in `MovingToBrood` walks toward Queen-chamber Open tiles via the re-purposed `nursing` chamber-flow field. On arrival at a tile holding an alive uncarried brood, the nurse claims it (`carryingBroodId` on the nurse, `carriedBy` on the brood, atomic both-ends) and flips to `Feeding`. Gated on a completed Nursery (symmetric with the pre-v10 transport gate).
- **Carry**: each tick the brood's position syncs to the carrier's. Movement reads the new `nurseDeposit` Nursery-only chamber-flow field. Render: brood sprite shifted ~1/4 tile up so it sits "in arms."
- **Deposit**: on arrival at a Nursery Open tile, deposit at the same `broodId % openCount` spread the legacy teleport used (extracted to a shared `computeNurseryDepositPosition` helper).
- **Edge cases**: carrier dies mid-carry → brood drops at last-synced tile, next nurse reclaims via the dead-carrier exception in pickup. Brood dies mid-carry → carrier drops, returns to Idle. Larva→worker maturation while carried → carry dropped in `tickLifecycleTransitions`. Egg→larva preserves carry.

Gated on a new `SIM_VERSION_V10_VISIBLE_BROOD_CARRY = 10` sentinel; pre-v10 saves replay byte-identically with the legacy teleport (SCEN-06).

## Test plan

- [x] `npx vitest run` — 1747 passing (60 new tests covering pickup/carry/deposit/death/maturation/render-offset/v9-boundary)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Internal code review loop — 3 passes (3 BLOCKERs + 12 WARNINGs in pass 1, 3 WARNINGs in pass 2, PASS verdict in pass 3)
- [ ] Manual UAT: confirm visible nurse → brood → nursery flow renders smoothly; verify pre-v10 saves still load and run identically.

## Files

7 commits, ~2,075 lines of diff across 14 files. New SoA fields, chamber-flow field, version sentinel, save format, render offset, and full test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)