### PR TITLE
fix(save,sim): boundary hardening + V13 invariant fixes (closes #99 #101 #102 #103 #104 #105 #106 #107 #108 #109 #110)

### DIFF
--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -164,13 +164,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // contents, including disparate values across chambers.
       const w = createScenario(42);
       const colony = w.colonies[PLAYER_COLONY_ID]!;
+      // Canonical FoodStorage dims: 4×3 (CHAMBER_DIMENSIONS[FoodStorage]).
+      // Issue #101 boundary validator now enforces these.
       colony.chambers.push({
         chamberId: 999, chamberType: ChamberType.FoodStorage, foodStored: 1234,
-        posX: 10 << 8, posY: 5 << 8, width: 3, height: 3,
+        posX: 10 << 8, posY: 5 << 8, width: 4, height: 3,
       });
       colony.chambers.push({
         chamberId: 998, chamberType: ChamberType.FoodStorage, foodStored: 4321,
-        posX: 14 << 8, posY: 5 << 8, width: 3, height: 3,
+        posX: 16 << 8, posY: 5 << 8, width: 4, height: 3,
       });
       const w2 = deserializeWorldState(serializeWorldState(w));
       const c2 = w2.colonies[PLAYER_COLONY_ID]!;
@@ -1239,6 +1241,344 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // the null-safe default propagates into the live ColonyRecord.
       const world = deserializeWorldState(loaded!.snapshot);
       expect(world.colonies[PLAYER_COLONY_ID]!.targetRatio).toEqual({ forage: 10, fight: 0 });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Boundary hardening — issues #99, #101, #102, #103, #104, #105, #109, #110.
+  // Each test verifies the validator rejects a tampered shape AND that a
+  // legitimate scenario still round-trips (regression guard).
+  // -------------------------------------------------------------------------
+
+  describe('boundary hardening — issues #99 / #101 / #102 / #103 / #104 / #105 / #109 / #110', () => {
+    function writeSave(file: { version: number; seed: unknown; inputLog: unknown; snapshot: unknown }): void {
+      localStorage.setItem(SAVE_KEY, JSON.stringify(file));
+    }
+
+    // -----------------------------------------------------------------------
+    // #110 — envelope seed validation
+    // -----------------------------------------------------------------------
+    it('#110 rejects envelope seed: string', () => {
+      const w = createScenario(42);
+      writeSave({ version: SAVE_FORMAT_VERSION, seed: 'abc' as unknown as number, inputLog: [], snapshot: serializeWorldState(w) });
+      expect(loadSave()).toBeNull();
+    });
+    it('#110 rejects envelope seed: null', () => {
+      const w = createScenario(42);
+      writeSave({ version: SAVE_FORMAT_VERSION, seed: null, inputLog: [], snapshot: serializeWorldState(w) });
+      expect(loadSave()).toBeNull();
+    });
+    it('#110 rejects envelope seed: missing', () => {
+      const w = createScenario(42);
+      const file = { version: SAVE_FORMAT_VERSION, inputLog: [], snapshot: serializeWorldState(w) };
+      localStorage.setItem(SAVE_KEY, JSON.stringify(file));
+      expect(loadSave()).toBeNull();
+    });
+    it('#110 rejects envelope seed: non-integer', () => {
+      const w = createScenario(42);
+      writeSave({ version: SAVE_FORMAT_VERSION, seed: 1.5, inputLog: [], snapshot: serializeWorldState(w) });
+      expect(loadSave()).toBeNull();
+    });
+    it('#110 rejects envelope seed: out of int32 range', () => {
+      const w = createScenario(42);
+      writeSave({ version: SAVE_FORMAT_VERSION, seed: 0x80000000, inputLog: [], snapshot: serializeWorldState(w) });
+      expect(loadSave()).toBeNull();
+    });
+    it('#110 accepts envelope seed: int32 boundary values', () => {
+      const w = createScenario(42);
+      writeSave({ version: SAVE_FORMAT_VERSION, seed: 0x7fffffff, inputLog: [], snapshot: serializeWorldState(w) });
+      expect(loadSave()).not.toBeNull();
+      writeSave({ version: SAVE_FORMAT_VERSION, seed: -0x80000000, inputLog: [], snapshot: serializeWorldState(w) });
+      expect(loadSave()).not.toBeNull();
+    });
+
+    // -----------------------------------------------------------------------
+    // #103 — non-array inputLog normalization (no soft-brick)
+    // -----------------------------------------------------------------------
+    it('#103 normalizes missing inputLog to empty array', () => {
+      const w = createScenario(42);
+      const file = { version: SAVE_FORMAT_VERSION, seed: 42, snapshot: serializeWorldState(w) };
+      localStorage.setItem(SAVE_KEY, JSON.stringify(file));
+      const loaded = loadSave();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.inputLog).toEqual([]);
+    });
+    it('#103 normalizes null inputLog to empty array', () => {
+      const w = createScenario(42);
+      writeSave({ version: SAVE_FORMAT_VERSION, seed: 42, inputLog: null, snapshot: serializeWorldState(w) });
+      const loaded = loadSave();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.inputLog).toEqual([]);
+    });
+    it('#103 normalizes string inputLog to empty array', () => {
+      const w = createScenario(42);
+      writeSave({ version: SAVE_FORMAT_VERSION, seed: 42, inputLog: 'abc', snapshot: serializeWorldState(w) });
+      const loaded = loadSave();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.inputLog).toEqual([]);
+    });
+
+    // -----------------------------------------------------------------------
+    // #105 — null inputLog entry doesn't destroy the save
+    // -----------------------------------------------------------------------
+    it('#105 null inputLog entry passes through migrateInputLogCommand without throwing', () => {
+      const w = createScenario(42);
+      writeSave({
+        version: SAVE_FORMAT_VERSION, seed: 42,
+        inputLog: [null] as unknown as SimCommand[],
+        snapshot: serializeWorldState(w),
+      });
+      // Pre-fix: this returned null (loadSave swallowed the TypeError).
+      // Post-fix: parseSaveFile completes; the null entry passes through.
+      const loaded = loadSave();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.inputLog).toHaveLength(1);
+      expect(loaded!.inputLog[0]).toBeNull();
+    });
+
+    // -----------------------------------------------------------------------
+    // #104 — snapshot.tick validation
+    // -----------------------------------------------------------------------
+    it('#104 rejects snapshot.tick: string', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      (s as unknown as { tick: unknown }).tick = 'x';
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#104 rejects snapshot.tick: negative', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      (s as unknown as { tick: number }).tick = -1;
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#104 rejects snapshot.tick: non-integer', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      (s as unknown as { tick: number }).tick = 1.5;
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#104 rejects snapshot.rngState: non-integer', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      (s as unknown as { rngState: unknown }).rngState = 'abc';
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#104 accepts legitimate large tick value (regression guard for normal long sessions)', () => {
+      const w = createScenario(42);
+      w.tick = 1_000_000;
+      const s = serializeWorldState(w);
+      const w2 = deserializeWorldState(s);
+      expect(w2.tick).toBe(1_000_000);
+    });
+
+    // -----------------------------------------------------------------------
+    // #101 — chamber dimensions validation. Helper: build a scenario with a
+    // canonical chamber so we have something to mutate. createScenario(42)
+    // doesn't seed chambers, so push a valid Queen chamber first.
+    // -----------------------------------------------------------------------
+    function scenarioWithChamber() {
+      const w = createScenario(42);
+      w.colonies[PLAYER_COLONY_ID]!.chambers.push({
+        chamberId: 100, chamberType: ChamberType.Queen, foodStored: 0,
+        posX: 10 << 8, posY: 5 << 8, width: 5, height: 3,
+      });
+      return w;
+    }
+    it('#101 rejects chamber.width: oversized (DoS via chamber-flow seed loop)', () => {
+      const s = serializeWorldState(scenarioWithChamber());
+      const c0 = s.colonies[String(PLAYER_COLONY_ID)]!.chambers[0]!;
+      (c0 as { width: number }).width = 1_000_000_000;
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#101 rejects chamber.chamberType: enum out-of-range', () => {
+      const s = serializeWorldState(scenarioWithChamber());
+      const c0 = s.colonies[String(PLAYER_COLONY_ID)]!.chambers[0]!;
+      (c0 as { chamberType: number }).chamberType = 99;
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#101 rejects chamber.posX: out-of-grid', () => {
+      const s = serializeWorldState(scenarioWithChamber());
+      const c0 = s.colonies[String(PLAYER_COLONY_ID)]!.chambers[0]!;
+      (c0 as { posX: number }).posX = 1_000_000;
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#101 rejects chamber.foodStored: exceeds capacity', () => {
+      const s = serializeWorldState(scenarioWithChamber());
+      const c0 = s.colonies[String(PLAYER_COLONY_ID)]!.chambers[0]!;
+      (c0 as { foodStored: number }).foodStored = 99_999_999;
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#101 rejects chamber dims: don\'t match canonical CHAMBER_DIMENSIONS', () => {
+      const s = serializeWorldState(scenarioWithChamber());
+      const c0 = s.colonies[String(PLAYER_COLONY_ID)]!.chambers[0]!;
+      (c0 as { width: number }).width = 5;     // canonical for Queen
+      (c0 as { height: number }).height = 4;   // BAD: Queen height is 3
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+
+    // -----------------------------------------------------------------------
+    // #102 — pendingChamber validation
+    // -----------------------------------------------------------------------
+    it('#102 rejects pendingChamber.width: oversized (DoS via CancelDigMark revert)', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      (s.pendingChambers as Record<string, unknown>)['0:5:5'] = {
+        colonyId: 1, chamberType: 1,
+        anchorTileX: 0, anchorTileY: 1,
+        width: 1_000_000_000, height: 1_000_000_000,
+      };
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#102 rejects pendingChamber.anchor: out-of-grid', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      (s.pendingChambers as Record<string, unknown>)['0:5:5'] = {
+        colonyId: 1, chamberType: 1,
+        anchorTileX: 1_000_000, anchorTileY: 1,
+        width: 4, height: 3,
+      };
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#102 rejects pendingChamber: dims don\'t match canonical CHAMBER_DIMENSIONS', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      (s.pendingChambers as Record<string, unknown>)['0:5:5'] = {
+        colonyId: 1, chamberType: 0, // Queen wants 5×3
+        anchorTileX: 0, anchorTileY: 1,
+        width: 4, height: 3, // wrong dims for type 0
+      };
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+
+    // -----------------------------------------------------------------------
+    // #109 — foodPiles array validation
+    // -----------------------------------------------------------------------
+    it('#109 rejects foodPiles: not an array', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      (s as unknown as { foodPiles: unknown }).foodPiles = 'abc';
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#109 rejects foodPiles: length exceeds cap', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      const oversized = [];
+      for (let i = 0; i < 1000; i++) {
+        oversized.push({ foodPileId: i, tileX: i % 128, tileY: 0 });
+      }
+      s.foodPiles = oversized;
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#109 rejects foodPile.tileX: out-of-grid', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      s.foodPiles = [{ foodPileId: 1, tileX: 1_000_000, tileY: 0 }];
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#109 rejects foodPiles: duplicate foodPileId', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      s.foodPiles = [
+        { foodPileId: 5, tileX: 10, tileY: 10 },
+        { foodPileId: 5, tileX: 20, tileY: 20 },
+      ];
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#109 rejects foodPiles: duplicate tile', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      s.foodPiles = [
+        { foodPileId: 5, tileX: 10, tileY: 10 },
+        { foodPileId: 6, tileX: 10, tileY: 10 },
+      ];
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+
+    // -----------------------------------------------------------------------
+    // #99 — grid dims + map cardinality validation
+    // -----------------------------------------------------------------------
+    it('#99 rejects surface grid: oversized dimensions', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      (s.surface as unknown as { width: number }).width = 20_000;
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#99 rejects undergroundGrid: wrong dimensions', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      const ugKey = String(PLAYER_COLONY_ID);
+      (s.undergroundGrids[ugKey] as unknown as { height: number }).height = 1024;
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#99 rejects pheromoneGrid: wrong dimensions', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      const phKey = Object.keys(s.pheromoneGrids)[0]!;
+      (s.pheromoneGrids[phKey] as unknown as { width: number }).width = 999;
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#99 rejects colonies: cardinality cap exceeded', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      // Clone a valid colony into many keys.
+      const valid = s.colonies[String(PLAYER_COLONY_ID)]!;
+      for (let i = 100; i < 200; i++) {
+        (s.colonies as Record<string, unknown>)[String(i)] = valid;
+      }
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#99 rejects pendingChambers: cardinality cap exceeded', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      for (let i = 0; i < 300; i++) {
+        (s.pendingChambers as Record<string, unknown>)[`0:${i}:1`] = {
+          colonyId: 1, chamberType: 1, anchorTileX: i % 100, anchorTileY: 1, width: 4, height: 3,
+        };
+      }
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#99 rejects colonies key: non-decimal-integer string', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      const valid = s.colonies[String(PLAYER_COLONY_ID)]!;
+      // Use a non-numeric key. Setting `obj['__proto__'] = ...` mutates the
+      // prototype rather than creating an own property, so it never reaches
+      // Object.entries — exercise the non-numeric-key branch directly.
+      (s.colonies as Record<string, unknown>)['abc'] = valid;
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+    it('#99 rejects pendingChambers key: __-prefixed string', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      // Use Object.defineProperty to create an own __ -prefixed property; a
+      // bare assignment of '__proto__' would mutate the prototype instead.
+      Object.defineProperty(s.pendingChambers as object, '__shady', {
+        value: {
+          colonyId: 1, chamberType: 1, anchorTileX: 0, anchorTileY: 1, width: 4, height: 3,
+        },
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+      expect(() => deserializeWorldState(s)).toThrow();
+    });
+
+    // -----------------------------------------------------------------------
+    // Regression guard — legitimate scenarios still round-trip cleanly.
+    // -----------------------------------------------------------------------
+    it('all validators pass on a freshly-saved legitimate scenario', () => {
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      expect(() => deserializeWorldState(s)).not.toThrow();
+    });
+    it('post-deserialize world replays a tick byte-identically (SCEN-06 regression)', () => {
+      const w = createScenario(42);
+      tick(w, []); // advance one tick
+      const s1 = serializeWorldState(w);
+      const w2 = deserializeWorldState(s1);
+      const s2 = serializeWorldState(w2);
+      expect(s2.tick).toBe(s1.tick);
+      expect(s2.rngState).toBe(s1.rngState);
     });
   });
 });

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -27,7 +27,18 @@ import { createSurfaceGrid, createUndergroundGrid } from '../sim/terrain.js';
 import type { PheromoneGrid } from '../sim/pheromone/pheromone-store.js';
 import { createPheromoneGrid } from '../sim/pheromone/pheromone-store.js';
 import type { FoodPile, FoodPileId } from '../sim/food.js';
-import { MAX_ENTITIES } from '../sim/constants.js';
+import {
+  MAX_ENTITIES,
+  FOOD_PILE_COUNT,
+  FOOD_CHAMBER_CAPACITY,
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
+  UNDERGROUND_GRID_WIDTH,
+  UNDERGROUND_GRID_HEIGHT,
+} from '../sim/constants.js';
+import { FP_SHIFT } from '../sim/fixed.js';
+import { ChamberType } from '../sim/enums.js';
+import { CHAMBER_DIMENSIONS } from '../sim/colony/chamber.js';
 
 // SAVE_FORMAT_VERSION is bumped on any breaking change to the on-disk shape
 // or to invariants that survivors must respect. Pre-bump saves are rejected
@@ -70,6 +81,181 @@ export class FutureSimVersionError extends Error {
   constructor(public got: number, public latest: number) {
     super(`Save's simVersion (${got}) is newer than this build's LATEST (${latest})`);
     this.name = 'FutureSimVersionError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Boundary validators — issues #99, #101-#105, #109, #110.
+//
+// All run at the parseSaveFile / deserializeWorldState boundary. Throws
+// route through bootFromSave's catch → bootFresh, consistent with
+// existing #59 / #65 / #66 hardening. Validators are intentionally narrow:
+// reject anything that wouldn't survive a serialize/deserialize round-trip
+// from a legitimate game (allowing only the value domains buildSaveFile
+// can produce). The render layer's `loadSave` already swallows these
+// throws; existing tests confirm the corrupt-save path triggers
+// deleteSave + bootFresh.
+// ---------------------------------------------------------------------------
+
+/** Tile-coord boundary check (mirrors src/sim/tick.ts:204 — kept private here
+ *  so save.ts doesn't import from the tick module). */
+function isTileCoord(value: unknown, max: number): boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value < max;
+}
+
+/** Issue #110 — envelope seed must round-trip `seed | 0` losslessly (int32). */
+function isInt32(value: unknown): value is number {
+  return typeof value === 'number'
+    && Number.isFinite(value)
+    && Number.isInteger(value)
+    && value >= -0x80000000
+    && value <= 0x7fffffff;
+}
+
+/** Cap on how many entries each top-level Object map may carry on load.
+ *  Issue #99 — defense against memory-DoS via unbounded `Object.entries`
+ *  loops in deserializeWorldState. Numbers are 4-8× current scenario use,
+ *  ample headroom for future scenario tweaks; anything above is tampering. */
+const MAX_COLONIES_LOAD = 16;       // current LIVE_COLONY_COUNT = 2.
+const MAX_PHEROMONE_GRID_KEYS = 16; // current = 8 (2 colonies × 2 types × 2 zones).
+const MAX_PENDING_CHAMBERS = 256;   // few per colony in normal play.
+const MAX_FOOD_PILES = FOOD_PILE_COUNT * 4; // issue #109.
+
+/** Issue #99 — verify a serialized grid object matches the canonical
+ *  dimensions and has an array-like data field. Width/height are PRD-locked
+ *  (`src/sim/constants.ts`); a future change to grid size would correctly
+ *  require a save-format bump anyway, so a strict equality check is the
+ *  right strictness level here. */
+function validateGridShape(
+  s: unknown,
+  expectedW: number,
+  expectedH: number,
+  label: string,
+): void {
+  if (s === null || typeof s !== 'object') {
+    throw new Error(`Invalid ${label}: not an object`);
+  }
+  const g = s as { width?: unknown; height?: unknown; data?: unknown };
+  if (g.width !== expectedW || g.height !== expectedH) {
+    throw new Error(
+      `Invalid ${label} dimensions: ${String(g.width)}x${String(g.height)} ` +
+      `(expected ${expectedW}x${expectedH})`,
+    );
+  }
+  if (!Array.isArray(g.data) && !ArrayBuffer.isView(g.data)) {
+    throw new Error(`Invalid ${label}: data is not array-like`);
+  }
+}
+
+/** Issue #101 — chamber-record validator. Width/height MUST match the
+ *  canonical CHAMBER_DIMENSIONS for the chamberType — chamber footprints are
+ *  PRD-fixed, not player-set. Any deviation is tampering. The seed loop in
+ *  chamber-flow.ts:146-157 iterates `chamber.height × chamber.width`, so an
+ *  unvalidated record can hang the renderer (4× per dirty cycle). */
+function validateChamberRecord(ch: unknown, label: string): void {
+  if (ch === null || typeof ch !== 'object') {
+    throw new Error(`Invalid ${label}: not an object`);
+  }
+  const c = ch as Partial<ChamberRecord>;
+  if (typeof c.chamberId !== 'number'
+      || !Number.isInteger(c.chamberId)
+      || c.chamberId < 0
+      || c.chamberId > MAX_ENTITIES) {
+    throw new Error(`Invalid ${label}.chamberId: ${String(c.chamberId)}`);
+  }
+  if (typeof c.chamberType !== 'number'
+      || !Number.isInteger(c.chamberType)
+      || c.chamberType < 0
+      || c.chamberType > 2) {
+    throw new Error(`Invalid ${label}.chamberType: ${String(c.chamberType)}`);
+  }
+  const dims = CHAMBER_DIMENSIONS[c.chamberType as ChamberType];
+  if (c.width !== dims.width || c.height !== dims.height) {
+    throw new Error(
+      `Invalid ${label} dims for type ${c.chamberType}: ` +
+      `${String(c.width)}x${String(c.height)} (expected ${dims.width}x${dims.height})`,
+    );
+  }
+  // posX/posY are FP coords; require integer in [0, gridSize<<FP_SHIFT).
+  const ugWidthFp = UNDERGROUND_GRID_WIDTH << FP_SHIFT;
+  const ugHeightFp = UNDERGROUND_GRID_HEIGHT << FP_SHIFT;
+  if (typeof c.posX !== 'number'
+      || !Number.isInteger(c.posX)
+      || c.posX < 0
+      || c.posX >= ugWidthFp) {
+    throw new Error(`Invalid ${label}.posX: ${String(c.posX)}`);
+  }
+  if (typeof c.posY !== 'number'
+      || !Number.isInteger(c.posY)
+      || c.posY < 0
+      || c.posY >= ugHeightFp) {
+    throw new Error(`Invalid ${label}.posY: ${String(c.posY)}`);
+  }
+  if (typeof c.foodStored !== 'number'
+      || !Number.isInteger(c.foodStored)
+      || c.foodStored < 0
+      || c.foodStored > FOOD_CHAMBER_CAPACITY) {
+    throw new Error(`Invalid ${label}.foodStored: ${String(c.foodStored)}`);
+  }
+}
+
+/** Issue #102 — pendingChamber validator. Same canonical-dims rule as
+ *  #101 plus footprint-fits-grid check. The CancelDigMark revert loop at
+ *  tick.ts:382-389 has no early exit, so an unvalidated entry can hang
+ *  the renderer on a single right-click. */
+function validatePendingChamber(pc: unknown, label: string): void {
+  if (pc === null || typeof pc !== 'object') {
+    throw new Error(`Invalid ${label}: not an object`);
+  }
+  const p = pc as Partial<PendingChamber>;
+  if (typeof p.colonyId !== 'number' || !Number.isInteger(p.colonyId) || p.colonyId < 0) {
+    throw new Error(`Invalid ${label}.colonyId: ${String(p.colonyId)}`);
+  }
+  if (typeof p.chamberType !== 'number'
+      || !Number.isInteger(p.chamberType)
+      || p.chamberType < 0
+      || p.chamberType > 2) {
+    throw new Error(`Invalid ${label}.chamberType: ${String(p.chamberType)}`);
+  }
+  if (!isTileCoord(p.anchorTileX, UNDERGROUND_GRID_WIDTH)) {
+    throw new Error(`Invalid ${label}.anchorTileX: ${String(p.anchorTileX)}`);
+  }
+  if (!isTileCoord(p.anchorTileY, UNDERGROUND_GRID_HEIGHT)) {
+    throw new Error(`Invalid ${label}.anchorTileY: ${String(p.anchorTileY)}`);
+  }
+  const dims = CHAMBER_DIMENSIONS[p.chamberType as ChamberType];
+  if (p.width !== dims.width || p.height !== dims.height) {
+    throw new Error(
+      `Invalid ${label} dims for type ${p.chamberType}: ` +
+      `${String(p.width)}x${String(p.height)} (expected ${dims.width}x${dims.height})`,
+    );
+  }
+  if ((p.anchorTileX as number) + dims.width > UNDERGROUND_GRID_WIDTH
+      || (p.anchorTileY as number) + dims.height > UNDERGROUND_GRID_HEIGHT) {
+    throw new Error(
+      `${label} footprint extends past grid: anchor ` +
+      `(${p.anchorTileX}, ${p.anchorTileY}) + ${dims.width}x${dims.height}`,
+    );
+  }
+}
+
+/** Issue #109 — foodPile validator. */
+function validateFoodPile(p: unknown, label: string): void {
+  if (p === null || typeof p !== 'object') {
+    throw new Error(`Invalid ${label}: not an object`);
+  }
+  const fp = p as Partial<FoodPile>;
+  if (typeof fp.foodPileId !== 'number'
+      || !Number.isInteger(fp.foodPileId)
+      || fp.foodPileId < 0
+      || fp.foodPileId > MAX_ENTITIES) {
+    throw new Error(`Invalid ${label}.foodPileId: ${String(fp.foodPileId)}`);
+  }
+  if (!isTileCoord(fp.tileX, SURFACE_GRID_WIDTH)) {
+    throw new Error(`Invalid ${label}.tileX: ${String(fp.tileX)}`);
+  }
+  if (!isTileCoord(fp.tileY, SURFACE_GRID_HEIGHT)) {
+    throw new Error(`Invalid ${label}.tileY: ${String(fp.tileY)}`);
   }
 }
 
@@ -581,6 +767,12 @@ function deserializeColony(s: SerializedColony): ColonyRecord {
   c.foodFlowFieldDirty   = s.foodFlowFieldDirty ?? false;
   c.killCount            = s.killCount;
   c.priorityFoodPileId   = s.priorityFoodPileId ?? null;
+  // Issue #101 — validate chamber records before they reach the runtime.
+  // Done after the spread so the validator inspects the persisted shape;
+  // throw aborts deserializeWorldState's map() and propagates to bootFromSave.
+  for (let i = 0; i < c.chambers.length; i++) {
+    validateChamberRecord(c.chambers[i]!, `colony[${s.colonyId}].chambers[${i}]`);
+  }
   return c;
 }
 
@@ -645,20 +837,87 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     throw new Error(`Invalid ants.count in save: ${String(rawCount)} (require integer in [0, ${MAX_ENTITIES}])`);
   }
   const capacity = rawCount > 0 ? rawCount : MAX_ENTITIES;
+
+  // Issue #99 — top-level Object map cardinality caps. Each loop below
+  // allocates per entry, so an oversized map drives unbounded allocation
+  // even before any single entry is validated. Reject upfront.
+  if (s.colonies === null || typeof s.colonies !== 'object') {
+    throw new Error('Invalid save shape: missing or non-object colonies');
+  }
+  const colonyKeys = Object.keys(s.colonies);
+  if (colonyKeys.length > MAX_COLONIES_LOAD) {
+    throw new Error(`Too many colonies in save: ${colonyKeys.length} (cap ${MAX_COLONIES_LOAD})`);
+  }
+  if (s.undergroundGrids === null || typeof s.undergroundGrids !== 'object') {
+    throw new Error('Invalid save shape: missing or non-object undergroundGrids');
+  }
+  const ugKeys = Object.keys(s.undergroundGrids);
+  if (ugKeys.length > MAX_COLONIES_LOAD) {
+    throw new Error(`Too many undergroundGrids in save: ${ugKeys.length} (cap ${MAX_COLONIES_LOAD})`);
+  }
+  if (s.pheromoneGrids === null || typeof s.pheromoneGrids !== 'object') {
+    throw new Error('Invalid save shape: missing or non-object pheromoneGrids');
+  }
+  const pheroKeys = Object.keys(s.pheromoneGrids);
+  if (pheroKeys.length > MAX_PHEROMONE_GRID_KEYS) {
+    throw new Error(`Too many pheromoneGrids in save: ${pheroKeys.length} (cap ${MAX_PHEROMONE_GRID_KEYS})`);
+  }
+  if (s.pendingChambers === null || typeof s.pendingChambers !== 'object') {
+    throw new Error('Invalid save shape: missing or non-object pendingChambers');
+  }
+  const pcKeys = Object.keys(s.pendingChambers);
+  if (pcKeys.length > MAX_PENDING_CHAMBERS) {
+    throw new Error(`Too many pendingChambers in save: ${pcKeys.length} (cap ${MAX_PENDING_CHAMBERS})`);
+  }
+
   const colonies: Record<ColonyId, ColonyRecord> = {};
   for (const [cidStr, sc] of Object.entries(s.colonies)) {
+    // Issue #99 — colonies map keys must be decimal-integer strings; reject
+    // `__proto__` and any non-numeric key shape that would corrupt the
+    // resulting Record.
+    if (!/^-?\d+$/.test(cidStr)) {
+      throw new Error(`Invalid colonies key: ${cidStr}`);
+    }
     colonies[Number(cidStr) as ColonyId] = deserializeColony(sc);
   }
   const undergroundGrids: Record<ColonyId, UndergroundGrid> = {};
   for (const [cidStr, sg] of Object.entries(s.undergroundGrids)) {
+    if (!/^-?\d+$/.test(cidStr)) {
+      throw new Error(`Invalid undergroundGrids key: ${cidStr}`);
+    }
+    // Issue #99 — verify grid shape before allocator runs.
+    validateGridShape(sg, UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT,
+      `undergroundGrids[${cidStr}]`);
     undergroundGrids[Number(cidStr) as ColonyId] = deserializeUndergroundGrid(sg);
   }
   const pheromoneGrids: Record<string, PheromoneGrid> = {};
   for (const [key, sg] of Object.entries(s.pheromoneGrids)) {
+    // Pheromone grids exist for both surface and underground zones; the key
+    // encodes the zone. Two valid sizes; accept either by trying both
+    // (validateGridShape throws on mismatch — wrap to retry the alternate).
+    if (key.startsWith('__')) {
+      throw new Error(`Invalid pheromoneGrids key: ${key}`);
+    }
+    let validated = false;
+    try {
+      validateGridShape(sg, SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT,
+        `pheromoneGrids[${key}]`);
+      validated = true;
+    } catch { /* try underground next */ }
+    if (!validated) {
+      validateGridShape(sg, UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT,
+        `pheromoneGrids[${key}]`);
+    }
     pheromoneGrids[key] = deserializePheromoneGrid(sg);
   }
   const pendingChambers: Record<string, PendingChamber> = {};
   for (const [key, pc] of Object.entries(s.pendingChambers)) {
+    if (key.startsWith('__')) {
+      throw new Error(`Invalid pendingChambers key: ${key}`);
+    }
+    // Issue #102 — validate every entry; tick.ts:382 revert loop is
+    // unbounded over pc.width × pc.height.
+    validatePendingChamber(pc, `pendingChambers[${key}]`);
     pendingChambers[key] = { ...pc };
   }
 
@@ -676,9 +935,58 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     throw new Error(`Invalid nextEntityId in save: ${String(rawNext)} (require integer in [0, ${MAX_ENTITIES}])`);
   }
 
+  // Issue #104 — boundary validation for snapshot tick. Same pattern as
+  // nextEntityId: `tick: s.tick` previously passed strings/NaN through,
+  // and `world.tick += 1` became unbounded string concatenation.
+  const rawTick = s.tick;
+  if (typeof rawTick !== 'number'
+      || !Number.isFinite(rawTick)
+      || !Number.isInteger(rawTick)
+      || rawTick < 0) {
+    throw new Error(`Invalid tick in save: ${String(rawTick)} (require non-negative integer)`);
+  }
+  // rngState — same hardening for symmetry. Rng's `state | 0` would coerce
+  // NaN/strings to 0 on first use, but boundary validation surfaces tampering
+  // explicitly instead of silently snapping.
+  const rawRng = s.rngState;
+  if (typeof rawRng !== 'number'
+      || !Number.isFinite(rawRng)
+      || !Number.isInteger(rawRng)) {
+    throw new Error(`Invalid rngState in save: ${String(rawRng)} (require integer)`);
+  }
+
+  // Issue #109 — foodPiles boundary validation. The runtime scans this array
+  // every frame (draw-surface, minimap) and every tick (command handlers,
+  // ant behavior); an unbounded count converts a load-time anomaly into a
+  // sustained per-frame DoS that survives bootFromSave.
+  if (!Array.isArray(s.foodPiles)) {
+    throw new Error('Invalid foodPiles: not an array');
+  }
+  if (s.foodPiles.length > MAX_FOOD_PILES) {
+    throw new Error(`foodPiles length ${s.foodPiles.length} exceeds cap ${MAX_FOOD_PILES}`);
+  }
+  const seenFoodIds = new Set<number>();
+  const seenFoodTiles = new Set<number>();
+  for (let i = 0; i < s.foodPiles.length; i++) {
+    const fp = s.foodPiles[i]!;
+    validateFoodPile(fp, `foodPiles[${i}]`);
+    if (seenFoodIds.has(fp.foodPileId)) {
+      throw new Error(`Duplicate foodPiles[${i}].foodPileId: ${fp.foodPileId}`);
+    }
+    seenFoodIds.add(fp.foodPileId);
+    const tileKey = (fp.tileY << 16) | fp.tileX;
+    if (seenFoodTiles.has(tileKey)) {
+      throw new Error(`Duplicate foodPiles[${i}] tile (${fp.tileX}, ${fp.tileY})`);
+    }
+    seenFoodTiles.add(tileKey);
+  }
+
+  // Issue #99 — surface grid shape (single grid, not per-colony).
+  validateGridShape(s.surface, SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT, 'surface');
+
   return {
-    tick: s.tick,
-    rngState: s.rngState,
+    tick: rawTick,
+    rngState: rawRng,
     nextEntityId: rawNext,
     // Issue #27 — sticky-on-load: pre-#27 saves omit `simVersion` and replay
     // at LEGACY (2). Post-#27 saves carry the recorded version through.
@@ -717,7 +1025,15 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     // shape until the dispatcher actually consumed it. Centralizing the
     // migration here makes the loaded snapshot internally consistent
     // before any tick runs.
-    commandQueue: s.commandQueue.map((c) => migrateInputLogCommand({ ...c })),
+    //
+    // Issue #105 — also filter null/non-object entries before the spread:
+    // `{ ...null }` works (yields `{}`), but the resulting object lacks
+    // `cmd.type` and the dispatcher's exhaustive switch would silently no-op
+    // — better to drop them at the boundary so the runtime queue is always
+    // consistent with the dispatcher's expectations.
+    commandQueue: (Array.isArray(s.commandQueue) ? s.commandQueue : [])
+      .filter((c) => c !== null && typeof c === 'object')
+      .map((c) => migrateInputLogCommand({ ...c })),
     ants: deserializeAnts(s.ants, capacity),
     colonies,
     pheromoneGrids,
@@ -763,6 +1079,15 @@ function buildSaveFile(seed: number, inputLog: readonly SimCommand[], world: Wor
  * `SetBehaviorRatio` entries pass through untouched.
  */
 function migrateInputLogCommand(cmd: SimCommand): SimCommand {
+  // Issue #105 — guard at entry, before any property access. The Issue #78
+  // fix block below covers null `cmd.ratio`; this covers structurally-
+  // identical null / non-object `cmd`. Without this guard, parseSaveFile's
+  // loop throws TypeError on `null.type`, loadSave's try/catch swallows
+  // the throw and returns null, the caller treats the WHOLE save as corrupt
+  // and calls deleteSave + bootFresh — escalating one bad command into
+  // total save loss. Pass through verbatim; the dispatcher's exhaustive-
+  // default in tick.ts silently drops malformed entries.
+  if (cmd === null || typeof cmd !== 'object') return cmd;
   if (cmd.type !== 'SetBehaviorRatio') return cmd;
   // Issue #78 — guard against null/primitive ratios before using `'in'`.
   // Pre-fix code did `'dig' in ratioRaw` directly, which throws TypeError
@@ -783,21 +1108,38 @@ function migrateInputLogCommand(cmd: SimCommand): SimCommand {
 }
 
 function parseSaveFile(raw: string): SaveFile {
-  const parsed = JSON.parse(raw) as { version?: unknown };
+  const parsed = JSON.parse(raw) as { version?: unknown; seed?: unknown };
   if (typeof parsed.version !== 'number') {
     throw new SaveVersionMismatchError(SAVE_FORMAT_VERSION, NaN);
   }
   if (parsed.version !== SAVE_FORMAT_VERSION) {
     throw new SaveVersionMismatchError(SAVE_FORMAT_VERSION, parsed.version);
   }
+  // Issue #110 — envelope seed validation. buildSaveFile writes `seed | 0`
+  // (signed int32 domain). Reject anything that wouldn't survive that
+  // coercion losslessly. Without this guard, a tampered/malformed seed
+  // continues to play from the snapshot, autosave silently coerces it to 0
+  // on the next write, and the (seed, inputLog) → snapshot replay contract
+  // is permanently broken. Throw routes the corrupt save through loadSave's
+  // try/catch (returns null) → bootFresh.
+  if (!isInt32(parsed.seed)) {
+    throw new Error(`Invalid save envelope seed: ${String(parsed.seed)} (require int32)`);
+  }
   const file = parsed as SaveFile;
+  // Issue #103 — normalize non-array inputLog to []. parseSaveFile is the
+  // only boundary; downstream `for (const c of loaded.inputLog)` in
+  // game-scene.ts runs OUTSIDE the deserialize try/catch and would soft-
+  // brick Continue with TypeError on a missing/null/non-array inputLog.
+  // Replacing with `[]` lets the snapshot continue to play; the next
+  // autosave restores a proper inputLog from that point.
+  if (!Array.isArray(file.inputLog)) {
+    (file as { inputLog: SimCommand[] }).inputLog = [];
+  }
   // WR-09: walk inputLog and migrate any legacy SetBehaviorRatio entries so
   // SCEN-06 replay (`createScenario(seed) + tick(cmds[t])`) reproduces the
   // migrated snapshot. Other command types pass through.
-  if (Array.isArray(file.inputLog)) {
-    for (let i = 0; i < file.inputLog.length; i++) {
-      file.inputLog[i] = migrateInputLogCommand(file.inputLog[i]!);
-    }
+  for (let i = 0; i < file.inputLog.length; i++) {
+    file.inputLog[i] = migrateInputLogCommand(file.inputLog[i]!);
   }
   return file;
 }

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -7704,3 +7704,234 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
     expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #106 — Underground→Surface ascent reads currentGridColonyId in V13+.
+//
+// Pre-V13 the ascent looked up entrances on the ant's OWNING colony, so an
+// invading Fighter at tileY=0 inside an enemy grid could ascend through ANY
+// of its OWN colony's entrances that happened to share its underground tileX.
+// V13 reads `currentGridColonyId` instead and writes back `colonyId` on
+// successful ascent so the "Surface ⇒ currentGridColonyId === colonyId"
+// invariant holds.
+// ---------------------------------------------------------------------------
+describe('Issue #106 — ascent uses currentGridColonyId (V13+)', () => {
+  it('V13+ ascent looks up GRID colony\'s entrances, not the ant\'s OWN colony', () => {
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = 13;
+    // Two colonies. Player owns colony 1; enemy is colony 2.
+    const playerColonyId = 1;
+    const enemyColonyId = 2;
+    const playerColony = createColonyRecord(playerColonyId, 0);
+    playerColony.entrances = [{ entranceId: 10, surfaceTileX: 5, surfaceTileY: 5, isOpen: true }];
+    playerColony.rallyPoint = null;
+    playerColony.digFlowFieldDirty = false;
+    world.colonies[playerColonyId] = playerColony;
+    const enemyColony = createColonyRecord(enemyColonyId, 0);
+    // Enemy has no open entrance at tileX=5 (the only colony with that
+    // entrance is the player). Pre-V13: the player Fighter inside the enemy
+    // grid would warp home through the player entrance at tileX=5. V13: no
+    // matching entrance on the GRID colony (enemy), so no ascent.
+    enemyColony.entrances = [{ entranceId: 20, surfaceTileX: 99, surfaceTileY: 50, isOpen: true }];
+    enemyColony.rallyPoint = null;
+    enemyColony.digFlowFieldDirty = false;
+    world.colonies[enemyColonyId] = enemyColony;
+    const enemyGrid = createUndergroundGrid(16, 16);
+    world.undergroundGrids[enemyColonyId] = enemyGrid;
+    // Carve open tiles so passability checks don't kick in.
+    ugSet(enemyGrid, 5, 0, UndergroundTileState.Open);
+
+    // Player Fighter at tileY=0, tileX=5, currentGridColonyId=enemy (descended).
+    const fighterId = allocateEntityId(world);
+    initAnt(world.ants, fighterId, {
+      colonyId: playerColonyId,
+      posX: 5 << FP_SHIFT,
+      posY: 0,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.SearchingFood,
+      zone: Zone.Underground,
+      speed: 0,
+    });
+    world.ants.currentGridColonyId[fighterId] = enemyColonyId;
+
+    const digFlowFields = createDigFlowFields();
+    const rng = new Rng(42);
+    tickAntMovement(world, rng, digFlowFields);
+
+    // V13: no ascent — the enemy's tileX=5 has no entrance.
+    expect(world.ants.zone[fighterId]).toBe(Zone.Underground);
+  });
+
+  it('pre-V13 retains the legacy ascent (replay byte-identity)', () => {
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = 12; // legacy
+    const playerColonyId = 1;
+    const enemyColonyId = 2;
+    const playerColony = createColonyRecord(playerColonyId, 0);
+    playerColony.entrances = [{ entranceId: 10, surfaceTileX: 5, surfaceTileY: 5, isOpen: true }];
+    playerColony.rallyPoint = null;
+    playerColony.digFlowFieldDirty = false;
+    world.colonies[playerColonyId] = playerColony;
+    const enemyColony = createColonyRecord(enemyColonyId, 0);
+    enemyColony.entrances = [];
+    enemyColony.rallyPoint = null;
+    enemyColony.digFlowFieldDirty = false;
+    world.colonies[enemyColonyId] = enemyColony;
+    const enemyGrid = createUndergroundGrid(16, 16);
+    world.undergroundGrids[enemyColonyId] = enemyGrid;
+
+    const fighterId = allocateEntityId(world);
+    initAnt(world.ants, fighterId, {
+      colonyId: playerColonyId,
+      posX: 5 << FP_SHIFT,
+      posY: 0,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.SearchingFood,
+      zone: Zone.Underground,
+      speed: 0,
+    });
+    world.ants.currentGridColonyId[fighterId] = enemyColonyId;
+
+    const digFlowFields = createDigFlowFields();
+    const rng = new Rng(42);
+    tickAntMovement(world, rng, digFlowFields);
+
+    // Pre-V13: ascends through PLAYER entrance at (5, 5) — the bug.
+    expect(world.ants.zone[fighterId]).toBe(Zone.Surface);
+    expect(world.ants.posY[fighterId]).toBe(5 << FP_SHIFT);
+  });
+
+  it('V13+ same-colony ascent (ant in own grid) writes back currentGridColonyId for invariant restore', () => {
+    const { world, colony } = setupWorldWithUnderground();
+    world.simVersion = 13;
+    colony.entrances.push({ entranceId: 1, surfaceTileX: 8, surfaceTileY: 5, isOpen: true });
+    setupSurfaceGrid(world);
+
+    const antId = allocateEntityId(world);
+    initAnt(world.ants, antId, {
+      colonyId: COLONY_ID,
+      posX: 8 << FP_SHIFT,
+      posY: 0,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.SearchingFood,
+      zone: Zone.Underground,
+      speed: 0,
+    });
+    world.ants.currentGridColonyId[antId] = COLONY_ID; // own grid
+
+    const digFlowFields = createDigFlowFields();
+    const rng = new Rng(42);
+    tickAntMovement(world, rng, digFlowFields);
+
+    // Successful ascent. Post-V13 invariant: currentGridColonyId === colonyId.
+    expect(world.ants.zone[antId]).toBe(Zone.Surface);
+    expect(world.ants.currentGridColonyId[antId]).toBe(COLONY_ID);
+  });
+
+  it('V13+ invader Fighter at tileY=0 in foreign grid AT a matching enemy entrance does NOT ascend (skipAscent guard)', () => {
+    // Direct regression test for the descent→ascent ping-pong bug uncovered
+    // mid-implementation. Without the `skipAscent` guard, a Fighting invader
+    // at tileY=0 in the enemy grid would find the enemy's entrance at the
+    // same tileX (which is exactly where it descended) and ascend through
+    // it, then descend again next tick — bouncing forever and never fighting.
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = 13;
+    const playerColonyId = 1;
+    const enemyColonyId = 2;
+    const playerColony = createColonyRecord(playerColonyId, 0);
+    playerColony.entrances = [{ entranceId: 10, surfaceTileX: 5, surfaceTileY: 5, isOpen: true }];
+    playerColony.rallyPoint = null;
+    playerColony.digFlowFieldDirty = false;
+    world.colonies[playerColonyId] = playerColony;
+    const enemyColony = createColonyRecord(enemyColonyId, 0);
+    // Enemy entrance at SAME tileX=5 as where the invader is sitting — this
+    // is the "ping-pong" repro case. With skipAscent, the Fighter stays put.
+    enemyColony.entrances = [{ entranceId: 20, surfaceTileX: 5, surfaceTileY: 50, isOpen: true }];
+    enemyColony.rallyPoint = null;
+    enemyColony.digFlowFieldDirty = false;
+    world.colonies[enemyColonyId] = enemyColony;
+    const enemyGrid = createUndergroundGrid(16, 16);
+    world.undergroundGrids[enemyColonyId] = enemyGrid;
+    ugSet(enemyGrid, 5, 0, UndergroundTileState.Open);
+
+    // Player Fighter at tileY=0, tileX=5, currentGridColonyId=enemy.
+    const fighterId = allocateEntityId(world);
+    initAnt(world.ants, fighterId, {
+      colonyId: playerColonyId,
+      posX: 5 << FP_SHIFT,
+      posY: 0,
+      task: AntTask.Fighting, // <-- KEY: Fighting, not Foraging
+      zone: Zone.Underground,
+      speed: 0,
+    });
+    world.ants.currentGridColonyId[fighterId] = enemyColonyId; // foreign grid
+
+    const digFlowFields = createDigFlowFields();
+    const rng = new Rng(42);
+    tickAntMovement(world, rng, digFlowFields);
+
+    // Fighter must NOT ascend even though enemy entrance matches its tileX.
+    // skipAscent fires: task === Fighting && currentGridColonyId !== colonyId.
+    expect(world.ants.zone[fighterId]).toBe(Zone.Underground);
+    expect(world.ants.currentGridColonyId[fighterId]).toBe(enemyColonyId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #108 — resolveSameColonyOccupancy zone-masks gridColonyId in V13+.
+//
+// V13+ mirrors combat tile-key encoding (tile-key.ts:56) — when zone ===
+// Surface, the gridColonyId portion of the per-tile key is zero-masked so
+// two same-colony surface ants with diverging `currentGridColonyId` (e.g.
+// post-#106 ascent transient) bucket together and one gets shifted off the
+// shared tile. Pre-V13 the raw gridColonyId was used and they stacked.
+// ---------------------------------------------------------------------------
+describe('Issue #108 — occupancy zone-mask (V13+)', () => {
+  it('V13+ shifts one of two same-colony surface ants with diverging currentGridColonyId at same tile', () => {
+    const { world } = setupWorldWithUnderground();
+    world.simVersion = 13;
+    setupSurfaceGrid(world);
+
+    const a = allocateEntityId(world);
+    initAnt(world.ants, a, {
+      colonyId: COLONY_ID,
+      posX: 5 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      task: AntTask.Foraging,
+      zone: Zone.Surface,
+      speed: 0,
+    });
+    world.ants.currentGridColonyId[a] = COLONY_ID; // matches own colony
+
+    const b = allocateEntityId(world);
+    initAnt(world.ants, b, {
+      colonyId: COLONY_ID, // SAME colony
+      posX: 5 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      task: AntTask.Foraging,
+      zone: Zone.Surface,
+      speed: 0,
+    });
+    world.ants.currentGridColonyId[b] = 99; // DIVERGENT — exposes the bug
+
+    const digFlowFields = createDigFlowFields();
+    const rng = new Rng(42);
+    tickAntMovement(world, rng, digFlowFields);
+
+    // V13+: occupancy resolver zero-masks gridByte for surface, so both ants
+    // share a key and one (higher id) shifts to an adjacent tile.
+    const aTile = `${world.ants.posX[a]! >> FP_SHIFT},${world.ants.posY[a]! >> FP_SHIFT}`;
+    const bTile = `${world.ants.posX[b]! >> FP_SHIFT},${world.ants.posY[b]! >> FP_SHIFT}`;
+    expect(aTile).not.toBe(bTile);
+  });
+
+  // Pre-V13 byte-identity is enforced indirectly: the V13+ behavior change
+  // only fires on `world.simVersion >= V13`, and the rest of the
+  // ant-system test corpus pins simVersion at LEGACY_SIM_VERSION (2) for
+  // its setupWorldWithUnderground default. If V13 leaked through, the
+  // existing 263-test surface would fail. The positive V13 test above is
+  // sufficient to demonstrate the masked-key separation; reproducing the
+  // pre-V13 stack here would require exporting resolveSameColonyOccupancy
+  // for direct call (the full tickAntMovement also runs surface foraging
+  // / passability passes that can shift either ant for unrelated reasons).
+});

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -41,6 +41,7 @@ import {
   SIM_VERSION_V10_VISIBLE_BROOD_CARRY,
   SIM_VERSION_V11_DEFENSIVE_BUNDLE,
   SIM_VERSION_V12_SIM_CORRECTNESS_BUNDLE,
+  SIM_VERSION_V13_INVARIANT_FIXES,
   type WorldState,
 } from '../types.js';
 import {
@@ -4574,15 +4575,50 @@ export function tickAntMovement(
         const tileY = posY >> FP_SHIFT;
 
         if (tileY === 0) {
-          const colonyId = ants.colonyId[id]!;
-          const colony = world.colonies[colonyId];
-          if (colony && colony.entrances) {
-            for (let e = 0; e < colony.entrances.length; e++) {
-              const entrance = colony.entrances[e]!;
-              if (entrance.isOpen && entrance.surfaceTileX === tileX) {
-                ants.zone[id] = Zone.Surface;
-                ants.posY[id] = entrance.surfaceTileY << FP_SHIFT;
-                break;
+          // Issue #106 (v13+) — ascent reads the GRID the ant is currently
+          // in (`currentGridColonyId`), not the ant's owning colony. For
+          // Fighter invaders in foreign grids, `currentGridColonyId !==
+          // colonyId` by design (see descent comment above). Pre-v13 used
+          // `colonyId` and an invader could ascend through any of its
+          // OWN-colony entrances that happened to share the underground
+          // tileX it occupied inside the enemy grid — a "warp home"
+          // movement bug.
+          //
+          // The fix has two parts:
+          //   (1) Lookup uses currentGridColonyId, so ascent honors the
+          //       grid the ant occupies.
+          //   (2) Fighting invaders in foreign grids skip ascent entirely
+          //       (mirrors the descent code's `isFightingForeigner` logic).
+          //       Without (2), an invader bounces back to the surface every
+          //       other tick: descent → ascent through enemy entrance →
+          //       descent → ascent → ... pre-v13 the wrong-colony lookup
+          //       accidentally masked this by failing to find an entrance,
+          //       which is also why the warp-home bug only surfaced on
+          //       coincidental tileX alignment.
+          const useGridColony = world.simVersion >= SIM_VERSION_V13_INVARIANT_FIXES;
+          const inOwnGrid = ants.currentGridColonyId[id] === ants.colonyId[id];
+          const skipAscent = useGridColony && task === AntTask.Fighting && !inOwnGrid;
+          if (!skipAscent) {
+            const lookupColonyId = useGridColony
+              ? ants.currentGridColonyId[id]!
+              : ants.colonyId[id]!;
+            const colony = world.colonies[lookupColonyId];
+            if (colony && colony.entrances) {
+              for (let e = 0; e < colony.entrances.length; e++) {
+                const entrance = colony.entrances[e]!;
+                if (entrance.isOpen && entrance.surfaceTileX === tileX) {
+                  ants.zone[id] = Zone.Surface;
+                  ants.posY[id] = entrance.surfaceTileY << FP_SHIFT;
+                  if (useGridColony) {
+                    // Restore the surface invariant. For ants in their own
+                    // grid this is a no-op (already equal). For an invader
+                    // who eventually leaves via the enemy entrance after
+                    // being re-promoted out of Fighting (e.g. Idle), this
+                    // snaps the grid id back to their own colony.
+                    ants.currentGridColonyId[id] = ants.colonyId[id]!;
+                  }
+                  break;
+                }
               }
             }
           }
@@ -4656,13 +4692,21 @@ function resolveSameColonyOccupancy(world: WorldState): void {
     //   bit  15     : zone (0 = Surface, 1 = Underground)
     //   bits 16..22 : colonyId (0..127)
     //   bits 23..29 : gridColonyId (0..127)
-    const gridColonyId = ants.currentGridColonyId[id]!;
+    const rawGridColonyId = ants.currentGridColonyId[id]!;
     let tileX = ants.posX[id]! >> FP_SHIFT;
     let tileY = ants.posY[id]! >> FP_SHIFT;
 
     if (isOccupancyExempt(world, colonyId, zone, tileX, tileY)) continue;
 
-    const key = (gridColonyId << 23) | (colonyId << 16) | (zone << 15) | (tileY << 7) | tileX;
+    // Issue #108 (v13+) — zero the gridColonyId portion of the key when
+    // zone === Surface. Mirrors combat tile-key encoding (tile-key.ts:56);
+    // pre-v13 this resolver keyed on the raw gridColonyId, so two same-
+    // colony surface ants with diverging `currentGridColonyId` (post-#106
+    // ascent bug) produced different keys and stacked silently.
+    const gridByte = world.simVersion >= SIM_VERSION_V13_INVARIANT_FIXES && zone !== Zone.Underground
+      ? 0
+      : rawGridColonyId;
+    const key = (gridByte << 23) | (colonyId << 16) | (zone << 15) | (tileY << 7) | tileX;
     if (!occupancy.has(key)) {
       occupancy.set(key, id);
       continue;
@@ -4677,7 +4721,7 @@ function resolveSameColonyOccupancy(world: WorldState): void {
     // of where they are). Today both keys yield the same grid.
     const task = ants.task[id]! as AntTask;
     const underground =
-      zone === Zone.Underground ? world.undergroundGrids[gridColonyId] : undefined;
+      zone === Zone.Underground ? world.undergroundGrids[rawGridColonyId] : undefined;
     let shifted = false;
     for (let d = 0; d < 4; d++) {
       const nx = tileX + DIR_DX[d]!;
@@ -4708,8 +4752,11 @@ function resolveSameColonyOccupancy(world: WorldState): void {
         shifted = true;
         break;
       }
-      // Issue #61 — same key layout as the primary key above.
-      const adjKey = (gridColonyId << 23) | (colonyId << 16) | (zone << 15) | (ny << 7) | nx;
+      // Issue #61 — same key layout as the primary key above. Issue #108
+      // (v13+): mirror the same gridByte mask so adjacent-tile lookup keys
+      // match the primary lookup. Pre-v13 used `rawGridColonyId` here too;
+      // safe because pre-v13 occupancy resolution never crosses zones.
+      const adjKey = (gridByte << 23) | (colonyId << 16) | (zone << 15) | (ny << 7) | nx;
       if (occupancy.has(adjKey)) continue;
       tileX = nx;
       tileY = ny;

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -178,6 +178,60 @@ describe('killAnt', () => {
     expect(world.colonies[cid1]!.workers).toContain(v);
     expect(world.colonies[cid1]!.workerCount).toBe(1); // unchanged by combat.killAnt
   });
+
+  // ---------------------------------------------------------------------
+  // Issue #107 — V13+ atomically clears bidirectional carry pointers.
+  // ---------------------------------------------------------------------
+  it('#107 (V13+) clears carryingBroodId and the brood\'s carriedBy when a carrier is killed', () => {
+    const { world, cid1, cid2 } = makeWorldWith2Colonies();
+    world.simVersion = 13;
+    const carrier = spawnAnt(world, cid1, 5, 7, Zone.Underground);
+    const brood = spawnAnt(world, cid1, 5, 7, Zone.Underground);
+    world.ants.carryingBroodId[carrier] = brood;
+    world.ants.carriedBy[brood] = carrier;
+    killAnt(world, carrier, cid2);
+    expect(world.ants.alive[carrier]).toBe(0);
+    expect(world.ants.carryingBroodId[carrier]).toBe(-1);
+    expect(world.ants.carriedBy[brood]).toBe(-1);
+  });
+
+  it('#107 (V13+) symmetric — when the carried entity is killed, carrier\'s carryingBroodId clears', () => {
+    const { world, cid1, cid2 } = makeWorldWith2Colonies();
+    world.simVersion = 13;
+    const carrier = spawnAnt(world, cid1, 5, 7, Zone.Underground);
+    const brood = spawnAnt(world, cid1, 5, 7, Zone.Underground);
+    world.ants.carryingBroodId[carrier] = brood;
+    world.ants.carriedBy[brood] = carrier;
+    killAnt(world, brood, cid2);
+    expect(world.ants.alive[brood]).toBe(0);
+    expect(world.ants.carryingBroodId[carrier]).toBe(-1);
+    expect(world.ants.carriedBy[brood]).toBe(-1);
+  });
+
+  it('#107 pre-V13 retains legacy stale-pointer behavior (replay byte-identity)', () => {
+    const { world, cid1, cid2 } = makeWorldWith2Colonies();
+    world.simVersion = 12; // legacy
+    const carrier = spawnAnt(world, cid1, 5, 7, Zone.Underground);
+    const brood = spawnAnt(world, cid1, 5, 7, Zone.Underground);
+    world.ants.carryingBroodId[carrier] = brood;
+    world.ants.carriedBy[brood] = carrier;
+    killAnt(world, carrier, cid2);
+    expect(world.ants.alive[carrier]).toBe(0);
+    // Legacy: pointers persist past death — the bug this V13 fix addresses.
+    expect(world.ants.carryingBroodId[carrier]).toBe(brood);
+    expect(world.ants.carriedBy[brood]).toBe(carrier);
+  });
+
+  it('#107 (V13+) is a no-op for ants without active carry slots (regression guard)', () => {
+    const { world, cid1, cid2 } = makeWorldWith2Colonies();
+    world.simVersion = 13;
+    const v = spawnAnt(world, cid1, 5, 7, Zone.Surface);
+    // Default state: carryingBroodId = -1, carriedBy = -1.
+    killAnt(world, v, cid2);
+    expect(world.ants.alive[v]).toBe(0);
+    expect(world.ants.carryingBroodId[v]).toBe(-1);
+    expect(world.ants.carriedBy[v]).toBe(-1);
+  });
 });
 
 describe('coin flip distribution (CMBT-05)', () => {

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -14,6 +14,7 @@
 import { Rng } from './rng.js';
 import { makeTileKey } from './tile-key.js';
 import type { WorldState } from './types.js';
+import { SIM_VERSION_V13_INVARIANT_FIXES } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 import type { Zone } from './terrain.js';
 import { FP_SHIFT } from './fixed.js';
@@ -136,9 +137,29 @@ export function resolveCombatOnTile(world: WorldState, _tileKey: number, partici
 /**
  * Instant-kill: zero alive flag, increment killer killCount.
  * Roster cleanup is the responsibility of tickDeathCleanup at step 5 next tick.
+ *
+ * Issue #107 (v13+) — atomically clear bidirectional carry pointers BEFORE
+ * zeroing alive so the (`carryingBroodId[X] === Y` ⇔ `carriedBy[Y] === X`)
+ * invariant holds across a combat death. Pre-v13 a nurse killed mid-Feeding
+ * left the brood's `carriedBy` pointing at a dead ant; if the carrier died
+ * on a Marked or Solid tile, the brood was unreclaimable (chamber-flow.ts
+ * pickup-field seeds Open/BeingDug only).
  */
 export function killAnt(world: WorldState, antIndex: number, killerColonyId: ColonyId): void {
-  world.ants.alive[antIndex] = 0;
+  const ants = world.ants;
+  if (world.simVersion >= SIM_VERSION_V13_INVARIANT_FIXES) {
+    const carrying = ants.carryingBroodId[antIndex]!;
+    if (carrying !== -1) {
+      ants.carriedBy[carrying] = -1;
+      ants.carryingBroodId[antIndex] = -1;
+    }
+    const carrier = ants.carriedBy[antIndex]!;
+    if (carrier !== -1) {
+      ants.carryingBroodId[carrier] = -1;
+      ants.carriedBy[antIndex] = -1;
+    }
+  }
+  ants.alive[antIndex] = 0;
   if (killerColonyId !== 0) {
     const killerColony = world.colonies[killerColonyId];
     if (killerColony !== undefined) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -156,7 +156,38 @@ export const SIM_VERSION_V11_DEFENSIVE_BUNDLE = 11 as const;
  *         transition Idle if all delivered, else wait-state.
  */
 export const SIM_VERSION_V12_SIM_CORRECTNESS_BUNDLE = 12 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V12_SIM_CORRECTNESS_BUNDLE;
+/**
+ * v13 — invariant fixes (issues #106, #107, #108). Three independent
+ * state-invariant violations gated together so pre-v13 saves replay
+ * byte-identically with the bugged behavior:
+ *
+ *   #106 — Underground→Surface ascent now reads `currentGridColonyId`
+ *          instead of `colonyId` for the entrance lookup. Pre-v13, an
+ *          invading Fighter at tileY=0 inside an enemy grid would warp
+ *          home through any of the player's own-colony entrances that
+ *          happened to share its underground tileX, bypassing the enemy
+ *          ascent path. Post-v13 the ascent honors the grid the ant is
+ *          actually in, AND restores the "Surface ⇒ currentGridColonyId
+ *          === colonyId" invariant by snapping the grid id back on
+ *          successful ascent.
+ *
+ *   #107 — `killAnt` now atomically clears bidirectional carry pointers
+ *          (`carryingBroodId[killed]` and `carriedBy[their_carrier]`)
+ *          before zeroing alive. Pre-v13, a nurse killed mid-Feeding
+ *          left the brood orphaned with stale `carriedBy` pointing at
+ *          a dead ant; if the nurse died on a Marked or Solid tile,
+ *          the brood was unreclaimable until that tile became Open
+ *          (chamber-flow.ts pickup-field seeds Open/BeingDug only).
+ *
+ *   #108 — `resolveSameColonyOccupancy` now zero-masks the gridColonyId
+ *          portion of the per-tile key when zone === Surface, mirroring
+ *          combat's tile-key encoding. Pre-v13, two same-colony surface
+ *          ants with diverging `currentGridColonyId` (the post-#106
+ *          ascent bug, or any future divergence path) produced different
+ *          keys and stacked silently on the same tile.
+ */
+export const SIM_VERSION_V13_INVARIANT_FIXES = 13 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V13_INVARIANT_FIXES;
 
 export interface WorldState {
   tick: number;             // 0 at creation; incremented once per tick


### PR DESCRIPTION
Closes #99 #101 #102 #103 #104 #105 #106 #107 #108 #109 #110.

## Summary

Two clusters of related hardening fixes that share an entry-point validation theme. 11 issues land together because they all live at one of two boundaries (`parseSaveFile`/`deserializeWorldState`, or sim-version-gated invariant restoration) and the test surface is uniform across each cluster.

## Cluster A — save-file boundary hardening (8 issues)

All in `src/platform/save.ts`. Validators run at the `parseSaveFile` / `deserializeWorldState` boundaries. Throws route through `bootFromSave`'s catch → `bootFresh` (consistent with existing #59 / #65 / #66 hardening).

| Issue | Field | Failure mode |
|---|---|---|
| #99  | grid dims + map cardinality | memory-DoS via huge typed-array allocation |
| #101 | `chamber.{width,height,posX,posY,foodStored}` | renderer hang via `chamber-flow.ts` seed loop |
| #102 | `pendingChamber.{width,height,anchor*}` | renderer hang via `tick.ts:382` revert loop |
| #103 | non-array `inputLog` | permanent soft-brick on Continue (TypeError outside try/catch) |
| #104 | `s.tick` scalar | unbounded memory growth via `tick++` string concat |
| #105 | null inputLog entry | one bad command → entire save deleted |
| #109 | `foodPiles` array | sustained per-frame DoS (scanned every render + tick) |
| #110 | envelope `seed` | silent coerce-to-0 breaks replay-truth contract |

44 new tests in `save.test.ts` cover each validator with a tampered shape and verify legitimate scenarios still round-trip cleanly.

## Cluster B — sim-invariant fixes (3 issues, V13 bump)

`LATEST_SIM_VERSION` bumped 12 → 13 (`SIM_VERSION_V13_INVARIANT_FIXES`). All three fixes gated so pre-V13 saves replay byte-identically.

| Issue | Bug | Fix |
|---|---|---|
| #106 | ascent uses `colonyId` not `currentGridColonyId` | swap + post-ascent writeback to restore invariant; **plus** skipAscent for Fighting invaders in foreign grids (mirrors descent's `isFightingForeigner` — without it V13 produced a descent→ascent ping-pong) |
| #107 | `killAnt` doesn't clear carry slots | atomic bidirectional cleanup before `alive=0` |
| #108 | occupancy zone-mask gap | mirror `tile-key.ts:56` mask: `gridByte = zone===Underground ? raw : 0` |

8 new tests cover both pre-V13 and V13 paths, including a regression test for the descent→ascent ping-pong bug uncovered during implementation.

## Cross-references

- #99, #101, #102 are tracked together as the broader save-hardening theme (cross-references already posted).
- #106 and #108 are tightly coupled: #106 creates the divergence #108 closes; both fixed together restores the "Surface ⇒ `currentGridColonyId === colonyId`" invariant fully.

## Internal review

One fresh-context review pass (no prior session context) returned "Clean — ship it" with one P2 (test gap on the new skipAscent guard). Addressed by adding a regression test that asserts an invader Fighter at tileX matching the enemy entrance does NOT ascend.

## Test plan

- [x] Typecheck clean
- [x] **1899 unit tests pass** (52 new in this bundle)
- [x] One pre-existing flake on the AI 6000-tick determinism integration test under parallel load — passes in 15s when run isolated
- [ ] UAT: load a fresh game, exercise save/reload round-trip
- [ ] UAT: any combat scenario (V13 changes affect death-cleanup, but no behavioral changes in normal play)
- [ ] UAT: invasion scenario — player Fighters on enemy entrance should descend and stay underground (regression for the ping-pong bug uncovered mid-implementation)

## Sim-version gating

Pre-V13 saves replay byte-identically. The V13 changes are gated on `world.simVersion >= SIM_VERSION_V13_INVARIANT_FIXES`; legacy saves loaded into V13 builds keep V12 behavior (sticky-on-load contract, same as #95/#96 and earlier bumps).