### PR TITLE
fix(input,render): UX bundle (#73, #76, #85, #86)

### DIFF
--- a/src/input/camera-input.test.ts
+++ b/src/input/camera-input.test.ts
@@ -504,6 +504,62 @@ describe('processCameraInput — clamp after pan', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Issue #85 — keyboard pan suppressed during drag-pan.
+// ---------------------------------------------------------------------------
+
+describe('processCameraInput — kbd pan suppressed while drag-pan active (#85)', () => {
+  beforeEach(() => {
+    panInputState.isPanning = false;
+  });
+
+  it('does not advance camera when isPanning=true and Right is held', () => {
+    const vs = makeViewState('surface', 64, 64);
+    panInputState.isPanning = true;
+    try {
+      processCameraInput(vs, makePanInputs({ rightDown: true }));
+      // No keyboard delta applied — drag-pan owns the camera.
+      expect(vs.surfaceCamera.x).toBe(64);
+      expect(vs.surfaceCamera.y).toBe(64);
+    } finally {
+      panInputState.isPanning = false;
+    }
+  });
+
+  it('does not advance camera when isPanning=true and Down is held', () => {
+    const vs = makeViewState('surface', 64, 64);
+    panInputState.isPanning = true;
+    try {
+      processCameraInput(vs, makePanInputs({ downDown: true }));
+      expect(vs.surfaceCamera.x).toBe(64);
+      expect(vs.surfaceCamera.y).toBe(64);
+    } finally {
+      panInputState.isPanning = false;
+    }
+  });
+
+  it('clamp still runs even when keyboard input is suppressed', () => {
+    // Pre-position camera outside grid; isPanning=true should still clamp it
+    // (the early-return runs clampCamera before bailing).
+    const vs = makeViewState('surface', -10, 64);
+    panInputState.isPanning = true;
+    try {
+      processCameraInput(vs, makePanInputs({ rightDown: true }));
+      // Clamped to viewport-edge minimum (viewportWidth/2 = 22).
+      expect(vs.surfaceCamera.x).toBeGreaterThanOrEqual(0);
+    } finally {
+      panInputState.isPanning = false;
+    }
+  });
+
+  it('with isPanning=false (default), kbd pan resumes normally', () => {
+    const vs = makeViewState('surface', 64, 64);
+    expect(panInputState.isPanning).toBe(false);
+    processCameraInput(vs, makePanInputs({ rightDown: true }));
+    expect(vs.surfaceCamera.x).toBeGreaterThan(64);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // processCameraInput — surface vs underground world dimensions sanity
 // ---------------------------------------------------------------------------
 

--- a/src/input/camera-input.ts
+++ b/src/input/camera-input.ts
@@ -251,6 +251,16 @@ export function processCameraInput(viewState: ViewState, inputs: PanInputs): voi
   const cam = activeCamera(viewState);
   const [worldW, worldH] = worldDimensions(viewState);
 
+  // Issue #85 — suppress keyboard pan while a drag-pan gesture is active.
+  // Pre-fix both pan systems applied on the same frame, so holding a
+  // direction key during a space-drag-pan stacked deltas (drag delta +
+  // CAMERA_SCROLL_SPEED). Drag is a 'claim the camera' gesture; keyboard
+  // resumes as soon as the drag ends.
+  if (panInputState.isPanning) {
+    clampCamera(cam, worldW, worldH);
+    return;
+  }
+
   // --- Keyboard pan ---
   if (inputs.cursors.left.isDown || inputs.wasd.A.isDown) {
     cam.x -= CAMERA_SCROLL_SPEED;
@@ -364,7 +374,17 @@ export function registerDragPan(scene: Phaser.Scene, viewState: ViewState): Drag
     if (!dragState.active) return;
     // Continue pan only while the originating trigger is still held.
     if (!isPanTriggerDown(pointer)) return;
-    if (isPointerOverHUD(pointer.x, pointer.y, viewState)) return;
+    // Issue #73 — when the pointer is over a HUD widget mid-drag, suppress
+    // the camera delta but STILL update lastX/lastY. Pre-fix the last-pos
+    // accumulator was frozen during the HUD crossing, so the next non-HUD
+    // pointermove computed a delta across the entire HUD strip — visible
+    // camera jump. Tracking the position through the HUD keeps the next
+    // valid move incremental.
+    if (isPointerOverHUD(pointer.x, pointer.y, viewState)) {
+      dragState.lastX = pointer.x;
+      dragState.lastY = pointer.y;
+      return;
+    }
 
     const dx = (pointer.x - dragState.lastX) / TILE_SIZE_PX;
     const dy = (pointer.y - dragState.lastY) / TILE_SIZE_PX;

--- a/src/input/camera-input.ts
+++ b/src/input/camera-input.ts
@@ -401,11 +401,21 @@ export function registerDragPan(scene: Phaser.Scene, viewState: ViewState): Drag
     dragState.isDragging = true;
   });
 
-  scene.input.on('pointerup', () => {
+  // Issue #85 codex P2 follow-up — register on BOTH `pointerup` and
+  // `pointerupoutside`. Phaser fires the latter when the pointer is
+  // released outside the canvas (drag started in-canvas, ended over
+  // the page chrome / dev-tools / window edge). Pre-fix only `pointerup`
+  // cleared `panInputState.isPanning`, so a drag ending outside the
+  // canvas left the flag stuck true — combined with #85's keyboard-pan
+  // suppression, that meant arrow keys would silently no-op forever
+  // until another in-canvas pointerup.
+  const releaseDrag = (): void => {
     dragState.active = false;
     dragState.isDragging = false;
     panInputState.isPanning = false;
-  });
+  };
+  scene.input.on('pointerup', releaseDrag);
+  scene.input.on('pointerupoutside', releaseDrag);
 
   return dragState;
 }

--- a/src/render/minimap.ts
+++ b/src/render/minimap.ts
@@ -19,8 +19,9 @@ import {
   COLOR_BARREN_EARTH,
   COLOR_BARREN_EARTH_DARK,
 } from './terrain-atlas.js';
-import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT, PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
+import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT, UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT, PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
 import { FP_SHIFT } from '../sim/fixed.js';
+import { isAlive } from '../sim/ant/ant-store.js';
 import { sgGet } from '../sim/terrain.js';
 import { spatialHash } from './terrain-noise.js';
 import type { WorldState } from '../sim/types.js';
@@ -30,6 +31,13 @@ import type { GfxLike } from './draw-surface.js';
 
 export const MINIMAP_SCALE_X = HUD.MINIMAP.w / SURFACE_GRID_WIDTH;   // 160 / 128 = 1.25
 export const MINIMAP_SCALE_Y = HUD.MINIMAP.h / SURFACE_GRID_HEIGHT;  // 1.25
+
+// Issue #76 — memorial marker color/size for fully-dead colonies (queen
+// dead AND no live entrances). Distinct dark gray (not a darkened
+// colony-color, which could be misread as 'low-health'). Smaller (2×2)
+// than the live 4×4 marker — subtler, conveys 'remains' rather than
+// active colony.
+const COLOR_DEAD_COLONY_MEMORIAL = 0x444444 as const;
 
 export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewState): void {
   // Surface terrain (issue #40 reframe — barren-earth-default). Base layer
@@ -81,31 +89,62 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
     gfx.fillRect(px - 1, py - 1, 2, 2);
   }
 
-  // Colony markers (4x4 pixels, colored by colony ID)
+  // Colony markers — live (4×4 colored) or memorial (2×2 dark gray).
+  //
+  // Issue #76 — fix the queen-status check. Pre-fix used `queenEntityId >= 0`
+  // which is true forever (allocateEntityId never recycles ids and
+  // queenEntityId is set once at colony creation). Switched to isAlive()
+  // and added a memorial-marker branch for fully-dead colonies (queen
+  // dead AND no live entrances), so wiped colonies don't confusingly
+  // persist on the minimap.
   for (const colonyIdStr of Object.keys(world.colonies)) {
     const colonyId = Number(colonyIdStr);
     const colony = world.colonies[colonyId]!;
-    const color = colonyId === PLAYER_COLONY_ID ? COLOR_PLAYER_COLONY
-                : colonyId === ENEMY_COLONY_ID  ? COLOR_ENEMY_COLONY
-                : COLOR_PLAYER_COLONY;
+    const liveColor = colonyId === PLAYER_COLONY_ID ? COLOR_PLAYER_COLONY
+                    : colonyId === ENEMY_COLONY_ID  ? COLOR_ENEMY_COLONY
+                    : COLOR_PLAYER_COLONY;
+    // Per #76 design: a 'live foothold' is an OPEN entrance (workers can
+    // actively transition zones through it). Merely-designated closed
+    // entrances are pre-excavation intent — show as live only if the
+    // queen is still alive (then it's a young colony still excavating).
+    const liveEntrances = colony.entrances ?? [];
+    const firstOpenEntrance = liveEntrances.find((e) => e.isOpen);
+    const queenAlive = isAlive(world.ants, colony.queenEntityId);
 
     let tileX = 0, tileY = 0;
-    if (colony.entrances && colony.entrances.length > 0) {
-      // Prefer the first entrance position (surface tile)
-      tileX = colony.entrances[0]!.surfaceTileX;
-      tileY = colony.entrances[0]!.surfaceTileY;
-    } else if (colony.queenEntityId >= 0) {
-      // Fall back to queen entity position (fixed-point coords → tile coords).
-      // Issue #77 — use FP_SHIFT import rather than hardcoding `>> 8`.
+    let color = liveColor;
+    let size: 2 | 4 = 4;
+    let halfOffset: 1 | 2 = 2;
+
+    if (firstOpenEntrance !== undefined) {
+      // Prefer the first OPEN entrance position. Live colored marker —
+      // an open entrance is a live foothold even if the queen is dead
+      // (workers still doing things; it's beheaded, not gone).
+      tileX = firstOpenEntrance.surfaceTileX;
+      tileY = firstOpenEntrance.surfaceTileY;
+    } else if (queenAlive) {
+      // No entrances yet but queen alive — pre-excavation colony. Live
+      // colored marker at queen's tile. Issue #77 uses FP_SHIFT import.
       const queenId = colony.queenEntityId;
       tileX = world.ants.posX[queenId]! >> FP_SHIFT;
       tileY = world.ants.posY[queenId]! >> FP_SHIFT;
+    } else {
+      // Fully-dead colony: queen dead AND no live entrances. Memorial
+      // marker at queen's last-known position. Entity slots preserve
+      // posX/posY after death, so this is the most meaningful 'where
+      // was this colony' landmark.
+      const queenId = colony.queenEntityId;
+      tileX = world.ants.posX[queenId]! >> FP_SHIFT;
+      tileY = world.ants.posY[queenId]! >> FP_SHIFT;
+      color = COLOR_DEAD_COLONY_MEMORIAL;
+      size = 2;
+      halfOffset = 1;
     }
 
     const px = HUD.MINIMAP.x + tileX * MINIMAP_SCALE_X;
     const py = HUD.MINIMAP.y + tileY * MINIMAP_SCALE_Y;
     gfx.fillStyle(color, 1);
-    gfx.fillRect(px - 2, py - 2, 4, 4);
+    gfx.fillRect(px - halfOffset, py - halfOffset, size, size);
   }
 
   // Viewport rect — always tracks surfaceCamera (minimap shows surface always per PRD §7a)
@@ -138,9 +177,15 @@ export function applyMinimapClick(viewState: ViewState, px: number, py: number):
   viewState.surfaceCamera.x = tile.tileX;
   viewState.surfaceCamera.y = tile.tileY;
   clampCamera(viewState.surfaceCamera, SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT);
-  // X-link per PRD §7c: minimap pans surface; underground X follows surface X
+  // X-link per PRD §7c: minimap pans surface; underground X follows surface X.
+  // Issue #86 — defensive clamp the underground camera with its own dimensions
+  // after the X-link. Today SURFACE_GRID_WIDTH === UNDERGROUND_GRID_WIDTH so
+  // this is a no-op, but the constants are independent and a future width
+  // change to either side would silently let the underground camera fall
+  // outside its grid without this clamp.
   if (viewState.activeView === 'underground') {
     viewState.undergroundCamera.x = viewState.surfaceCamera.x;
+    clampCamera(viewState.undergroundCamera, UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
   }
   return true;
 }


### PR DESCRIPTION
## Summary

Bundle 1 of 4 — small UX/render fixes from the 2026-05-03 codebase review pass. No sim impact, no simVersion gate.

| # | Theme | Fix |
|---|---|---|
| **#73** | Drag-pan jumps over HUD | Track `lastX/lastY` through HUD without applying camera delta |
| **#85** | Kbd + drag-pan double-apply | Early-return from `processCameraInput` when `panInputState.isPanning` is true |
| **#86** | Minimap underground camera not clamped after X-link | Defensive clamp with `UNDERGROUND_GRID_WIDTH/HEIGHT` |
| **#76** | Minimap renders dead colonies | `isAlive(queenEntityId)` check; new memorial marker (2×2 dark gray at queen's last position) for fully-dead colonies |

Closes #73, #76, #85, #86.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1830 passing (+4 for #85)
- [x] `pnpm lint` clean
- [x] 1 internal review round (5 LOWs found and addressed: import block reorder, `isOpen` predicate refinement, kbd-pan tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)