### PR TITLE
fix: defensive bundle Group H+I+J (#57, #58, #61, #63, #64, #67, #69, #75, #83, #84)

### DIFF
--- a/src/render/ai-controller.test.ts
+++ b/src/render/ai-controller.test.ts
@@ -143,17 +143,20 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       expect(world.commandQueue.length).toBeGreaterThanOrEqual(2);
     });
 
-    it('does not push commands when colony already has entrances and no cadence match (tick=1)', () => {
+    it('does not push commands when AI post-conditions are met and no cadence match (tick=1)', () => {
       const world = makeWorld(1);
       const colony = addColony(world, 2 as ColonyId, 0);
       colony.entrances = [{ entranceId: 1, surfaceTileX: 10, surfaceTileY: 0, isOpen: true }];
+      // Issue #75 — aiInitialSetup is now post-condition-gated. Matching the
+      // AI ratio AND having an entrance means setup is complete.
+      colony.targetRatio.forage = AI_BEHAVIOR_RATIO.forage;
+      colony.targetRatio.fight  = AI_BEHAVIOR_RATIO.fight;
       setQueenPos(world, 0, 10, 5);
       addUndergroundGrid(world, 2 as ColonyId);
       runAIController(world, 2 as ColonyId);
-      // tick=1: aiInitialSetup no-ops (not tick 0), aiDigHeuristic no-ops (1%40≠0),
-      // aiChamberPlacement: no queen chamber → tries to find open spot (all Solid → null)
-      // aiEntranceDesignation: has entrances → skip
-      // So 0 commands
+      // tick=1: aiInitialSetup no-ops (post-conditions met), aiDigHeuristic
+      // no-ops (1%40≠0), aiChamberPlacement: no queen chamber → tries to find
+      // open spot (all Solid → null), aiEntranceDesignation: has entrances → skip.
       expect(world.commandQueue).toHaveLength(0);
     });
 
@@ -187,12 +190,34 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       expect(entranceCmd!.issuedAtTick).toBe(0);
     });
 
-    it('does NOT push initial-setup commands after tick 0', () => {
+    it('does NOT push initial-setup commands when post-conditions already met (#75 idempotent)', () => {
+      // Issue #75 — pre-fix gate was `world.tick !== 0` so any tick > 0 was
+      // a no-op. Post-fix the gate is `entrances exist AND ratio matches`,
+      // which is the actual contract. A save loaded mid-game (tick > 0)
+      // with both post-conditions met short-circuits as expected.
+      const world = makeWorld(1);
+      const colony = addColony(world, 2 as ColonyId, 0);
+      colony.entrances = [{ entranceId: 1, surfaceTileX: 10, surfaceTileY: 0, isOpen: true }];
+      colony.targetRatio.forage = AI_BEHAVIOR_RATIO.forage;
+      colony.targetRatio.fight  = AI_BEHAVIOR_RATIO.fight;
+      setQueenPos(world, 0, 10, 5);
+      aiInitialSetup(world, colony);
+      expect(world.commandQueue).toHaveLength(0);
+    });
+    it('DOES push initial-setup commands after tick 0 when post-conditions unmet (#75)', () => {
+      // Pre-fix this scenario was broken: a save written before
+      // aiInitialSetup existed (or where some future code path cleared
+      // the AI's targetRatio / entrances) would never reinitialize. Post-
+      // fix the function pushes whichever commands the post-condition
+      // check determines are needed, regardless of `world.tick`.
       const world = makeWorld(1);
       const colony = addColony(world, 2 as ColonyId, 0);
       setQueenPos(world, 0, 10, 5);
       aiInitialSetup(world, colony);
-      expect(world.commandQueue).toHaveLength(0);
+      // Both ratio and entrance commands push because both post-conditions are unmet.
+      expect(world.commandQueue.length).toBeGreaterThanOrEqual(2);
+      expect(world.commandQueue.some((c) => c.type === 'SetBehaviorRatio')).toBe(true);
+      expect(world.commandQueue.some((c) => c.type === 'DesignateEntrance')).toBe(true);
     });
 
     it('every command pushed by aiInitialSetup carries issuedAtTick: world.tick', () => {

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -87,33 +87,50 @@ export function runAIController(world: WorldState, aiColonyId: ColonyId): void {
 }
 
 /**
- * CMBT-02: one-shot initialization on tick 0.
- * - Pushes SetBehaviorRatio with the fixed AI ratio.
- * - Pushes DesignateEntrance at the queen's surface tile (derived from queen position).
+ * CMBT-02: one-shot initialization. Idempotent — safe to call every tick.
+ * - Pushes SetBehaviorRatio with the fixed AI ratio (if not already set).
+ * - Pushes DesignateEntrance at the queen's surface tile (if no entrance yet).
+ *
+ * Issue #75 — pre-fix gated on `world.tick !== 0`, so on `bootFromSave`
+ * (where `world.tick > 0`) the function was a no-op. That worked when the
+ * saved snapshot already contained both post-conditions, but is fragile:
+ * a save written before `aiInitialSetup` existed (or where the ratio /
+ * entrance got cleared by some future feature) would never reinitialize
+ * and the AI would sit dormant. New gate: check the post-conditions
+ * directly. Idempotent post-condition gate also serves as the canonical
+ * "AI ready" check the rest of the controller can rely on.
  */
 export function aiInitialSetup(world: WorldState, colony: ColonyRecord): void {
-  if (world.tick !== 0) return;
+  // 1. Set fixed behavior ratio for AI (CMBT-02). Skip if the colony's
+  //    targetRatio already matches the AI ratio (idempotent across boots).
+  const ratioReady =
+    colony.targetRatio.forage === AI_BEHAVIOR_RATIO.forage &&
+    colony.targetRatio.fight === AI_BEHAVIOR_RATIO.fight;
+  if (!ratioReady) {
+    const setRatioCmd: SetBehaviorRatioCommand = {
+      type: 'SetBehaviorRatio',
+      colonyId: colony.colonyId,
+      ratio: { ...AI_BEHAVIOR_RATIO },
+      issuedAtTick: world.tick,
+    };
+    world.commandQueue.push(setRatioCmd);
+  }
 
-  // 1. Set fixed behavior ratio for AI (CMBT-02).
-  const setRatioCmd: SetBehaviorRatioCommand = {
-    type: 'SetBehaviorRatio',
-    colonyId: colony.colonyId,
-    ratio: { ...AI_BEHAVIOR_RATIO },
-    issuedAtTick: world.tick,
-  };
-  world.commandQueue.push(setRatioCmd);
-
-  // 2. Designate entrance at queen's surface tile.
-  const queenTileX = world.ants.posX[colony.queenEntityId]! >> FP_SHIFT;
-  // Queen Y is underground; the entrance is on the surface row directly above her column.
-  const designateCmd: DesignateEntranceCommand = {
-    type: 'DesignateEntrance',
-    colonyId: colony.colonyId,
-    surfaceTileX: queenTileX,
-    surfaceTileY: 0,   // surface row
-    issuedAtTick: world.tick,
-  };
-  world.commandQueue.push(designateCmd);
+  // 2. Designate entrance at queen's surface tile. Skip if any entrance
+  //    already exists for this colony — including ones the player/AI
+  //    designated in earlier sessions and the save preserved.
+  if (colony.entrances.length === 0) {
+    const queenTileX = world.ants.posX[colony.queenEntityId]! >> FP_SHIFT;
+    // Queen Y is underground; the entrance is on the surface row directly above her column.
+    const designateCmd: DesignateEntranceCommand = {
+      type: 'DesignateEntrance',
+      colonyId: colony.colonyId,
+      surfaceTileX: queenTileX,
+      surfaceTileY: 0,   // surface row
+      issuedAtTick: world.tick,
+    };
+    world.commandQueue.push(designateCmd);
+  }
 }
 
 export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
@@ -697,6 +714,17 @@ function findOpenChamberSpot(
     for (const [dx, dy] of [[0, -1], [1, 0], [0, 1], [-1, 0]] as const) {
       const nx = tx + dx;
       const ny = ty + dy;
+      // Issue #64 — bounds-check before computing the visited-set key.
+      // The same author already documented and fixed this exact alias
+      // pattern in `collectFrontierTiles` (see the comment around line
+      // 478). Without the bounds check, an OOB neighbour like (width, 0)
+      // computes key = `0 * width + width = width`, which collides with
+      // the in-bounds tile (0, 1) at key `1 * width + 0 = width`. If
+      // BFS reaches (width-1, 0) and right-expands first, the OOB add
+      // poisons the in-bounds tile's slot and (0, 1) gets silently
+      // skipped — leaving valid AI chamber anchors unfound on certain
+      // seeds.
+      if (nx < 0 || ny < 0 || nx >= grid.width || ny >= grid.height) continue;
       const nkey = ny * grid.width + nx;
       if (visited.has(nkey)) continue;
       visited.add(nkey);

--- a/src/render/draw-underground.ts
+++ b/src/render/draw-underground.ts
@@ -413,8 +413,8 @@ export function drawUndergroundEntities(
   // from the brood entity positions exactly — the sim's nurses have already
   // moved them into the nursery footprint, so rendering at the entity's
   // current tile is what places them inside the chamber visually.
-  drawBrood(sprites, curr, colony.eggs, 'egg', left, top, canvasW, canvasH);
-  drawBrood(sprites, curr, colony.larvae, 'larva', left, top, canvasW, canvasH);
+  drawBrood(sprites, curr, colony.eggs, 'egg', left, top, canvasW, canvasH, activeUndergroundColonyId);
+  drawBrood(sprites, curr, colony.larvae, 'larva', left, top, canvasW, canvasH, activeUndergroundColonyId);
 }
 
 /**
@@ -437,10 +437,17 @@ function drawBrood(
   top: number,
   canvasW: number,
   canvasH: number,
+  activeUndergroundColonyId: ColonyId,
 ): void {
   const ants = curr.ants;
   for (const id of entityIds) {
     if (!isAlive(ants, id)) continue;
+    // Issue #84 — mirror the ant-loop grid filter at line 351. Today
+    // brood-never-invades is a sim invariant (carry/lay/transition all stay
+    // in-grid), but if a future change lets brood cross grids (carrier-led
+    // evacuation, debug tools, etc.) the sprite would otherwise render at the
+    // wrong screen offset using the active grid's camera. Fail safe.
+    if (ants.currentGridColonyId[id] !== activeUndergroundColonyId) continue;
     const tileX = ants.posX[id]! >> FP_SHIFT;
     const tileY = ants.posY[id]! >> FP_SHIFT;
     const screenX = (tileX - left) * TILE_SIZE_PX;

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -17,6 +17,8 @@ import {
   antDepositFood,
   canEnterUndergroundTile,
   pickCardinalStep,
+  unpackStepDx,
+  unpackStepDy,
   getTaskDirection,
   tickDigExecution,
   routeForagerPriority,
@@ -2586,6 +2588,59 @@ describe('chooseExcursionDirection', () => {
     expect(dir.dx).toBeGreaterThanOrEqual(0);
     // After bounce, heading is a valid on-grid cardinal.
     expect(Math.abs(dir.dx) + Math.abs(dir.dy)).toBe(1);
+  });
+
+  // Issue #83 — uniform-RNG-consumption contract. The function pulls
+  // exactly 3 RNG values up-front regardless of branch, to keep the
+  // post-call rng stream identical across all branches. If a future
+  // PR adds a 4th rng.nextInt inside a conditional branch, this test
+  // (combined with the seed-determinism test above) catches the drift.
+  it('advances RNG by exactly 3 nextU32 calls regardless of branch (#83)', () => {
+    // Each nextInt call invokes nextU32 exactly once (rng.ts:27-29).
+    // We verify the post-call state matches a fresh Rng advanced 3x.
+    const expectedAfter3 = (seed: number): number => {
+      const r = new Rng(seed);
+      r.nextU32(); r.nextU32(); r.nextU32();
+      return r.getState();
+    };
+
+    // Walk the matrix of branches:
+    //   - initial-heading branch (hx===0 && hy===0)
+    //   - active-heading branch with hx,hy outward
+    //   - active-heading branch with hx,hy inward (bounce path)
+    //   - ant inside grid bounds vs. near edge
+    const seedsToProbe = [0, 1, 7, 42, 1000, 999_999];
+    const cases: Array<() => { world: WorldState; antId: number }> = [
+      // Initial-heading branch
+      () => setupWorldWithEntrance(24, 64, 30, 70),
+      // Active-outward heading
+      () => {
+        const r = setupWorldWithEntrance(24, 64, 30, 70);
+        r.world.ants.searchHeadingX[r.antId]     = 1;
+        r.world.ants.searchHeadingY[r.antId]     = 0;
+        r.world.ants.searchHeadingTicks[r.antId] = 5;
+        return r;
+      },
+      // Active-inward (bounce) heading
+      () => {
+        const r = setupWorldWithEntrance(24, 64, 30, 70);
+        r.world.ants.searchHeadingX[r.antId]     = -1;
+        r.world.ants.searchHeadingY[r.antId]     = 0;
+        r.world.ants.searchHeadingTicks[r.antId] = 10;
+        return r;
+      },
+      // Edge of grid (forces axis-clamp branches in the bounce/refresh path)
+      () => setupWorldWithEntrance(24, 64, 1, 1),
+    ];
+
+    for (const seed of seedsToProbe) {
+      for (const buildCase of cases) {
+        const { world, antId } = buildCase();
+        const rng = new Rng(seed);
+        chooseExcursionDirection(world, antId, rng);
+        expect(rng.getState()).toBe(expectedAfter3(seed));
+      }
+    }
   });
 });
 
@@ -6152,7 +6207,15 @@ describe('tickNurseActions — P2 brood transport to Nursery', () => {
 //                                                 for replay determinism.
 //   v4 (SIM_VERSION_V4_DIAGONAL_MOTION) — 8-connected diagonal step when both
 //                                         axes have non-zero delta.
+//
+// Issue #69: pickCardinalStep now returns a packed int (dx + 1) | ((dy + 1) << 2).
+// Test helper `step(p)` decodes back to {dx, dy} for assertion convenience.
 // ---------------------------------------------------------------------------
+
+/** Decode a pickCardinalStep result for test assertions. */
+function step(packed: number): { dx: number; dy: number } {
+  return { dx: unpackStepDx(packed), dy: unpackStepDy(packed) };
+}
 
 describe('pickCardinalStep (issue #34) — v2/v3 legacy greedy cardinal', () => {
   function emptyAnts(): ReturnType<typeof createAntComponents> {
@@ -6161,13 +6224,13 @@ describe('pickCardinalStep (issue #34) — v2/v3 legacy greedy cardinal', () => 
 
   it('zero delta returns (0, 0) under v3', () => {
     const ants = emptyAnts();
-    expect(pickCardinalStep(ants, 0, 0, 0, SIM_VERSION_V3)).toEqual({ dx: 0, dy: 0 });
+    expect(step(pickCardinalStep(ants, 0, 0, 0, SIM_VERSION_V3))).toEqual({ dx: 0, dy: 0 });
   });
 
   it('pure +X / -Y cardinals are unchanged under v3', () => {
     const ants = emptyAnts();
-    expect(pickCardinalStep(ants, 0, 5, 0, SIM_VERSION_V3)).toEqual({ dx: 1, dy: 0 });
-    expect(pickCardinalStep(ants, 0, 0, -3, SIM_VERSION_V3)).toEqual({ dx: 0, dy: -1 });
+    expect(step(pickCardinalStep(ants, 0, 5, 0, SIM_VERSION_V3))).toEqual({ dx: 1, dy: 0 });
+    expect(step(pickCardinalStep(ants, 0, 0, -3, SIM_VERSION_V3))).toEqual({ dx: 0, dy: -1 });
   });
 
   it('v3 greedy at 45° alternates per tick — the visible zig-zag issue #34 v4 ultimately fixes', () => {
@@ -6183,11 +6246,11 @@ describe('pickCardinalStep (issue #34) — v2/v3 legacy greedy cardinal', () => 
     let x = 0;
     let y = 0;
     for (let i = 0; i < 6; i++) {
-      const step = pickCardinalStep(ants, 0, 3 - x, 3 - y, SIM_VERSION_V3);
-      dxs.push(step.dx);
-      dys.push(step.dy);
-      x += step.dx;
-      y += step.dy;
+      const stepP = pickCardinalStep(ants, 0, 3 - x, 3 - y, SIM_VERSION_V3);
+      dxs.push(unpackStepDx(stepP));
+      dys.push(unpackStepDy(stepP));
+      x += unpackStepDx(stepP);
+      y += unpackStepDy(stepP);
     }
     expect(x).toBe(3);
     expect(y).toBe(3);
@@ -6205,11 +6268,11 @@ describe('pickCardinalStep (issue #34) — v2/v3 legacy greedy cardinal', () => 
     let x = 0;
     let y = 0;
     for (let i = 0; i < 4; i++) {
-      const step = pickCardinalStep(ants, 0, 3 - x, 1 - y, SIM_VERSION_V3);
-      dxs.push(step.dx);
-      dys.push(step.dy);
-      x += step.dx;
-      y += step.dy;
+      const stepP = pickCardinalStep(ants, 0, 3 - x, 1 - y, SIM_VERSION_V3);
+      dxs.push(unpackStepDx(stepP));
+      dys.push(unpackStepDy(stepP));
+      x += unpackStepDx(stepP);
+      y += unpackStepDy(stepP);
     }
     expect(x).toBe(3);
     expect(y).toBe(1);
@@ -6232,7 +6295,8 @@ describe('pickCardinalStep (issue #34) — v2/v3 legacy greedy cardinal', () => 
     // identically through pickCardinalStep.
     const a2 = emptyAnts();
     const a3 = emptyAnts();
-    expect(pickCardinalStep(a2, 0, 3, 3, LEGACY_SIM_VERSION)).toEqual(
+    // Two packed ints — toBe rather than toEqual since they're primitive.
+    expect(pickCardinalStep(a2, 0, 3, 3, LEGACY_SIM_VERSION)).toBe(
       pickCardinalStep(a3, 0, 3, 3, SIM_VERSION_V3),
     );
   });
@@ -6245,9 +6309,9 @@ describe('pickCardinalStep (issue #34) — v4 8-connected diagonal', () => {
 
   it('pure cardinals are unchanged in v4 (single-axis targets behave identically)', () => {
     const ants = emptyAnts();
-    expect(pickCardinalStep(ants, 0, 5, 0, SIM_VERSION_V4_DIAGONAL_MOTION)).toEqual({ dx: 1, dy: 0 });
-    expect(pickCardinalStep(ants, 0, 0, -3, SIM_VERSION_V4_DIAGONAL_MOTION)).toEqual({ dx: 0, dy: -1 });
-    expect(pickCardinalStep(ants, 0, 0, 0, SIM_VERSION_V4_DIAGONAL_MOTION)).toEqual({ dx: 0, dy: 0 });
+    expect(step(pickCardinalStep(ants, 0, 5, 0, SIM_VERSION_V4_DIAGONAL_MOTION))).toEqual({ dx: 1, dy: 0 });
+    expect(step(pickCardinalStep(ants, 0, 0, -3, SIM_VERSION_V4_DIAGONAL_MOTION))).toEqual({ dx: 0, dy: -1 });
+    expect(step(pickCardinalStep(ants, 0, 0, 0, SIM_VERSION_V4_DIAGONAL_MOTION))).toEqual({ dx: 0, dy: 0 });
   });
 
   it('45° target (3,3) reaches the target in 3 diagonal steps — no zig-zag', () => {
@@ -6257,11 +6321,11 @@ describe('pickCardinalStep (issue #34) — v4 8-connected diagonal', () => {
     const dxs: number[] = [];
     const dys: number[] = [];
     for (let i = 0; i < 3; i++) {
-      const step = pickCardinalStep(ants, 0, 3 - x, 3 - y, SIM_VERSION_V4_DIAGONAL_MOTION);
-      dxs.push(step.dx);
-      dys.push(step.dy);
-      x += step.dx;
-      y += step.dy;
+      const stepP = pickCardinalStep(ants, 0, 3 - x, 3 - y, SIM_VERSION_V4_DIAGONAL_MOTION);
+      dxs.push(unpackStepDx(stepP));
+      dys.push(unpackStepDy(stepP));
+      x += unpackStepDx(stepP);
+      y += unpackStepDy(stepP);
     }
     expect(x).toBe(3);
     expect(y).toBe(3);
@@ -6280,10 +6344,10 @@ describe('pickCardinalStep (issue #34) — v4 8-connected diagonal', () => {
     let y = 0;
     const trace: Array<[number, number]> = [];
     for (let i = 0; i < 3; i++) {
-      const step = pickCardinalStep(ants, 0, 3 - x, 1 - y, SIM_VERSION_V4_DIAGONAL_MOTION);
-      trace.push([step.dx, step.dy]);
-      x += step.dx;
-      y += step.dy;
+      const stepP = pickCardinalStep(ants, 0, 3 - x, 1 - y, SIM_VERSION_V4_DIAGONAL_MOTION);
+      trace.push([unpackStepDx(stepP), unpackStepDy(stepP)]);
+      x += unpackStepDx(stepP);
+      y += unpackStepDy(stepP);
     }
     expect(x).toBe(3);
     expect(y).toBe(1);
@@ -6298,11 +6362,11 @@ describe('pickCardinalStep (issue #34) — v4 8-connected diagonal', () => {
     let x = 0;
     let y = 0;
     for (let i = 0; i < 3; i++) {
-      const step = pickCardinalStep(ants, 0, -3 - x, -3 - y, SIM_VERSION_V4_DIAGONAL_MOTION);
-      expect(step.dx).toBe(-1);
-      expect(step.dy).toBe(-1);
-      x += step.dx;
-      y += step.dy;
+      const stepP = pickCardinalStep(ants, 0, -3 - x, -3 - y, SIM_VERSION_V4_DIAGONAL_MOTION);
+      expect(unpackStepDx(stepP)).toBe(-1);
+      expect(unpackStepDy(stepP)).toBe(-1);
+      x += unpackStepDx(stepP);
+      y += unpackStepDy(stepP);
     }
     expect(x).toBe(-3);
     expect(y).toBe(-3);
@@ -6311,8 +6375,8 @@ describe('pickCardinalStep (issue #34) — v4 8-connected diagonal', () => {
   it('mixed-quadrant diagonals: (rawDx=2, rawDy=-2) → (1, -1)', () => {
     // sign(rawDx) = +1, sign(rawDy) = -1 → SE-quadrant diagonal.
     const ants = emptyAnts();
-    const step = pickCardinalStep(ants, 0, 2, -2, SIM_VERSION_V4_DIAGONAL_MOTION);
-    expect(step).toEqual({ dx: 1, dy: -1 });
+    const stepP = pickCardinalStep(ants, 0, 2, -2, SIM_VERSION_V4_DIAGONAL_MOTION);
+    expect(step(stepP)).toEqual({ dx: 1, dy: -1 });
   });
 
   it('v4 leaves pathErr untouched when stepping diagonally', () => {

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -3808,13 +3808,30 @@ export function tickAntMovement(
         }
       }
 
-      // Issue #63 (v11+) — surface ants targeting an entrance consume the
-      // surface entrance flow-field instead of straight-line pickCardinalStep.
-      // The field is a true BFS through non-HardBlock tiles, so the ant
-      // routes around multi-tile feature pockets (4×4 boulders, 6×3 twigs,
-      // 3×4 BigLeaves) that the 1-tile pickSurfaceDetour can't escape.
+      // Issue #63 (v11+) — surface ants RETURNING to an open entrance to
+      // deposit food consume the surface entrance flow-field instead of
+      // straight-line pickCardinalStep. The field is a true BFS through
+      // non-HardBlock tiles, so the ant routes around multi-tile feature
+      // pockets (4×4 boulders, 6×3 twigs, 3×4 BigLeaves) that the 1-tile
+      // pickSurfaceDetour can't escape.
+      //
+      // Codex P1 follow-up — narrow the BFS branch to ONLY the
+      // CarryingFood/ReturningToNest cases the issue described. The
+      // surface BFS field is seeded only from OPEN entrances, so any
+      // ant with a target that ISN'T an open entrance (Diggers heading
+      // to a freshly-designated closed shaft to excavate it; Fighting
+      // invaders targeting an enemy's open entrance which isn't on the
+      // player's BFS field) would be misrouted toward the nearest open
+      // own-colony entrance. Pin the branch to Foraging + Carry/Return
+      // and let other tasks fall through to the existing straight-line.
+      const subTaskHere = ants.subTask[id]!;
+      const isHomeBoundForager =
+        task === AntTask.Foraging &&
+        (subTaskHere === ForagingSubState.CarryingFood ||
+         subTaskHere === ForagingSubState.ReturningToNest);
       if (!stepped
         && zone === Zone.Surface
+        && isHomeBoundForager
         && entranceFlowFields !== undefined
         && world.simVersion >= SIM_VERSION_V11_DEFENSIVE_BUNDLE
       ) {

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -39,6 +39,7 @@ import {
   SIM_VERSION_V7_SURFACE_PASSABILITY,
   SIM_VERSION_V8_LEASH_HYSTERESIS,
   SIM_VERSION_V10_VISIBLE_BROOD_CARRY,
+  SIM_VERSION_V11_DEFENSIVE_BUNDLE,
   type WorldState,
 } from '../types.js';
 import {
@@ -46,6 +47,7 @@ import {
   surfaceMovementAt,
   surfaceMovementAtCached,
   createSurfaceMovementCache,
+  resetSurfaceMovementCache,
   type SurfaceMovementCache,
 } from '../surface-features.js';
 import type { AntComponents } from './ant-store.js';
@@ -245,57 +247,105 @@ export function antPickupFood(
 // pickCardinalStep call.
 // ---------------------------------------------------------------------------
 
-interface CardinalStep { dx: number; dy: number }
+export interface CardinalStep { dx: number; dy: number }
 
-const cardinalStepScratch: CardinalStep = { dx: 0, dy: 0 };
-
+/**
+ * Issue #69 — return a primitive packed int instead of a shared scratch
+ * struct. Pre-fix `pickCardinalStep` wrote into a module-level singleton
+ * `cardinalStepScratch` and returned it. The shared mutable was safe for
+ * current call paths (each consumer read dx/dy immediately before any
+ * other call), but a latent footgun: a future refactor that calls
+ * pickCardinalStep twice within the same expression would silently
+ * corrupt the first caller's dx/dy.
+ *
+ * Output encoding:
+ *   bits 0..1: dx + 1 (so dx ∈ {-1, 0, 1} maps to {0, 1, 2})
+ *   bits 2..3: dy + 1
+ * Decode helpers below: `unpackStepDx(p)` / `unpackStepDy(p)`.
+ *
+ * Returning a number sidesteps the scratch-aliasing problem entirely:
+ * two consecutive calls produce two independent integer results.
+ */
 export function pickCardinalStep(
   ants: AntComponents,
   id: number,
   rawDx: number,
   rawDy: number,
   simVersion: number,
-): CardinalStep {
+): number {
   void ants; void id; // pathErr is inert under v4-and-later; not read here.
   const absDx = rawDx < 0 ? -rawDx : rawDx;
   const absDy = rawDy < 0 ? -rawDy : rawDy;
-  if (absDx === 0 && absDy === 0) {
-    cardinalStepScratch.dx = 0;
-    cardinalStepScratch.dy = 0;
-    return cardinalStepScratch;
-  }
-  if (absDx === 0) {
-    cardinalStepScratch.dx = 0;
-    cardinalStepScratch.dy = rawDy > 0 ? 1 : -1;
-    return cardinalStepScratch;
-  }
-  if (absDy === 0) {
-    cardinalStepScratch.dx = rawDx > 0 ? 1 : -1;
-    cardinalStepScratch.dy = 0;
-    return cardinalStepScratch;
-  }
+  if (absDx === 0 && absDy === 0) return packStep(0, 0);
+  if (absDx === 0)                return packStep(0, rawDy > 0 ? 1 : -1);
+  if (absDy === 0)                return packStep(rawDx > 0 ? 1 : -1, 0);
 
   // Both axes non-zero.
   if (simVersion >= SIM_VERSION_V4_DIAGONAL_MOTION) {
     // v4 — 8-connected diagonal step.
-    cardinalStepScratch.dx = rawDx > 0 ? 1 : -1;
-    cardinalStepScratch.dy = rawDy > 0 ? 1 : -1;
-    return cardinalStepScratch;
+    return packStep(rawDx > 0 ? 1 : -1, rawDy > 0 ? 1 : -1);
   }
 
   // v2 / v3 — legacy greedy major-axis pick (pre-issue-#34). Exhausts the
   // larger-magnitude axis before switching, producing the stair-step that
   // v4 fixes. Preserved verbatim so pre-v4 save replays are bit-exact.
   // Tie (|rawDx| === |rawDy|) goes to X axis.
-  if (absDx >= absDy) {
-    cardinalStepScratch.dx = rawDx > 0 ? 1 : -1;
-    cardinalStepScratch.dy = 0;
-  } else {
-    cardinalStepScratch.dx = 0;
-    cardinalStepScratch.dy = rawDy > 0 ? 1 : -1;
-  }
-  return cardinalStepScratch;
+  if (absDx >= absDy) return packStep(rawDx > 0 ? 1 : -1, 0);
+  return packStep(0, rawDy > 0 ? 1 : -1);
 }
+
+/** Encode a (dx, dy) cardinal step into a 4-bit int. dx, dy ∈ {-1, 0, 1}. */
+function packStep(dx: number, dy: number): number {
+  return ((dy + 1) << 2) | (dx + 1);
+}
+
+/** Decode dx from a packStep result. */
+export function unpackStepDx(packed: number): number {
+  return (packed & 3) - 1;
+}
+
+/** Decode dy from a packStep result. */
+export function unpackStepDy(packed: number): number {
+  return ((packed >> 2) & 3) - 1;
+}
+
+/**
+ * Module-level scratch for `diagonalizeFlowStep`'s `out` parameter.
+ *
+ * Issue #69 narrowed scope to `pickCardinalStep` (which now returns a
+ * primitive). `diagonalizeFlowStep` retains a struct out-param because
+ * it writes the cardinal as a fallback then conditionally upgrades to a
+ * diagonal — encoding both axes' independent state cleanly into a single
+ * int while preserving the in-place mutation contract is awkward.
+ *
+ * Each caller passes this single shared scratch — read dx/dy immediately
+ * before any subsequent diagonalizeFlowStep call. The shared mutable is
+ * acceptable because (a) the sim is single-threaded and (b) every current
+ * caller reads dx/dy on the next two lines.
+ */
+const cardinalStepScratch: CardinalStep = { dx: 0, dy: 0 };
+
+/**
+ * Issue #67 — module-level surface movement cache. Reset (not reallocated)
+ * each tick by `tickAntMovement`. Allocating ~16 KB of Uint8Array per tick
+ * and discarding it was a measurable GC burden in long sessions. Reset is
+ * identical to `createSurfaceMovementCache`'s post-construction fill.
+ */
+const SURFACE_MOVE_CACHE_SCRATCH = createSurfaceMovementCache();
+
+/**
+ * Issue #67 — module-level scratch for `resolveSameColonyOccupancy`. Cleared
+ * (not reallocated) each call. Map.clear() is much cheaper than `new Map()`
+ * + GC release of the prior tick's map.
+ */
+const OCCUPANCY_SCRATCH = new Map<number, number>();
+
+/**
+ * Issue #67 — module-level scratch for `collectAliveQueenIds`. Cleared and
+ * refilled each call. Reused across the per-tick lookup loops in
+ * `tickAntMovement`. Single-threaded sim — no concurrent collection risk.
+ */
+const QUEEN_IDS_SCRATCH = new Set<number>();
 
 // ---------------------------------------------------------------------------
 // diagonalizeFlowStep — issue #34 follow-up
@@ -1411,8 +1461,8 @@ export function getTaskDirection(
         bestChamberTileY - antTileY,
         world.simVersion,
       );
-      bestDx = step.dx;
-      bestDy = step.dy;
+      bestDx = unpackStepDx(step);
+      bestDy = unpackStepDy(step);
     }
 
     return { dx: bestDx, dy: bestDy };
@@ -2512,9 +2562,25 @@ function findNearestScentPile(
 export function tickPheromoneDeposit(world: WorldState): void {
   const ants = world.ants;
 
+  // Issue #57 — gate underground carriers OUT of the surface FoodTrail loop.
+  // Pre-v11 this loop iterated EVERY alive food-carrying ant and deposited
+  // at `pheromoneGridKey(colonyId, FoodTrail, 'surface')` using the ant's
+  // tile coords. Underground tiles (0..127, 0..63) all map to real surface
+  // cells — nothing was clipped — so underground carriers wrote phantom
+  // trails on the surface that surface foragers then read. The entrance-
+  // suppression check below also compared surface entrance tiles to
+  // underground coords, producing nonsense distances that effectively
+  // never fired the radius cutoff.
+  //
+  // Pre-v11 saves keep the bugged behaviour for replay determinism — the
+  // pheromone grids round-trip through saves and any phantom trails baked
+  // into a v10 snapshot must continue to influence v10-replay routing.
+  const v11OrLater = world.simVersion >= SIM_VERSION_V11_DEFENSIVE_BUNDLE;
+
   for (let id = 0; id < world.nextEntityId; id++) {
     if (ants.alive[id] !== 1) continue;
     if (ants.foodCarrying[id]! <= 0) continue;
+    if (v11OrLater && ants.zone[id] !== Zone.Surface) continue;
 
     const colonyId = ants.colonyId[id]!;
     const tileX = ants.posX[id]! >> FP_SHIFT;
@@ -2734,7 +2800,42 @@ export function pickSurfaceDetour(
       const passYOnly = canEnterSurfaceTile(world, prevTileX, prevTileY + pdy);
       if (!passXOnly && !passYOnly) continue;
     }
-    const score = Math.abs(cx - targetX) + Math.abs(cy - targetY);
+    let score = Math.abs(cx - targetX) + Math.abs(cy - targetY);
+    // Issue #63 (v11+) — pocket-escape penalty. Pre-v11 the score above
+    // is purely Manhattan distance to target, which deadlocks ants in
+    // pockets formed by clusters of multi-tile HardBlocks (4×4 boulders,
+    // 6×3 twigs, 3×4 BigLeaves): every candidate inside the pocket has a
+    // similar Manhattan score, the picker locks onto one, and the post-
+    // step guard's 1-tile detour can't see far enough to escape. Add a
+    // 2-tile lookahead: penalize candidates whose onward step is blocked
+    // by HardBlock features that themselves continue beyond — a real
+    // pocket is at least 2 deep in the same direction. Pre-v11 keeps the
+    // pure-Manhattan score for replay byte-identity (SCEN-06).
+    //
+    // Edge-cases handled to avoid false positives:
+    //   - OOB (world boundary) ahead is NOT a pocket — boundaries are
+    //     a normal terminus, not a HardBlock cluster. Skip the penalty.
+    //   - Single-tile dead-ends (ahead blocked, ahead2 walkable or OOB)
+    //     are not "pockets"; the post-step guard's existing handling
+    //     escapes them in one detour cycle. Don't penalize.
+    if (world.simVersion >= SIM_VERSION_V11_DEFENSIVE_BUNDLE) {
+      const aheadX = cx + pdx;
+      const aheadY = cy + pdy;
+      const aheadInBounds = aheadX >= 0 && aheadY >= 0
+        && aheadX < SURFACE_GRID_WIDTH && aheadY < SURFACE_GRID_HEIGHT;
+      // Only penalize when (ahead in-bounds AND blocked) AND (ahead2 in-bounds AND blocked).
+      // This isolates the multi-tile-feature pocket case from OOB + shallow dead-ends.
+      if (aheadInBounds && !canEnterSurfaceTile(world, aheadX, aheadY)) {
+        const ahead2X = aheadX + pdx;
+        const ahead2Y = aheadY + pdy;
+        const ahead2InBounds = ahead2X >= 0 && ahead2Y >= 0
+          && ahead2X < SURFACE_GRID_WIDTH && ahead2Y < SURFACE_GRID_HEIGHT;
+        if (ahead2InBounds && !canEnterSurfaceTile(world, ahead2X, ahead2Y)) {
+          // Real pocket: dominate Manhattan differences in this 128x128 grid.
+          score += 1000;
+        }
+      }
+    }
     // Recent-tiles preference (not a hard filter): a Foraging ant whose
     // direct path is blocked otherwise oscillates between the blocked
     // tile and a sideways alternate every other tick. We prefer fresh
@@ -2862,6 +2963,15 @@ export function pickNearestHostileUnderground(
 // Gate 6 in lifecycle-system.ts.
 // ---------------------------------------------------------------------------
 
+/**
+ * Collect alive queen entity ids. Returns the module-level
+ * `QUEEN_IDS_SCRATCH` singleton (filled in place) or `null` if no queens
+ * qualify. Caller MUST consume the returned set before any other call to
+ * `collectAliveQueenIds` — the next call clears and refills the same
+ * instance, silently invalidating prior references. Today's only caller
+ * (`tickAntMovement`) consumes inline within the same function body, so
+ * the shared mutable is safe.
+ */
 function collectAliveQueenIds(world: WorldState): Set<number> | null {
   // Only skip ants that the relocation pass actually drives. That requires a
   // completed Queen chamber AND task=Idle (the queen's canonical task). This
@@ -2870,7 +2980,12 @@ function collectAliveQueenIds(world: WorldState): Set<number> | null {
   // entity 0 as a forager and createColonyRecord(..., 0) as the queen slot).
   // Without a Queen chamber moveQueens is a no-op, so the main loop must
   // remain responsible for moving that entity.
-  let set: Set<number> | null = null;
+  //
+  // Issue #67 — clear-and-fill the module-level scratch instead of
+  // allocating a new Set per tick. Returning `null` for "no queens to skip"
+  // is preserved; callers fast-path on null without touching the set.
+  QUEEN_IDS_SCRATCH.clear();
+  let any = false;
   for (const key in world.colonies) {
     if (!Object.hasOwn(world.colonies, key)) continue;
     const colony = world.colonies[key as unknown as number]!;
@@ -2878,10 +2993,10 @@ function collectAliveQueenIds(world: WorldState): Set<number> | null {
     if (world.ants.alive[qId] !== 1) continue;
     if (world.ants.task[qId] !== AntTask.Idle) continue;
     if (!hasCompletedChamber(colony, ChamberType.Queen)) continue;
-    if (set === null) set = new Set<number>();
-    set.add(qId);
+    QUEEN_IDS_SCRATCH.add(qId);
+    any = true;
   }
-  return set;
+  return any ? QUEEN_IDS_SCRATCH : null;
 }
 
 /**
@@ -3016,8 +3131,8 @@ function moveQueens(
       // Math.abs(rawDy)` greedy axis pick that exhausted the leading
       // axis before switching, producing visible stair-step.
       const step = pickCardinalStep(ants, qId, targetTileX - tileX, targetTileY - tileY, world.simVersion);
-      dx = step.dx;
-      dy = step.dy;
+      dx = unpackStepDx(step);
+      dy = unpackStepDy(step);
     } else if (zone === Zone.Surface) {
       // Pre-move descent: if the queen is already standing on one of her
       // colony's OPEN entrance tiles, descend immediately rather than computing
@@ -3063,8 +3178,8 @@ function moveQueens(
       if (targetTileX < 0) continue; // no open entrance — queen cannot descend yet.
       // Issue #34: see pickCardinalStep helper above.
       const step = pickCardinalStep(ants, qId, targetTileX - tileX, targetTileY - tileY, world.simVersion);
-      dx = step.dx;
-      dy = step.dy;
+      dx = unpackStepDx(step);
+      dy = unpackStepDy(step);
     } else {
       // Underground → follow the queen flow-field (seeded only from Queen
       // chamber Open tiles). A Nursery-only chamber tile must NOT be a
@@ -3142,8 +3257,8 @@ function moveQueens(
         if (targetTileX < 0) continue;
         // Issue #34: see pickCardinalStep helper above.
         const step = pickCardinalStep(ants, qId, targetTileX - tileX, targetTileY - tileY, world.simVersion);
-        dx = step.dx;
-        dy = step.dy;
+        dx = unpackStepDx(step);
+        dy = unpackStepDy(step);
       }
     }
 
@@ -3358,10 +3473,15 @@ export function tickAntMovement(
   // Issue #44 step 5 — per-tick surface movement cache. The SoftCost check
   // fires for every surface ant on every tick; without memoisation each
   // call re-walks the surface-feature selector (anchor scan + suppression).
-  // The cache flattens it to O(1) per repeated tile lookup. ~16 KB Uint8Array
-  // allocated once per tickAntMovement, discarded at end. Pre-v6 worlds
+  // The cache flattens it to O(1) per repeated tile lookup. Pre-v6 worlds
   // never consult it (gate below skips the SoftCost block entirely).
-  const surfaceMoveCache = createSurfaceMovementCache();
+  //
+  // Issue #67 — module-level scratch, reset each tick instead of allocating
+  // a fresh ~16 KB Uint8Array. The reset is the same fill(255) work that
+  // createSurfaceMovementCache does after allocation, just without the
+  // allocation+GC churn.
+  resetSurfaceMovementCache(SURFACE_MOVE_CACHE_SCRATCH);
+  const surfaceMoveCache = SURFACE_MOVE_CACHE_SCRATCH;
 
   // P1 queen-relocation: queens have their own movement path (route to Queen
   // chamber). They must be skipped in the main loop below so the default
@@ -3629,8 +3749,8 @@ export function tickAntMovement(
           (chamberTargetY >> FP_SHIFT) - (posY >> FP_SHIFT),
           world.simVersion,
         );
-        dx = step.dx;
-        dy = step.dy;
+        dx = unpackStepDx(step);
+        dy = unpackStepDy(step);
       }
     } else if (entranceTargetX !== -1) {
       // Zone-transitioning ant — move toward nearest open entrance.
@@ -3697,8 +3817,8 @@ export function tickAntMovement(
           (entranceTargetY >> FP_SHIFT) - (posY >> FP_SHIFT),
           world.simVersion,
         );
-        dx = step.dx;
-        dy = step.dy;
+        dx = unpackStepDx(step);
+        dy = unpackStepDy(step);
       }
     } else if (task === AntTask.Foraging) {
       // Issue #35 — pause-while-searching. Real ants scurry-stop-scurry; we
@@ -3761,8 +3881,8 @@ export function tickAntMovement(
           (targetY >> FP_SHIFT) - (posY >> FP_SHIFT),
           world.simVersion,
         );
-        dx = step.dx;
-        dy = step.dy;
+        dx = unpackStepDx(step);
+        dy = unpackStepDy(step);
       } else {
         const colonyId = ants.colonyId[id]!;
         const tileX = ants.posX[id]! >> FP_SHIFT;
@@ -3777,8 +3897,8 @@ export function tickAntMovement(
         if (scent !== null) {
           // Issue #34: see pickCardinalStep helper above.
           const step = pickCardinalStep(ants, id, scent.tileX - tileX, scent.tileY - tileY, world.simVersion);
-          dx = step.dx;
-          dy = step.dy;
+          dx = unpackStepDx(step);
+          dy = unpackStepDy(step);
         } else {
           const key = pheromoneGridKey(colonyId, PheromoneType.FoodTrail, 'surface');
           const grid = world.pheromoneGrids[key];
@@ -3875,8 +3995,8 @@ export function tickAntMovement(
         const tileX = posX >> FP_SHIFT;
         const tileY = posY >> FP_SHIFT;
         const step = pickCardinalStep(ants, id, targetTileX - tileX, targetTileY - tileY, world.simVersion);
-        dx = step.dx;
-        dy = step.dy;
+        dx = unpackStepDx(step);
+        dy = unpackStepDy(step);
       } else {
         // No target and no entrance fallback — hold. updateFightAntTargets
         // writes targetPosX/Y whenever rallyPoint or entrances exist, so this
@@ -4337,7 +4457,13 @@ export function tickAntMovement(
 // ---------------------------------------------------------------------------
 function resolveSameColonyOccupancy(world: WorldState): void {
   const ants = world.ants;
-  const occupancy = new Map<number, number>(); // tileKey → lowest-id claimant
+  // Issue #67 — reuse a module-level Map instead of allocating per tick.
+  // Map.clear() is O(n) where n is the size of the previous tick's map;
+  // negligible vs. the prior `new Map()` + GC churn. Same observable
+  // behavior — Map iteration order is insertion order, which we don't
+  // rely on (lookups are key-based).
+  const occupancy = OCCUPANCY_SCRATCH;
+  occupancy.clear();
 
   for (let id = 0; id < world.nextEntityId; id++) {
     if (ants.alive[id] !== 1) continue;
@@ -4354,12 +4480,29 @@ function resolveSameColonyOccupancy(world: WorldState): void {
 
     const colonyId = ants.colonyId[id]!;
     const zone = ants.zone[id]!;
+    // Issue #61 — include `gridColonyId` in the occupancy key so cross-grid
+    // ants (Phase 09.1 Chunk 3+4 fighter invaders with currentGridColonyId !==
+    // colonyId) never alias home-grid same-colony ants. Today gridColonyId ===
+    // colonyId for every ant by construction (initAnt establishes the
+    // invariant; only mid-attack invaders break it once 09.1 lands), so the
+    // key value differs from pre-fix but ant pairs collide at the same key —
+    // observable behavior unchanged. Shifts when invasion lands.
+    //
+    // Bit layout (preserves existing 17 low bits for zone + tile coords,
+    // adds gridColonyId in bits 17..23 — 7 bits is plenty since ColonyId is
+    // a small enum):
+    //   bits  0..6  : tileX (0..127)
+    //   bits  7..14 : tileY (0..127, fits SURFACE_GRID_HEIGHT and underground)
+    //   bit  15     : zone (0 = Surface, 1 = Underground)
+    //   bits 16..22 : colonyId (0..127)
+    //   bits 23..29 : gridColonyId (0..127)
+    const gridColonyId = ants.currentGridColonyId[id]!;
     let tileX = ants.posX[id]! >> FP_SHIFT;
     let tileY = ants.posY[id]! >> FP_SHIFT;
 
     if (isOccupancyExempt(world, colonyId, zone, tileX, tileY)) continue;
 
-    const key = (colonyId << 16) | (zone << 15) | (tileY << 7) | tileX;
+    const key = (gridColonyId << 23) | (colonyId << 16) | (zone << 15) | (tileY << 7) | tileX;
     if (!occupancy.has(key)) {
       occupancy.set(key, id);
       continue;
@@ -4373,7 +4516,6 @@ function resolveSameColonyOccupancy(world: WorldState): void {
     // keys occupancy detection (same-colony ants compete for tiles regardless
     // of where they are). Today both keys yield the same grid.
     const task = ants.task[id]! as AntTask;
-    const gridColonyId = ants.currentGridColonyId[id]!;
     const underground =
       zone === Zone.Underground ? world.undergroundGrids[gridColonyId] : undefined;
     let shifted = false;
@@ -4406,7 +4548,8 @@ function resolveSameColonyOccupancy(world: WorldState): void {
         shifted = true;
         break;
       }
-      const adjKey = (colonyId << 16) | (zone << 15) | (ny << 7) | nx;
+      // Issue #61 — same key layout as the primary key above.
+      const adjKey = (gridColonyId << 23) | (colonyId << 16) | (zone << 15) | (ny << 7) | nx;
       if (occupancy.has(adjKey)) continue;
       tileX = nx;
       tileY = ny;

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -3808,6 +3808,42 @@ export function tickAntMovement(
         }
       }
 
+      // Issue #63 (v11+) — surface ants targeting an entrance consume the
+      // surface entrance flow-field instead of straight-line pickCardinalStep.
+      // The field is a true BFS through non-HardBlock tiles, so the ant
+      // routes around multi-tile feature pockets (4×4 boulders, 6×3 twigs,
+      // 3×4 BigLeaves) that the 1-tile pickSurfaceDetour can't escape.
+      if (!stepped
+        && zone === Zone.Surface
+        && entranceFlowFields !== undefined
+        && world.simVersion >= SIM_VERSION_V11_DEFENSIVE_BUNDLE
+      ) {
+        const colonyId = ants.colonyId[id]!;
+        const surfaceField = entranceFlowFields.surface[colonyId];
+        if (surfaceField) {
+          const tileX = posX >> FP_SHIFT;
+          const tileY = posY >> FP_SHIFT;
+          if (tileX >= 0 && tileX < SURFACE_GRID_WIDTH && tileY >= 0 && tileY < SURFACE_GRID_HEIGHT) {
+            const sIdx = tileY * SURFACE_GRID_WIDTH + tileX;
+            const sDir = surfaceField[sIdx]!;
+            if (sDir === -1) {
+              // Source tile — at the entrance. Hold so the zone-transition
+              // block below promotes to Underground.
+              dx = 0;
+              dy = 0;
+              stepped = true;
+            } else if (sDir >= 0 && sDir < 4) {
+              dx = DIR_DX[sDir]!;
+              dy = DIR_DY[sDir]!;
+              stepped = true;
+            }
+            // sDir === -2 (unreachable) → fall through to straight-line below.
+            // Shouldn't happen in practice (entrance always reachable from any
+            // walkable surface tile in a connected map), but defensive.
+          }
+        }
+      }
+
       if (!stepped) {
         // Issue #34 + codex coord-scale fix: tile-space deltas (see the
         // chamber-target site above for rationale).

--- a/src/sim/combat-cross-grid.test.ts
+++ b/src/sim/combat-cross-grid.test.ts
@@ -29,6 +29,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { detectAndResolveCombat } from './combat.js';
+import { Rng } from './rng.js';
 import { checkQueenDeath, GameOutcome } from './game-over.js';
 import { createWorldState, allocateEntityId } from './types.js';
 import { createColonyRecord } from './colony/colony-store.js';
@@ -165,7 +166,7 @@ describe('combat cross-grid — tile-key gridColonyId extension (REQ-C4)', () =>
     // Act --------------------------------------------------------------------
     // Pin rngState to the known-player-wins seed value immediately before combat.
     world.rngState = 3;
-    detectAndResolveCombat(world);
+    detectAndResolveCombat(world, new Rng(world.rngState));
 
     // MANDATORY t=N outcome assertions ---------------------------------------
     // Enemy queen is dead.
@@ -262,7 +263,7 @@ describe('combat cross-grid — tile-key gridColonyId extension (REQ-C4)', () =>
     expect(world.ants.colonyId[antB]).toBe(ENEMY_COLONY_ID);
 
     // Act --------------------------------------------------------------------
-    detectAndResolveCombat(world);
+    detectAndResolveCombat(world, new Rng(world.rngState));
 
     // MANDATORY t=N outcome assertions ---------------------------------------
     // Neither ant died — they never bucketed together.

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { detectAndResolveCombat, killAnt } from './combat.js';
 import { createWorldState, allocateEntityId } from './types.js';
+import { Rng } from './rng.js';
 import { createColonyRecord } from './colony/colony-store.js';
 import { initAnt } from './ant/ant-store.js';
 import { AntTask } from './enums.js';
@@ -51,7 +52,7 @@ describe('detectAndResolveCombat', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
     const a = spawnAnt(world, cid1, 5, 5, Zone.Surface);
     const b = spawnAnt(world, cid2, 10, 10, Zone.Surface);
-    detectAndResolveCombat(world);
+    detectAndResolveCombat(world, new Rng(world.rngState));
     expect(world.ants.alive[a]).toBe(1);
     expect(world.ants.alive[b]).toBe(1);
     expect(world.colonies[cid1]!.killCount).toBe(0);
@@ -62,7 +63,7 @@ describe('detectAndResolveCombat', () => {
     const { world, cid1 } = makeWorldWith2Colonies();
     const a = spawnAnt(world, cid1, 7, 7, Zone.Surface);
     const b = spawnAnt(world, cid1, 7, 7, Zone.Surface);
-    detectAndResolveCombat(world);
+    detectAndResolveCombat(world, new Rng(world.rngState));
     expect(world.ants.alive[a]).toBe(1);
     expect(world.ants.alive[b]).toBe(1);
   });
@@ -71,7 +72,7 @@ describe('detectAndResolveCombat', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
     const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
     const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
-    detectAndResolveCombat(world);
+    detectAndResolveCombat(world, new Rng(world.rngState));
     const aliveCount = world.ants.alive[a]! + world.ants.alive[b]!;
     expect(aliveCount).toBe(1); // exactly one died
     const totalKills = world.colonies[cid1]!.killCount + world.colonies[cid2]!.killCount;
@@ -82,7 +83,7 @@ describe('detectAndResolveCombat', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
     const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
     const b = spawnAnt(world, cid2, 5, 7, Zone.Underground);
-    detectAndResolveCombat(world);
+    detectAndResolveCombat(world, new Rng(world.rngState));
     expect(world.ants.alive[a]).toBe(1);
     expect(world.ants.alive[b]).toBe(1);
     expect(world.colonies[cid1]!.killCount).toBe(0);
@@ -97,9 +98,9 @@ describe('detectAndResolveCombat', () => {
       return { ...x, a, b };
     };
     const run1 = build();
-    detectAndResolveCombat(run1.world);
+    detectAndResolveCombat(run1.world, new Rng(run1.world.rngState));
     const run2 = build();
-    detectAndResolveCombat(run2.world);
+    detectAndResolveCombat(run2.world, new Rng(run2.world.rngState));
     expect(run1.world.ants.alive[run1.a]).toBe(run2.world.ants.alive[run2.a]);
     expect(run1.world.ants.alive[run1.b]).toBe(run2.world.ants.alive[run2.b]);
   });
@@ -120,19 +121,26 @@ describe('resolveCombatOnTile', () => {
     const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
     const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
     const c = spawnAnt(world, 3 as ColonyId, 5, 7, Zone.Surface);
-    detectAndResolveCombat(world);
+    detectAndResolveCombat(world, new Rng(world.rngState));
     const alive = [world.ants.alive[a] ?? 0, world.ants.alive[b] ?? 0, world.ants.alive[c] ?? 0];
     expect(alive.reduce((s, v) => s + v, 0)).toBe(1); // exactly one survives
   });
 
-  it('advances world.rngState exactly once per round', () => {
+  it('advances the caller-passed rng exactly once per round (#58)', () => {
+    // Issue #58 — combat no longer writes back to world.rngState; tick.ts
+    // owns the single end-of-tick writeback via the shared rng_tick instance.
+    // This test pins the new contract: combat advances the rng IT was given,
+    // not world.rngState directly.
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
     spawnAnt(world, cid1, 5, 7, Zone.Surface);
     spawnAnt(world, cid2, 5, 7, Zone.Surface);
-    const before = world.rngState;
-    detectAndResolveCombat(world);
+    const rng = new Rng(world.rngState);
+    const before = rng.getState();
+    detectAndResolveCombat(world, rng);
     // One round = one nextInt(2) call = one state advance. State should differ.
-    expect(world.rngState).not.toBe(before);
+    expect(rng.getState()).not.toBe(before);
+    // And world.rngState is NOT touched by combat directly anymore.
+    expect(world.rngState).toBe(before);
   });
 });
 
@@ -174,14 +182,18 @@ describe('killAnt', () => {
 
 describe('coin flip distribution (CMBT-05)', () => {
   it('over 1000 fights, A-wins is within ±3σ of 500 (approx 453..547)', () => {
-    // Share world.rngState across fights — real sequence, not 1000 fresh RNGs.
+    // Issue #58 — combat now advances the rng instance the caller passes,
+    // not world.rngState. Pass ONE shared rng across all iterations so the
+    // sequence advances naturally between fights (the prior test relied on
+    // combat's now-removed writeback to world.rngState).
     const { world, cid1, cid2 } = makeWorldWith2Colonies(42);
+    const rng = new Rng(world.rngState);
     let aWins = 0;
     for (let i = 0; i < 1000; i++) {
-      // Reset only the two combatants — keep rngState unchanged between iterations.
+      // Reset only the two combatants — keep rng unchanged between iterations.
       const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
       const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
-      detectAndResolveCombat(world);
+      detectAndResolveCombat(world, rng);
       if (world.ants.alive[a] === 1) aWins += 1;
       // Kill the survivor (whichever) so next iteration starts fresh — set both alive=0 to avoid
       // cross-iteration state. spawnAnt allocates new ids so there is no slot collision.

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -23,7 +23,23 @@ import { FP_SHIFT } from './fixed.js';
  * Mutates: world.ants.alive (instant-kills losers), world.colonies[*].killCount (increments
  * winners), world.rngState (advances once per round).
  */
-export function detectAndResolveCombat(world: WorldState): void {
+/**
+ * Issue #58 — caller passes the rng instance.
+ *
+ * Pre-fix this function was `(world)`-only and constructed a fresh Rng from
+ * `world.rngState` internally. That state was still the tick-start value
+ * (tickAntMovement mutates a separate rng_tick instance and only writes
+ * back at end-of-tick), so combat's RNG sequence was effectively a
+ * parallel stream that the end-of-tick writeback discarded — the
+ * `world.rngState = rng.getState()` line we used to do here was overwritten
+ * by tick.ts step 19. Functionally byte-deterministic (same seed → same
+ * outcomes) but contradicts the design intent that "rng pulls accumulate."
+ *
+ * v11+: caller passes `rng_tick` so combat shares the tick's stream.
+ * pre-v11: caller passes a fresh `Rng(world.rngState)` to preserve the
+ *          dead-writeback behaviour for byte-identical replay of older saves.
+ */
+export function detectAndResolveCombat(world: WorldState, rng: Rng): void {
   const { ants } = world;
   const count = ants.alive.length; // capacity; iterate all slots (alive/colonyId guard)
 
@@ -64,17 +80,20 @@ export function detectAndResolveCombat(world: WorldState): void {
       }
     }
     if (!multiColony) continue;
-    resolveCombatOnTile(world, key, participants);
+    resolveCombatOnTile(world, key, participants, rng);
   }
 }
 
 /**
  * Resolve combat on a single tile. Runs rounds until fewer than 2 distinct colonies remain.
- * Mutates world.rngState, world.ants.alive, world.colonies[*].killCount.
+ * Mutates world.ants.alive, world.colonies[*].killCount, and the passed rng instance.
+ *
+ * Issue #58 — caller passes rng. Previously constructed `new Rng(world.rngState)`
+ * internally and did `world.rngState = rng.getState()` at the bottom; both
+ * removed because tick.ts step 19 owns the world.rngState writeback.
  */
-export function resolveCombatOnTile(world: WorldState, _tileKey: number, participants: readonly number[]): void {
+export function resolveCombatOnTile(world: WorldState, _tileKey: number, participants: readonly number[], rng: Rng): void {
   const { ants } = world;
-  const rng = new Rng(world.rngState);
 
   // Loop until only one colony remains among alive participants.
   // Each round guarantees one death → provably terminates in ≤ participants.length - 1 rounds.
@@ -109,8 +128,9 @@ export function resolveCombatOnTile(world: WorldState, _tileKey: number, partici
       killAnt(world, antA, cidB);
     }
   }
-
-  world.rngState = rng.getState();
+  // Issue #58 — no writeback. The pre-fix `world.rngState = rng.getState()`
+  // was always overwritten by tick.ts step 19 (rng_tick.getState()) so it
+  // was dead code. Caller (tick.ts) owns the single end-of-tick writeback.
 }
 
 /**

--- a/src/sim/entrance-flow.ts
+++ b/src/sim/entrance-flow.ts
@@ -24,6 +24,9 @@ import type { ColonyId } from './colony/colony-store.js';
 import type { NestEntrance } from './colony/entrance.js';
 import { UndergroundTileState } from './terrain.js';
 import type { UndergroundGrid } from './terrain.js';
+import type { WorldState } from './types.js';
+import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT } from './constants.js';
+import { surfaceMovementAt, SurfaceMovementEffect } from './surface-features.js';
 // Issue #87 — shared BFS expansion (was inline pre-#87, near-identical to
 // dig-system.ts and chamber-flow.ts copies). Direction encoding:
 //   0=N (toward tileY=0, surface side of a shaft), 1=E, 2=S, 3=W;
@@ -35,18 +38,28 @@ import { bfsExpandSeededField } from './bfs-flow-field.js';
 // ---------------------------------------------------------------------------
 
 export interface EntranceFlowFields {
-  /** Direction array per colony. Key = colonyId. Value = Int32Array of length W*H. */
+  /** Underground direction array per colony — points toward nearest open entrance underground tile. */
   fields: Record<ColonyId, Int32Array>;
-  /** BFS scratch queue per colony. Pre-allocated to avoid per-tick allocation. */
+  /** BFS scratch queue per colony for the underground field. */
   queues: Record<ColonyId, Int32Array>;
+  /**
+   * Issue #63 — surface direction array per colony. Points toward the nearest
+   * open entrance through non-HardBlock surface tiles. Lets surface ants
+   * targeting an entrance (CarryingFood / ReturningToNest) escape pockets
+   * formed by clusters of multi-tile HardBlock features (boulders, twigs,
+   * leaves) that the 1-tile pickSurfaceDetour can't reason about.
+   */
+  surface: Record<ColonyId, Int32Array>;
+  /** BFS scratch queue per colony for the surface field. */
+  surfaceQueues: Record<ColonyId, Int32Array>;
 }
 
 /**
  * Create an EntranceFlowFields cache — call once at module init.
- * Both maps start empty; ensureEntranceFlowField allocates lazily per colony.
+ * All maps start empty; ensureEntranceFlowField allocates lazily per colony.
  */
 export function createEntranceFlowFields(): EntranceFlowFields {
-  return { fields: {}, queues: {} };
+  return { fields: {}, queues: {}, surface: {}, surfaceQueues: {} };
 }
 
 /**
@@ -67,6 +80,22 @@ export function ensureEntranceFlowField(
     cache.queues[colonyId] = new Int32Array(gridSize);
   }
   return cache.fields[colonyId]!;
+}
+
+/**
+ * Issue #63 — ensure the SURFACE flow-field buffers for a colony are allocated.
+ * Sized to the surface grid (128×128 fixed). Lazy per colony.
+ */
+export function ensureSurfaceEntranceFlowField(
+  cache: EntranceFlowFields,
+  colonyId: ColonyId,
+): Int32Array {
+  if (!(colonyId in cache.surface)) {
+    const size = SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT;
+    cache.surface[colonyId] = new Int32Array(size);
+    cache.surfaceQueues[colonyId] = new Int32Array(size);
+  }
+  return cache.surface[colonyId]!;
 }
 
 /**
@@ -117,4 +146,100 @@ export function computeEntranceFlowField(
   // Step 3: BFS expansion through Open and BeingDug (shared helper).
   // Solid and Marked are walls for a non-digger returning to the surface.
   bfsExpandSeededField(out, queue, tail, data, width, height);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #63 — surface entrance flow field.
+//
+// Multi-source BFS from each open entrance's SURFACE tile (at row 0 column
+// surfaceTileX), expanded through non-HardBlock surface tiles. Output at
+// each reachable tile is the direction an ant should step to head one tile
+// closer to the nearest open entrance.
+//
+// Why a dedicated field:
+//   - Pre-#63 surface ants targeting an entrance used straight-line
+//     pickCardinalStep + 1-tile pickSurfaceDetour. The detour can't escape
+//     pockets formed by clusters of multi-tile HardBlock features (4×4
+//     boulder, 6×3 twig, 3×4 BigLeaf), and the picker scores by Manhattan
+//     to the BLOCKED tile rather than the actual destination — so candidate
+//     scores tie and the compass tie-break can route the ant AWAY from goal.
+//   - The BFS is a true shortest-path-through-walkable-tiles solver.
+//     No tie-break ambiguity, no pocket trapping.
+//
+// Encoding mirrors the underground field at the top of this file:
+//   0=N  1=E  2=S  3=W  -1=source  -2=unreachable
+//
+// Direction at each tile is `out[ty * width + tx]`, where width =
+// SURFACE_GRID_WIDTH (128). Caller derives `tileX/tileY` from the ant's
+// posX/posY and reads `out[ty * width + tx]`.
+//
+// Cost: O(W*H) per call. With W*H = 128*128 = 16384, this is comparable to
+// the underground field. Recomputed only when surface flow goes dirty (today:
+// every tick alongside underground; future optimization could gate on
+// entrance changes since surface terrain features are static post-init).
+// ---------------------------------------------------------------------------
+
+export function computeSurfaceEntranceFlowField(
+  world: WorldState,
+  entrances: ReadonlyArray<NestEntrance>,
+  out: Int32Array,
+  queue: Int32Array,
+): void {
+  const width = SURFACE_GRID_WIDTH;
+  const height = SURFACE_GRID_HEIGHT;
+
+  // Step 1: -2 fill (unvisited sentinel).
+  out.fill(-2);
+
+  // Step 2: seed from open entrance surface tiles. The entrance's surface
+  // tile is (surfaceTileX, surfaceTileY) — typically (sx, 0) but read both
+  // for forward-compat with future entrance-elevation features.
+  let tail = 0;
+  for (let e = 0; e < entrances.length; e++) {
+    const ent = entrances[e]!;
+    if (!ent.isOpen) continue;
+    const sx = ent.surfaceTileX;
+    const sy = ent.surfaceTileY;
+    if (sx < 0 || sx >= width) continue;
+    if (sy < 0 || sy >= height) continue;
+    // Defensive: skip if the entrance tile itself is a HardBlock (shouldn't
+    // happen — DesignateEntrance handler guards against placement on a
+    // HardBlock — but the BFS would never reach it from itself anyway).
+    if (surfaceMovementAt(world, sx, sy) === SurfaceMovementEffect.HardBlock) continue;
+    const idx = sy * width + sx;
+    if (out[idx] !== -2) continue; // dedupe
+    out[idx] = -1; // source
+    queue[tail++] = idx;
+  }
+
+  // Step 3: 4-cardinal BFS expansion through non-HardBlock surface tiles.
+  // Inline rather than reusing bfsExpandSeededField because the predicate
+  // differs (surface uses SurfaceMovementEffect, not UndergroundTileState).
+  // Direction encoding matches: 0=N, 1=E, 2=S, 3=W; out[neighbor] gets
+  // REVERSE[d] = direction pointing back toward the source.
+  const REVERSE = [2, 3, 0, 1] as const;
+  const NEIGHBOR_DR = [-1, 0, 1, 0] as const;
+  const NEIGHBOR_DC = [0, 1, 0, -1] as const;
+
+  let head = 0;
+  while (head < tail) {
+    const idx = queue[head++]!;
+    // eslint-disable-next-line no-restricted-syntax -- integer division via `| 0`; BFS index→row conversion, not fixed-point math
+    const row = (idx / width) | 0;
+    const col = idx % width;
+
+    for (let d = 0; d < 4; d++) {
+      const nRow = row + NEIGHBOR_DR[d]!;
+      const nCol = col + NEIGHBOR_DC[d]!;
+      if (nRow < 0 || nRow >= height || nCol < 0 || nCol >= width) continue;
+      const nIdx = nRow * width + nCol;
+      if (out[nIdx] !== -2) continue;
+      // Predicate: any non-HardBlock surface tile is passable. Cosmetic and
+      // SoftCost both pass — the SoftCost speed penalty is applied separately
+      // by the per-step movement code, doesn't affect routing reachability.
+      if (surfaceMovementAt(world, nCol, nRow) === SurfaceMovementEffect.HardBlock) continue;
+      out[nIdx] = REVERSE[d]!;
+      queue[tail++] = nIdx;
+    }
+  }
 }

--- a/src/sim/entrance-flow.ts
+++ b/src/sim/entrance-flow.ts
@@ -27,6 +27,14 @@ import type { UndergroundGrid } from './terrain.js';
 import type { WorldState } from './types.js';
 import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT } from './constants.js';
 import { surfaceMovementAt, SurfaceMovementEffect } from './surface-features.js';
+
+// Static check: the surface BFS at the bottom of this file uses bit-shift
+// row decode (`idx >> 7`) on the assumption that SURFACE_GRID_WIDTH is a
+// power of 2. If the constant ever leaves 128, the SURFACE_WIDTH_SHIFT
+// constant inside `computeSurfaceEntranceFlowField` MUST update in
+// lockstep. This satisfies-clause fails to compile if the value drifts.
+const _SURFACE_WIDTH_IS_128: 128 = SURFACE_GRID_WIDTH;
+void _SURFACE_WIDTH_IS_128;
 // Issue #87 — shared BFS expansion (was inline pre-#87, near-identical to
 // dig-system.ts and chamber-flow.ts copies). Direction encoding:
 //   0=N (toward tileY=0, surface side of a shaft), 1=E, 2=S, 3=W;
@@ -217,6 +225,16 @@ export function computeSurfaceEntranceFlowField(
   // differs (surface uses SurfaceMovementEffect, not UndergroundTileState).
   // Direction encoding matches: 0=N, 1=E, 2=S, 3=W; out[neighbor] gets
   // REVERSE[d] = direction pointing back toward the source.
+  //
+  // Codex P1 follow-up — `(idx / width) | 0` was disabled-eslint here in
+  // the first pass; replaced with shift/mask. SURFACE_GRID_WIDTH is fixed
+  // at 128 = 2^7, so `idx >> 7` equals integer division for our range
+  // (idx in [0, 128*128)). Same for column via `idx & 127`. Integer-only,
+  // ESLint-clean, single-instruction. If SURFACE_GRID_WIDTH ever leaves
+  // power-of-2 territory, this needs a strategy change (and the
+  // SHIFT/MASK constants below need to update accordingly).
+  const SURFACE_WIDTH_SHIFT = 7;       // log2(128)
+  const SURFACE_WIDTH_MASK  = width - 1; // 127
   const REVERSE = [2, 3, 0, 1] as const;
   const NEIGHBOR_DR = [-1, 0, 1, 0] as const;
   const NEIGHBOR_DC = [0, 1, 0, -1] as const;
@@ -224,9 +242,8 @@ export function computeSurfaceEntranceFlowField(
   let head = 0;
   while (head < tail) {
     const idx = queue[head++]!;
-    // eslint-disable-next-line no-restricted-syntax -- integer division via `| 0`; BFS index→row conversion, not fixed-point math
-    const row = (idx / width) | 0;
-    const col = idx % width;
+    const row = idx >> SURFACE_WIDTH_SHIFT;
+    const col = idx & SURFACE_WIDTH_MASK;
 
     for (let d = 0; d < 4; d++) {
       const nRow = row + NEIGHBOR_DR[d]!;

--- a/src/sim/surface-features.ts
+++ b/src/sim/surface-features.ts
@@ -568,6 +568,16 @@ export function createSurfaceMovementCache(): SurfaceMovementCache {
 }
 
 /**
+ * Issue #67 — reset a previously-allocated cache for reuse, instead of
+ * allocating a fresh 16KB Uint8Array per tick. Caller pre-allocates once at
+ * module scope (or via a tick-scratch struct) and resets each tick before
+ * the first lookup. Same observable behaviour as `createSurfaceMovementCache`.
+ */
+export function resetSurfaceMovementCache(cache: SurfaceMovementCache): void {
+  cache.fill(SURFACE_MOVE_CACHE_SENTINEL);
+}
+
+/**
  * Cached variant of `surfaceMovementAt`. Returns the same value as the
  * uncached form; just memoises within a tick.
  *

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -2555,16 +2555,16 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeUndefined();
   });
 
-  it('new worlds run at LATEST_SIM_VERSION (== V10_VISIBLE_BROOD_CARRY after #17 phase 1)', () => {
+  it('new worlds run at LATEST_SIM_VERSION (>= V10_VISIBLE_BROOD_CARRY)', () => {
     // Verify createWorldState uses the LATEST_SIM_VERSION constant exactly.
     // Tracks the constant rather than a hard-coded number so future bumps
     // don't have to update this assertion, while still proving the factory
-    // is wired to the latest version (not stuck on a stale literal). Also
-    // pins the explicit v10 sentinel so a downgrade (e.g. accidental revert
-    // of the #17 visible-brood-carry phase 1) trips here.
+    // is wired to the latest version (not stuck on a stale literal). Pins
+    // the v10 sentinel as a floor — an accidental downgrade below v10
+    // would silently re-enable the visible-carry-render assumptions.
     const world = createWorldState(42);
     expect(world.simVersion).toBe(LATEST_SIM_VERSION);
-    expect(world.simVersion).toBe(SIM_VERSION_V10_VISIBLE_BROOD_CARRY);
+    expect(world.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V10_VISIBLE_BROOD_CARRY);
     // The v9 cancel-drops-pending floor still belongs to LATEST as well —
     // an accidental drop below v9 would silently re-enable the #54 Queen
     // chamber soft-lock.

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -115,15 +115,20 @@ const chamberFlowFields: ChamberFlowFields = createChamberFlowFields();
  * In-place deletion preserves the const-bound record identities held by step 9.
  */
 export function resetFlowFieldCaches(): void {
-  for (const k in digFlowFields.fields)       delete digFlowFields.fields[k as unknown as ColonyId];
-  for (const k in digFlowFields.queues)       delete digFlowFields.queues[k as unknown as ColonyId];
-  for (const k in entranceFlowFields.fields)  delete entranceFlowFields.fields[k as unknown as ColonyId];
-  for (const k in entranceFlowFields.queues)  delete entranceFlowFields.queues[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.food)         delete chamberFlowFields.food[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.nursing)      delete chamberFlowFields.nursing[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.queen)        delete chamberFlowFields.queen[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.nurseDeposit) delete chamberFlowFields.nurseDeposit[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.queues)       delete chamberFlowFields.queues[k as unknown as ColonyId];
+  for (const k in digFlowFields.fields)              delete digFlowFields.fields[k as unknown as ColonyId];
+  for (const k in digFlowFields.queues)              delete digFlowFields.queues[k as unknown as ColonyId];
+  for (const k in entranceFlowFields.fields)         delete entranceFlowFields.fields[k as unknown as ColonyId];
+  for (const k in entranceFlowFields.queues)         delete entranceFlowFields.queues[k as unknown as ColonyId];
+  // Issue #63 — surface entrance flow-field cache also needs reset, otherwise
+  // a session-restart or save-load with different colony IDs leaves stale
+  // arrays resident (codex P2 on PR #92).
+  for (const k in entranceFlowFields.surface)        delete entranceFlowFields.surface[k as unknown as ColonyId];
+  for (const k in entranceFlowFields.surfaceQueues)  delete entranceFlowFields.surfaceQueues[k as unknown as ColonyId];
+  for (const k in chamberFlowFields.food)            delete chamberFlowFields.food[k as unknown as ColonyId];
+  for (const k in chamberFlowFields.nursing)         delete chamberFlowFields.nursing[k as unknown as ColonyId];
+  for (const k in chamberFlowFields.queen)           delete chamberFlowFields.queen[k as unknown as ColonyId];
+  for (const k in chamberFlowFields.nurseDeposit)    delete chamberFlowFields.nurseDeposit[k as unknown as ColonyId];
+  for (const k in chamberFlowFields.queues)          delete chamberFlowFields.queues[k as unknown as ColonyId];
 }
 
 // Suppress unused-import TS error for PendingChamber (used in PlaceChamber case shape)

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1,6 +1,6 @@
 // src/sim/tick.ts — Phase 9 19-step tick dispatcher.
 import type { WorldState } from './types.js';
-import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY } from './types.js';
+import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY, SIM_VERSION_V11_DEFENSIVE_BUNDLE } from './types.js';
 import { MAX_COMMANDS_PER_TICK, type SimCommand } from './commands.js';
 import { GameOutcome, checkQueenDeath } from './game-over.js';
 import { detectAndResolveCombat } from './combat.js';
@@ -1096,8 +1096,24 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
 
   // ---------------------------------------------------------------------------
   // Step 17: combat detection + resolution (Phase 9 / CMBT-04) — runs after step 16 tickAntMovement.
+  //
+  // Issue #58 — pre-v11 combat constructed its own Rng from the tick-start
+  // world.rngState (still tick-start because nobody updates it mid-tick) and
+  // wrote back to world.rngState, but tick.ts step 19 below then overwrote
+  // that writeback with rng_tick's state. The combat RNG sequence was a
+  // parallel stream that ended at the writeback — functionally byte-
+  // deterministic but with the design contract violated.
+  //
+  // v11+: combat shares the tick rng so its pulls accumulate into the next
+  //       tick's RNG state, matching the design contract.
+  // pre-v11: combat gets a fresh Rng from world.rngState — same parallel
+  //          stream as before for byte-identical replay of older saves.
   // ---------------------------------------------------------------------------
-  detectAndResolveCombat(world);
+  if (world.simVersion >= SIM_VERSION_V11_DEFENSIVE_BUNDLE) {
+    detectAndResolveCombat(world, rng);
+  } else {
+    detectAndResolveCombat(world, new Rng(world.rngState));
+  }
 
   // ---------------------------------------------------------------------------
   // Step 18: game-over detection (Phase 9 / CMBT-06/07).

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -62,7 +62,9 @@ import {
 import type { DigFlowFields } from './dig-system.js';
 import {
   computeEntranceFlowField,
+  computeSurfaceEntranceFlowField,
   ensureEntranceFlowField,
+  ensureSurfaceEntranceFlowField,
   createEntranceFlowFields,
 } from './entrance-flow.js';
 import type { EntranceFlowFields } from './entrance-flow.js';
@@ -726,6 +728,17 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     const entOut = ensureEntranceFlowField(entranceFlowFields, colony.colonyId, gridSize);
     const entQueue = entranceFlowFields.queues[colony.colonyId]!;
     computeEntranceFlowField(underground, colony.entrances ?? [], entOut, entQueue);
+
+    // Issue #63 (v11+) — surface entrance flow field. Recomputed on the
+    // same cadence as the underground entrance field. Tile features are
+    // static post-init, so the only inputs that change are the entrance
+    // list (open/closed). Recomputing every dirty cycle is generous but
+    // simple; future optimization could gate on entrance-changed-only.
+    if (world.simVersion >= SIM_VERSION_V11_DEFENSIVE_BUNDLE) {
+      const sfcOut = ensureSurfaceEntranceFlowField(entranceFlowFields, colony.colonyId);
+      const sfcQueue = entranceFlowFields.surfaceQueues[colony.colonyId]!;
+      computeSurfaceEntranceFlowField(world, colony.entrances ?? [], sfcOut, sfcQueue);
+    }
 
     // Recompute chamber flow-fields on the same cycle. Chamber completion
     // (which flips tile states from Marked/BeingDug to Open) is one of the

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -112,7 +112,29 @@ export const SIM_VERSION_V7_SURFACE_PASSABILITY = 7 as const;
 export const SIM_VERSION_V8_LEASH_HYSTERESIS = 8 as const;
 export const SIM_VERSION_V9_CANCEL_DROPS_PENDING = 9 as const;
 export const SIM_VERSION_V10_VISIBLE_BROOD_CARRY = 10 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V10_VISIBLE_BROOD_CARRY;
+/**
+ * v11 — defensive bundle from the codebase review pass (issues #57, #58, #63).
+ * Three simultaneous sim fixes, gated together so pre-v11 saves replay byte-
+ * identically with the bugged behaviour:
+ *
+ *   #57 — `tickPheromoneDeposit` now requires `ants.zone[id] === Zone.Surface`
+ *         before depositing on the surface FoodTrail grid. Pre-v11 underground
+ *         carriers wrote phantom trails on the surface using their underground
+ *         tile coordinates (corrupting surface forager behaviour).
+ *
+ *   #58 — `detectAndResolveCombat` now receives the same `Rng` instance that
+ *         `tickAntMovement` mutates. Pre-v11 combat read stale tick-start
+ *         rngState and its writeback was overwritten by the end-of-tick
+ *         rng_tick.getState() write, so combat's RNG advance was effectively
+ *         dead code.
+ *
+ *   #63 — Surface ants targeting an entrance now consume the entrance flow-
+ *         field on the surface side too. Pre-v11 they used straight-line
+ *         pickCardinalStep steering and could permanently stall in HardBlock
+ *         pockets formed by surface-feature clusters.
+ */
+export const SIM_VERSION_V11_DEFENSIVE_BUNDLE = 11 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V11_DEFENSIVE_BUNDLE;
 
 export interface WorldState {
   tick: number;             // 0 at creation; incremented once per tick


### PR DESCRIPTION
## Summary

Big bundle: 9 issues from the codebase review pass (Groups H, I, and J combined per request). Mix of pure refactors and sim corrections; sim-affecting fixes gated behind a single new `SIM_VERSION_V11_DEFENSIVE_BUNDLE` constant.

| # | Severity | Theme | Gate |
|---|---|---|---|
| **#84** | MEDIUM | render — drawBrood activeUndergroundColonyId filter | none |
| **#83** | MEDIUM | test — chooseExcursionDirection RNG contract | none |
| **#69** | HIGH | refactor — pickCardinalStep returns packed int, no shared scratch | none |
| **#67** | HIGH | hygiene — module-level scratches for 3 biggest per-tick allocators | none |
| **#61** | BLOCKER (latent) | sim — occupancy key includes gridColonyId | none (today gridColonyId === colonyId) |
| **#64** | BLOCKER | AI — bounds-check before visited.add in findOpenChamberSpot | none (AI not in replay) |
| **#75** | HIGH | AI — aiInitialSetup post-condition gate (idempotent across save load) | none |
| **#57** | BLOCKER | sim — tickPheromoneDeposit zone gate | V11 |
| **#58** | BLOCKER | sim — combat shares rng_tick, dead-writeback removed | V11 |
| **#63** | BLOCKER | sim — surface pocket-escape lookahead penalty | V11 |

Closes #57, #58, #61, #63, #64, #67, #69, #75, #83, #84.

**Deferred (#67 follow-up):** Smaller record-literal allocations in `tickSearchLeash`, `updateFightAntTargets`, `routeForagerPriority`, `findNearestScentPile`. Each is a separate hoist with thread-through-call-hierarchy. Lower impact than the 16KB cache + Map + Set that this PR addresses.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1826 passing (1 added vs main for #83)
- [x] `pnpm lint` clean
- [x] 2 internal review rounds (round 1 found 3 LOWs in #63 / #67; all addressed; round 2 clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)