### PR TITLE
fix(sim): validate command coordinates against NaN/Infinity/non-integer (#60)

### DIFF
--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -4031,3 +4031,114 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     expect(world.ants.subTask[widIdle]).toBe(NursingSubState.MovingToBrood);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #60 — coordinate validation at command boundary.
+// Pre-fix every coord handler had a `< 0 || >= max` range check that
+// rejected Infinity but let NaN through (NaN <,>= comparisons are
+// always false). Some handlers happened to silently no-op (typed-array
+// writes at NaN index are dropped, pile.tileX === NaN is false), but
+// DesignateEntrance / SetRallyPoint / PlaceChamber persisted malformed
+// state into colony.entrances / colony.rallyPoint / pendingChambers
+// keys, breaking SCEN-06 byte-identity on save round-trip.
+// ---------------------------------------------------------------------------
+describe('Issue #60 — command coordinate validation', () => {
+  // Use the full createScenario fixture so undergroundGrids, surface,
+  // foodPiles, and colony.entrances are all initialized — the same setup
+  // the live game uses.
+  const PLAYER = 1 as ColonyId;
+  let world: WorldState;
+  beforeEach(() => {
+    world = createScenario(42);
+  });
+
+  it('MarkDigTile with NaN coords is dropped (no underground state change)', () => {
+    const cmd = { type: 'MarkDigTile', colonyId: PLAYER, tileX: NaN, tileY: 5, issuedAtTick: 0 } as unknown as SimCommand;
+    const before = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
+    expect(() => tick(world, [cmd])).not.toThrow();
+    const after = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
+    expect(after).toBe(before);
+  });
+  it('CancelDigMark with NaN coords is dropped', () => {
+    const cmd = { type: 'CancelDigMark', colonyId: PLAYER, tileX: NaN, tileY: NaN, issuedAtTick: 0 } as unknown as SimCommand;
+    expect(() => tick(world, [cmd])).not.toThrow();
+  });
+  it('MarkDigTile with non-integer coords is dropped', () => {
+    // eslint-disable-next-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
+    const cmd = { type: 'MarkDigTile', colonyId: PLAYER, tileX: 1.5, tileY: 5, issuedAtTick: 0 } as unknown as SimCommand;
+    const before = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
+    tick(world, [cmd]);
+    const after = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
+    expect(after).toBe(before);
+  });
+  it('MarkDigTile with Infinity coords is dropped (no underground state change)', () => {
+    const cmd = { type: 'MarkDigTile', colonyId: PLAYER, tileX: Infinity, tileY: 5, issuedAtTick: 0 } as unknown as SimCommand;
+    const before = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
+    expect(() => tick(world, [cmd])).not.toThrow();
+    const after = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
+    expect(after).toBe(before);
+  });
+  it('SetRallyPoint with NaN coords is dropped — rallyPoint stays null', () => {
+    const cmd = { type: 'SetRallyPoint', colonyId: PLAYER, tileX: NaN, tileY: NaN, issuedAtTick: 0 } as unknown as SimCommand;
+    tick(world, [cmd]);
+    expect(world.colonies[PLAYER]!.rallyPoint).toBeNull();
+  });
+  it('SetRallyPoint with non-integer coords is dropped', () => {
+    // eslint-disable-next-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
+    const cmd = { type: 'SetRallyPoint', colonyId: PLAYER, tileX: 5.5, tileY: 5, issuedAtTick: 0 } as unknown as SimCommand;
+    tick(world, [cmd]);
+    expect(world.colonies[PLAYER]!.rallyPoint).toBeNull();
+  });
+  it('SetRallyPoint with valid integer coords sets rallyPoint normally', () => {
+    const cmd: SimCommand = { type: 'SetRallyPoint', colonyId: PLAYER, tileX: 7, tileY: 8, issuedAtTick: 0 };
+    tick(world, [cmd]);
+    expect(world.colonies[PLAYER]!.rallyPoint).toEqual({ tileX: 7, tileY: 8 });
+  });
+  it('DesignateEntrance with NaN coords is dropped — no new entrance pushed', () => {
+    const before = world.colonies[PLAYER]!.entrances.length;
+    const cmd = { type: 'DesignateEntrance', colonyId: PLAYER, surfaceTileX: NaN, surfaceTileY: 0, issuedAtTick: 0 } as unknown as SimCommand;
+    tick(world, [cmd]);
+    expect(world.colonies[PLAYER]!.entrances.length).toBe(before);
+  });
+  it('DesignateEntrance with non-integer coords is dropped', () => {
+    const before = world.colonies[PLAYER]!.entrances.length;
+    // eslint-disable-next-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
+    const cmd = { type: 'DesignateEntrance', colonyId: PLAYER, surfaceTileX: 7.5, surfaceTileY: 0, issuedAtTick: 0 } as unknown as SimCommand;
+    tick(world, [cmd]);
+    expect(world.colonies[PLAYER]!.entrances.length).toBe(before);
+  });
+  it('PlaceChamber with NaN anchor is dropped — no PendingChamber created', () => {
+    const before = Object.keys(world.pendingChambers).length;
+    const cmd = { type: 'PlaceChamber', colonyId: PLAYER, chamberType: ChamberType.FoodStorage, anchorTileX: NaN, anchorTileY: NaN, issuedAtTick: 0 } as unknown as SimCommand;
+    tick(world, [cmd]);
+    expect(Object.keys(world.pendingChambers).length).toBe(before);
+    // Critically: no malformed `${colonyId}:NaN:NaN` key should have been created.
+    expect(Object.keys(world.pendingChambers).some((k) => k.includes('NaN'))).toBe(false);
+  });
+  it('PlaceChamber with non-integer anchor is dropped', () => {
+    const before = Object.keys(world.pendingChambers).length;
+    // eslint-disable-next-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
+    const cmd = { type: 'PlaceChamber', colonyId: PLAYER, chamberType: ChamberType.FoodStorage, anchorTileX: 5.5, anchorTileY: 5, issuedAtTick: 0 } as unknown as SimCommand;
+    tick(world, [cmd]);
+    expect(Object.keys(world.pendingChambers).length).toBe(before);
+  });
+  it('MarkFoodPile with NaN coords is dropped — priorityFoodPileId unchanged', () => {
+    const before = world.colonies[PLAYER]!.priorityFoodPileId;
+    const cmd = { type: 'MarkFoodPile', colonyId: PLAYER, tileX: NaN, tileY: NaN, issuedAtTick: 0 } as unknown as SimCommand;
+    tick(world, [cmd]);
+    expect(world.colonies[PLAYER]!.priorityFoodPileId).toBe(before);
+  });
+  it('save round-trip: a NaN-coord SetRallyPoint never lands in the snapshot', async () => {
+    // Direct demonstration of the SCEN-06 byte-identity guarantee — even
+    // if a malformed command somehow reaches the queue (cast-defeated TS,
+    // tampered inputLog), the colony state never absorbs the NaN.
+    const { serializeWorldState } = await import('../platform/save.js');
+    const cmd = { type: 'SetRallyPoint', colonyId: PLAYER, tileX: NaN, tileY: NaN, issuedAtTick: 0 } as unknown as SimCommand;
+    tick(world, [cmd]);
+    const json = JSON.stringify(serializeWorldState(world));
+    expect(json).not.toContain('NaN');
+    // rallyPoint is still null, not {tileX: null, tileY: null}.
+    const parsed = JSON.parse(json) as { colonies: Record<string, { rallyPoint: unknown }> };
+    expect(parsed.colonies[String(PLAYER)]!.rallyPoint).toBeNull();
+  });
+});

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -169,6 +169,35 @@ void (undefined as unknown as PendingChamber);
  *                   Commands beyond MAX_COMMANDS_PER_TICK are silently dropped FIFO (PRD §5).
  * @returns GameOutcome — None each tick until a win/lose condition is detected (Phase 9).
  */
+/**
+ * Issue #60 — boundary validator for command-coordinate fields.
+ *
+ * Rejects:
+ *   - Non-numbers (cast-defeated TypeScript types reaching the dispatcher)
+ *   - Non-integer numbers (a fractional camera coord landing in a queue
+ *     cmd from a future render-side bug)
+ *   - NaN (the existing `< 0 || >= max` range checks let NaN through —
+ *     `NaN < 0` and `NaN >= max` are both false)
+ *   - Out-of-range integers (matches the inline guards we already had)
+ *
+ * Pre-fix every coordinate handler had its own `< 0 || >= max` guard
+ * that caught Infinity (`Infinity >= max` is true) but NOT NaN. A NaN
+ * that reaches a typed-array index is silently dropped on write; a NaN
+ * that lands in a colony.entrances entry, colony.rallyPoint, or a
+ * pendingChambers map key persists into save state and breaks SCEN-06
+ * byte-identity (`JSON.stringify(NaN) === "null"`).
+ *
+ * Per codex review: PlaceChamber's pendingChambers key is built from
+ * `${colonyId}:${tileX}:${tileY}` — a NaN there would create a "1:NaN:NaN"
+ * key that no future PlaceChamber/CancelDigMark can address.
+ *
+ * Drop-the-command policy matches the existing OOB / unknown-variant
+ * rejection style (silent break out of the case).
+ */
+function isTileCoord(value: unknown, max: number): boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value < max;
+}
+
 export function tick(world: WorldState, commands: readonly SimCommand[]): GameOutcome {
   // Reconstruct Rng from saved state at tick start (PRD §4 contract).
   const rng = new Rng(world.rngState);
@@ -260,8 +289,9 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         // PRD §3a — mark a Solid tile for excavation; silently drop non-Solid or out-of-bounds.
         const underground = world.undergroundGrids[cmd.colonyId];
         if (!underground) break;
-        // T-07-10: bounds check (mitigate tamper — reject out-of-range silently)
-        if (cmd.tileX < 0 || cmd.tileX >= UNDERGROUND_GRID_WIDTH || cmd.tileY < 0 || cmd.tileY >= UNDERGROUND_GRID_HEIGHT) break;
+        // Issue #60 — integer + bounds. Pre-fix `< 0 || >= max` let NaN through.
+        if (!isTileCoord(cmd.tileX, UNDERGROUND_GRID_WIDTH)) break;
+        if (!isTileCoord(cmd.tileY, UNDERGROUND_GRID_HEIGHT)) break;
         // Issue #30 (sim-side): reject ceiling-strip dispatches at the
         // MarkDigTile boundary. The renderer paints `tileY === 0` as grass
         // for non-entrance columns (entrance columns get the gold-tinted
@@ -292,6 +322,11 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         // "redirect" semantics the player expects, not an additive flag.
         const colony = world.colonies[cmd.colonyId];
         if (!colony) break;
+        // Issue #60 — integer + bounds. NaN coords reach the pile loop and
+        // never match (every pile.tileX === NaN is false), so pre-fix this
+        // case was safe by luck; codify the boundary regardless.
+        if (!isTileCoord(cmd.tileX, SURFACE_GRID_WIDTH)) break;
+        if (!isTileCoord(cmd.tileY, SURFACE_GRID_HEIGHT)) break;
         let matched: FoodPileId | null = null;
         for (const pile of world.foodPiles) {
           if (pile.tileX === cmd.tileX && pile.tileY === cmd.tileY) {
@@ -309,7 +344,9 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         // PRD §3b — cancel a Marked tile (only Marked — NOT BeingDug; finish-then-switch rule per CTRL-04).
         const underground = world.undergroundGrids[cmd.colonyId];
         if (!underground) break;
-        if (cmd.tileX < 0 || cmd.tileX >= UNDERGROUND_GRID_WIDTH || cmd.tileY < 0 || cmd.tileY >= UNDERGROUND_GRID_HEIGHT) break;
+        // Issue #60 — integer + bounds.
+        if (!isTileCoord(cmd.tileX, UNDERGROUND_GRID_WIDTH)) break;
+        if (!isTileCoord(cmd.tileY, UNDERGROUND_GRID_HEIGHT)) break;
         if (ugGet(underground, cmd.tileX, cmd.tileY) !== UndergroundTileState.Marked) break;
         ugSet(underground, cmd.tileX, cmd.tileY, UndergroundTileState.Solid);
         const colony2 = world.colonies[cmd.colonyId];
@@ -355,9 +392,12 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         if (!underground) break;
         const dims = CHAMBER_DIMENSIONS[cmd.chamberType];
         if (!dims) break;
-        // (a)(b) Bounds check (T-07-11 first guard)
-        if (cmd.anchorTileX < 0 || cmd.anchorTileX + dims.width > UNDERGROUND_GRID_WIDTH) break;
-        if (cmd.anchorTileY < 0 || cmd.anchorTileY + dims.height > UNDERGROUND_GRID_HEIGHT) break;
+        // Issue #60 — integer + bounds. NaN here would create a malformed
+        // pendingChambers map key (`${colonyId}:NaN:NaN`) that no future
+        // PlaceChamber/CancelDigMark can address; persists into save state
+        // and breaks SCEN-06 byte-identity. Validate before any field use.
+        if (!isTileCoord(cmd.anchorTileX, UNDERGROUND_GRID_WIDTH - dims.width + 1)) break;
+        if (!isTileCoord(cmd.anchorTileY, UNDERGROUND_GRID_HEIGHT - dims.height + 1)) break;
         // Issue #30 (sim-side): reject any chamber whose footprint overlaps
         // the ceiling row. CHAMBER_DIMENSIONS extend DOWN from the anchor,
         // so anchorTileY === UNDERGROUND_CEILING_ROW_Y is exactly the
@@ -499,9 +539,12 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         if (!colony4) break;
         const underground = world.undergroundGrids[cmd.colonyId];
         if (!underground) break;
-        // Surface-coord bounds (PRD §3g silent-drop first bullet)
-        if (cmd.surfaceTileX < 0 || cmd.surfaceTileX >= SURFACE_GRID_WIDTH) break;
-        if (cmd.surfaceTileY < 0 || cmd.surfaceTileY >= SURFACE_GRID_HEIGHT) break;
+        // Issue #60 — integer + bounds. NaN here pushes an entrance with
+        // `{surfaceTileX: NaN, surfaceTileY: NaN}` into colony.entrances,
+        // which persists into save state and breaks SCEN-06 byte-identity
+        // (NaN doesn't round-trip cleanly through JSON.stringify).
+        if (!isTileCoord(cmd.surfaceTileX, SURFACE_GRID_WIDTH)) break;
+        if (!isTileCoord(cmd.surfaceTileY, SURFACE_GRID_HEIGHT)) break;
         // T-07-12: cap check (mitigate tamper — prevent unbounded entrance creation)
         if (colony4.entrances.length >= MAX_ENTRANCES_PER_COLONY) break;
         // Column uniqueness — same surfaceTileX collapses in underground view (PRD §3g)
@@ -576,8 +619,12 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       case 'SetRallyPoint': {
         const colony = world.colonies[cmd.colonyId];
         if (colony === undefined) break;
-        if (cmd.tileX < 0 || cmd.tileX >= SURFACE_GRID_WIDTH) break;
-        if (cmd.tileY < 0 || cmd.tileY >= SURFACE_GRID_HEIGHT) break;
+        // Issue #60 — integer + bounds. NaN here writes `rallyPoint =
+        // {tileX: NaN, tileY: NaN}`, which persists into colony state
+        // and round-trips through JSON.stringify as `null` — breaking
+        // SCEN-06 byte-identity for replays past the bad command.
+        if (!isTileCoord(cmd.tileX, SURFACE_GRID_WIDTH)) break;
+        if (!isTileCoord(cmd.tileY, SURFACE_GRID_HEIGHT)) break;
         colony.rallyPoint = { tileX: cmd.tileX, tileY: cmd.tileY };
         break;
       }


### PR DESCRIPTION
## Summary

Group D (#60 BLOCKER): command handler coordinate validation. Pre-fix the existing `< 0 || >= max` range checks rejected Infinity but **not** NaN (NaN-vs-number comparisons are always false), and didn't enforce integer-ness.

**Failure modes pre-fix:**
- DesignateEntrance pushed `{surfaceTileX: NaN, surfaceTileY: NaN}` into `colony.entrances`
- SetRallyPoint stored `rallyPoint = {tileX: NaN, tileY: NaN}`
- PlaceChamber created malformed `pendingChambers` keys (`${colonyId}:NaN:NaN`) that no future PlaceChamber/CancelDigMark can address
- `JSON.stringify(NaN) === 'null'` — any of the above persisting into save state breaks SCEN-06 byte-identity round-trip

**Fix:** new `isTileCoord(value, max)` helper at the boundary; applied at `MarkDigTile`, `CancelDigMark`, `PlaceChamber`, `DesignateEntrance`, `SetRallyPoint`, `MarkFoodPile`.

Drop-the-command on validation failure (matches existing OOB / unknown-variant style — silent break out of the case).

13 new tests including a save-round-trip test that directly demonstrates SCEN-06 byte-identity preservation when a malformed command reaches the queue.

Closes #60.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1823 passing (13 new boundary tests for #60)
- [x] `pnpm lint` clean
- [x] 2 internal code-review rounds (round 1: 2 LOW notes addressed; round 2: clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)