### PR TITLE
fix(sim): standardize target-coord writers on tile-center (#70)

### DIFF
--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -1119,8 +1119,10 @@ describe('routeForagerPriority', () => {
 
     routeForagerPriority(world);
 
-    expect(world.ants.targetPosX[antId]).toBe(15 << FP_SHIFT);
-    expect(world.ants.targetPosY[antId]).toBe(20 << FP_SHIFT);
+    // Issue #70 — tile-center semantics. Pre-fix used tile-corner; now
+    // standardized with all other target writers (FP_ONE/2 offset).
+    expect(world.ants.targetPosX[antId]).toBe((15 << FP_SHIFT) + (FP_ONE >> 1));
+    expect(world.ants.targetPosY[antId]).toBe((20 << FP_SHIFT) + (FP_ONE >> 1));
   });
 
   it('6. priority target is exclusive: ant routes to the chosen pile even when a closer pile exists', () => {
@@ -1150,8 +1152,9 @@ describe('routeForagerPriority', () => {
     routeForagerPriority(world);
 
     // Targets pile 10 (player's explicit choice), not the closer pile 20.
-    expect(world.ants.targetPosX[antId]).toBe(10 << FP_SHIFT);
-    expect(world.ants.targetPosY[antId]).toBe(5 << FP_SHIFT);
+    // Issue #70 — tile-center semantics.
+    expect(world.ants.targetPosX[antId]).toBe((10 << FP_SHIFT) + (FP_ONE >> 1));
+    expect(world.ants.targetPosY[antId]).toBe((5 << FP_SHIFT) + (FP_ONE >> 1));
   });
 
   it('7. ant not in SearchingFood sub-state → targetPosX/Y unchanged', () => {
@@ -1218,8 +1221,9 @@ describe('routeForagerPriority', () => {
     routeForagerPriority(world);
 
     // A routes to the pile; B is cleared (its colony has no priority).
-    expect(world.ants.targetPosX[antA]).toBe(15 << FP_SHIFT);
-    expect(world.ants.targetPosY[antA]).toBe(20 << FP_SHIFT);
+    // Issue #70 — tile-center semantics on A's target.
+    expect(world.ants.targetPosX[antA]).toBe((15 << FP_SHIFT) + (FP_ONE >> 1));
+    expect(world.ants.targetPosY[antA]).toBe((20 << FP_SHIFT) + (FP_ONE >> 1));
     expect(world.ants.targetPosX[antB]).toBe(-1);
     expect(world.ants.targetPosY[antB]).toBe(-1);
   });

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -2057,8 +2057,16 @@ export function routeForagerPriority(world: WorldState): void {
       const pile = world.foodPiles[p]!;
       if (pile.foodPileId === colony.priorityFoodPileId) {
         priorityTargets[colony.colonyId] = {
-          targetX: pile.tileX << FP_SHIFT,
-          targetY: pile.tileY << FP_SHIFT,
+          // Issue #70 — tile-center, not tile-corner. All target-coord
+          // writers in the sim use `(tileX << FP_SHIFT) + (FP_ONE >> 1)`
+          // for tile-center semantics (matches updateFightAntTargets,
+          // SetRallyPoint, etc.). Pre-fix used corner coords; observably
+          // identical today because every consumer rounds back via
+          // `>> FP_SHIFT`, but a future caller doing FP arithmetic
+          // (distance check, "have we arrived?") would see a half-tile
+          // bias differing per writer.
+          targetX: (pile.tileX << FP_SHIFT) + (FP_ONE >> 1),
+          targetY: (pile.tileY << FP_SHIFT) + (FP_ONE >> 1),
         };
         break;
       }
@@ -3665,8 +3673,13 @@ export function tickAntMovement(
               const dist = Math.abs(cx - antTileX) + Math.abs(cy - antTileY);
               if (bestDist < 0 || dist < bestDist) {
                 bestDist = dist;
-                chamberTargetX = cx << FP_SHIFT;
-                chamberTargetY = cy << FP_SHIFT;
+                // Issue #70 — tile-center, not tile-corner. Standardized with
+                // updateFightAntTargets / SetRallyPoint / etc. Observably
+                // identical today (consumer rounds back via >> FP_SHIFT)
+                // but eliminates the half-tile-bias foot-gun for future
+                // FP-arithmetic consumers.
+                chamberTargetX = (cx << FP_SHIFT) + (FP_ONE >> 1);
+                chamberTargetY = (cy << FP_SHIFT) + (FP_ONE >> 1);
               }
             }
           }

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -2056,18 +2056,21 @@ export function routeForagerPriority(world: WorldState): void {
     for (let p = 0; p < world.foodPiles.length; p++) {
       const pile = world.foodPiles[p]!;
       if (pile.foodPileId === colony.priorityFoodPileId) {
-        priorityTargets[colony.colonyId] = {
-          // Issue #70 — tile-center, not tile-corner. All target-coord
-          // writers in the sim use `(tileX << FP_SHIFT) + (FP_ONE >> 1)`
-          // for tile-center semantics (matches updateFightAntTargets,
-          // SetRallyPoint, etc.). Pre-fix used corner coords; observably
-          // identical today because every consumer rounds back via
-          // `>> FP_SHIFT`, but a future caller doing FP arithmetic
-          // (distance check, "have we arrived?") would see a half-tile
-          // bias differing per writer.
-          targetX: (pile.tileX << FP_SHIFT) + (FP_ONE >> 1),
-          targetY: (pile.tileY << FP_SHIFT) + (FP_ONE >> 1),
-        };
+        // Issue #70 — tile-center, not tile-corner. All target-coord
+        // writers in the sim use `(tileX << FP_SHIFT) + (FP_ONE >> 1)`
+        // for tile-center semantics (matches updateFightAntTargets,
+        // SetRallyPoint, etc.). Pre-fix used corner coords.
+        //
+        // Codex P1 follow-up: gate behind V12 even though movement is
+        // observably identical. The targetPos values themselves differ
+        // (corner=N×256, center=N×256+128) and round-trip through saves,
+        // so a v11 snapshot loaded by v12 code would write tile-center
+        // where the saved bytes had tile-corner — breaking SCEN-06
+        // byte-identity for any save with priority foragers active.
+        const useTileCenter = world.simVersion >= SIM_VERSION_V12_SIM_CORRECTNESS_BUNDLE;
+        priorityTargets[colony.colonyId] = useTileCenter
+          ? { targetX: (pile.tileX << FP_SHIFT) + (FP_ONE >> 1), targetY: (pile.tileY << FP_SHIFT) + (FP_ONE >> 1) }
+          : { targetX: pile.tileX << FP_SHIFT, targetY: pile.tileY << FP_SHIFT };
         break;
       }
     }
@@ -3673,13 +3676,18 @@ export function tickAntMovement(
               const dist = Math.abs(cx - antTileX) + Math.abs(cy - antTileY);
               if (bestDist < 0 || dist < bestDist) {
                 bestDist = dist;
-                // Issue #70 — tile-center, not tile-corner. Standardized with
-                // updateFightAntTargets / SetRallyPoint / etc. Observably
-                // identical today (consumer rounds back via >> FP_SHIFT)
-                // but eliminates the half-tile-bias foot-gun for future
-                // FP-arithmetic consumers.
-                chamberTargetX = (cx << FP_SHIFT) + (FP_ONE >> 1);
-                chamberTargetY = (cy << FP_SHIFT) + (FP_ONE >> 1);
+                // Issue #70 — tile-center, not tile-corner. Codex P1 gate
+                // behind V12: targetPos values round-trip through saves,
+                // so changing the writer breaks SCEN-06 byte-identity for
+                // pre-v12 snapshots even though the cardinal step pick is
+                // unchanged.
+                if (world.simVersion >= SIM_VERSION_V12_SIM_CORRECTNESS_BUNDLE) {
+                  chamberTargetX = (cx << FP_SHIFT) + (FP_ONE >> 1);
+                  chamberTargetY = (cy << FP_SHIFT) + (FP_ONE >> 1);
+                } else {
+                  chamberTargetX = cx << FP_SHIFT;
+                  chamberTargetY = cy << FP_SHIFT;
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary

Bundle 2 of 4 — eliminate the tile-corner vs tile-center foot-gun in target-coord writers. Two sites still used tile-corner (\`tile << FP_SHIFT\` with no FP_ONE/2 offset) while every other writer (\`updateFightAntTargets\`, \`SetRallyPoint\`, etc.) used tile-center. Observably identical today because consumers round back via \`>> FP_SHIFT\`, but a future FP-arithmetic consumer (distance check, arrival detection) would see a half-tile bias varying per writer.

Sites updated:
- \`routeForagerPriority\` priority-target literal
- chamber-target inline write (food-chamber routing)

Closes #70.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 1826 passing (3 routeForagerPriority test expectations updated for tile-center)
- [x] \`pnpm lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)