### PR TITLE
Menu + render polish bundle: pause menu, save/load dialog, pheromone toggle, round entrances

### DIFF
--- a/src/input/camera-input.test.ts
+++ b/src/input/camera-input.test.ts
@@ -64,6 +64,7 @@ function makeViewState(
     },
     undergroundVisited: false,
     activeUndergroundColonyId: PLAYER_COLONY_ID,
+    showPheromoneOverlay: true,
   };
 }
 
@@ -184,6 +185,7 @@ describe('isPointerOverHUD', () => {
         undergroundCamera: { x: 0, y: 0, viewportWidth: 1, viewportHeight: 1 },
         undergroundVisited: true,
         activeUndergroundColonyId: 1,
+        showPheromoneOverlay: true,
       };
     }
 

--- a/src/input/surface-input.test.ts
+++ b/src/input/surface-input.test.ts
@@ -55,6 +55,7 @@ function makeViewState(
     undergroundCamera: { x: camX, y: camY, viewportWidth: VIEWPORT_WIDTH_TILES, viewportHeight: VIEWPORT_HEIGHT_TILES },
     undergroundVisited: false,
     activeUndergroundColonyId: PLAYER_COLONY_ID,
+    showPheromoneOverlay: true,
   };
 }
 

--- a/src/input/underground-input.test.ts
+++ b/src/input/underground-input.test.ts
@@ -57,6 +57,7 @@ function makeViewState(
     undergroundCamera: { x: camX, y: camY, viewportWidth: VIEWPORT_WIDTH_TILES, viewportHeight: VIEWPORT_HEIGHT_TILES },
     undergroundVisited: true,
     activeUndergroundColonyId: PLAYER_COLONY_ID,
+    showPheromoneOverlay: true,
   };
 }
 
@@ -1041,6 +1042,7 @@ describe('underground-input read-only when activeUndergroundColonyId !== PLAYER_
       undergroundCamera: { x: 64, y: 32, viewportWidth: VIEWPORT_WIDTH_TILES, viewportHeight: VIEWPORT_HEIGHT_TILES },
       undergroundVisited: true,
       activeUndergroundColonyId: ENEMY_COLONY_ID,
+      showPheromoneOverlay: true,
     };
   }
 

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -1879,6 +1879,46 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       }));
       expect(hasIncompatibleSave()).toBe(true);
     });
+
+    it('round-4 (Rob): returns true when snapshot is empty object (parseable but unloadable — Continue would lie)', async () => {
+      // Pre-fix: parseSaveFile succeeds, snapshot is non-null object,
+      // simVersion is missing (passes the prior check), Continue would
+      // appear enabled — but bootFromSave would throw on missing required
+      // fields and silently fall through to bootFresh. Now flagged via
+      // the full-deserialize boundary check.
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
+        version: SAVE_FORMAT_VERSION,
+        seed: 1,
+        inputLog: [],
+        snapshot: {},
+      }));
+      expect(hasIncompatibleSave()).toBe(true);
+    });
+
+    it('round-4 (Rob): returns true when simVersion is below LEGACY_SIM_VERSION (tampered down)', async () => {
+      const { LEGACY_SIM_VERSION } = await import('../sim/types.js');
+      const world = createScenario(7);
+      const snap = serializeWorldState(world);
+      snap.simVersion = LEGACY_SIM_VERSION - 1;
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
+        version: SAVE_FORMAT_VERSION,
+        seed: 7,
+        inputLog: [],
+        snapshot: snap,
+        savedAtMs: Date.now(),
+      }));
+      expect(hasIncompatibleSave()).toBe(true);
+    });
+
+    it('round-4 (Rob): returns true when snapshot.colonies is missing (deserialize would throw)', () => {
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
+        version: SAVE_FORMAT_VERSION,
+        seed: 1,
+        inputLog: [],
+        snapshot: { tick: 0, rngState: 0, nextEntityId: 0, commandQueue: [] },
+      }));
+      expect(hasIncompatibleSave()).toBe(true);
+    });
   });
 
   describe('Issue #115 — getSaveInfo', () => {

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -1826,6 +1826,45 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(info!.playerFoodStored).toBe(playerColony.foodStored >> FP_SHIFT);
     });
 
+    it('returns the wall-clock savedAtMs from the envelope (issue #115)', () => {
+      const before = Date.now();
+      manualSave(42, [], createScenario(42));
+      const after = Date.now();
+      const info = getSaveInfo();
+      expect(info!.savedAtMs).toBeGreaterThanOrEqual(before);
+      expect(info!.savedAtMs).toBeLessThanOrEqual(after);
+    });
+
+    it('returns savedAtMs=0 when the envelope omits the field (pre-issue-#115 saves)', () => {
+      // Simulate an older v3 envelope written before issue #115 added savedAtMs.
+      // parseSaveFile must accept it (no version bump) and getSaveInfo falls
+      // back to 0 ("unknown") rather than NaN or a 1970 stamp.
+      const env = {
+        version: SAVE_FORMAT_VERSION,
+        seed: 1,
+        inputLog: [],
+        snapshot: serializeWorldState(createScenario(1)),
+        // savedAtMs intentionally omitted
+      };
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
+      const info = getSaveInfo();
+      expect(info).not.toBeNull();
+      expect(info!.savedAtMs).toBe(0);
+    });
+
+    it('returns savedAtMs=0 when the envelope field is malformed (negative or non-finite)', () => {
+      const env = {
+        version: SAVE_FORMAT_VERSION,
+        seed: 1,
+        inputLog: [],
+        snapshot: serializeWorldState(createScenario(1)),
+        savedAtMs: -1,
+      };
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
+      const info = getSaveInfo();
+      expect(info!.savedAtMs).toBe(0);
+    });
+
     it('reflects updated tick count after the world advances', () => {
       const world = createScenario(42);
       for (let i = 0; i < 5; i++) tick(world, []);

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -4,6 +4,7 @@ import {
   SAVE_FORMAT_VERSION, SAVE_KEY, AUTOSAVE_INTERVAL_MS,
   serializeWorldState, deserializeWorldState,
   hasSave, loadSave, deleteSave, tickAutosave,
+  manualSave, hasIncompatibleSave, getSaveInfo,
   migrateBehaviorRatio,
   parseSaveFile,
   FutureSimVersionError,
@@ -1705,6 +1706,165 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       };
       s.recentlyDepletedFood[0]!.tileX = -1; // out of bounds
       expect(() => deserializeWorldState(s as never)).toThrow(/recentlyDepletedFood\[0\]\.tileX/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #115 — manualSave + hasIncompatibleSave + getSaveInfo
+  // -------------------------------------------------------------------------
+
+  describe('Issue #115 — manualSave', () => {
+    it('writes a parseable save under SAVE_KEY and returns true on success', () => {
+      const world = createScenario(42);
+      const ok = manualSave(42, [], world);
+      expect(ok).toBe(true);
+      expect(window.localStorage.getItem(SAVE_KEY)).not.toBeNull();
+      // Round-trip via the public read path.
+      const loaded = loadSave();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.seed).toBe(42);
+      expect(loaded!.snapshot.tick).toBe(0);
+    });
+
+    it('preserves the inputLog the caller supplies', () => {
+      const world = createScenario(42);
+      const log: SimCommand[] = [
+        { type: 'SetBehaviorRatio', colonyId: PLAYER_COLONY_ID, ratio: { forage: 5, fight: 5 }, issuedAtTick: 0 },
+      ];
+      manualSave(42, log, world);
+      const loaded = loadSave();
+      expect(loaded!.inputLog).toHaveLength(1);
+      expect(loaded!.inputLog[0]!.type).toBe('SetBehaviorRatio');
+    });
+
+    it('returns false (does not throw) when localStorage.setItem rejects', () => {
+      const world = createScenario(42);
+      const orig = window.localStorage.setItem;
+      window.localStorage.setItem = vi.fn(() => { throw new Error('QuotaExceededError'); });
+      try {
+        const ok = manualSave(42, [], world);
+        expect(ok).toBe(false);
+      } finally {
+        window.localStorage.setItem = orig;
+      }
+    });
+
+    it('does NOT depend on or update the autosave timer (manual save is independent)', () => {
+      // tickAutosave returns the new lastSaveMs each call. A manual save in
+      // between two autosave windows must not bump the autosave's clock —
+      // they share the SAVE_KEY but track cadence independently.
+      const world = createScenario(42);
+      // First autosave at t=0 → writes, returns 0.
+      const t0 = tickAutosave(42, [], world, -AUTOSAVE_INTERVAL_MS, 0);
+      expect(t0).toBe(0);
+      // Manual save at t=5000 — should write, but the autosave's lastSaveMs
+      // is whatever the caller passes; manualSave doesn't see it. Verify by
+      // calling tickAutosave again at t = AUTOSAVE_INTERVAL_MS-1 with the
+      // unchanged lastSaveMs → still NOT due (cooldown not elapsed).
+      manualSave(42, [], world);
+      const t1 = tickAutosave(42, [], world, t0, AUTOSAVE_INTERVAL_MS - 1);
+      expect(t1).toBe(t0); // still pre-cooldown — unchanged
+    });
+  });
+
+  describe('Issue #115 — hasIncompatibleSave', () => {
+    it('returns false when localStorage is empty', () => {
+      expect(hasIncompatibleSave()).toBe(false);
+    });
+
+    it('returns false for a freshly-written compatible save', () => {
+      manualSave(42, [], createScenario(42));
+      expect(hasIncompatibleSave()).toBe(false);
+      // hasSave is the symmetric positive case
+      expect(hasSave()).toBe(true);
+    });
+
+    it('returns true when SAVE_KEY holds a v2-shaped envelope (rejected by parseSaveFile)', () => {
+      // Stash a known-v2 envelope. parseSaveFile throws SaveVersionMismatchError
+      // → hasIncompatibleSave returns true; hasSave returns false. The pair
+      // lets the dialog distinguish "no save" from "save present, this build
+      // can't read it" instead of silently booting fresh.
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
+        version: 2,
+        seed: 1,
+        inputLog: [],
+        snapshot: {},
+      }));
+      expect(hasIncompatibleSave()).toBe(true);
+      expect(hasSave()).toBe(false);
+    });
+
+    it('returns true when SAVE_KEY holds completely malformed JSON', () => {
+      window.localStorage.setItem(SAVE_KEY, '{not-json');
+      expect(hasIncompatibleSave()).toBe(true);
+      expect(hasSave()).toBe(false);
+    });
+  });
+
+  describe('Issue #115 — getSaveInfo', () => {
+    it('returns null when no save exists', () => {
+      expect(getSaveInfo()).toBeNull();
+    });
+
+    it('returns null when the save is unreadable (would let the dialog show "incompatible save")', () => {
+      window.localStorage.setItem(SAVE_KEY, '{not-json');
+      expect(getSaveInfo()).toBeNull();
+    });
+
+    it('returns tick + player worker count + player food (human units) for a fresh save', () => {
+      const world = createScenario(42);
+      manualSave(42, [], world);
+      const info = getSaveInfo();
+      expect(info).not.toBeNull();
+      expect(info!.tick).toBe(0);
+      // Fresh scenario: queen alive; workerCount tracks living workers (no
+      // hatched workers yet at tick 0). Match against the live colony.
+      const playerColony = world.colonies[PLAYER_COLONY_ID]!;
+      expect(info!.playerWorkers).toBe(playerColony.workerCount);
+      // playerFoodStored is reported in human units (foodStored >> FP_SHIFT).
+      const FP_SHIFT = 8;
+      expect(info!.playerFoodStored).toBe(playerColony.foodStored >> FP_SHIFT);
+    });
+
+    it('reflects updated tick count after the world advances', () => {
+      const world = createScenario(42);
+      for (let i = 0; i < 5; i++) tick(world, []);
+      manualSave(42, [], world);
+      const info = getSaveInfo();
+      expect(info!.tick).toBe(5);
+    });
+
+    it('returns 0 worker / 0 food when the player colony key is absent (defensive)', () => {
+      // Hand-craft an envelope with a missing player colony record. This
+      // should never happen in legitimate gameplay, but the dialog must not
+      // crash if it does — surface zeros and let the player decide.
+      const env = {
+        version: SAVE_FORMAT_VERSION,
+        seed: 1,
+        inputLog: [],
+        snapshot: {
+          tick: 7,
+          rngState: 1,
+          nextEntityId: 0,
+          commandQueue: [],
+          ants: { count: 0, posX: [], posY: [], colonyId: [], task: [], subTask: [],
+                  speed: [], foodCarrying: [], starvationTimer: [], age: [], alive: [],
+                  lifespan: [], zone: [], digTileX: [], digTileY: [], digTicksRemaining: [],
+                  targetPosX: [], targetPosY: [], targetSet: [] },
+          colonies: {}, // PLAYER_COLONY_ID intentionally missing
+          pheromoneGrids: {},
+          surface: { width: 1, height: 1, data: [0] },
+          undergroundGrids: {},
+          foodPiles: [],
+          pendingChambers: {},
+        },
+      };
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
+      const info = getSaveInfo();
+      expect(info).not.toBeNull();
+      expect(info!.tick).toBe(7);
+      expect(info!.playerWorkers).toBe(0);
+      expect(info!.playerFoodStored).toBe(0);
     });
   });
 });

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -1799,6 +1799,63 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(hasIncompatibleSave()).toBe(true);
       expect(hasSave()).toBe(false);
     });
+
+    it('round-3 (Codex P2): returns true when snapshot.simVersion exceeds LATEST_SIM_VERSION (future-build save)', async () => {
+      // Build a parseable envelope and stamp simVersion above LATEST so
+      // bootFromSave's deserialize would throw FutureSimVersionError. The
+      // envelope itself parses fine — hasSave returns true today — but the
+      // dialog needs to know this save is unloadable so Continue stays
+      // disabled and the warning info line surfaces.
+      const { LATEST_SIM_VERSION } = await import('../sim/types.js');
+      const world = createScenario(7);
+      const snap = serializeWorldState(world);
+      snap.simVersion = LATEST_SIM_VERSION + 1;
+      const env = {
+        version: SAVE_FORMAT_VERSION,
+        seed: 7,
+        inputLog: [],
+        snapshot: snap,
+        savedAtMs: Date.now(),
+      };
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
+      expect(hasIncompatibleSave()).toBe(true);
+      // hasSave still returns true (envelope parses) — caller is expected
+      // to gate on `hasSave() && !hasIncompatibleSave()` for "loadable".
+      expect(hasSave()).toBe(true);
+    });
+
+    it('round-3: returns false when simVersion equals LATEST_SIM_VERSION (loadable)', async () => {
+      const { LATEST_SIM_VERSION } = await import('../sim/types.js');
+      const world = createScenario(7);
+      const snap = serializeWorldState(world);
+      snap.simVersion = LATEST_SIM_VERSION;
+      const env = {
+        version: SAVE_FORMAT_VERSION,
+        seed: 7,
+        inputLog: [],
+        snapshot: snap,
+        savedAtMs: Date.now(),
+      };
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
+      expect(hasIncompatibleSave()).toBe(false);
+      expect(hasSave()).toBe(true);
+    });
+
+    it('round-3: returns false when simVersion is omitted (legacy save — defaults to LEGACY on load)', async () => {
+      const world = createScenario(7);
+      const snap = serializeWorldState(world);
+      // Strip simVersion to simulate a pre-issue-#27 envelope.
+      delete (snap as { simVersion?: number }).simVersion;
+      const env = {
+        version: SAVE_FORMAT_VERSION,
+        seed: 7,
+        inputLog: [],
+        snapshot: snap,
+        savedAtMs: Date.now(),
+      };
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
+      expect(hasIncompatibleSave()).toBe(false);
+    });
   });
 
   describe('Issue #115 — getSaveInfo', () => {

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -1856,6 +1856,29 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
       expect(hasIncompatibleSave()).toBe(false);
     });
+
+    it('Codex round-3 P1: returns true when snapshot is null (parseable envelope, garbage payload)', () => {
+      // parseSaveFile only validates the envelope. A v3 envelope with
+      // snapshot=null parses fine but reading snapshot.simVersion would
+      // throw and crash the dialog. Treat as incompatible.
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
+        version: SAVE_FORMAT_VERSION,
+        seed: 1,
+        inputLog: [],
+        snapshot: null,
+      }));
+      expect(hasIncompatibleSave()).toBe(true);
+    });
+
+    it('Codex round-3 P1: returns true when snapshot is a non-object (string / number)', () => {
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
+        version: SAVE_FORMAT_VERSION,
+        seed: 1,
+        inputLog: [],
+        snapshot: 'not an object',
+      }));
+      expect(hasIncompatibleSave()).toBe(true);
+    });
   });
 
   describe('Issue #115 — getSaveInfo', () => {
@@ -1928,6 +1951,51 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       manualSave(42, [], world);
       const info = getSaveInfo();
       expect(info!.tick).toBe(5);
+    });
+
+    it('Codex round-3 P1: does NOT throw when snapshot is null (parseable envelope, garbage payload)', () => {
+      // The dialog opens by calling getSaveInfo + hasIncompatibleSave. Both
+      // need to survive a parseable-but-garbage envelope so the user sees
+      // the "incompatible" warning + can use Delete/New Game to recover.
+      // Pre-fix this case threw inside getSaveInfo and crashed dialog
+      // rendering before the user could click anything.
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
+        version: SAVE_FORMAT_VERSION,
+        seed: 1,
+        inputLog: [],
+        snapshot: null,
+      }));
+      expect(() => getSaveInfo()).not.toThrow();
+      expect(getSaveInfo()).toBeNull();
+    });
+
+    it('Codex round-3 P1: does NOT throw when snapshot.colonies is missing', () => {
+      // A snapshot with tick/rngState/etc. but no `colonies` field.
+      // Pre-fix: dereferencing colonies[playerKey] would throw TypeError.
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
+        version: SAVE_FORMAT_VERSION,
+        seed: 1,
+        inputLog: [],
+        snapshot: { tick: 5, rngState: 1, nextEntityId: 0 },
+      }));
+      expect(() => getSaveInfo()).not.toThrow();
+      const info = getSaveInfo();
+      expect(info).not.toBeNull();
+      expect(info!.tick).toBe(5);
+      expect(info!.playerWorkers).toBe(0);
+      expect(info!.playerFoodStored).toBe(0);
+    });
+
+    it('Codex round-3 P1: returns 0 fields when snapshot.tick is missing/non-numeric', () => {
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
+        version: SAVE_FORMAT_VERSION,
+        seed: 1,
+        inputLog: [],
+        snapshot: { colonies: {} },
+      }));
+      const info = getSaveInfo();
+      expect(info).not.toBeNull();
+      expect(info!.tick).toBe(0);
     });
 
     it('returns 0 worker / 0 food when the player colony key is absent (defensive)', () => {

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -466,6 +466,14 @@ export interface SaveFile {
   readonly seed: number;
   readonly inputLog: SimCommand[];
   readonly snapshot: SerializedWorldState;
+  /**
+   * Issue #115 — wall-clock timestamp (Date.now() epoch ms) when the
+   * envelope was written. Populated by buildSaveFile so all writers
+   * (manualSave + tickAutosave) include it consistently. Optional in the
+   * type so older envelopes without the field still load — getSaveInfo
+   * falls back to 0 ("unknown") for the dialog when the field is absent.
+   */
+  readonly savedAtMs?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -1140,6 +1148,11 @@ function buildSaveFile(seed: number, inputLog: readonly SimCommand[], world: Wor
     seed: seed | 0,
     inputLog: inputLog.map((c) => ({ ...c })),
     snapshot: serializeWorldState(world),
+    // Issue #115 — wall-clock stamp, surfaced in the Save/Load dialog's info
+    // line. Date.now() is allowed in src/platform (not src/sim — see file
+    // header rule list). Determinism unaffected: SCEN-06 replay is keyed on
+    // (seed, inputLog) and never reads this field.
+    savedAtMs: Date.now(),
   };
 }
 
@@ -1322,10 +1335,15 @@ export function manualSave(
  *  from `hasSave === false` which can mean "no save written yet" OR "save
  *  present but unreadable" — the Save/Load dialog needs to tell the player
  *  the difference so a v2 save in localStorage doesn't silently disappear
- *  on a New Game click. */
+ *  on a New Game click.
+ *
+ *  Round-2 review: also fires the legacy-save purge so an external caller
+ *  that hits this method first (without a prior hasSave call) still cleans
+ *  up the old subterrans:save:v1/v2 keys. Symmetry with hasSave/loadSave. */
 export function hasIncompatibleSave(): boolean {
   let raw: string | null;
   try {
+    purgeLegacySaves();
     raw = localStorage.getItem(SAVE_KEY);
   } catch {
     return false;
@@ -1341,7 +1359,7 @@ export function hasIncompatibleSave(): boolean {
 
 /** Lightweight save summary surfaced in the Save/Load dialog's info line.
  *  Avoids deserializeWorldState (which allocates the full typed-array world)
- *  by reading only three primitives from the JSON envelope. */
+ *  by reading only a handful of primitives from the JSON envelope. */
 export interface SaveInfo {
   /** Sim tick at the moment the snapshot was taken. */
   tick: number;
@@ -1349,6 +1367,10 @@ export interface SaveInfo {
   playerWorkers: number;
   /** Player colony's stored-food count in HUMAN units (post `>> FP_SHIFT`). */
   playerFoodStored: number;
+  /** Wall-clock timestamp (Date.now() epoch ms) when the envelope was last
+   *  written. 0 if the field is absent from a pre-issue-#115 envelope —
+   *  callers should treat 0 as "unknown" rather than "1970-01-01." */
+  savedAtMs: number;
 }
 
 /** Issue #115 — extract the dialog's summary fields without a full
@@ -1375,10 +1397,18 @@ export function getSaveInfo(): SaveInfo | null {
   // Right-shift is safe here: foodStored is a non-negative int in the
   // serialized envelope (validated upstream).
   const foodFp = playerColony?.foodStored ?? 0;
+  // Issue #115 — savedAtMs is optional in the envelope; pre-fix saves and
+  // any tampered/malformed timestamp fall back to 0 ("unknown") so the
+  // dialog can render a sensible placeholder.
+  const stampRaw = (file as { savedAtMs?: unknown }).savedAtMs;
+  const savedAtMs = typeof stampRaw === 'number' && Number.isFinite(stampRaw) && stampRaw >= 0
+    ? stampRaw
+    : 0;
   return {
     tick: file.snapshot.tick,
     playerWorkers: playerColony?.workerCount ?? 0,
     playerFoodStored: foodFp >> FP_SHIFT,
+    savedAtMs,
   };
 }
 

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -1371,25 +1371,30 @@ export function hasIncompatibleSave(): boolean {
   }
   // Codex round-3 P1: parseSaveFile only validates the envelope (version,
   // seed, inputLog). `snapshot` itself can be `null` or any non-object on
-  // a tampered/malformed envelope. Reading `file.snapshot.simVersion`
-  // would throw and crash the dialog open path. Treat any non-object
-  // snapshot as incompatible — bootFromSave's deserializeWorldState would
-  // also reject it, so the dialog's "incompatible warning + Delete enabled"
-  // recovery path is the right outcome.
+  // a tampered/malformed envelope. Reject the obviously-broken case before
+  // the deserialize attempt below so we don't waste an allocation on it.
   const snapshot = file.snapshot as unknown;
   if (snapshot === null || typeof snapshot !== 'object') return true;
 
-  // Future-sim guard. Defensive type-check on simVersion: the field is
-  // optional in SerializedWorldState (legacy saves omit it; defaults to
-  // LEGACY_SIM_VERSION on load). We only flag as incompatible when the
-  // field is present AND exceeds the current LATEST. Anything else
-  // (missing, equal, lower) is loadable — `deserializeWorldState`
-  // handles legacy-default and same-version paths cleanly.
-  const simVersion = (snapshot as { simVersion?: unknown }).simVersion;
-  if (typeof simVersion === 'number' && simVersion > LATEST_SIM_VERSION) {
+  // Round-4 (Rob's manual review of 6d840ef): the prior simVersion-only
+  // check left a UI-lie window for parseable envelopes whose snapshot is
+  // shape-valid at the top level but missing required deeper fields
+  // (e.g. `snapshot: {}`, or `simVersion: LEGACY_SIM_VERSION - 1`).
+  // Continue would look enabled; bootFromSave would then throw on
+  // deserialize and fall through to bootFresh. Align the dialog's
+  // compatibility boundary with the canonical one — attempt the full
+  // deserialize. Any throw (FutureSimVersionError, plain Error from
+  // tampered/missing-fields, etc.) means Continue would not actually
+  // load the save, so surface as incompatible.
+  //
+  // Cost: one full WorldState allocation per call. The dialog open path
+  // calls this once (cached for the render); user-initiated, infrequent.
+  try {
+    deserializeWorldState(file.snapshot);
+    return false;
+  } catch {
     return true;
   }
-  return false;
 }
 
 /** Lightweight save summary surfaced in the Save/Load dialog's info line.

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -38,6 +38,7 @@ import {
   SURFACE_GRID_HEIGHT,
   UNDERGROUND_GRID_WIDTH,
   UNDERGROUND_GRID_HEIGHT,
+  PLAYER_COLONY_ID,
 } from '../sim/constants.js';
 import { FP_SHIFT } from '../sim/fixed.js';
 import { ChamberType } from '../sim/enums.js';
@@ -1276,6 +1277,109 @@ export function deleteSave(): void {
   } catch {
     // swallow — quota / private-mode errors are non-fatal for delete
   }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #115 — manual save / save-info / incompatible-save detection
+//
+// The autosave path (tickAutosave) writes opportunistically every 30s. A
+// manual "Save now" button needs an explicit write that doesn't disturb the
+// autosave cooldown — so manualSave is a thin wrapper around buildSaveFile +
+// setItem that does NOT update the lastSaveMs timer. The next autosave still
+// fires on its own schedule, which is fine: a manual save followed by an
+// autosave 5 seconds later costs one extra setItem call, not "two competing
+// writers."
+//
+// hasIncompatibleSave distinguishes "no save in localStorage" from "save
+// present but unreadable by this build" so the Save/Load dialog can surface
+// a one-time recovery message instead of silently booting fresh.
+//
+// getSaveInfo extracts the cheap summary fields the dialog displays without
+// running deserializeWorldState (which allocates typed arrays and validates
+// every field). It only parses the JSON envelope and reads three primitive
+// fields, so it's safe to call on every dialog open.
+// ---------------------------------------------------------------------------
+
+/** Issue #115 — manual save. Returns true on successful write, false on
+ *  quota / private-mode / blocked-storage failure. Does NOT touch the
+ *  autosave timer; callers driving tickAutosave keep their own lastSaveMs. */
+export function manualSave(
+  seed: number,
+  inputLog: readonly SimCommand[],
+  world: WorldState,
+): boolean {
+  try {
+    const envelope = buildSaveFile(seed, inputLog, world);
+    localStorage.setItem(SAVE_KEY, JSON.stringify(envelope));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Issue #115 — true iff bytes exist under SAVE_KEY but parseSaveFile cannot
+ *  read them (wrong version, corrupt envelope, future simVersion). Distinct
+ *  from `hasSave === false` which can mean "no save written yet" OR "save
+ *  present but unreadable" — the Save/Load dialog needs to tell the player
+ *  the difference so a v2 save in localStorage doesn't silently disappear
+ *  on a New Game click. */
+export function hasIncompatibleSave(): boolean {
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(SAVE_KEY);
+  } catch {
+    return false;
+  }
+  if (raw === null) return false;
+  try {
+    parseSaveFile(raw);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/** Lightweight save summary surfaced in the Save/Load dialog's info line.
+ *  Avoids deserializeWorldState (which allocates the full typed-array world)
+ *  by reading only three primitives from the JSON envelope. */
+export interface SaveInfo {
+  /** Sim tick at the moment the snapshot was taken. */
+  tick: number;
+  /** Player colony's living worker count, or 0 when the field is missing. */
+  playerWorkers: number;
+  /** Player colony's stored-food count in HUMAN units (post `>> FP_SHIFT`). */
+  playerFoodStored: number;
+}
+
+/** Issue #115 — extract the dialog's summary fields without a full
+ *  deserialize. Returns null if no save exists or the envelope is unreadable.
+ *  Player colony key is `String(PLAYER_COLONY_ID)` per the colonies map's
+ *  stringified-int convention (ADR-0006). */
+export function getSaveInfo(): SaveInfo | null {
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(SAVE_KEY);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  let file: SaveFile;
+  try {
+    file = parseSaveFile(raw);
+  } catch {
+    return null;
+  }
+  const playerKey = String(PLAYER_COLONY_ID);
+  const playerColony = file.snapshot.colonies[playerKey];
+  // foodStored is fixed-point; convert to whole-food units for display.
+  // Right-shift is safe here: foodStored is a non-negative int in the
+  // serialized envelope (validated upstream).
+  const foodFp = playerColony?.foodStored ?? 0;
+  return {
+    tick: file.snapshot.tick,
+    playerWorkers: playerColony?.workerCount ?? 0,
+    playerFoodStored: foodFp >> FP_SHIFT,
+  };
 }
 
 /**

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -1369,13 +1369,23 @@ export function hasIncompatibleSave(): boolean {
   } catch {
     return true;
   }
+  // Codex round-3 P1: parseSaveFile only validates the envelope (version,
+  // seed, inputLog). `snapshot` itself can be `null` or any non-object on
+  // a tampered/malformed envelope. Reading `file.snapshot.simVersion`
+  // would throw and crash the dialog open path. Treat any non-object
+  // snapshot as incompatible — bootFromSave's deserializeWorldState would
+  // also reject it, so the dialog's "incompatible warning + Delete enabled"
+  // recovery path is the right outcome.
+  const snapshot = file.snapshot as unknown;
+  if (snapshot === null || typeof snapshot !== 'object') return true;
+
   // Future-sim guard. Defensive type-check on simVersion: the field is
   // optional in SerializedWorldState (legacy saves omit it; defaults to
   // LEGACY_SIM_VERSION on load). We only flag as incompatible when the
   // field is present AND exceeds the current LATEST. Anything else
   // (missing, equal, lower) is loadable — `deserializeWorldState`
   // handles legacy-default and same-version paths cleanly.
-  const simVersion = file.snapshot.simVersion;
+  const simVersion = (snapshot as { simVersion?: unknown }).simVersion;
   if (typeof simVersion === 'number' && simVersion > LATEST_SIM_VERSION) {
     return true;
   }
@@ -1416,12 +1426,39 @@ export function getSaveInfo(): SaveInfo | null {
   } catch {
     return null;
   }
+  // Codex round-3 P1: parseSaveFile validates the envelope only. A
+  // parseable-but-corrupt envelope can have `snapshot: null` or
+  // `snapshot.colonies: undefined`, both of which would throw on the
+  // dereferences below and crash the dialog open path. Return null so
+  // the dialog falls back to the "no save / incompatible" branch in
+  // formatSaveInfoLine.
+  const snapshot = file.snapshot as unknown;
+  if (snapshot === null || typeof snapshot !== 'object') return null;
+  const colonies = (snapshot as { colonies?: unknown }).colonies as
+    | Record<string, { foodStored?: unknown; workerCount?: unknown } | undefined>
+    | undefined;
   const playerKey = String(PLAYER_COLONY_ID);
-  const playerColony = file.snapshot.colonies[playerKey];
+  // colonies may be undefined / null / a non-object on a malformed envelope;
+  // probe defensively before keying into it.
+  const playerColony = colonies !== undefined && colonies !== null && typeof colonies === 'object'
+    ? colonies[playerKey]
+    : undefined;
   // foodStored is fixed-point; convert to whole-food units for display.
-  // Right-shift is safe here: foodStored is a non-negative int in the
-  // serialized envelope (validated upstream).
-  const foodFp = playerColony?.foodStored ?? 0;
+  // Right-shift on a non-number short-circuits cleanly via the ?? fallback.
+  const foodFpRaw = playerColony?.foodStored;
+  const foodFp = typeof foodFpRaw === 'number' && Number.isFinite(foodFpRaw) && foodFpRaw >= 0
+    ? foodFpRaw
+    : 0;
+  const workerCountRaw = playerColony?.workerCount;
+  const playerWorkers = typeof workerCountRaw === 'number' && Number.isFinite(workerCountRaw) && workerCountRaw >= 0
+    ? workerCountRaw
+    : 0;
+  // tick may also be missing on a malformed envelope — surface 0 rather
+  // than rendering "Tick undefined" in the dialog.
+  const tickRaw = (snapshot as { tick?: unknown }).tick;
+  const tick = typeof tickRaw === 'number' && Number.isFinite(tickRaw) && tickRaw >= 0
+    ? tickRaw
+    : 0;
   // Issue #115 — savedAtMs is optional in the envelope; pre-fix saves and
   // any tampered/malformed timestamp fall back to 0 ("unknown") so the
   // dialog can render a sensible placeholder.
@@ -1430,8 +1467,8 @@ export function getSaveInfo(): SaveInfo | null {
     ? stampRaw
     : 0;
   return {
-    tick: file.snapshot.tick,
-    playerWorkers: playerColony?.workerCount ?? 0,
+    tick,
+    playerWorkers,
     playerFoodStored: foodFp >> FP_SHIFT,
     savedAtMs,
   };

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -1330,16 +1330,30 @@ export function manualSave(
   }
 }
 
-/** Issue #115 — true iff bytes exist under SAVE_KEY but parseSaveFile cannot
- *  read them (wrong version, corrupt envelope, future simVersion). Distinct
- *  from `hasSave === false` which can mean "no save written yet" OR "save
- *  present but unreadable" — the Save/Load dialog needs to tell the player
- *  the difference so a v2 save in localStorage doesn't silently disappear
- *  on a New Game click.
+/** Issue #115 — true iff bytes exist under SAVE_KEY but this build cannot
+ *  load them. Three categories of incompatibility:
+ *    1. envelope parse fails (wrong save format version, malformed JSON,
+ *       tampered seed, etc. — `parseSaveFile` throws)
+ *    2. envelope parses but `snapshot.simVersion > LATEST_SIM_VERSION` —
+ *       the save was written by a NEWER build. `bootFromSave`'s
+ *       `deserializeWorldState` would throw `FutureSimVersionError` and
+ *       fall through to `bootFresh` with autosave suspended (issue #66).
+ *       Surface this at the dialog level so Continue stays disabled and
+ *       the info line warns the user instead of letting them click
+ *       Continue and silently get a fresh world.
+ *
+ *  Distinct from `hasSave === false` which can mean "no save written yet"
+ *  OR "save present but unreadable." The dialog uses
+ *  `hasSave() && !hasIncompatibleSave()` to decide whether Continue is
+ *  actionable.
  *
  *  Round-2 review: also fires the legacy-save purge so an external caller
  *  that hits this method first (without a prior hasSave call) still cleans
- *  up the old subterrans:save:v1/v2 keys. Symmetry with hasSave/loadSave. */
+ *  up the old subterrans:save:v1/v2 keys. Symmetry with hasSave/loadSave.
+ *
+ *  Round-3 (Codex P2 follow-up): the simVersion check above replaces the
+ *  prior "envelope-parse only" check that returned false for future-sim
+ *  saves and enabled a Continue click that would silently lose the save. */
 export function hasIncompatibleSave(): boolean {
   let raw: string | null;
   try {
@@ -1349,12 +1363,23 @@ export function hasIncompatibleSave(): boolean {
     return false;
   }
   if (raw === null) return false;
+  let file: SaveFile;
   try {
-    parseSaveFile(raw);
-    return false;
+    file = parseSaveFile(raw);
   } catch {
     return true;
   }
+  // Future-sim guard. Defensive type-check on simVersion: the field is
+  // optional in SerializedWorldState (legacy saves omit it; defaults to
+  // LEGACY_SIM_VERSION on load). We only flag as incompatible when the
+  // field is present AND exceeds the current LATEST. Anything else
+  // (missing, equal, lower) is loadable — `deserializeWorldState`
+  // handles legacy-default and same-version paths cleanly.
+  const simVersion = file.snapshot.simVersion;
+  if (typeof simVersion === 'number' && simVersion > LATEST_SIM_VERSION) {
+    return true;
+  }
+  return false;
 }
 
 /** Lightweight save summary surfaced in the Save/Load dialog's info line.

--- a/src/platform/settings.test.ts
+++ b/src/platform/settings.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  loadSettings,
+  saveSettings,
+  DEFAULT_SETTINGS,
+  SETTINGS_KEY,
+  SETTINGS_VERSION,
+  type Settings,
+} from './settings.js';
+
+// jsdom provides a real localStorage in the test environment (test-setup.ts
+// mounts it). Each test resets the namespace key to ensure isolation.
+beforeEach(() => {
+  localStorage.removeItem(SETTINGS_KEY);
+});
+
+describe('loadSettings', () => {
+  it('returns DEFAULT_SETTINGS when localStorage is empty', () => {
+    expect(loadSettings()).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('returns a fresh copy each call (caller can mutate freely)', () => {
+    const a = loadSettings();
+    const b = loadSettings();
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+
+  it('round-trips a saved Settings object losslessly', () => {
+    const next: Settings = { pheromoneOverlay: false };
+    saveSettings(next);
+    expect(loadSettings()).toEqual(next);
+  });
+
+  it('falls back to DEFAULT_SETTINGS on malformed JSON', () => {
+    localStorage.setItem(SETTINGS_KEY, '{not-json');
+    expect(loadSettings()).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('falls back to DEFAULT_SETTINGS when envelope is missing version', () => {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify({ settings: { pheromoneOverlay: false } }));
+    expect(loadSettings()).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('falls back to DEFAULT_SETTINGS when version is newer than this build supports', () => {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify({
+      version: SETTINGS_VERSION + 1,
+      settings: { pheromoneOverlay: false },
+    }));
+    expect(loadSettings()).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('replaces a wrong-typed pheromoneOverlay with the default but keeps siblings intact', () => {
+    // Permissive merge: a single corrupt field shouldn't wipe valid neighbors.
+    // Today we only have one boolean field; this guards the merge logic so a
+    // future field is safe to add.
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify({
+      version: SETTINGS_VERSION,
+      settings: { pheromoneOverlay: 'not-a-bool' },
+    }));
+    expect(loadSettings()).toEqual({ pheromoneOverlay: DEFAULT_SETTINGS.pheromoneOverlay });
+  });
+
+  it('ignores unknown extra keys in the settings object', () => {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify({
+      version: SETTINGS_VERSION,
+      settings: { pheromoneOverlay: false, futureKey: 'whatever' },
+    }));
+    expect(loadSettings()).toEqual({ pheromoneOverlay: false });
+  });
+});
+
+describe('saveSettings', () => {
+  it('writes a versioned envelope under SETTINGS_KEY', () => {
+    saveSettings({ pheromoneOverlay: false });
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed).toEqual({
+      version: SETTINGS_VERSION,
+      settings: { pheromoneOverlay: false },
+    });
+  });
+
+  it('overwrites an earlier saved state', () => {
+    saveSettings({ pheromoneOverlay: true });
+    saveSettings({ pheromoneOverlay: false });
+    expect(loadSettings()).toEqual({ pheromoneOverlay: false });
+  });
+});

--- a/src/platform/settings.ts
+++ b/src/platform/settings.ts
@@ -1,0 +1,85 @@
+// src/platform/settings.ts
+// Issue #116 — UI/render preferences persisted across sessions.
+//
+// Distinct from save.ts:
+//   - save.ts stores the simulation snapshot + replay log (subterrans:save:v3).
+//     Subject to format-version bumps that intentionally invalidate old saves.
+//   - settings.ts stores cosmetic preferences (subterrans:settings:v1). Survives
+//     deleteSave(); never round-trips through replay.
+//
+// Storage shape is permissive: missing keys fall back to defaults so a future
+// build that adds a new setting can read older settings files without forcing
+// a wipe. A version field is included for forward compatibility — bumping it
+// is the explicit opt-out (mirrors save.ts's invalidate-on-bump policy, but
+// for settings the bump should be vanishingly rare since defaults can usually
+// substitute for unknown keys).
+
+export const SETTINGS_KEY = 'subterrans:settings:v1' as const;
+export const SETTINGS_VERSION = 1 as const;
+
+export interface Settings {
+  /** Pheromone trail overlay visibility (issue #114). When false, the player's
+   *  pheromone overlay is not drawn. Render-only; does not affect simulation. */
+  pheromoneOverlay: boolean;
+}
+
+export const DEFAULT_SETTINGS: Readonly<Settings> = {
+  pheromoneOverlay: true,
+};
+
+interface SettingsEnvelope {
+  version: number;
+  settings: Settings;
+}
+
+/** Load settings from localStorage. Returns DEFAULT_SETTINGS if missing,
+ *  malformed, or for any version beyond SETTINGS_VERSION. Never throws. */
+export function loadSettings(): Settings {
+  if (typeof localStorage === 'undefined') return { ...DEFAULT_SETTINGS };
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(SETTINGS_KEY);
+  } catch {
+    return { ...DEFAULT_SETTINGS };
+  }
+  if (raw === null) return { ...DEFAULT_SETTINGS };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ...DEFAULT_SETTINGS };
+  }
+  if (parsed === null || typeof parsed !== 'object') return { ...DEFAULT_SETTINGS };
+  const env = parsed as Partial<SettingsEnvelope>;
+  if (typeof env.version !== 'number' || env.version > SETTINGS_VERSION) {
+    return { ...DEFAULT_SETTINGS };
+  }
+  if (env.settings === null || typeof env.settings !== 'object') {
+    return { ...DEFAULT_SETTINGS };
+  }
+  // Permissive merge: unknown keys ignored, missing keys filled from defaults.
+  // Type-check each known field; reject the value (fall back to default) if
+  // its type is wrong rather than the whole envelope, so a single corrupt key
+  // doesn't wipe valid neighbors.
+  const s = env.settings as Partial<Settings>;
+  return {
+    pheromoneOverlay: typeof s.pheromoneOverlay === 'boolean'
+      ? s.pheromoneOverlay
+      : DEFAULT_SETTINGS.pheromoneOverlay,
+  };
+}
+
+/** Persist settings to localStorage. Silent on quota / availability errors —
+ *  settings are nice-to-have, not load-bearing. */
+export function saveSettings(settings: Settings): void {
+  if (typeof localStorage === 'undefined') return;
+  const env: SettingsEnvelope = {
+    version: SETTINGS_VERSION,
+    settings,
+  };
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(env));
+  } catch {
+    // Quota exceeded, private browsing restrictions, etc. — best-effort.
+  }
+}

--- a/src/render/camera.test.ts
+++ b/src/render/camera.test.ts
@@ -75,6 +75,24 @@ describe('createViewState', () => {
     expect(vs.undergroundCamera.viewportWidth).toBe(VIEWPORT_WIDTH_TILES);
     expect(vs.undergroundCamera.viewportHeight).toBe(VIEWPORT_HEIGHT_TILES);
   });
+
+  it('issue #114 — showPheromoneOverlay defaults to true (matches DEFAULT_SETTINGS)', () => {
+    // jsdom has localStorage available but the suite clears between tests,
+    // so loadSettings falls back to DEFAULT_SETTINGS.pheromoneOverlay = true.
+    localStorage.removeItem('subterrans:settings:v1');
+    const vs = createViewState(10, 20);
+    expect(vs.showPheromoneOverlay).toBe(true);
+  });
+
+  it('issue #114 — showPheromoneOverlay hydrates from persisted settings', () => {
+    localStorage.setItem(
+      'subterrans:settings:v1',
+      JSON.stringify({ version: 1, settings: { pheromoneOverlay: false } }),
+    );
+    const vs = createViewState(10, 20);
+    expect(vs.showPheromoneOverlay).toBe(false);
+    localStorage.removeItem('subterrans:settings:v1');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -142,6 +160,20 @@ describe('resetViewState', () => {
     expect(vs.surfaceCamera.viewportHeight).toBe(VIEWPORT_HEIGHT_TILES);
     expect(vs.undergroundCamera.viewportWidth).toBe(VIEWPORT_WIDTH_TILES);
     expect(vs.undergroundCamera.viewportHeight).toBe(VIEWPORT_HEIGHT_TILES);
+  });
+
+  it('issue #114 — re-reads pheromoneOverlay setting from localStorage on reset', () => {
+    // Settings are cosmetic preferences, not session state — a restart should
+    // honor the player's current toggle, not snap back to the boot-time value.
+    const vs = createViewState(10, 10);
+    expect(vs.showPheromoneOverlay).toBe(true);
+    localStorage.setItem(
+      'subterrans:settings:v1',
+      JSON.stringify({ version: 1, settings: { pheromoneOverlay: false } }),
+    );
+    resetViewState(vs, 24, 64);
+    expect(vs.showPheromoneOverlay).toBe(false);
+    localStorage.removeItem('subterrans:settings:v1');
   });
 
   it('restart simulation: mid-game underground pan does not leak into fresh session', () => {

--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -9,6 +9,7 @@
 import { TILE_SIZE_PX } from './sprites.js';
 import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
+import { loadSettings } from '../platform/settings.js';
 
 // Suppress unused import warning — TILE_SIZE_PX is used in screenToTile below.
 void TILE_SIZE_PX;
@@ -112,6 +113,14 @@ export interface ViewState {
    * still render (Research Risk D, Chunk 0 dependency).
    */
   activeUndergroundColonyId: ColonyId;
+  /**
+   * Issue #114 — render-only flag controlling whether the player's pheromone
+   * overlay is drawn. Hydrated from persisted settings (subterrans:settings:v1)
+   * on createViewState / resetViewState; toggled by the P key and by the pause
+   * menu Settings sub-screen, both of which write back through saveSettings.
+   * Skipped at draw time in game-scene.ts; never round-trips through save.ts.
+   */
+  showPheromoneOverlay: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -151,6 +160,11 @@ export function createViewState(startTileX: number, startTileY: number): ViewSta
     // 09.1 Chunk 2 — fresh boot always starts looking at the player's own
     // underground so the first Tab to underground shows "Your Colony".
     activeUndergroundColonyId: PLAYER_COLONY_ID,
+    // Issue #114 — hydrate the pheromone overlay flag from persisted settings.
+    // localStorage may be unavailable (Node test runs); loadSettings falls back
+    // to DEFAULT_SETTINGS, which keeps the overlay ON to match the prior
+    // always-visible behavior.
+    showPheromoneOverlay: loadSettings().pheromoneOverlay,
   };
 }
 
@@ -188,6 +202,10 @@ export function resetViewState(
   // player's own grid. Save files do not persist which enemy nest was being
   // inspected, so continue-from-save also defaults to "Your Colony".
   viewState.activeUndergroundColonyId = PLAYER_COLONY_ID;
+  // Issue #114 — re-read the persisted overlay preference. The setting is a
+  // cosmetic preference, not session state, so a restart should respect the
+  // current localStorage value rather than snap back to ON unconditionally.
+  viewState.showPheromoneOverlay = loadSettings().pheromoneOverlay;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/render/draw-surface.test.ts
+++ b/src/render/draw-surface.test.ts
@@ -894,7 +894,7 @@ describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
     return w;
   }
 
-  it('emits 4 thin COLOR_ENEMY_COLONY fillRects forming a perimeter ring around the enemy entrance tile', () => {
+  it('emits one COLOR_ENEMY_COLONY strokeCircle ringing the enemy entrance mound (issue #117)', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
     const tileX = 10;
@@ -903,35 +903,38 @@ describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
     const cam = makeCamera(tileX, tileY, 10, 4);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
 
-    // Find every fillRect emitted under COLOR_ENEMY_COLONY style — the
-    // perimeter ring is exactly 4 strokes (top/bottom/left/right).
-    const enemyRects: Array<[number, number, number, number]> = [];
-    let style: number | undefined;
+    // Issue #117 replaced the four-rect perimeter with a single strokeCircle
+    // traced just outside the round mound. Track lineStyle COLOR_ENEMY_COLONY
+    // as the stroke-color sentinel; the next strokeCircle is the enemy ring.
+    const enemyStrokes: Array<[number, number, number]> = [];
+    let lineColor: number | undefined;
     for (const c of gfx.calls) {
-      if (c.method === 'fillStyle') style = c.args[0] as number;
-      else if (c.method === 'fillRect' && style === COLOR_ENEMY_COLONY) {
-        enemyRects.push(c.args as [number, number, number, number]);
+      if (c.method === 'lineStyle') lineColor = c.args[1] as number;
+      else if (c.method === 'strokeCircle' && lineColor === COLOR_ENEMY_COLONY) {
+        enemyStrokes.push(c.args as [number, number, number]);
       }
     }
-    expect(enemyRects.length).toBe(4);
+    expect(enemyStrokes.length).toBe(1);
 
-    // Compute expected screen-space tile origin and assert a 1-pixel ring.
+    // Center on tile center, radius = mound outer radius (TILE_SIZE_PX/2 + 2).
     const left = Math.floor(cam.x - cam.viewportWidth  / 2);
     const top  = Math.floor(cam.y - cam.viewportHeight / 2);
-    const sx = (tileX - left) * TILE_SIZE_PX;
-    const sy = (tileY - top)  * TILE_SIZE_PX;
-    const expected = new Set([
-      [sx,                  sy,                  TILE_SIZE_PX, 1].join(','),                 // top
-      [sx,                  sy + TILE_SIZE_PX-1, TILE_SIZE_PX, 1].join(','),                 // bottom
-      [sx,                  sy + 1,              1, TILE_SIZE_PX - 2].join(','),             // left
-      [sx + TILE_SIZE_PX-1, sy + 1,              1, TILE_SIZE_PX - 2].join(','),             // right
-    ]);
-    for (const r of enemyRects) {
-      expect(expected.has(r.join(','))).toBe(true);
+    const expectedCx = (tileX - left) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    const expectedCy = (tileY - top)  * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    const expectedR  = TILE_SIZE_PX / 2 + 2;
+    expect(enemyStrokes[0]).toEqual([expectedCx, expectedCy, expectedR]);
+
+    // No enemy-colored fillRect should remain — the four-rect rectangle is gone.
+    let fillStyle: number | undefined;
+    let enemyFillRects = 0;
+    for (const c of gfx.calls) {
+      if (c.method === 'fillStyle') fillStyle = c.args[0] as number;
+      else if (c.method === 'fillRect' && fillStyle === COLOR_ENEMY_COLONY) enemyFillRects += 1;
     }
+    expect(enemyFillRects).toBe(0);
   });
 
-  it('player entrance does NOT receive the enemy-color border', () => {
+  it('player entrance does NOT receive the enemy-color ring', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
     // Setup: only the player colony, no enemy.
@@ -945,14 +948,52 @@ describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
     const cam = makeCamera(0, 0, 10, 4);
     drawSurfaceEntities(gfx, sprites, w, w, 0, cam);
 
-    // No enemy-colored fillRects anywhere.
-    let style: number | undefined;
-    let enemyRectCount = 0;
+    // No enemy-colored stroke should be present (lineStyle never sets COLOR_ENEMY_COLONY).
+    let lineColor: number | undefined;
+    let enemyStrokes = 0;
     for (const c of gfx.calls) {
-      if (c.method === 'fillStyle') style = c.args[0] as number;
-      else if (c.method === 'fillRect' && style === COLOR_ENEMY_COLONY) enemyRectCount += 1;
+      if (c.method === 'lineStyle') lineColor = c.args[1] as number;
+      else if (c.method === 'strokeCircle' && lineColor === COLOR_ENEMY_COLONY) enemyStrokes += 1;
     }
-    expect(enemyRectCount).toBe(0);
+    expect(enemyStrokes).toBe(0);
+  });
+
+  it('renders three concentric fillCircles per entrance: outer mound rim, mound body, and round hole (issue #117)', () => {
+    const gfx = new MockGfx();
+    const sprites = new MockAntSprites();
+    const tileX = 5;
+    const tileY = 5;
+    const world = makeWorldWithEnemyEntrance(tileX, tileY);
+    // Drop the player entrance so the only entrance under inspection is the enemy's.
+    world.colonies[PLAYER_COLONY_ID]!.entrances = [];
+    const cam = makeCamera(tileX, tileY, 10, 10);
+    drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
+
+    // Walk fillStyle/fillCircle pairs and group by color.
+    const circlesByColor = new Map<number, Array<[number, number, number]>>();
+    let fillColor: number | undefined;
+    for (const c of gfx.calls) {
+      if (c.method === 'fillStyle') fillColor = c.args[0] as number;
+      else if (c.method === 'fillCircle' && fillColor !== undefined) {
+        const arr = circlesByColor.get(fillColor) ?? [];
+        arr.push(c.args as [number, number, number]);
+        circlesByColor.set(fillColor, arr);
+      }
+    }
+
+    // Each entrance contributes exactly one circle per color: mound outer, mound body, hole.
+    expect(circlesByColor.get(0x6d563a)?.length).toBe(1); // COLOR_BARREN_EARTH_MOUND
+    expect(circlesByColor.get(0x5a4a30)?.length).toBe(1); // COLOR_BARREN_EARTH_DAMP
+    expect(circlesByColor.get(0x1a0f00)?.length).toBe(1); // COLOR_SURFACE_ENTRANCE_HOLE
+
+    // Concentric and centered on the tile center; radii match mound > body > hole.
+    const left = Math.floor(cam.x - cam.viewportWidth  / 2);
+    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const cx = (tileX - left) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    const cy = (tileY - top)  * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    expect(circlesByColor.get(0x6d563a)![0]).toEqual([cx, cy, TILE_SIZE_PX / 2 + 2]);
+    expect(circlesByColor.get(0x5a4a30)![0]).toEqual([cx, cy, TILE_SIZE_PX / 2 + 1]);
+    expect(circlesByColor.get(0x1a0f00)![0]).toEqual([cx, cy, TILE_SIZE_PX / 2 - 2]);
   });
 });
 

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -30,7 +30,11 @@ import {
   COLOR_QUEEN_OUTLINE,
   COLOR_RALLY_POINT,
 } from './sprites.js';
-import { drawBarrenEarthTile, COLOR_BARREN_EARTH_DAMP } from './terrain-atlas.js';
+import {
+  drawBarrenEarthTile,
+  COLOR_BARREN_EARTH_DAMP,
+  COLOR_BARREN_EARTH_MOUND,
+} from './terrain-atlas.js';
 export type { AntSpriteLayer } from './ant-sprite-layer.js';
 import type { CameraState } from './camera.js';
 
@@ -177,38 +181,55 @@ export function drawSurfaceEntities(
     gfx.strokeCircle(cx, cy, r);
   }
 
-  // --- Entrance holes on surface ---
-  // Phase 8.5 readability: render a 2-px dirt rim around the dark hole interior
-  // so the entrance reads as a dug-out hole with a piled-dirt mound, not an
-  // arbitrary black square.
+  // --- Entrance holes on surface (issue #117) ---
+  // Round hole in a piled-dirt mound. Three concentric circles (mound rim →
+  // mound body → hole interior) plus, for enemy entrances, a thin
+  // enemy-colored ring traced just outside the mound.
   //
-  // Issue #14 cue: enemy entrances also get a 1-px enemy-colony perimeter
-  // overlaid on the dirt rim so the player reads them as "rally here to
-  // invade" targets rather than just neutral terrain features. Player
-  // entrances are unchanged — the existing brown-mound style still reads
-  // as "my entrance."
+  // Footprint spills 2 px onto each adjacent tile so the entrance reads as a
+  // 3-D bump on the surface, not a flat painted disc. The viewport cull
+  // margin below is widened from `TILE_SIZE_PX` to `TILE_SIZE_PX + MOUND_SPILL_PX + 1`
+  // so a tile whose mound spills onto a visible neighbor is still drawn even
+  // when its own center sits slightly off-screen.
+  //
+  // Diameters / radii at TILE_SIZE_PX = 16:
+  //   mound (outer)   = 10 px → spills 2 px onto each neighbor
+  //   mound (body)    = 9 px  → 1 px lighter rim around the body for shading
+  //   hole (interior) = 6 px  → matches food-pile baseRadius for visual weight
+  //
+  // Issue #14 cue: enemy entrances get a 1-px enemy-colony stroke around the
+  // mound so the player reads them as "rally here to invade" targets.
+  const MOUND_SPILL_PX = 2;
+  const MOUND_OUTER_R  = TILE_SIZE_PX / 2 + MOUND_SPILL_PX; // 10
+  const MOUND_BODY_R   = TILE_SIZE_PX / 2 + 1;              // 9 — 1px lighter rim shows around the body
+  const HOLE_R         = TILE_SIZE_PX / 2 - 2;              // 6 — matches food pile baseRadius
   for (const colony of Object.values(curr.colonies)) {
     if (!colony.entrances) continue;
     const isEnemy = colony.colonyId !== PLAYER_COLONY_ID;
     for (const entrance of colony.entrances) {
       const sx = (entrance.surfaceTileX - left) * TILE_SIZE_PX;
       const sy = (entrance.surfaceTileY - top)  * TILE_SIZE_PX;
-      if (sx < -TILE_SIZE_PX || sx > canvasW || sy < -TILE_SIZE_PX || sy > canvasH) continue;
-      // Entrance backplate — dampened earth so the dark hole reads against
-      // the lighter barren-earth surrounding.
+      const cullMargin = TILE_SIZE_PX + MOUND_SPILL_PX + 1;
+      if (sx < -cullMargin || sx > canvasW + MOUND_SPILL_PX
+        || sy < -cullMargin || sy > canvasH + MOUND_SPILL_PX) continue;
+      const cx = sx + TILE_SIZE_PX / 2;
+      const cy = sy + TILE_SIZE_PX / 2;
+      // Outer mound rim: lighter spoil tone — reads as "raised dirt edge."
+      gfx.fillStyle(COLOR_BARREN_EARTH_MOUND, 1);
+      gfx.fillCircle(cx, cy, MOUND_OUTER_R);
+      // Mound body: darker damp earth — reads as the "shadowed inside" of the mound.
       gfx.fillStyle(COLOR_BARREN_EARTH_DAMP, 1);
-      gfx.fillRect(sx, sy, TILE_SIZE_PX, TILE_SIZE_PX);
+      gfx.fillCircle(cx, cy, MOUND_BODY_R);
+      // Hole interior — round dark cavity.
       gfx.fillStyle(COLOR_SURFACE_ENTRANCE_HOLE, 1);
-      gfx.fillRect(sx + 2, sy + 2, TILE_SIZE_PX - 4, TILE_SIZE_PX - 4);
+      gfx.fillCircle(cx, cy, HOLE_R);
       if (isEnemy) {
-        // 1-px enemy-colony border. Four thin fillRects draw a perimeter
-        // ring inside the tile's outermost pixel (no GfxLike.strokeRect
-        // available; the four-rect pattern is the established alternative).
-        gfx.fillStyle(COLOR_ENEMY_COLONY, 1);
-        gfx.fillRect(sx,                  sy,                  TILE_SIZE_PX, 1); // top
-        gfx.fillRect(sx,                  sy + TILE_SIZE_PX-1, TILE_SIZE_PX, 1); // bottom
-        gfx.fillRect(sx,                  sy + 1,              1, TILE_SIZE_PX - 2); // left
-        gfx.fillRect(sx + TILE_SIZE_PX-1, sy + 1,              1, TILE_SIZE_PX - 2); // right
+        // 1-px enemy-colony ring traced just outside the mound. Replaces the
+        // four-rect rectangle with a stroke that follows the mound's circular
+        // silhouette so the cue reads as "this is an enemy entrance" without
+        // visually fighting the round shape.
+        gfx.lineStyle(1, COLOR_ENEMY_COLONY, 1);
+        gfx.strokeCircle(cx, cy, MOUND_OUTER_R);
       }
     }
   }

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -30,7 +30,7 @@ import { createScenario } from '../sim/scenario.js';
 import { copyWorldState, type WorldState } from '../sim/types.js';
 import { tick, resetFlowFieldCaches } from '../sim/tick.js';
 import { createGameLoop, type GameLoop, MS_PER_TICK } from '../platform/game-loop.js';
-import { hasSave, loadSave, deleteSave, tickAutosave, FutureSimVersionError } from '../platform/save.js';
+import { hasSave, loadSave, deleteSave, tickAutosave, FutureSimVersionError, manualSave } from '../platform/save.js';
 import { deserializeWorldState } from '../platform/save.js';
 import { loadSettings, saveSettings } from '../platform/settings.js';
 import { runAIController } from './ai-controller.js';
@@ -131,6 +131,16 @@ interface UIScenePhase9 {
   }): void;
   hidePauseMenuOverlay(): void;
   isPauseMenuVisible(): boolean;
+  // Issue #115 — Save/Load dialog overlay. Shown on top of the pause menu;
+  // GameScene hides the pause menu before showing the dialog so the layered
+  // chrome stays clean, and re-shows the menu when Back is pressed.
+  showSaveLoadDialogOverlay(callbacks: {
+    onContinue: () => void;
+    onNewGame: () => void;
+    onSaveNow: () => boolean;
+    onBack: () => void;
+  }): void;
+  hideSaveLoadDialogOverlay(): void;
 }
 import type { SimCommand } from '../sim/commands.js';
 
@@ -512,8 +522,7 @@ export class GameScene extends Phaser.Scene {
         const snap = buildDebugSnapshot(this.world, this.currentSeed, this.inputLog);
         downloadDebugSnapshot(snap);
       },
-      // Issue #115 will provide onOpenSaveLoad here. Until then the menu's
-      // Save/Load row renders disabled (callbacks.onOpenSaveLoad === undefined).
+      onOpenSaveLoad: () => this.openSaveLoadDialog(),
     });
   }
 
@@ -521,8 +530,55 @@ export class GameScene extends Phaser.Scene {
     if (this.gamePhase !== GamePhase.Paused) return;
     const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
     uiScene.hidePauseMenuOverlay();
+    uiScene.hideSaveLoadDialogOverlay();
     this.gamePhase = GamePhase.Playing;
     this.gameLoop.resume();
+  }
+
+  // Issue #115 — opens the Save/Load dialog on top of the pause menu. Hides
+  // the menu first so the dialog has the canvas to itself; Back re-shows
+  // the menu via openPauseMenu's flow path. The game stays Paused throughout
+  // — Continue / New Game are the only paths that resume the loop.
+  private openSaveLoadDialog(): void {
+    if (this.gamePhase !== GamePhase.Paused) return;
+    const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
+    // Hide the menu before showing the dialog so the menu's button rects
+    // don't bleed through hit-testing while the dialog is up.
+    uiScene.hidePauseMenuOverlay();
+    uiScene.showSaveLoadDialogOverlay({
+      onContinue: () => {
+        // bootFromSave does its own resetSessionState + finishBoot, including
+        // gameLoop.resume(). We just need to flip out of Paused phase first
+        // so finishBoot's `gamePhase = Playing` overwrite is consistent.
+        this.gamePhase = GamePhase.Playing;
+        this.bootFromSave();
+      },
+      onNewGame: () => {
+        // restartGame deletes the existing save (preserving the issue #66
+        // guard) and bootFreshes; finishBoot resumes the loop and flips to
+        // Playing. Set Playing here too so the transitional moment between
+        // dialog dismissal and finishBoot doesn't observe a dangling Paused.
+        this.gamePhase = GamePhase.Playing;
+        this.restartGame();
+      },
+      onSaveNow: () => {
+        if (this.world === undefined) return false;
+        return manualSave(this.currentSeed, this.inputLog, this.world);
+      },
+      onBack: () => {
+        // Re-open the pause menu — gamePhase is still Paused, gameLoop is
+        // still paused, so this just restores the menu chrome.
+        uiScene.showPauseMenuOverlay({
+          onResume: () => this.closePauseMenu(),
+          onDownloadDebug: () => {
+            if (this.world === undefined) return;
+            const snap = buildDebugSnapshot(this.world, this.currentSeed, this.inputLog);
+            downloadDebugSnapshot(snap);
+          },
+          onOpenSaveLoad: () => this.openSaveLoadDialog(),
+        });
+      },
+    });
   }
 
   private restartGame(): void {

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -279,12 +279,20 @@ export class GameScene extends Phaser.Scene {
     // menu's Settings sub-screen drives the same write path; gating P on
     // Playing means the menu is the only writer while paused (no label
     // desync — see comment block above).
+    //
+    // Round-6 P2 (Codex): flip from in-memory state, NOT from loadSettings().
+    // If localStorage writes are blocked (quota / private-mode), saveSettings
+    // is a no-op; loadSettings then returns DEFAULT_SETTINGS on the NEXT
+    // press and we'd recompute `!true = false` every time — the toggle gets
+    // stuck OFF. ViewState is the authoritative in-mem source; persist is
+    // best-effort and survives reload only when storage cooperates.
     this.input.keyboard!.on('keydown-P', () => {
       if (this.gamePhase !== GamePhase.Playing) return;
-      const next = loadSettings();
-      next.pheromoneOverlay = !next.pheromoneOverlay;
-      saveSettings(next);
-      this.viewState.showPheromoneOverlay = next.pheromoneOverlay;
+      const next = !this.viewState.showPheromoneOverlay;
+      this.viewState.showPheromoneOverlay = next;
+      const persisted = loadSettings();
+      persisted.pheromoneOverlay = next;
+      saveSettings(persisted);
     });
 
     // 09.1 Chunk 2 — X toggles the active underground colony view. Only

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -598,6 +598,16 @@ export class GameScene extends Phaser.Scene {
       },
       onSaveNow: () => {
         if (this.world === undefined) return false;
+        // Round-5 P1 (Codex): bootFromSave sets autosaveSuspended = true when
+        // it catches a FutureSimVersionError so the preserved newer-build
+        // save bytes survive in localStorage for recovery (user reloads on
+        // a newer build that knows the simVersion). The tickAutosave path
+        // already respects this flag (see update() below). The dialog's
+        // Save Now must respect it too — without this gate a manual save
+        // from the fall-through fresh session silently destroys those
+        // preserved bytes. Surface as a failed save so the player gets a
+        // flash and can recover via Delete / a newer-build reload.
+        if (this.autosaveSuspended) return false;
         const ok = manualSave(this.currentSeed, this.inputLog, this.world);
         // Round-2 review: bump the autosave cooldown so the next autosave
         // window doesn't fire seconds later and overwrite the manual save's

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -59,8 +59,8 @@ import {
   UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT,
 } from '../sim/constants.js';
 import { GameOutcome } from '../sim/game-over.js';
-import { drawSurface, type GfxLike } from './draw-surface.js';
-import { drawUnderground } from './draw-underground.js';
+import { drawSurfaceTerrain, drawSurfaceEntities, type GfxLike } from './draw-surface.js';
+import { drawUndergroundTerrain, drawUndergroundEntities } from './draw-underground.js';
 import { drawPheromoneOverlay } from './draw-pheromone.js';
 import { AntFacingCache } from './ant-facing-cache.js';
 import {
@@ -185,7 +185,11 @@ export class GameScene extends Phaser.Scene {
    */
   private autosaveSuspended: boolean = false;
   private currentSeed: number = 0;
-  private speedMultiplier: number = 1;
+  // Issue #114 UAT — Settings sub-screen has a "Speed: N×" cycle row that
+  // reads/writes this field via callbacks. The 1/2/4 keyboard shortcuts
+  // below set the same field directly. Narrowed to the cycle set so the
+  // type aligns with PauseMenuLayout's SpeedMultiplier.
+  private speedMultiplier: 1 | 2 | 4 = 1;
 
   constructor() { super({ key: 'GameScene' }); }
 
@@ -541,6 +545,8 @@ export class GameScene extends Phaser.Scene {
     onResume: () => void;
     onDownloadDebug: () => void;
     onOpenSaveLoad: () => void;
+    getSpeedMultiplier: () => 1 | 2 | 4;
+    onCycleSpeed: (next: 1 | 2 | 4) => void;
   } {
     return {
       onResume: () => this.closePauseMenu(),
@@ -550,6 +556,12 @@ export class GameScene extends Phaser.Scene {
         downloadDebugSnapshot(snap);
       },
       onOpenSaveLoad: () => this.openSaveLoadDialog(),
+      // Issue #114 UAT — read/write the live speedMultiplier so the menu's
+      // Settings sub-screen has parity with the 1/2/4 keyboard shortcuts.
+      // The shortcuts are Playing-only-gated; the menu surface gives the
+      // same control a discoverable home while paused.
+      getSpeedMultiplier: () => this.speedMultiplier,
+      onCycleSpeed: (next: 1 | 2 | 4) => { this.speedMultiplier = next; },
     };
   }
 
@@ -692,14 +704,27 @@ export class GameScene extends Phaser.Scene {
     const gfx = this.gfx as unknown as GfxLike;
     gfx.clear();
     this.antSprites.beginFrame();
-    // Issue #114 — pheromone overlay is gated on the viewState flag so the P
-    // key (and the pause menu's Settings sub-screen) can hide it without
-    // touching the simulation. Player colony only — enemy pheromones stay
-    // hidden regardless of toggle state (PRD §7b / T-08-05).
-    if (this.viewState.showPheromoneOverlay) {
-      drawPheromoneOverlay(gfx, this.world, cam, this.viewState.activeView);
-    }
+    // UAT regression fix: pheromone overlay MUST render between terrain and
+    // entities, not before the orchestrator. drawSurface / drawUnderground
+    // paint opaque terrain THEN entities; an overlay drawn before the
+    // orchestrator gets wiped by the terrain pass. The bug had been
+    // invisible since the Phase 9.06 wiring (9f5b23f) — pheromones were in
+    // the world state but never showed up on canvas. Issue #114 surfaced it
+    // when the toggle had no visible effect (both ON and OFF rendered the
+    // same — because ON was always being overpainted).
+    //
+    // Fix: call the split terrain + entities functions explicitly so the
+    // pheromone overlay lands in the middle. The orchestrator wrappers
+    // (drawSurface / drawUnderground) stay for callers that don't need
+    // the overlay slot (e.g. unit tests).
+    //
+    // Player colony only — enemy pheromones stay hidden regardless of toggle
+    // state (PRD §7b / T-08-05).
     if (this.viewState.activeView === 'surface') {
+      drawSurfaceTerrain(gfx, this.world, cam);
+      if (this.viewState.showPheromoneOverlay) {
+        drawPheromoneOverlay(gfx, this.world, cam, 'surface');
+      }
       const pending =
         this.surfaceInputState.pendingEntranceTileX !== null &&
         this.surfaceInputState.pendingEntranceTileY !== null
@@ -708,7 +733,7 @@ export class GameScene extends Phaser.Scene {
               tileY: this.surfaceInputState.pendingEntranceTileY,
             }
           : null;
-      drawSurface(
+      drawSurfaceEntities(
         gfx,
         this.antSprites,
         this.prevState,
@@ -719,7 +744,11 @@ export class GameScene extends Phaser.Scene {
         this.antFacingCache,
       );
     } else {
-      drawUnderground(
+      drawUndergroundTerrain(gfx, this.world, cam, this.viewState.activeUndergroundColonyId);
+      if (this.viewState.showPheromoneOverlay) {
+        drawPheromoneOverlay(gfx, this.world, cam, 'underground');
+      }
+      drawUndergroundEntities(
         gfx,
         this.antSprites,
         this.prevState,

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -21,7 +21,9 @@
 // Pitfall 3: scale.mode = NONE, fixed 800x592 — no DPR scaling.
 // Pitfall 4: NEVER use .keys()/.entries()/.get() on world.colonies — it is a PLAIN OBJECT (ADR-0006).
 // Pitfall 5: No setMsPerTick(Infinity) for pause — use gameLoop.pause()/resume() (Plan 06 Task 1).
-// Pitfall 6: Pause key is P, NOT Space — Space+left-drag is the primary map-pan gesture (Phase 8.5).
+// Pitfall 6: Pause is opened via Esc (issue #116) and routed through the UIScene pause-menu
+//            overlay — there is no bare keyboard pause anymore. The previous P-binding moved
+//            to the pheromone toggle in issue #114. Space stays reserved for the pan gesture.
 
 import * as Phaser from 'phaser';
 import { createScenario } from '../sim/scenario.js';
@@ -118,6 +120,16 @@ interface UIScenePhase9 {
   hideGameOverOverlay(): void;
   showSavePromptOverlay(callbacks: { onContinue: () => void; onNewGame: () => void }): void;
   hideSavePromptOverlay(): void;
+  // Issue #116 — pause menu overlay. The callbacks object is intentionally
+  // open-ended: onOpenSaveLoad is omitted until issue #115 wires the dialog,
+  // at which point the menu's Save/Load row activates.
+  showPauseMenuOverlay(callbacks: {
+    onResume: () => void;
+    onDownloadDebug: () => void;
+    onOpenSaveLoad?: () => void;
+  }): void;
+  hidePauseMenuOverlay(): void;
+  isPauseMenuVisible(): boolean;
 }
 import type { SimCommand } from '../sim/commands.js';
 
@@ -216,15 +228,17 @@ export class GameScene extends Phaser.Scene {
     // Drag-pan registration — returns dragState ref for processCameraInput
     this.dragState = registerDragPan(this, this.viewState);
 
-    // Phase 9 Plan 06 keyboard — P toggles pause; 1/2/4 set speed.
-    // SPACE is reserved for pan gesture (Phase 8.5 decision — see file header Pitfall 6).
-    this.input.keyboard!.on('keydown-P', () => {
-      if (this.gamePhase === GamePhase.Playing) {
-        this.gamePhase = GamePhase.Paused;
-        this.gameLoop.pause();
-      } else if (this.gamePhase === GamePhase.Paused) {
-        this.gamePhase = GamePhase.Playing;
-        this.gameLoop.resume();
+    // Issue #116 — Esc opens the pause menu overlay (which also pauses the
+    // sim) and toggles it closed when already visible. Replaces the prior
+    // bare P-pause binding so P is free for the pheromone overlay toggle
+    // in issue #114. Speed-multiplier keys (1/2/4) are unchanged.
+    this.input.keyboard!.on('keydown-ESC', () => {
+      if (this.gamePhase === GamePhase.SavePrompt
+       || this.gamePhase === GamePhase.GameOver) return;
+      if (this.gamePhase === GamePhase.Paused) {
+        this.closePauseMenu();
+      } else {
+        this.openPauseMenu();
       }
     });
     this.input.keyboard!.on('keydown-ONE', () => { this.speedMultiplier = 1; });
@@ -461,6 +475,41 @@ export class GameScene extends Phaser.Scene {
     // UIScene and world-input handlers resolve `this.world` lazily via the
     // getWorld accessor installed in create(), so the new reference is picked
     // up automatically on bootFresh, bootFromSave, and restartGame.
+  }
+
+  // ---------------------------------------------------------------------------
+  // Issue #116 — pause menu open/close
+  //
+  // Opens the UIScene pause-menu overlay AND pauses the game loop in one
+  // gesture; closing reverses both. Phase transitions are gated through
+  // gamePhase so concurrent SavePrompt / GameOver phases don't get clobbered
+  // (the Esc handler also early-returns in those phases as a belt-and-braces
+  // guard).
+  // ---------------------------------------------------------------------------
+
+  private openPauseMenu(): void {
+    if (this.gamePhase !== GamePhase.Playing) return;
+    this.gamePhase = GamePhase.Paused;
+    this.gameLoop.pause();
+    const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
+    uiScene.showPauseMenuOverlay({
+      onResume: () => this.closePauseMenu(),
+      onDownloadDebug: () => {
+        if (this.world === undefined) return;
+        const snap = buildDebugSnapshot(this.world, this.currentSeed, this.inputLog);
+        downloadDebugSnapshot(snap);
+      },
+      // Issue #115 will provide onOpenSaveLoad here. Until then the menu's
+      // Save/Load row renders disabled (callbacks.onOpenSaveLoad === undefined).
+    });
+  }
+
+  private closePauseMenu(): void {
+    if (this.gamePhase !== GamePhase.Paused) return;
+    const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
+    uiScene.hidePauseMenuOverlay();
+    this.gamePhase = GamePhase.Playing;
+    this.gameLoop.resume();
   }
 
   private restartGame(): void {

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -240,28 +240,43 @@ export class GameScene extends Phaser.Scene {
     this.dragState = registerDragPan(this, this.viewState);
 
     // Issue #116 — Esc opens the pause menu overlay (which also pauses the
-    // sim) and toggles it closed when already visible. Replaces the prior
-    // bare P-pause binding so P is free for the pheromone overlay toggle
-    // in issue #114. Speed-multiplier keys (1/2/4) are unchanged.
-    this.input.keyboard!.on('keydown-ESC', () => {
-      if (this.gamePhase === GamePhase.SavePrompt
-       || this.gamePhase === GamePhase.GameOver) return;
-      if (this.gamePhase === GamePhase.Paused) {
-        this.closePauseMenu();
-      } else {
-        this.openPauseMenu();
-      }
+    // sim). The Esc keybinding itself lives in UIScene (which already owned
+    // Esc for the ant-activity panel hide and the dialog/menu close paths);
+    // routing all Esc through one scene avoids the dual-handler race that
+    // had GameScene open the menu and UIScene immediately close it on the
+    // same press. UIScene calls back to openPauseMenu via the onEscape
+    // callback supplied below at scene.launch.
+    // Speed-multiplier keys (1/2/4) and the P pheromone toggle (issue #114)
+    // stay on GameScene because they're game-state actions, not UI chrome.
+    // Speed-multiplier keys (1/2/4), the pheromone toggle (P), and the
+    // underground colony toggle (X) all mutate state that the player
+    // expects the menu to be the modal source of truth for while paused.
+    // Round-2 review: gating these on `gamePhase === Playing` prevents
+    // a P press while the pause menu's Settings page is up from desyncing
+    // the on-screen "ON/OFF" label from the persisted setting (the menu
+    // captures the label at render time and would no longer match), and
+    // prevents Resume from snapping the camera to the enemy nest because
+    // X was pressed while paused.
+    this.input.keyboard!.on('keydown-ONE', () => {
+      if (this.gamePhase !== GamePhase.Playing) return;
+      this.speedMultiplier = 1;
     });
-    this.input.keyboard!.on('keydown-ONE', () => { this.speedMultiplier = 1; });
-    this.input.keyboard!.on('keydown-TWO', () => { this.speedMultiplier = 2; });
-    this.input.keyboard!.on('keydown-FOUR', () => { this.speedMultiplier = 4; });
+    this.input.keyboard!.on('keydown-TWO', () => {
+      if (this.gamePhase !== GamePhase.Playing) return;
+      this.speedMultiplier = 2;
+    });
+    this.input.keyboard!.on('keydown-FOUR', () => {
+      if (this.gamePhase !== GamePhase.Playing) return;
+      this.speedMultiplier = 4;
+    });
     // Issue #114 — P toggles the player's pheromone overlay. Render-only:
     // the flag lives on ViewState (so the next frame skips drawPheromoneOverlay)
-    // AND in persisted settings (so the choice survives reloads). Inert during
-    // SavePrompt so the toggle can't accidentally fire while the boot prompt
-    // is up. The pause menu's Settings sub-screen drives the same write path.
+    // AND in persisted settings (so the choice survives reloads). The pause
+    // menu's Settings sub-screen drives the same write path; gating P on
+    // Playing means the menu is the only writer while paused (no label
+    // desync — see comment block above).
     this.input.keyboard!.on('keydown-P', () => {
-      if (this.gamePhase === GamePhase.SavePrompt) return;
+      if (this.gamePhase !== GamePhase.Playing) return;
       const next = loadSettings();
       next.pheromoneOverlay = !next.pheromoneOverlay;
       saveSettings(next);
@@ -274,13 +289,10 @@ export class GameScene extends Phaser.Scene {
     // P/F9/speed-multiplier pattern above — the keyboard-plugin event bus
     // handles edge-trigger semantics for us (one keydown event per press),
     // avoiding the key-repeat DoS that Phase 08-04 guarded against for
-    // Tab via JustDown. SavePrompt phase early-returns in update() but
-    // this listener fires from Phaser's keyboard plugin; the SavePrompt
-    // overlay is click-driven (no X binding) so a spurious X press during
-    // SavePrompt is harmless — it mutates a ViewState field the overlay
-    // does not render.
+    // Tab via JustDown. Gated on Playing so a paused player doesn't Resume
+    // into a surprise camera flip onto the enemy nest.
     this.input.keyboard!.on('keydown-X', () => {
-      if (this.gamePhase === GamePhase.SavePrompt) return;
+      if (this.gamePhase !== GamePhase.Playing) return;
       if (this.viewState.activeView !== 'underground') return;
       toggleUndergroundColony(this.viewState);
     });
@@ -303,7 +315,15 @@ export class GameScene extends Phaser.Scene {
     const getWorld = (): WorldState | undefined => this.world;
 
     // Launch HUD scene on top.
-    this.scene.launch('UIScene', { viewState: this.viewState, getWorld });
+    this.scene.launch('UIScene', {
+      viewState: this.viewState,
+      getWorld,
+      // Issue #116 — UIScene owns Esc; this callback fires on Esc when no
+      // UIScene overlay/panel is open and is the trigger to spawn the pause
+      // menu. GameScene was previously binding keydown-ESC alongside
+      // UIScene's escKey handler, which raced (open → close in one press).
+      onEscape: () => this.openPauseMenu(),
+    });
     this.scene.bringToTop('UIScene');
 
     // World input dispatchers — internally guard on viewState.activeView.
@@ -510,12 +530,19 @@ export class GameScene extends Phaser.Scene {
   // guard).
   // ---------------------------------------------------------------------------
 
-  private openPauseMenu(): void {
-    if (this.gamePhase !== GamePhase.Playing) return;
-    this.gamePhase = GamePhase.Paused;
-    this.gameLoop.pause();
-    const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
-    uiScene.showPauseMenuOverlay({
+  /**
+   * Round-2 review: the openPauseMenu callbacks were duplicated inline
+   * inside openSaveLoadDialog's onBack — silent drift waiting to happen
+   * when a future change adds an entry to one but not the other. This
+   * helper is the single source of truth for what callbacks the menu
+   * receives; both call sites pass through it.
+   */
+  private buildPauseMenuCallbacks(): {
+    onResume: () => void;
+    onDownloadDebug: () => void;
+    onOpenSaveLoad: () => void;
+  } {
+    return {
       onResume: () => this.closePauseMenu(),
       onDownloadDebug: () => {
         if (this.world === undefined) return;
@@ -523,7 +550,15 @@ export class GameScene extends Phaser.Scene {
         downloadDebugSnapshot(snap);
       },
       onOpenSaveLoad: () => this.openSaveLoadDialog(),
-    });
+    };
+  }
+
+  private openPauseMenu(): void {
+    if (this.gamePhase !== GamePhase.Playing) return;
+    this.gamePhase = GamePhase.Paused;
+    this.gameLoop.pause();
+    const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
+    uiScene.showPauseMenuOverlay(this.buildPauseMenuCallbacks());
   }
 
   private closePauseMenu(): void {
@@ -563,20 +598,19 @@ export class GameScene extends Phaser.Scene {
       },
       onSaveNow: () => {
         if (this.world === undefined) return false;
-        return manualSave(this.currentSeed, this.inputLog, this.world);
+        const ok = manualSave(this.currentSeed, this.inputLog, this.world);
+        // Round-2 review: bump the autosave cooldown so the next autosave
+        // window doesn't fire seconds later and overwrite the manual save's
+        // timestamp. The dialog's "Saved 15:32" line otherwise jumps to
+        // 15:33 the next time the player opens it, with no action of theirs.
+        if (ok) this.lastAutosaveMs = performance.now();
+        return ok;
       },
       onBack: () => {
         // Re-open the pause menu — gamePhase is still Paused, gameLoop is
-        // still paused, so this just restores the menu chrome.
-        uiScene.showPauseMenuOverlay({
-          onResume: () => this.closePauseMenu(),
-          onDownloadDebug: () => {
-            if (this.world === undefined) return;
-            const snap = buildDebugSnapshot(this.world, this.currentSeed, this.inputLog);
-            downloadDebugSnapshot(snap);
-          },
-          onOpenSaveLoad: () => this.openSaveLoadDialog(),
-        });
+        // still paused, so this just restores the menu chrome. Same callback
+        // payload as the initial openPauseMenu via the shared helper.
+        uiScene.showPauseMenuOverlay(this.buildPauseMenuCallbacks());
       },
     });
   }

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -32,6 +32,7 @@ import { tick, resetFlowFieldCaches } from '../sim/tick.js';
 import { createGameLoop, type GameLoop, MS_PER_TICK } from '../platform/game-loop.js';
 import { hasSave, loadSave, deleteSave, tickAutosave, FutureSimVersionError } from '../platform/save.js';
 import { deserializeWorldState } from '../platform/save.js';
+import { loadSettings, saveSettings } from '../platform/settings.js';
 import { runAIController } from './ai-controller.js';
 import { buildDebugSnapshot } from '../platform/debug-snapshot.js';
 import { downloadDebugSnapshot } from './debug-snapshot-download.js';
@@ -244,6 +245,18 @@ export class GameScene extends Phaser.Scene {
     this.input.keyboard!.on('keydown-ONE', () => { this.speedMultiplier = 1; });
     this.input.keyboard!.on('keydown-TWO', () => { this.speedMultiplier = 2; });
     this.input.keyboard!.on('keydown-FOUR', () => { this.speedMultiplier = 4; });
+    // Issue #114 — P toggles the player's pheromone overlay. Render-only:
+    // the flag lives on ViewState (so the next frame skips drawPheromoneOverlay)
+    // AND in persisted settings (so the choice survives reloads). Inert during
+    // SavePrompt so the toggle can't accidentally fire while the boot prompt
+    // is up. The pause menu's Settings sub-screen drives the same write path.
+    this.input.keyboard!.on('keydown-P', () => {
+      if (this.gamePhase === GamePhase.SavePrompt) return;
+      const next = loadSettings();
+      next.pheromoneOverlay = !next.pheromoneOverlay;
+      saveSettings(next);
+      this.viewState.showPheromoneOverlay = next.pheromoneOverlay;
+    });
 
     // 09.1 Chunk 2 — X toggles the active underground colony view. Only
     // flips when activeView === 'underground'; inert on the surface view
@@ -579,7 +592,13 @@ export class GameScene extends Phaser.Scene {
     const gfx = this.gfx as unknown as GfxLike;
     gfx.clear();
     this.antSprites.beginFrame();
-    drawPheromoneOverlay(gfx, this.world, cam, this.viewState.activeView);
+    // Issue #114 — pheromone overlay is gated on the viewState flag so the P
+    // key (and the pause menu's Settings sub-screen) can hide it without
+    // touching the simulation. Player colony only — enemy pheromones stay
+    // hidden regardless of toggle state (PRD §7b / T-08-05).
+    if (this.viewState.showPheromoneOverlay) {
+      drawPheromoneOverlay(gfx, this.world, cam, this.viewState.activeView);
+    }
     if (this.viewState.activeView === 'surface') {
       const pending =
         this.surfaceInputState.pendingEntranceTileX !== null &&

--- a/src/render/pause-menu-layout.test.ts
+++ b/src/render/pause-menu-layout.test.ts
@@ -11,11 +11,12 @@ import {
   PAUSE_MENU_BUTTON_GAP,
   type PauseMenuRenderContext,
 } from './pause-menu-layout.js';
-import { DEFAULT_SETTINGS } from '../platform/settings.js';
+// (DEFAULT_SETTINGS no longer imported — ctx now uses in-memory boolean
+// for currentPheromoneOverlay instead of a full Settings snapshot.)
 
 const ctx: PauseMenuRenderContext = {
   saveLoadEnabled: true,
-  settings: { ...DEFAULT_SETTINGS },
+  currentPheromoneOverlay: true,
   currentSpeedMultiplier: 1,
 };
 
@@ -77,18 +78,12 @@ describe('pauseMenuItems — settings page', () => {
   });
 
   it('pheromone toggle label reflects the current ON state', () => {
-    const items = pauseMenuItems('settings', {
-      ...ctx,
-      settings: { ...DEFAULT_SETTINGS, pheromoneOverlay: true },
-    });
+    const items = pauseMenuItems('settings', { ...ctx, currentPheromoneOverlay: true });
     expect(items.find(i => i.id === 'pheromone-toggle')!.label).toContain('ON');
   });
 
   it('pheromone toggle label reflects the current OFF state', () => {
-    const items = pauseMenuItems('settings', {
-      ...ctx,
-      settings: { ...DEFAULT_SETTINGS, pheromoneOverlay: false },
-    });
+    const items = pauseMenuItems('settings', { ...ctx, currentPheromoneOverlay: false });
     expect(items.find(i => i.id === 'pheromone-toggle')!.label).toContain('OFF');
   });
 

--- a/src/render/pause-menu-layout.test.ts
+++ b/src/render/pause-menu-layout.test.ts
@@ -3,6 +3,7 @@ import {
   pauseMenuItems,
   pageTitle,
   itemAt,
+  nextSpeedMultiplier,
   CANVAS_W,
   CANVAS_H,
   PAUSE_MENU_BUTTON_W,
@@ -15,6 +16,7 @@ import { DEFAULT_SETTINGS } from '../platform/settings.js';
 const ctx: PauseMenuRenderContext = {
   saveLoadEnabled: true,
   settings: { ...DEFAULT_SETTINGS },
+  currentSpeedMultiplier: 1,
 };
 
 describe('pauseMenuItems — main page', () => {
@@ -69,9 +71,9 @@ describe('pauseMenuItems — main page', () => {
 });
 
 describe('pauseMenuItems — settings page', () => {
-  it('returns the pheromone toggle and a back button', () => {
+  it('returns the pheromone toggle, speed cycle, and a back button', () => {
     const items = pauseMenuItems('settings', ctx);
-    expect(items.map(i => i.id)).toEqual(['pheromone-toggle', 'back']);
+    expect(items.map(i => i.id)).toEqual(['pheromone-toggle', 'speed-cycle', 'back']);
   });
 
   it('pheromone toggle label reflects the current ON state', () => {
@@ -89,6 +91,19 @@ describe('pauseMenuItems — settings page', () => {
     });
     expect(items.find(i => i.id === 'pheromone-toggle')!.label).toContain('OFF');
   });
+
+  it('speed-cycle label reflects the current speed multiplier', () => {
+    expect(pauseMenuItems('settings', { ...ctx, currentSpeedMultiplier: 1 })
+      .find(i => i.id === 'speed-cycle')!.label).toContain('1×');
+    expect(pauseMenuItems('settings', { ...ctx, currentSpeedMultiplier: 2 })
+      .find(i => i.id === 'speed-cycle')!.label).toContain('2×');
+    expect(pauseMenuItems('settings', { ...ctx, currentSpeedMultiplier: 4 })
+      .find(i => i.id === 'speed-cycle')!.label).toContain('4×');
+  });
+
+  it('speed-cycle row is enabled', () => {
+    expect(pauseMenuItems('settings', ctx).find(i => i.id === 'speed-cycle')!.enabled).toBe(true);
+  });
 });
 
 describe('pageTitle', () => {
@@ -98,6 +113,12 @@ describe('pageTitle', () => {
   it('returns "Settings" for the settings page', () => {
     expect(pageTitle('settings')).toBe('Settings');
   });
+});
+
+describe('nextSpeedMultiplier — cycle 1→2→4→1', () => {
+  it('1 → 2', () => { expect(nextSpeedMultiplier(1)).toBe(2); });
+  it('2 → 4', () => { expect(nextSpeedMultiplier(2)).toBe(4); });
+  it('4 → 1', () => { expect(nextSpeedMultiplier(4)).toBe(1); });
 });
 
 describe('itemAt', () => {

--- a/src/render/pause-menu-layout.test.ts
+++ b/src/render/pause-menu-layout.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pauseMenuItems,
+  pageTitle,
+  itemAt,
+  CANVAS_W,
+  CANVAS_H,
+  PAUSE_MENU_BUTTON_W,
+  PAUSE_MENU_BUTTON_H,
+  PAUSE_MENU_BUTTON_GAP,
+  type PauseMenuRenderContext,
+} from './pause-menu-layout.js';
+import { DEFAULT_SETTINGS } from '../platform/settings.js';
+
+const ctx: PauseMenuRenderContext = {
+  saveLoadEnabled: true,
+  settings: { ...DEFAULT_SETTINGS },
+};
+
+describe('pauseMenuItems — main page', () => {
+  it('returns 4 items in the documented order', () => {
+    const items = pauseMenuItems('main', ctx);
+    expect(items.map(i => i.id)).toEqual([
+      'resume', 'save-load', 'settings', 'debug-snapshot',
+    ]);
+  });
+
+  it('Save/Load row is disabled when saveLoadEnabled=false (issue #115 not yet wired)', () => {
+    const items = pauseMenuItems('main', { ...ctx, saveLoadEnabled: false });
+    const saveLoad = items.find(i => i.id === 'save-load')!;
+    expect(saveLoad.enabled).toBe(false);
+  });
+
+  it('Save/Load row is enabled when saveLoadEnabled=true', () => {
+    const items = pauseMenuItems('main', { ...ctx, saveLoadEnabled: true });
+    expect(items.find(i => i.id === 'save-load')!.enabled).toBe(true);
+  });
+
+  it('every button has the documented w×h dimensions', () => {
+    const items = pauseMenuItems('main', ctx);
+    for (const i of items) {
+      expect(i.rect.w).toBe(PAUSE_MENU_BUTTON_W);
+      expect(i.rect.h).toBe(PAUSE_MENU_BUTTON_H);
+    }
+  });
+
+  it('buttons stack vertically with the documented gap', () => {
+    const items = pauseMenuItems('main', ctx);
+    for (let i = 1; i < items.length; i++) {
+      const prevBottom = items[i - 1]!.rect.y + items[i - 1]!.rect.h;
+      const currTop = items[i]!.rect.y;
+      expect(currTop - prevBottom).toBe(PAUSE_MENU_BUTTON_GAP);
+    }
+  });
+
+  it('buttons are horizontally centered on the canvas', () => {
+    const items = pauseMenuItems('main', ctx);
+    for (const i of items) {
+      expect(i.rect.x + i.rect.w / 2).toBeCloseTo(CANVAS_W / 2, 5);
+    }
+  });
+
+  it('vertical stack stays inside the canvas bounds', () => {
+    const items = pauseMenuItems('main', ctx);
+    expect(items[0]!.rect.y).toBeGreaterThanOrEqual(0);
+    const lastBottom = items[items.length - 1]!.rect.y + items[items.length - 1]!.rect.h;
+    expect(lastBottom).toBeLessThanOrEqual(CANVAS_H);
+  });
+});
+
+describe('pauseMenuItems — settings page', () => {
+  it('returns the pheromone toggle and a back button', () => {
+    const items = pauseMenuItems('settings', ctx);
+    expect(items.map(i => i.id)).toEqual(['pheromone-toggle', 'back']);
+  });
+
+  it('pheromone toggle label reflects the current ON state', () => {
+    const items = pauseMenuItems('settings', {
+      ...ctx,
+      settings: { ...DEFAULT_SETTINGS, pheromoneOverlay: true },
+    });
+    expect(items.find(i => i.id === 'pheromone-toggle')!.label).toContain('ON');
+  });
+
+  it('pheromone toggle label reflects the current OFF state', () => {
+    const items = pauseMenuItems('settings', {
+      ...ctx,
+      settings: { ...DEFAULT_SETTINGS, pheromoneOverlay: false },
+    });
+    expect(items.find(i => i.id === 'pheromone-toggle')!.label).toContain('OFF');
+  });
+});
+
+describe('pageTitle', () => {
+  it('returns "Paused" for the main page', () => {
+    expect(pageTitle('main')).toBe('Paused');
+  });
+  it('returns "Settings" for the settings page', () => {
+    expect(pageTitle('settings')).toBe('Settings');
+  });
+});
+
+describe('itemAt', () => {
+  it('returns the item whose rect contains the pointer', () => {
+    const items = pauseMenuItems('main', ctx);
+    const r = items[1]!.rect;
+    const hit = itemAt(items, r.x + 5, r.y + 5);
+    expect(hit?.id).toBe(items[1]!.id);
+  });
+
+  it('returns null when the pointer is outside every rect', () => {
+    const items = pauseMenuItems('main', ctx);
+    expect(itemAt(items, 0, 0)).toBeNull();
+  });
+
+  it('skips disabled items even when the pointer is inside their rect', () => {
+    const items = pauseMenuItems('main', { ...ctx, saveLoadEnabled: false });
+    const saveLoad = items.find(i => i.id === 'save-load')!;
+    expect(itemAt(items, saveLoad.rect.x + 5, saveLoad.rect.y + 5)).toBeNull();
+  });
+});

--- a/src/render/pause-menu-layout.ts
+++ b/src/render/pause-menu-layout.ts
@@ -1,0 +1,168 @@
+// pause-menu-layout.ts — issue #116 pause menu layout + hit-testing.
+//
+// Pure-TypeScript module: no Phaser, no DOM. UIScene consumes the menu items
+// to lay out Game Objects, and reuses the hit-test for pointerdown dispatch.
+// Pure-data shape mirrors context-menu-layout.ts so the menu is testable in
+// Vitest without spinning up a Phaser scene.
+//
+// Layout: vertical stack of fixed-size buttons, centered horizontally on the
+// 800×592 canvas. Vertical anchor is the canvas centerline minus half the
+// stack height, so the stack stays visually centered as page contents change.
+//
+// State machine (consumer drives, this module renders):
+//   main     → Resume / Save+Load / Settings → / Download debug log
+//   settings → (page entries, populated by callers — issue #114 adds pheromone
+//              toggle) / ← Back
+//
+// The `Save/Load` row carries an `enabled` flag so it can render disabled
+// while issue #115's dialog isn't yet wired in.
+
+import type { Settings } from '../platform/settings.js';
+
+// ---------------------------------------------------------------------------
+// Geometry constants (canvas-local pixels)
+// ---------------------------------------------------------------------------
+
+export const CANVAS_W = 800;
+export const CANVAS_H = 592;
+
+export const PAUSE_MENU_BUTTON_W = 320;
+export const PAUSE_MENU_BUTTON_H = 40;
+export const PAUSE_MENU_BUTTON_GAP = 10;
+
+/** Pixels of vertical padding above/below the stack inside the modal panel. */
+export const PAUSE_MENU_STACK_VPAD = 32;
+/** Pixels of vertical space reserved at the top of the stack for the title. */
+export const PAUSE_MENU_TITLE_HEIGHT = 56;
+
+// ---------------------------------------------------------------------------
+// Item types
+// ---------------------------------------------------------------------------
+
+export type PauseMenuPage = 'main' | 'settings';
+
+export type PauseMenuItemId =
+  | 'resume'
+  | 'save-load'
+  | 'settings'
+  | 'debug-snapshot'
+  | 'back'
+  | 'pheromone-toggle';
+
+export interface MenuItemRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface PauseMenuItem {
+  id: PauseMenuItemId;
+  label: string;
+  /** False renders the row dimmer and `itemAt` returns null on hit so the
+   *  callback is never fired. Used by Save/Load until issue #115 lands. */
+  enabled: boolean;
+  rect: MenuItemRect;
+}
+
+export interface PauseMenuRenderContext {
+  /** True once issue #115's Save/Load dialog is wired in; until then the row
+   *  renders disabled to signal "coming soon" without removing the affordance. */
+  saveLoadEnabled: boolean;
+  /** Latest settings snapshot — Settings page reads this to render toggle state. */
+  settings: Settings;
+}
+
+// ---------------------------------------------------------------------------
+// Layout
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the vertical center anchor for a stack of n buttons (with the title
+ * gap), then derive each button's rect. Returns rects in render order top→bottom.
+ */
+function stackRects(n: number): MenuItemRect[] {
+  const stackHeight =
+    PAUSE_MENU_TITLE_HEIGHT
+    + n * PAUSE_MENU_BUTTON_H
+    + (n - 1) * PAUSE_MENU_BUTTON_GAP;
+  const top = (CANVAS_H - stackHeight) / 2 + PAUSE_MENU_TITLE_HEIGHT;
+  const x = (CANVAS_W - PAUSE_MENU_BUTTON_W) / 2;
+  const rects: MenuItemRect[] = [];
+  for (let i = 0; i < n; i++) {
+    rects.push({
+      x,
+      y: top + i * (PAUSE_MENU_BUTTON_H + PAUSE_MENU_BUTTON_GAP),
+      w: PAUSE_MENU_BUTTON_W,
+      h: PAUSE_MENU_BUTTON_H,
+    });
+  }
+  return rects;
+}
+
+/** Y-coordinate of the page title baseline (above the first button rect). */
+export function titleCenterY(itemCount: number): number {
+  const rects = stackRects(itemCount);
+  return rects[0]!.y - PAUSE_MENU_TITLE_HEIGHT / 2;
+}
+
+/** Compose the menu items for the current page. */
+export function pauseMenuItems(
+  page: PauseMenuPage,
+  ctx: PauseMenuRenderContext,
+): PauseMenuItem[] {
+  if (page === 'main') {
+    const labels: Array<{ id: PauseMenuItemId; label: string; enabled: boolean }> = [
+      { id: 'resume',         label: 'Resume',             enabled: true },
+      { id: 'save-load',      label: 'Save / Load',        enabled: ctx.saveLoadEnabled },
+      { id: 'settings',       label: 'Settings  >',        enabled: true },
+      { id: 'debug-snapshot', label: 'Download debug log', enabled: true },
+    ];
+    const rects = stackRects(labels.length);
+    return labels.map((l, i) => ({
+      id: l.id,
+      label: l.label,
+      enabled: l.enabled,
+      rect: rects[i]!,
+    }));
+  }
+  // settings page
+  const labels: Array<{ id: PauseMenuItemId; label: string; enabled: boolean }> = [
+    {
+      id: 'pheromone-toggle',
+      label: `Pheromone trails: ${ctx.settings.pheromoneOverlay ? 'ON' : 'OFF'}`,
+      enabled: true,
+    },
+    { id: 'back', label: '<  Back', enabled: true },
+  ];
+  const rects = stackRects(labels.length);
+  return labels.map((l, i) => ({
+    id: l.id,
+    label: l.label,
+    enabled: l.enabled,
+    rect: rects[i]!,
+  }));
+}
+
+/** Page title text. Centralized so the title and items share a single source. */
+export function pageTitle(page: PauseMenuPage): string {
+  return page === 'main' ? 'Paused' : 'Settings';
+}
+
+// ---------------------------------------------------------------------------
+// Hit testing
+// ---------------------------------------------------------------------------
+
+function pointInRect(px: number, py: number, r: MenuItemRect): boolean {
+  return px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h;
+}
+
+/** Returns the topmost ENABLED item under the pointer, or null. Disabled items
+ *  swallow no hit so callers can layer additional behavior beneath them later. */
+export function itemAt(items: readonly PauseMenuItem[], px: number, py: number): PauseMenuItem | null {
+  for (const it of items) {
+    if (!it.enabled) continue;
+    if (pointInRect(px, py, it.rect)) return it;
+  }
+  return null;
+}

--- a/src/render/pause-menu-layout.ts
+++ b/src/render/pause-menu-layout.ts
@@ -17,7 +17,8 @@
 // The `Save/Load` row carries an `enabled` flag so it can render disabled
 // while issue #115's dialog isn't yet wired in.
 
-import type { Settings } from '../platform/settings.js';
+// (Settings type was imported here pre-round-6; removed when the
+// pheromone-toggle label moved to an in-memory ctx field per Codex P2.)
 
 // ---------------------------------------------------------------------------
 // Geometry constants (canvas-local pixels)
@@ -74,8 +75,12 @@ export interface PauseMenuRenderContext {
   /** True once issue #115's Save/Load dialog is wired in; until then the row
    *  renders disabled to signal "coming soon" without removing the affordance. */
   saveLoadEnabled: boolean;
-  /** Latest settings snapshot — Settings page reads this to render toggle state. */
-  settings: Settings;
+  /** Current pheromone overlay state. Sourced from ViewState (in-memory) by
+   *  the caller, NOT from `loadSettings()` — round-6 P2 (Codex): in degraded-
+   *  storage environments saveSettings is a no-op and loadSettings keeps
+   *  returning the default, so reading the label from persisted state makes
+   *  the toggle look broken. The in-mem flag is the authoritative truth. */
+  currentPheromoneOverlay: boolean;
   /** Current speedMultiplier (1 | 2 | 4). The Settings page renders this in
    *  the "Speed: N×" cycle row. Source of truth is GameScene's live field —
    *  the menu reads via the onSpeedMultiplier callback at render time and
@@ -142,7 +147,7 @@ export function pauseMenuItems(
   const labels: Array<{ id: PauseMenuItemId; label: string; enabled: boolean }> = [
     {
       id: 'pheromone-toggle',
-      label: `Pheromone trails: ${ctx.settings.pheromoneOverlay ? 'ON' : 'OFF'}`,
+      label: `Pheromone trails: ${ctx.currentPheromoneOverlay ? 'ON' : 'OFF'}`,
       enabled: true,
     },
     {

--- a/src/render/pause-menu-layout.ts
+++ b/src/render/pause-menu-layout.ts
@@ -47,7 +47,12 @@ export type PauseMenuItemId =
   | 'settings'
   | 'debug-snapshot'
   | 'back'
-  | 'pheromone-toggle';
+  | 'pheromone-toggle'
+  | 'speed-cycle';
+
+/** Allowed speedMultiplier values. Cycled by the Settings sub-screen
+ *  speed-cycle row in the order 1 → 2 → 4 → 1. */
+export type SpeedMultiplier = 1 | 2 | 4;
 
 export interface MenuItemRect {
   x: number;
@@ -71,6 +76,13 @@ export interface PauseMenuRenderContext {
   saveLoadEnabled: boolean;
   /** Latest settings snapshot — Settings page reads this to render toggle state. */
   settings: Settings;
+  /** Current speedMultiplier (1 | 2 | 4). The Settings page renders this in
+   *  the "Speed: N×" cycle row. Source of truth is GameScene's live field —
+   *  the menu reads via the onSpeedMultiplier callback at render time and
+   *  writes via onCycleSpeed when the row is clicked. Session-only (no
+   *  settings persistence — matches the Phase 4 fresh-boot contract that
+   *  speed resets to 1× on restart). */
+  currentSpeedMultiplier: SpeedMultiplier;
 }
 
 // ---------------------------------------------------------------------------
@@ -133,6 +145,14 @@ export function pauseMenuItems(
       label: `Pheromone trails: ${ctx.settings.pheromoneOverlay ? 'ON' : 'OFF'}`,
       enabled: true,
     },
+    {
+      id: 'speed-cycle',
+      // Cycles 1→2→4→1 on click. Mirrors the 1/2/4 keyboard shortcuts that
+      // are Playing-only-gated; the menu surface gives a discoverable home
+      // for the same control while paused.
+      label: `Speed: ${ctx.currentSpeedMultiplier}×`,
+      enabled: true,
+    },
     { id: 'back', label: '<  Back', enabled: true },
   ];
   const rects = stackRects(labels.length);
@@ -165,4 +185,12 @@ export function itemAt(items: readonly PauseMenuItem[], px: number, py: number):
     if (pointInRect(px, py, it.rect)) return it;
   }
   return null;
+}
+
+/** Next speed in the 1→2→4→1 cycle. Pure function so the menu dispatch
+ *  doesn't need branching inline. */
+export function nextSpeedMultiplier(current: SpeedMultiplier): SpeedMultiplier {
+  if (current === 1) return 2;
+  if (current === 2) return 4;
+  return 1;
 }

--- a/src/render/save-load-dialog-layout.test.ts
+++ b/src/render/save-load-dialog-layout.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   saveLoadDialogItems,
   formatSaveInfoLine,
+  formatSaveTime,
   dialogTitle,
   firstButtonY,
   itemAt,
@@ -113,12 +114,25 @@ describe('saveLoadDialogItems', () => {
 });
 
 describe('formatSaveInfoLine', () => {
-  it('formats a fresh save with tick + workers + food', () => {
-    const info: SaveInfo = { tick: 42, playerWorkers: 12, playerFoodStored: 1500 };
+  it('formats a fresh save with timestamp + tick + workers + food (issue #115)', () => {
+    const info: SaveInfo = {
+      tick: 42, playerWorkers: 12, playerFoodStored: 1500,
+      // 2026-01-15 09:30 local — the formatter uses local time, so we don't
+      // assert exact HH:MM strings (would be flaky across CI timezones).
+      savedAtMs: new Date(2026, 0, 15, 9, 30, 0).getTime(),
+    };
     const line = formatSaveInfoLine(info, false);
+    expect(line.toLowerCase()).toContain('saved');
     expect(line).toContain('42');
     expect(line).toContain('12');
     expect(line).toContain('1500');
+  });
+
+  it('uses the "—" placeholder when savedAtMs is 0 (pre-issue-#115 envelope)', () => {
+    const info: SaveInfo = { tick: 5, playerWorkers: 0, playerFoodStored: 0, savedAtMs: 0 };
+    const line = formatSaveInfoLine(info, false);
+    // Should still render a Saved prefix with the placeholder, not crash.
+    expect(line).toContain('—');
   });
 
   it('shows the incompatible-save warning when there is no SaveInfo and bytes are unreadable', () => {
@@ -132,9 +146,42 @@ describe('formatSaveInfoLine', () => {
   });
 
   it('prefers SaveInfo over the incompatible flag (caller should pass the right combination)', () => {
-    const info: SaveInfo = { tick: 1, playerWorkers: 0, playerFoodStored: 0 };
+    const info: SaveInfo = {
+      tick: 1, playerWorkers: 0, playerFoodStored: 0, savedAtMs: 0,
+    };
     const line = formatSaveInfoLine(info, true);
     expect(line.toLowerCase()).not.toContain('incompatible');
+  });
+});
+
+describe('formatSaveTime', () => {
+  it('returns "—" for 0 (unknown / pre-issue-#115 envelope)', () => {
+    expect(formatSaveTime(0)).toBe('—');
+  });
+
+  it('returns "—" for negative values (defensive against tampered envelopes)', () => {
+    expect(formatSaveTime(-1)).toBe('—');
+  });
+
+  it('formats a positive epoch ms as zero-padded HH:MM in local time', () => {
+    const ts = new Date(2026, 4, 11, 7, 5).getTime(); // 07:05 local
+    expect(formatSaveTime(ts)).toBe('07:05');
+  });
+
+  it('handles late-night times correctly (no AM/PM rollover surprise)', () => {
+    const ts = new Date(2026, 4, 11, 23, 59).getTime();
+    expect(formatSaveTime(ts)).toBe('23:59');
+  });
+
+  it('returns "—" for huge values that construct an Invalid Date (round-2 review: tampered envelope guard)', () => {
+    // new Date(1e100) is Invalid Date. Without the NaN guard the formatter
+    // would produce "NaN:NaN" in the dialog. Round-2 review caught this as
+    // a tampered-envelope leakage path.
+    expect(formatSaveTime(1e100)).toBe('—');
+  });
+
+  it('returns "—" for NaN (defensive against tampered finite-but-NaN values)', () => {
+    expect(formatSaveTime(Number.NaN)).toBe('—');
   });
 });
 

--- a/src/render/save-load-dialog-layout.test.ts
+++ b/src/render/save-load-dialog-layout.test.ts
@@ -145,12 +145,18 @@ describe('formatSaveInfoLine', () => {
     expect(line.toLowerCase()).toContain('no save');
   });
 
-  it('prefers SaveInfo over the incompatible flag (caller should pass the right combination)', () => {
+  it('round-3 (Codex P2): warning wins over SaveInfo when the save is incompatible (future-sim case)', () => {
+    // A future-sim save has a parseable envelope (so getSaveInfo returns
+    // non-null) AND fails compatibility (hasIncompatibleSave === true).
+    // The dialog disables Continue; the info line must agree by showing
+    // the warning, NOT the saved-line — otherwise the player sees
+    // "Saved 14:30..." next to a grayed-out Continue and is confused.
     const info: SaveInfo = {
-      tick: 1, playerWorkers: 0, playerFoodStored: 0, savedAtMs: 0,
+      tick: 100, playerWorkers: 5, playerFoodStored: 200, savedAtMs: Date.now(),
     };
     const line = formatSaveInfoLine(info, true);
-    expect(line.toLowerCase()).not.toContain('incompatible');
+    expect(line.toLowerCase()).toContain('incompatible');
+    expect(line).not.toContain('Saved');
   });
 });
 

--- a/src/render/save-load-dialog-layout.test.ts
+++ b/src/render/save-load-dialog-layout.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import {
+  saveLoadDialogItems,
+  formatSaveInfoLine,
+  dialogTitle,
+  firstButtonY,
+  itemAt,
+  CANVAS_W,
+  DIALOG_BUTTON_W,
+  DIALOG_BUTTON_H,
+  DIALOG_BUTTON_GAP,
+  type SaveLoadDialogContext,
+} from './save-load-dialog-layout.js';
+import type { SaveInfo } from '../platform/save.js';
+
+const baseCtx: SaveLoadDialogContext = {
+  hasCompatibleSave: false,
+  hasIncompatibleSave: false,
+  confirming: { delete: false, newGame: false },
+};
+
+describe('saveLoadDialogItems', () => {
+  it('returns 5 items in the documented order', () => {
+    const items = saveLoadDialogItems(baseCtx);
+    expect(items.map(i => i.id)).toEqual([
+      'continue', 'save-now', 'delete', 'new-game', 'back',
+    ]);
+  });
+
+  it('Continue is disabled when there is no compatible save', () => {
+    const items = saveLoadDialogItems(baseCtx);
+    expect(items.find(i => i.id === 'continue')!.enabled).toBe(false);
+  });
+
+  it('Continue is enabled when a compatible save exists', () => {
+    const items = saveLoadDialogItems({ ...baseCtx, hasCompatibleSave: true });
+    expect(items.find(i => i.id === 'continue')!.enabled).toBe(true);
+  });
+
+  it('Delete is disabled when nothing exists in storage', () => {
+    const items = saveLoadDialogItems(baseCtx);
+    expect(items.find(i => i.id === 'delete')!.enabled).toBe(false);
+  });
+
+  it('Delete is enabled when an incompatible save needs to be cleared (issue #66 path)', () => {
+    const items = saveLoadDialogItems({
+      ...baseCtx,
+      hasCompatibleSave: false,
+      hasIncompatibleSave: true,
+    });
+    expect(items.find(i => i.id === 'delete')!.enabled).toBe(true);
+  });
+
+  it('Delete row swaps to "click to confirm" when confirming.delete is set', () => {
+    const items = saveLoadDialogItems({
+      ...baseCtx,
+      hasCompatibleSave: true,
+      confirming: { delete: true, newGame: false },
+    });
+    const del = items.find(i => i.id === 'delete')!;
+    expect(del.label.toLowerCase()).toContain('confirm');
+    expect(del.confirming).toBe(true);
+  });
+
+  it('New Game does NOT show confirm when no save exists (no progress at risk)', () => {
+    const items = saveLoadDialogItems({
+      ...baseCtx,
+      hasCompatibleSave: false,
+      confirming: { delete: false, newGame: true },
+    });
+    const ng = items.find(i => i.id === 'new-game')!;
+    expect(ng.label.toLowerCase()).not.toContain('confirm');
+  });
+
+  it('New Game shows confirm when a save exists and confirming.newGame is set', () => {
+    const items = saveLoadDialogItems({
+      ...baseCtx,
+      hasCompatibleSave: true,
+      confirming: { delete: false, newGame: true },
+    });
+    const ng = items.find(i => i.id === 'new-game')!;
+    expect(ng.label.toLowerCase()).toContain('confirm');
+  });
+
+  it('every button has the documented w×h dimensions', () => {
+    const items = saveLoadDialogItems(baseCtx);
+    for (const i of items) {
+      expect(i.rect.w).toBe(DIALOG_BUTTON_W);
+      expect(i.rect.h).toBe(DIALOG_BUTTON_H);
+    }
+  });
+
+  it('buttons stack vertically with the documented gap', () => {
+    const items = saveLoadDialogItems(baseCtx);
+    for (let i = 1; i < items.length; i++) {
+      const prevBottom = items[i - 1]!.rect.y + items[i - 1]!.rect.h;
+      const currTop = items[i]!.rect.y;
+      expect(currTop - prevBottom).toBe(DIALOG_BUTTON_GAP);
+    }
+  });
+
+  it('buttons are horizontally centered on the canvas', () => {
+    const items = saveLoadDialogItems(baseCtx);
+    for (const i of items) {
+      expect(i.rect.x + i.rect.w / 2).toBeCloseTo(CANVAS_W / 2, 5);
+    }
+  });
+
+  it('first button starts at firstButtonY()', () => {
+    const items = saveLoadDialogItems(baseCtx);
+    expect(items[0]!.rect.y).toBe(firstButtonY());
+  });
+});
+
+describe('formatSaveInfoLine', () => {
+  it('formats a fresh save with tick + workers + food', () => {
+    const info: SaveInfo = { tick: 42, playerWorkers: 12, playerFoodStored: 1500 };
+    const line = formatSaveInfoLine(info, false);
+    expect(line).toContain('42');
+    expect(line).toContain('12');
+    expect(line).toContain('1500');
+  });
+
+  it('shows the incompatible-save warning when there is no SaveInfo and bytes are unreadable', () => {
+    const line = formatSaveInfoLine(null, true);
+    expect(line.toLowerCase()).toContain('incompatible');
+  });
+
+  it('shows "no save in storage" when there is no SaveInfo and no bytes at all', () => {
+    const line = formatSaveInfoLine(null, false);
+    expect(line.toLowerCase()).toContain('no save');
+  });
+
+  it('prefers SaveInfo over the incompatible flag (caller should pass the right combination)', () => {
+    const info: SaveInfo = { tick: 1, playerWorkers: 0, playerFoodStored: 0 };
+    const line = formatSaveInfoLine(info, true);
+    expect(line.toLowerCase()).not.toContain('incompatible');
+  });
+});
+
+describe('dialogTitle', () => {
+  it('returns "Save / Load"', () => {
+    expect(dialogTitle()).toBe('Save / Load');
+  });
+});
+
+describe('itemAt', () => {
+  it('returns the item whose rect contains the pointer', () => {
+    const items = saveLoadDialogItems({ ...baseCtx, hasCompatibleSave: true });
+    const r = items[1]!.rect;
+    const hit = itemAt(items, r.x + 5, r.y + 5);
+    expect(hit?.id).toBe(items[1]!.id);
+  });
+
+  it('returns null when the pointer is outside every rect', () => {
+    const items = saveLoadDialogItems({ ...baseCtx, hasCompatibleSave: true });
+    expect(itemAt(items, 0, 0)).toBeNull();
+  });
+
+  it('skips disabled items', () => {
+    const items = saveLoadDialogItems(baseCtx); // Continue and Delete disabled
+    const continueItem = items.find(i => i.id === 'continue')!;
+    expect(itemAt(items, continueItem.rect.x + 5, continueItem.rect.y + 5)).toBeNull();
+  });
+});

--- a/src/render/save-load-dialog-layout.ts
+++ b/src/render/save-load-dialog-layout.ts
@@ -159,23 +159,31 @@ export function saveLoadDialogItems(ctx: SaveLoadDialogContext): SaveLoadDialogI
 // ---------------------------------------------------------------------------
 
 /** Compose the human-readable info line shown above the buttons. Pure text
- *  function so the dialog's only concern is rendering it. */
+ *  function so the dialog's only concern is rendering it.
+ *
+ *  Round-3 (Codex P2): the warning takes precedence over the saved-line.
+ *  Without that ordering a future-sim save (parseable envelope, but
+ *  simVersion > LATEST) would render as "Saved 14:30 · Tick 100 · …" while
+ *  Continue is disabled — visually contradicting the disabled state. The
+ *  warning wins so the disabled Continue and the info line tell the same
+ *  story. */
 export function formatSaveInfoLine(
   info: SaveInfo | null,
   hasIncompatibleSave: boolean,
 ): string {
+  if (hasIncompatibleSave) {
+    // Surfaces the issue #66 case where bytes exist but this build can't read
+    // them (envelope parse fails OR snapshot.simVersion > LATEST_SIM_VERSION).
+    // The player can Delete to clear them or click New Game to start fresh;
+    // Continue stays disabled.
+    return 'Incompatible save in storage — start a new game or delete it';
+  }
   if (info !== null) {
     // Fresh save line: timestamp · tick · workers · food. Keep it terse — one
     // line. The timestamp is rendered as the user's local "HH:MM" because the
     // dialog is a "saved when?" UX, not a forensic log; "moments ago" feels
     // wrong inside an explicit save/load surface and a full date sprawls.
     return `Saved ${formatSaveTime(info.savedAtMs)}  ·  Tick ${info.tick}  ·  Workers ${info.playerWorkers}  ·  Food ${info.playerFoodStored}`;
-  }
-  if (hasIncompatibleSave) {
-    // Surfaces the issue #66 case where bytes exist but this build can't read
-    // them. The player can Delete to clear them or click New Game to start
-    // fresh; Continue stays disabled.
-    return 'Incompatible save in storage — start a new game or delete it';
   }
   return 'No save in storage';
 }

--- a/src/render/save-load-dialog-layout.ts
+++ b/src/render/save-load-dialog-layout.ts
@@ -1,0 +1,205 @@
+// save-load-dialog-layout.ts — issue #115 Save/Load dialog layout + hit-testing.
+//
+// Pure-TypeScript module: no Phaser, no DOM. Mirrors pause-menu-layout's
+// pattern so UIScene composes both overlays the same way.
+//
+// The dialog has a single page (no sub-screens). Destructive actions
+// (delete save, new game over an existing save) confirm in place: the
+// first click flips a per-button confirm flag and re-renders with the
+// label changed to "Click to confirm"; the second click within the
+// confirm window commits. Reset on Back / dialog close.
+//
+// Buttons:
+//   - continue   — load the existing save and close everything (paused → resumed)
+//   - save-now   — manualSave; flashes a "Saved" line for ~1s
+//   - delete     — wipe the save; needs confirm if a save exists
+//   - new-game   — discard + restart; needs confirm if a save exists
+//   - back       — close the dialog, return to the pause menu (no game changes)
+
+import type { SaveInfo } from '../platform/save.js';
+
+// ---------------------------------------------------------------------------
+// Geometry constants (canvas-local pixels — 800 × 592)
+// ---------------------------------------------------------------------------
+
+export const CANVAS_W = 800;
+export const CANVAS_H = 592;
+
+export const DIALOG_BUTTON_W = 280;
+export const DIALOG_BUTTON_H = 36;
+export const DIALOG_BUTTON_GAP = 8;
+
+/** Pixels between the title row and the info line. */
+export const DIALOG_TITLE_TO_INFO_GAP = 32;
+/** Pixels between the info line and the first button. */
+export const DIALOG_INFO_TO_BUTTONS_GAP = 24;
+/** Title row Y center. */
+export const DIALOG_TITLE_Y = 120;
+/** Info line Y center. */
+export const DIALOG_INFO_Y = DIALOG_TITLE_Y + DIALOG_TITLE_TO_INFO_GAP;
+
+// ---------------------------------------------------------------------------
+// Item types
+// ---------------------------------------------------------------------------
+
+export type SaveLoadDialogItemId =
+  | 'continue'
+  | 'save-now'
+  | 'delete'
+  | 'new-game'
+  | 'back';
+
+export interface DialogItemRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface SaveLoadDialogItem {
+  id: SaveLoadDialogItemId;
+  label: string;
+  enabled: boolean;
+  /** True iff this row is currently in "click again to confirm" state.
+   *  Cosmetic — UIScene renders confirm rows in a warning color and uses
+   *  this to drive the second-click branch. */
+  confirming: boolean;
+  rect: DialogItemRect;
+}
+
+export interface SaveLoadDialogContext {
+  /** parseSaveFile-readable save bytes exist. Drives Continue enable + the
+   *  "save exists" branch in delete/new-game confirm. */
+  hasCompatibleSave: boolean;
+  /** Bytes exist under SAVE_KEY but parseSaveFile rejects them (issue #66
+   *  scenario). Surfaces "Incompatible save present" in the info line and
+   *  enables Delete so the player can clear them out. */
+  hasIncompatibleSave: boolean;
+  /** Per-row confirm flag — caller toggles on first click of a destructive
+   *  action, clears on second click or any other user action. */
+  confirming: { delete: boolean; newGame: boolean };
+}
+
+// ---------------------------------------------------------------------------
+// Layout
+// ---------------------------------------------------------------------------
+
+function buttonRects(buttonCount: number, firstY: number): DialogItemRect[] {
+  const x = (CANVAS_W - DIALOG_BUTTON_W) / 2;
+  const rects: DialogItemRect[] = [];
+  for (let i = 0; i < buttonCount; i++) {
+    rects.push({
+      x,
+      y: firstY + i * (DIALOG_BUTTON_H + DIALOG_BUTTON_GAP),
+      w: DIALOG_BUTTON_W,
+      h: DIALOG_BUTTON_H,
+    });
+  }
+  return rects;
+}
+
+/** First button Y center derived from info row + the documented gap. */
+export function firstButtonY(): number {
+  return DIALOG_INFO_Y + DIALOG_INFO_TO_BUTTONS_GAP;
+}
+
+/** Compose the dialog items. Order is fixed; enabled flags reflect ctx. */
+export function saveLoadDialogItems(ctx: SaveLoadDialogContext): SaveLoadDialogItem[] {
+  const saveExists = ctx.hasCompatibleSave;
+  const items: Array<{
+    id: SaveLoadDialogItemId;
+    label: string;
+    enabled: boolean;
+    confirming: boolean;
+  }> = [
+    {
+      id: 'continue',
+      label: 'Continue',
+      enabled: saveExists,
+      confirming: false,
+    },
+    {
+      id: 'save-now',
+      label: 'Save Now',
+      enabled: true,
+      confirming: false,
+    },
+    {
+      id: 'delete',
+      // Disabled when there is nothing to delete: no compatible save AND no
+      // incompatible bytes. With incompatible bytes only, the row enables so
+      // the player can clear them out and start fresh.
+      label: ctx.confirming.delete ? 'Click to confirm delete' : 'Delete Save',
+      enabled: saveExists || ctx.hasIncompatibleSave,
+      confirming: ctx.confirming.delete,
+    },
+    {
+      id: 'new-game',
+      // New Game without a save just restarts; confirm is only needed when
+      // a save exists (clicking would silently discard player progress).
+      label: saveExists && ctx.confirming.newGame
+        ? 'Click to confirm new game'
+        : 'New Game',
+      enabled: true,
+      confirming: ctx.confirming.newGame,
+    },
+    {
+      id: 'back',
+      label: '<  Back',
+      enabled: true,
+      confirming: false,
+    },
+  ];
+  const rects = buttonRects(items.length, firstButtonY());
+  return items.map((it, i) => ({ ...it, rect: rects[i]! }));
+}
+
+// ---------------------------------------------------------------------------
+// Info line composition
+// ---------------------------------------------------------------------------
+
+/** Compose the human-readable info line shown above the buttons. Pure text
+ *  function so the dialog's only concern is rendering it. */
+export function formatSaveInfoLine(
+  info: SaveInfo | null,
+  hasIncompatibleSave: boolean,
+): string {
+  if (info !== null) {
+    // Fresh save line: tick count + colony summary. Keep it terse — one line.
+    return `Tick ${info.tick}  ·  Workers ${info.playerWorkers}  ·  Food ${info.playerFoodStored}`;
+  }
+  if (hasIncompatibleSave) {
+    // Surfaces the issue #66 case where bytes exist but this build can't read
+    // them. The player can Delete to clear them or click New Game to start
+    // fresh; Continue stays disabled.
+    return 'Incompatible save in storage — start a new game or delete it';
+  }
+  return 'No save in storage';
+}
+
+/** Title text for the dialog. Centralized so UIScene and layout agree. */
+export function dialogTitle(): string {
+  return 'Save / Load';
+}
+
+// ---------------------------------------------------------------------------
+// Hit testing
+// ---------------------------------------------------------------------------
+
+function pointInRect(px: number, py: number, r: DialogItemRect): boolean {
+  return px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h;
+}
+
+/** Returns the topmost ENABLED item under the pointer, or null. Disabled
+ *  items don't fire callbacks, matching the pause-menu layout convention. */
+export function itemAt(
+  items: readonly SaveLoadDialogItem[],
+  px: number,
+  py: number,
+): SaveLoadDialogItem | null {
+  for (const it of items) {
+    if (!it.enabled) continue;
+    if (pointInRect(px, py, it.rect)) return it;
+  }
+  return null;
+}

--- a/src/render/save-load-dialog-layout.ts
+++ b/src/render/save-load-dialog-layout.ts
@@ -165,8 +165,11 @@ export function formatSaveInfoLine(
   hasIncompatibleSave: boolean,
 ): string {
   if (info !== null) {
-    // Fresh save line: tick count + colony summary. Keep it terse — one line.
-    return `Tick ${info.tick}  ·  Workers ${info.playerWorkers}  ·  Food ${info.playerFoodStored}`;
+    // Fresh save line: timestamp · tick · workers · food. Keep it terse — one
+    // line. The timestamp is rendered as the user's local "HH:MM" because the
+    // dialog is a "saved when?" UX, not a forensic log; "moments ago" feels
+    // wrong inside an explicit save/load surface and a full date sprawls.
+    return `Saved ${formatSaveTime(info.savedAtMs)}  ·  Tick ${info.tick}  ·  Workers ${info.playerWorkers}  ·  Food ${info.playerFoodStored}`;
   }
   if (hasIncompatibleSave) {
     // Surfaces the issue #66 case where bytes exist but this build can't read
@@ -175,6 +178,22 @@ export function formatSaveInfoLine(
     return 'Incompatible save in storage — start a new game or delete it';
   }
   return 'No save in storage';
+}
+
+/** Format an epoch-ms timestamp as "HH:MM" in the user's local time. Returns
+ *  "—" for unknown values: 0 (pre-issue-#115 envelope or a tampered field
+ *  that getSaveInfo coerced to 0), or any value that constructs an Invalid
+ *  Date (e.g. a tampered envelope with `savedAtMs: 1e100` — getSaveInfo's
+ *  isFinite guard accepts it but JS clamps `new Date(huge)` to Invalid).
+ *  Pure function. */
+export function formatSaveTime(epochMs: number): string {
+  if (epochMs <= 0) return '—';
+  const d = new Date(epochMs);
+  const hours = d.getHours();
+  if (Number.isNaN(hours)) return '—';
+  const hh = String(hours).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
 }
 
 /** Title text for the dialog. Centralized so UIScene and layout agree. */

--- a/src/render/terrain-atlas.ts
+++ b/src/render/terrain-atlas.ts
@@ -85,6 +85,9 @@ export const COLOR_BARREN_EARTH_DARK  = 0x6f5a3c;
 export const COLOR_BARREN_EARTH_LIGHT = 0xa28a63;
 /** Yet darker patch for occasional damper soil regions. */
 export const COLOR_BARREN_EARTH_DAMP  = 0x5a4a30;
+/** Piled-spoil mound around an entrance hole — between DAMP and BARREN_EARTH,
+ *  reading as "fresh excavation dirt" rather than "wet soil patch." */
+export const COLOR_BARREN_EARTH_MOUND = 0x6d563a;
 
 /** Underground solid rock palette. */
 export const COLOR_ROCK_BASE     = 0x2d1f14;

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -159,6 +159,11 @@ import {
   type SaveLoadDialogItem,
   type SaveLoadDialogItemId,
 } from './save-load-dialog-layout.js';
+
+/** Issue #115 — duration of the post-Save-Now "Saved" / "Save failed" flash
+ *  rendered above the dialog's info line. 1500 ms is long enough to be
+ *  noticed without slowing down a player who wants to chain Save → Continue. */
+const SAVE_FLASH_MS = 1500;
 import { loadSettings, saveSettings } from '../platform/settings.js';
 import {
   hasSave,
@@ -229,6 +234,11 @@ export class UIScene extends Phaser.Scene {
   // bootFresh/bootFromSave runs; direct capture in init() was a stale-reference
   // bug that froze the HUD on the pre-boot (undefined) world.
   private getWorld!: () => WorldState | undefined;
+  // Issue #116 / dual-handler-fix: GameScene supplies an Esc callback that
+  // fires only when no UIScene overlay is currently open. Optional so older
+  // call sites (none today, but kept for safety) can still launch UIScene
+  // without it; without the callback Esc on a clean canvas is a no-op.
+  private onEscape: (() => void) | null = null;
   private gfx!: Phaser.GameObjects.Graphics;
   private antsText!: Phaser.GameObjects.Text;
   private foodText!: Phaser.GameObjects.Text;
@@ -276,12 +286,25 @@ export class UIScene extends Phaser.Scene {
     delete: false,
     newGame: false,
   };
+  // Issue #115 — Save Now feedback. After a manualSave call, the dialog
+  // flashes a brief "Saved" / "Save failed" line above the regular info
+  // text for SAVE_FLASH_MS so the player sees an explicit acknowledgement
+  // instead of having to spot the (already-correct) tick increment.
+  // Cleared by a Phaser delayedCall so the dialog quietly returns to the
+  // standard info-line state.
+  private saveLoadDialogFlash: 'none' | 'saved' | 'failed' = 'none';
+  private saveLoadDialogFlashTimer: Phaser.Time.TimerEvent | null = null;
 
   constructor() { super({ key: 'UIScene' }); }
 
-  init(data: { viewState: ViewState; getWorld: () => WorldState | undefined }) {
+  init(data: {
+    viewState: ViewState;
+    getWorld: () => WorldState | undefined;
+    onEscape?: () => void;
+  }) {
     this.viewState = data.viewState;
     this.getWorld = data.getWorld;
+    this.onEscape = data.onEscape ?? null;
   }
 
   create() {
@@ -411,20 +434,16 @@ export class UIScene extends Phaser.Scene {
     this.antActivityText.setVisible(false);
     this.antActivityText.setDepth(11);
 
-    // Esc hides the panel. UIScene owns this key so GameScene's world
-    // keyboard handlers aren't forced to know about UI state.
+    // UIScene is the single owner of Esc. Precedence (close topmost UI first):
+    //   1. Save/Load dialog visible → close + onBack (returns to pause menu)
+    //   2. Pause menu visible       → close + onResume (resumes game loop)
+    //   3. Ant-activity panel open  → hide it
+    //   4. Nothing open             → call onEscape (GameScene opens menu)
     //
-    // Issue #116 — when the pause menu is visible, Esc closes the menu
-    // (via its captured onResume callback) instead of falling through to
-    // the ant-activity hide. Inside the Settings sub-screen Esc still
-    // closes the whole menu — Back is the explicit "go up one level"
-    // affordance. The pause menu is the only overlay on UIScene that has
-    // a self-resume action; SavePrompt and GameOver are click-driven.
-    //
-    // Issue #115 precedence: Save/Load dialog > pause menu > ant-activity.
-    // Esc on the dialog is "Back" (return to pause menu); Esc on the pause
-    // menu is "Resume game". This keeps Esc as a consistent "close the
-    // topmost UI" gesture across both overlays.
+    // Routing all Esc through one scene avoids the dual-handler race that
+    // existed when GameScene also bound keydown-ESC: GameScene opened the
+    // menu, then UIScene's escKey handler immediately closed it on the same
+    // press, leaving __phase9_ui.activeOverlay stuck at "none".
     const escKey = this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
     if (escKey) {
       escKey.on('down', () => {
@@ -440,7 +459,12 @@ export class UIScene extends Phaser.Scene {
           cb?.onResume();
           return;
         }
-        hideAntActivityPanel();
+        if (antActivityPanelState.visible) {
+          hideAntActivityPanel();
+          return;
+        }
+        // No UIScene overlay was up — let GameScene handle it (open menu).
+        this.onEscape?.();
       });
     }
 
@@ -874,13 +898,13 @@ export class UIScene extends Phaser.Scene {
     btnLabel.setDepth(22);
 
     this.gameOverGroup = [bg, title, subtitle, btnBg, btnLabel];
-    setActiveOverlay('game-over');
+    this.recomputeActiveOverlay();
   }
 
   public hideGameOverOverlay(): void {
     for (const obj of this.gameOverGroup) obj.destroy();
     this.gameOverGroup = [];
-    setActiveOverlay('none');
+    this.recomputeActiveOverlay();
   }
 
   // ---------------------------------------------------------------------------
@@ -959,13 +983,13 @@ export class UIScene extends Phaser.Scene {
     ngLabel.setDepth(22);
 
     this.savePromptGroup = [bg, title, subtitle, contBg, contLabel, ngBg, ngLabel];
-    setActiveOverlay('save-prompt');
+    this.recomputeActiveOverlay();
   }
 
   public hideSavePromptOverlay(): void {
     for (const obj of this.savePromptGroup) obj.destroy();
     this.savePromptGroup = [];
-    setActiveOverlay('none');
+    this.recomputeActiveOverlay();
   }
 
   // ---------------------------------------------------------------------------
@@ -992,16 +1016,24 @@ export class UIScene extends Phaser.Scene {
     this.pauseMenuSaveLoadEnabled = callbacks.onOpenSaveLoad !== undefined;
     this.pauseMenuPage = 'main';
     this.renderPauseMenuPage();
-    setActiveOverlay('pause-menu');
+    this.recomputeActiveOverlay();
   }
 
+  /**
+   * Round-2 review (orphan-overlay): closing the pause menu while the
+   * Save/Load dialog is on top would have left the dialog stranded — its
+   * onBack callback would re-show a menu the caller just dismissed. Tear
+   * down the dialog first so layered state stays coherent regardless of
+   * which scene calls hidePauseMenuOverlay.
+   */
   public hidePauseMenuOverlay(): void {
+    if (this.saveLoadDialogGroup.length > 0) this.hideSaveLoadDialogOverlay();
     for (const obj of this.pauseMenuGroup) obj.destroy();
     this.pauseMenuGroup = [];
     this.pauseMenuVisibleItems = [];
     this.pauseMenuCallbacks = null;
     this.pauseMenuPage = 'main';
-    setActiveOverlay('none');
+    this.recomputeActiveOverlay();
   }
 
   public isPauseMenuVisible(): boolean {
@@ -1050,7 +1082,16 @@ export class UIScene extends Phaser.Scene {
     this.pauseMenuGroup.push(title);
 
     // Buttons — one rectangle + one text per item. Disabled rows render
-    // dimmer and don't fire callbacks (see dispatchPauseMenuItem and itemAt).
+    // dimmer and skip dispatch (itemAt returns null for them).
+    //
+    // Dispatch flows ONLY through the scene-level pointerdown handler; we
+    // intentionally do NOT bind per-button `pointerdown` callbacks. Phaser
+    // fires object-level handlers BEFORE scene-level, so binding both
+    // dispatched the same item twice on a single click — flipping the
+    // pheromone toggle off-then-on (apparent no-op) and bypassing the
+    // confirm gate on Save/Load destructive rows. setInteractive() stays
+    // so the button rectangle absorbs the pointer hit and Phaser draws
+    // the input cursor; the scene handler does the work.
     for (const item of items) {
       const r = item.rect;
       const fillColor = item.enabled ? 0x333333 : 0x202020;
@@ -1065,12 +1106,6 @@ export class UIScene extends Phaser.Scene {
       );
       btn.setInteractive();
       btn.setDepth(21);
-      // The dispatch is also reachable via the scene-level pointerdown
-      // handler's hit test, but binding here gives us a precise per-button
-      // target so disabled rows don't accidentally consume hits.
-      if (item.enabled) {
-        btn.on('pointerdown', () => this.dispatchPauseMenuItem(item.id));
-      }
       this.pauseMenuGroup.push(btn);
 
       const label = this.add.text(
@@ -1141,7 +1176,7 @@ export class UIScene extends Phaser.Scene {
     this.saveLoadDialogCallbacks = callbacks;
     this.saveLoadDialogConfirming = { delete: false, newGame: false };
     this.renderSaveLoadDialog();
-    setActiveOverlay('save-load');
+    this.recomputeActiveOverlay();
   }
 
   public hideSaveLoadDialogOverlay(): void {
@@ -1150,7 +1185,14 @@ export class UIScene extends Phaser.Scene {
     this.saveLoadDialogVisibleItems = [];
     this.saveLoadDialogCallbacks = null;
     this.saveLoadDialogConfirming = { delete: false, newGame: false };
-    setActiveOverlay('none');
+    // Cancel any in-flight Save Now flash timer so an old "Saved" message
+    // can't fire renderSaveLoadDialog after the dialog is gone.
+    if (this.saveLoadDialogFlashTimer !== null) {
+      this.saveLoadDialogFlashTimer.remove();
+      this.saveLoadDialogFlashTimer = null;
+    }
+    this.saveLoadDialogFlash = 'none';
+    this.recomputeActiveOverlay();
   }
 
   public isSaveLoadDialogVisible(): boolean {
@@ -1210,8 +1252,32 @@ export class UIScene extends Phaser.Scene {
     infoLine.setDepth(31);
     this.saveLoadDialogGroup.push(infoLine);
 
+    // Save Now flash — sits between info line and buttons. Empty when no
+    // save was just attempted; replaced by "✓ Saved" or "✗ Save failed"
+    // for SAVE_FLASH_MS after a manual save (cleared by a delayedCall).
+    if (this.saveLoadDialogFlash !== 'none') {
+      const flashColor = this.saveLoadDialogFlash === 'saved' ? '#88ee88' : '#ff7766';
+      const flashText = this.saveLoadDialogFlash === 'saved' ? 'Saved' : 'Save failed';
+      const flash = this.add.text(
+        PAUSE_MENU_CANVAS_W / 2,
+        DIALOG_INFO_Y + 18,
+        flashText,
+        { fontSize: '12px', fontFamily: 'monospace', color: flashColor },
+      );
+      flash.setOrigin(0.5);
+      flash.setDepth(31);
+      this.saveLoadDialogGroup.push(flash);
+    }
+
     // Buttons. Confirming rows render in a warning color so the second-click
     // target is unambiguous.
+    //
+    // Same single-dispatcher rule as the pause menu: NO per-button pointerdown
+    // handlers. Without that constraint Phaser fires both object-level and
+    // scene-level pointerdown on a single click, and dispatchSaveLoadDialogItem
+    // runs twice — turning the two-click Delete/New Game confirm into a
+    // one-click destructive action. The scene-level pointerdown handler above
+    // is the sole entry point.
     for (const item of items) {
       const r = item.rect;
       const fillColor = !item.enabled ? 0x202020
@@ -1230,9 +1296,6 @@ export class UIScene extends Phaser.Scene {
       );
       btn.setInteractive();
       btn.setDepth(31);
-      if (item.enabled) {
-        btn.on('pointerdown', () => this.dispatchSaveLoadDialogItem(item.id));
-      }
       this.saveLoadDialogGroup.push(btn);
 
       const label = this.add.text(
@@ -1248,7 +1311,14 @@ export class UIScene extends Phaser.Scene {
   }
 
   /** Map dialog item id to its action. Destructive actions (delete, new-game
-   *  with an existing save) require a second click on the same row to commit. */
+   *  with an existing save) require a second click on the same row to commit.
+   *
+   *  cb is captured at the top because Continue / New Game's success paths
+   *  hide the dialog (which nulls saveLoadDialogCallbacks) BEFORE invoking
+   *  the callback. Reading from `this.saveLoadDialogCallbacks` after the hide
+   *  would silently land on null. The local `cb` keeps the original
+   *  reference alive — the round-2 review flagged this as fragile if a
+   *  future case is added without also capturing locally. */
   private dispatchSaveLoadDialogItem(id: SaveLoadDialogItemId): void {
     const cb = this.saveLoadDialogCallbacks;
     // Any non-confirm-target click clears the OTHER row's pending confirm so
@@ -1267,13 +1337,30 @@ export class UIScene extends Phaser.Scene {
         return;
       case 'save-now': {
         // GameScene owns (seed, inputLog, world) — the onSaveNow callback
-        // closes over those references and calls manualSave. Re-render so
-        // the info line picks up the new saved tick. We intentionally do
-        // not surface the boolean here: a storage failure leaves the prior
-        // save intact (info line stays valid) and a transient toast UI
-        // would add complexity without changing the player's recovery
-        // path (try again or check browser storage).
-        cb?.onSaveNow();
+        // closes over those references and calls manualSave. We surface the
+        // boolean as a brief flash above the info line so the player gets
+        // an explicit acknowledgement (issue #115 asked for a confirmation
+        // toast — the flash plays the same role without a separate Phaser
+        // tween / DOM-toast layer). Failure most often means quota /
+        // private-mode; retry once or close other tabs.
+        const ok = cb?.onSaveNow() ?? false;
+        this.saveLoadDialogFlash = ok ? 'saved' : 'failed';
+        // Cancel any in-flight prior flash timer so a second Save Now in
+        // quick succession doesn't clear the new flash early.
+        if (this.saveLoadDialogFlashTimer !== null) {
+          this.saveLoadDialogFlashTimer.remove();
+        }
+        this.saveLoadDialogFlashTimer = this.time.delayedCall(
+          SAVE_FLASH_MS,
+          () => {
+            this.saveLoadDialogFlashTimer = null;
+            this.saveLoadDialogFlash = 'none';
+            // Guard: dialog may have closed between Save Now and the timer
+            // firing (e.g. player clicked Continue or Back). Re-render only
+            // if the dialog is still on screen.
+            if (this.isSaveLoadDialogVisible()) this.renderSaveLoadDialog();
+          },
+        );
         this.renderSaveLoadDialog();
         return;
       }
@@ -1297,6 +1384,11 @@ export class UIScene extends Phaser.Scene {
           this.renderSaveLoadDialog();
           return;
         }
+        // Reset before commit (matches the delete case's pattern). The
+        // hideSaveLoadDialogOverlay below also clears the flags, but doing
+        // it explicitly here documents the intent and protects against a
+        // future change that exits this branch without hiding.
+        this.saveLoadDialogConfirming.newGame = false;
         this.hideSaveLoadDialogOverlay();
         this.hidePauseMenuOverlay();
         cb?.onNewGame();
@@ -1315,5 +1407,19 @@ export class UIScene extends Phaser.Scene {
     r: { x: number; y: number; w: number; h: number },
   ): boolean {
     return px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h;
+  }
+
+  /** Round-2 review: every `hide…Overlay()` previously called
+   *  `setActiveOverlay('none')` unconditionally. With layered overlays (e.g.
+   *  Save/Load dialog over pause menu, closed via Esc → re-shows menu) that
+   *  briefly published `activeOverlay = 'none'` between the hide and the
+   *  re-show — exactly the kind of observability lie round 1 was supposed
+   *  to fix. This recompute reflects whatever overlay is still on screen. */
+  private recomputeActiveOverlay(): void {
+    if (this.saveLoadDialogGroup.length > 0) setActiveOverlay('save-load');
+    else if (this.pauseMenuGroup.length > 0) setActiveOverlay('pause-menu');
+    else if (this.gameOverGroup.length > 0) setActiveOverlay('game-over');
+    else if (this.savePromptGroup.length > 0) setActiveOverlay('save-prompt');
+    else setActiveOverlay('none');
   }
 }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -143,11 +143,13 @@ import {
   pageTitle,
   itemAt as pauseMenuItemAt,
   titleCenterY as pauseMenuTitleCenterY,
+  nextSpeedMultiplier,
   CANVAS_W as PAUSE_MENU_CANVAS_W,
   CANVAS_H as PAUSE_MENU_CANVAS_H,
   type PauseMenuPage,
   type PauseMenuItem,
   type PauseMenuItemId,
+  type SpeedMultiplier,
 } from './pause-menu-layout.js';
 import {
   saveLoadDialogItems,
@@ -188,6 +190,14 @@ export interface PauseMenuCallbacks {
   /** Issue #115 — invoked when the Save/Load row is clicked. Until that issue
    *  lands, the row is rendered disabled and this is never called. */
   onOpenSaveLoad?(): void;
+  /** Read the live speedMultiplier so the Settings page can render the
+   *  current value in the "Speed: N×" cycle row. Session-only (no settings
+   *  persistence — speed resets to 1× on restart per the Phase 4 contract). */
+  getSpeedMultiplier?(): SpeedMultiplier;
+  /** Apply a new speed value when the Settings page's speed-cycle row is
+   *  clicked. The 1/2/4 keyboard shortcuts on GameScene call the same
+   *  setter under the hood; both paths converge on speedMultiplier writes. */
+  onCycleSpeed?(next: SpeedMultiplier): void;
 }
 
 /** Issue #115 — callbacks the Save/Load dialog invokes. The dialog reads
@@ -1051,6 +1061,10 @@ export class UIScene extends Phaser.Scene {
     const ctx = {
       saveLoadEnabled: this.pauseMenuSaveLoadEnabled,
       settings: loadSettings(),
+      // Settings page's "Speed: N×" row reads this each render so it
+      // reflects writes from EITHER the row click OR the live 1/2/4
+      // keyboard shortcuts on GameScene.
+      currentSpeedMultiplier: this.pauseMenuCallbacks?.getSpeedMultiplier?.() ?? 1,
     };
     const items = pauseMenuItems(page, ctx);
     this.pauseMenuVisibleItems = items;
@@ -1154,6 +1168,17 @@ export class UIScene extends Phaser.Scene {
         // Mirror to ViewState so the next render frame sees the new value
         // even if it doesn't re-read settings.
         this.viewState.showPheromoneOverlay = next.pheromoneOverlay;
+        this.renderPauseMenuPage();
+        return;
+      }
+      case 'speed-cycle': {
+        // Cycle the live speedMultiplier 1→2→4→1 via GameScene's setter.
+        // Session-only: speed is not persisted to settings (Phase 4 fresh-
+        // boot contract resets to 1× on restart). The 1/2/4 keyboard
+        // shortcuts on GameScene write to the same field, so both paths
+        // converge on a single source of truth.
+        const cur = cb?.getSpeedMultiplier?.() ?? 1;
+        cb?.onCycleSpeed?.(nextSpeedMultiplier(cur));
         this.renderPauseMenuPage();
         return;
       }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -35,7 +35,7 @@ export { formatOutcomeTitle, formatKillStatsSubtitle };
 // Plan 07 Playwright observability contract
 // ---------------------------------------------------------------------------
 
-export type ActiveOverlay = 'none' | 'save-prompt' | 'game-over';
+export type ActiveOverlay = 'none' | 'save-prompt' | 'game-over' | 'pause-menu';
 
 // Phase 09.1 Chunk 2 — enemy underground observability. Exposed via the same
 // __phase9_ui global so Playwright can read which colony the underground view
@@ -138,8 +138,36 @@ import {
   requestHideAntActivityPanel,
   applyPendingAntActivityPanelHide,
 } from './ant-activity-panel-state.js';
+import {
+  pauseMenuItems,
+  pageTitle,
+  itemAt as pauseMenuItemAt,
+  titleCenterY as pauseMenuTitleCenterY,
+  CANVAS_W as PAUSE_MENU_CANVAS_W,
+  CANVAS_H as PAUSE_MENU_CANVAS_H,
+  type PauseMenuPage,
+  type PauseMenuItem,
+  type PauseMenuItemId,
+} from './pause-menu-layout.js';
+import { loadSettings, saveSettings, type Settings } from '../platform/settings.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
 import type { SetBehaviorRatioCommand, PlaceChamberCommand } from '../sim/commands.js';
+
+// ---------------------------------------------------------------------------
+// Pause menu callbacks (issue #116)
+// ---------------------------------------------------------------------------
+
+/** Callbacks the pause menu invokes; supplied by GameScene when it opens the
+ *  menu so the menu module stays free of GameScene type knowledge. */
+export interface PauseMenuCallbacks {
+  /** Called when the player chooses Resume (or closes the menu via Esc). */
+  onResume(): void;
+  /** Called when the player picks "Download debug log". */
+  onDownloadDebug(): void;
+  /** Issue #115 — invoked when the Save/Load row is clicked. Until that issue
+   *  lands, the row is rendered disabled and this is never called. */
+  onOpenSaveLoad?(): void;
+}
 
 // HUD-02 stats row lives entirely inside the 200x24 HUD.STATS rect so
 // isPointerOverHUD() correctly masks world-input click-through. Per PRD §6c
@@ -185,6 +213,18 @@ export class UIScene extends Phaser.Scene {
   // Phase 9 Plan 06 — overlay groups (null = overlay not currently shown)
   private gameOverGroup: Phaser.GameObjects.GameObject[] = [];
   private savePromptGroup: Phaser.GameObjects.GameObject[] = [];
+  // Issue #116 — pause menu overlay state. Empty group means "not visible";
+  // page tracks which sub-screen is currently rendered. callbacks/saveLoadEnabled
+  // are captured at show time so we can re-render on page navigation without
+  // the caller re-supplying them.
+  private pauseMenuGroup: Phaser.GameObjects.GameObject[] = [];
+  private pauseMenuPage: PauseMenuPage = 'main';
+  private pauseMenuCallbacks: PauseMenuCallbacks | null = null;
+  private pauseMenuSaveLoadEnabled: boolean = false;
+  // Items snapshot used for hit-testing the click that fires after the next
+  // pointerdown — kept aligned with what was last drawn so a re-render between
+  // mouse events doesn't leave the hit-test against stale rects.
+  private pauseMenuVisibleItems: readonly PauseMenuItem[] = [];
 
   constructor() { super({ key: 'UIScene' }); }
 
@@ -322,15 +362,42 @@ export class UIScene extends Phaser.Scene {
 
     // Esc hides the panel. UIScene owns this key so GameScene's world
     // keyboard handlers aren't forced to know about UI state.
+    //
+    // Issue #116 — when the pause menu is visible, Esc closes the menu
+    // (via its captured onResume callback) instead of falling through to
+    // the ant-activity hide. Inside the Settings sub-screen Esc still
+    // closes the whole menu — Back is the explicit "go up one level"
+    // affordance. The pause menu is the only overlay on UIScene that has
+    // a self-resume action; SavePrompt and GameOver are click-driven.
     const escKey = this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
     if (escKey) {
       escKey.on('down', () => {
+        if (this.isPauseMenuVisible()) {
+          const cb = this.pauseMenuCallbacks;
+          this.hidePauseMenuOverlay();
+          cb?.onResume();
+          return;
+        }
         hideAntActivityPanel();
       });
     }
 
     // Pointer events for HUD interactions.
     this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      // Issue #116 — pause menu absorbs every click. Buttons fire their own
+      // callbacks via Phaser interactive handlers; this guard prevents a click
+      // outside any button from falling through to HUD widgets / world input
+      // and is also a safety net against double-firing if a button click and
+      // a HUD-zone click happen to coincide.
+      if (this.isPauseMenuVisible()) {
+        const items = this.pauseMenuVisibleItems;
+        const hit = pauseMenuItemAt(items, pointer.x, pointer.y);
+        if (hit !== null) {
+          this.dispatchPauseMenuItem(hit.id);
+        }
+        return;
+      }
+
       // Context menu takes precedence when visible. A click inside selects an
       // item; a click anywhere else dismisses the menu AND falls through so
       // the underlying HUD control still receives the click — prevents the
@@ -452,6 +519,7 @@ export class UIScene extends Phaser.Scene {
     this.events.on('shutdown', () => {
       this.hideGameOverOverlay();
       this.hideSavePromptOverlay();
+      this.hidePauseMenuOverlay();
       hideAntActivityPanel();
       setActiveOverlay('none');
     });
@@ -817,6 +885,163 @@ export class UIScene extends Phaser.Scene {
     for (const obj of this.savePromptGroup) obj.destroy();
     this.savePromptGroup = [];
     setActiveOverlay('none');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Issue #116 — Pause menu overlay
+  //
+  // Same Phaser-overlay-on-UIScene pattern as SavePrompt and GameOver: a
+  // semi-transparent input-blocking background, a centered button stack drawn
+  // from pause-menu-layout, click handlers via Phaser interactive objects, and
+  // setActiveOverlay('pause-menu') for Playwright observability.
+  //
+  // Two pages:
+  //   - main: Resume / Save+Load / Settings → / Download debug log
+  //   - settings: pheromone-toggle (issue #114) / Back
+  //
+  // Page navigation goes through `renderPauseMenuPage` which destroys the
+  // current group and rebuilds against the new page state. saveLoadEnabled
+  // reflects whether issue #115's dialog is wired in; until then the row
+  // renders disabled and is a no-op on click.
+  // ---------------------------------------------------------------------------
+
+  public showPauseMenuOverlay(callbacks: PauseMenuCallbacks): void {
+    this.hidePauseMenuOverlay(); // idempotent — clear any prior instance first
+    this.pauseMenuCallbacks = callbacks;
+    this.pauseMenuSaveLoadEnabled = callbacks.onOpenSaveLoad !== undefined;
+    this.pauseMenuPage = 'main';
+    this.renderPauseMenuPage();
+    setActiveOverlay('pause-menu');
+  }
+
+  public hidePauseMenuOverlay(): void {
+    for (const obj of this.pauseMenuGroup) obj.destroy();
+    this.pauseMenuGroup = [];
+    this.pauseMenuVisibleItems = [];
+    this.pauseMenuCallbacks = null;
+    this.pauseMenuPage = 'main';
+    setActiveOverlay('none');
+  }
+
+  public isPauseMenuVisible(): boolean {
+    return this.pauseMenuGroup.length > 0;
+  }
+
+  /** Render (or re-render) the current pause menu page in place. */
+  private renderPauseMenuPage(): void {
+    // Tear down any previously-drawn buttons/title before rebuilding so a
+    // page navigation doesn't leave the prior page's text on top of the new one.
+    for (const obj of this.pauseMenuGroup) obj.destroy();
+    this.pauseMenuGroup = [];
+
+    const page = this.pauseMenuPage;
+    const ctx = {
+      saveLoadEnabled: this.pauseMenuSaveLoadEnabled,
+      settings: loadSettings(),
+    };
+    const items = pauseMenuItems(page, ctx);
+    this.pauseMenuVisibleItems = items;
+
+    // Background scrim — input-blocking absorbs background clicks. Click-on-
+    // background does NOT dismiss the menu (see pointerdown handler above);
+    // dismissal is via Resume button or Esc key only.
+    const bg = this.add.rectangle(
+      PAUSE_MENU_CANVAS_W / 2,
+      PAUSE_MENU_CANVAS_H / 2,
+      PAUSE_MENU_CANVAS_W,
+      PAUSE_MENU_CANVAS_H,
+      0x000000,
+      0.7,
+    );
+    bg.setInteractive();
+    bg.setDepth(20);
+    this.pauseMenuGroup.push(bg);
+
+    // Title — "Paused" or "Settings" depending on page.
+    const title = this.add.text(
+      PAUSE_MENU_CANVAS_W / 2,
+      pauseMenuTitleCenterY(items.length),
+      pageTitle(page),
+      { fontSize: '32px', fontFamily: 'monospace', color: '#ffffff' },
+    );
+    title.setOrigin(0.5);
+    title.setDepth(21);
+    this.pauseMenuGroup.push(title);
+
+    // Buttons — one rectangle + one text per item. Disabled rows render
+    // dimmer and don't fire callbacks (see dispatchPauseMenuItem and itemAt).
+    for (const item of items) {
+      const r = item.rect;
+      const fillColor = item.enabled ? 0x333333 : 0x202020;
+      const labelColor = item.enabled ? '#ffffff' : '#777777';
+      const btn = this.add.rectangle(
+        r.x + r.w / 2,
+        r.y + r.h / 2,
+        r.w,
+        r.h,
+        fillColor,
+        1,
+      );
+      btn.setInteractive();
+      btn.setDepth(21);
+      // The dispatch is also reachable via the scene-level pointerdown
+      // handler's hit test, but binding here gives us a precise per-button
+      // target so disabled rows don't accidentally consume hits.
+      if (item.enabled) {
+        btn.on('pointerdown', () => this.dispatchPauseMenuItem(item.id));
+      }
+      this.pauseMenuGroup.push(btn);
+
+      const label = this.add.text(
+        r.x + r.w / 2,
+        r.y + r.h / 2,
+        item.label,
+        { fontSize: '16px', fontFamily: 'monospace', color: labelColor },
+      );
+      label.setOrigin(0.5);
+      label.setDepth(22);
+      this.pauseMenuGroup.push(label);
+    }
+  }
+
+  /** Map menu item id to its action. Lives here (not in the layout module) so
+   *  the layout stays Phaser-free — only UIScene knows about callbacks. */
+  private dispatchPauseMenuItem(id: PauseMenuItemId): void {
+    const cb = this.pauseMenuCallbacks;
+    switch (id) {
+      case 'resume':
+        this.hidePauseMenuOverlay();
+        cb?.onResume();
+        return;
+      case 'save-load':
+        cb?.onOpenSaveLoad?.();
+        return;
+      case 'settings':
+        this.pauseMenuPage = 'settings';
+        this.renderPauseMenuPage();
+        return;
+      case 'back':
+        this.pauseMenuPage = 'main';
+        this.renderPauseMenuPage();
+        return;
+      case 'debug-snapshot':
+        cb?.onDownloadDebug();
+        return;
+      case 'pheromone-toggle': {
+        // Issue #114 — flip the persisted setting and re-render so the
+        // ON/OFF label reflects the new state. ViewState (and the per-frame
+        // skip in GameScene.update) reads the same persisted value via
+        // loadSettings(), so the toggle takes effect on the next frame.
+        const next = loadSettings();
+        next.pheromoneOverlay = !next.pheromoneOverlay;
+        saveSettings(next);
+        // Mirror to ViewState so the next render frame sees the new value
+        // even if it doesn't re-read settings.
+        this.viewState.showPheromoneOverlay = next.pheromoneOverlay;
+        this.renderPauseMenuPage();
+        return;
+      }
+    }
   }
 
   private isInsideRect(

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -1207,7 +1207,13 @@ export class UIScene extends Phaser.Scene {
     this.saveLoadDialogGroup = [];
 
     const ctx = {
-      hasCompatibleSave: hasSave(),
+      // Round-3 (Codex P2): a future-sim save still passes parseSaveFile
+      // (so hasSave returns true) but bootFromSave would reject it via
+      // FutureSimVersionError. Treat the save as compatible only when
+      // BOTH envelope is parseable AND simVersion is loadable. The
+      // hasIncompatibleSave check covers both the parse-fails and the
+      // future-sim cases — see save.ts for the full classification.
+      hasCompatibleSave: hasSave() && !hasIncompatibleSave(),
       hasIncompatibleSave: hasIncompatibleSave(),
       confirming: { ...this.saveLoadDialogConfirming },
     };

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -1060,7 +1060,13 @@ export class UIScene extends Phaser.Scene {
     const page = this.pauseMenuPage;
     const ctx = {
       saveLoadEnabled: this.pauseMenuSaveLoadEnabled,
-      settings: loadSettings(),
+      // Round-6 P2 (Codex): the Settings page reads the pheromone overlay
+      // state from in-memory ViewState (the authoritative source) rather
+      // than from loadSettings(). In degraded-storage environments (private
+      // mode, quota), saveSettings drops the write and loadSettings keeps
+      // returning the default, which would freeze the label and make the
+      // toggle look broken. ViewState always reflects the current value.
+      currentPheromoneOverlay: this.viewState.showPheromoneOverlay,
       // Settings page's "Speed: N×" row reads this each render so it
       // reflects writes from EITHER the row click OR the live 1/2/4
       // keyboard shortcuts on GameScene.
@@ -1158,16 +1164,18 @@ export class UIScene extends Phaser.Scene {
         cb?.onDownloadDebug();
         return;
       case 'pheromone-toggle': {
-        // Issue #114 — flip the persisted setting and re-render so the
-        // ON/OFF label reflects the new state. ViewState (and the per-frame
-        // skip in GameScene.update) reads the same persisted value via
-        // loadSettings(), so the toggle takes effect on the next frame.
-        const next = loadSettings();
-        next.pheromoneOverlay = !next.pheromoneOverlay;
-        saveSettings(next);
-        // Mirror to ViewState so the next render frame sees the new value
-        // even if it doesn't re-read settings.
-        this.viewState.showPheromoneOverlay = next.pheromoneOverlay;
+        // Round-6 P2 (Codex): flip from in-memory state, NOT from
+        // loadSettings(). In degraded-storage environments saveSettings
+        // is a no-op; loadSettings then returns DEFAULT_SETTINGS on the
+        // next press and we'd recompute `!true = false` every time —
+        // the toggle gets stuck OFF. ViewState is the authoritative
+        // in-mem source; persist is best-effort and survives reload
+        // only when storage cooperates.
+        const next = !this.viewState.showPheromoneOverlay;
+        this.viewState.showPheromoneOverlay = next;
+        const persisted = loadSettings();
+        persisted.pheromoneOverlay = next;
+        saveSettings(persisted);
         this.renderPauseMenuPage();
         return;
       }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -35,7 +35,7 @@ export { formatOutcomeTitle, formatKillStatsSubtitle };
 // Plan 07 Playwright observability contract
 // ---------------------------------------------------------------------------
 
-export type ActiveOverlay = 'none' | 'save-prompt' | 'game-over' | 'pause-menu';
+export type ActiveOverlay = 'none' | 'save-prompt' | 'game-over' | 'pause-menu' | 'save-load';
 
 // Phase 09.1 Chunk 2 — enemy underground observability. Exposed via the same
 // __phase9_ui global so Playwright can read which colony the underground view
@@ -149,7 +149,23 @@ import {
   type PauseMenuItem,
   type PauseMenuItemId,
 } from './pause-menu-layout.js';
-import { loadSettings, saveSettings, type Settings } from '../platform/settings.js';
+import {
+  saveLoadDialogItems,
+  formatSaveInfoLine,
+  dialogTitle as saveLoadDialogTitle,
+  itemAt as saveLoadDialogItemAt,
+  DIALOG_TITLE_Y,
+  DIALOG_INFO_Y,
+  type SaveLoadDialogItem,
+  type SaveLoadDialogItemId,
+} from './save-load-dialog-layout.js';
+import { loadSettings, saveSettings } from '../platform/settings.js';
+import {
+  hasSave,
+  hasIncompatibleSave,
+  getSaveInfo,
+  deleteSave,
+} from '../platform/save.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
 import type { SetBehaviorRatioCommand, PlaceChamberCommand } from '../sim/commands.js';
 
@@ -167,6 +183,27 @@ export interface PauseMenuCallbacks {
   /** Issue #115 — invoked when the Save/Load row is clicked. Until that issue
    *  lands, the row is rendered disabled and this is never called. */
   onOpenSaveLoad?(): void;
+}
+
+/** Issue #115 — callbacks the Save/Load dialog invokes. The dialog reads
+ *  save state via the save.ts API directly (hasSave, getSaveInfo, deleteSave);
+ *  the callbacks cover GameScene-side actions that the dialog cannot perform
+ *  on its own — loading a save into the running scene, restarting the game,
+ *  and writing a manual save (which needs GameScene's live seed + inputLog +
+ *  world reference). */
+export interface SaveLoadDialogCallbacks {
+  /** Load the existing save into the running scene and resume play.
+   *  Closes the dialog AND the pause menu so the player lands back in game. */
+  onContinue(): void;
+  /** Discard any existing save and restart with a fresh scenario.
+   *  Closes the dialog AND the pause menu. */
+  onNewGame(): void;
+  /** Write the current world to localStorage via manualSave. Returns true on
+   *  success, false on storage failure. The dialog re-renders afterward so
+   *  the info line picks up the new saved tick. */
+  onSaveNow(): boolean;
+  /** Close the dialog and return to the pause menu (no game-state change). */
+  onBack(): void;
 }
 
 // HUD-02 stats row lives entirely inside the 200x24 HUD.STATS rect so
@@ -225,6 +262,20 @@ export class UIScene extends Phaser.Scene {
   // pointerdown — kept aligned with what was last drawn so a re-render between
   // mouse events doesn't leave the hit-test against stale rects.
   private pauseMenuVisibleItems: readonly PauseMenuItem[] = [];
+
+  // Issue #115 — Save/Load dialog overlay state. Mirrors the pause menu
+  // shape (group + visible-items snapshot + captured callbacks) and adds
+  // per-row confirm flags for destructive actions (Delete / New Game).
+  // The dialog REPLACES the pause menu visually while open; Back re-shows
+  // the pause menu. Game loop stays paused throughout — gameLoop.pause()
+  // was called when the menu opened and is reversed only by Resume / Continue.
+  private saveLoadDialogGroup: Phaser.GameObjects.GameObject[] = [];
+  private saveLoadDialogCallbacks: SaveLoadDialogCallbacks | null = null;
+  private saveLoadDialogVisibleItems: readonly SaveLoadDialogItem[] = [];
+  private saveLoadDialogConfirming: { delete: boolean; newGame: boolean } = {
+    delete: false,
+    newGame: false,
+  };
 
   constructor() { super({ key: 'UIScene' }); }
 
@@ -369,9 +420,20 @@ export class UIScene extends Phaser.Scene {
     // closes the whole menu — Back is the explicit "go up one level"
     // affordance. The pause menu is the only overlay on UIScene that has
     // a self-resume action; SavePrompt and GameOver are click-driven.
+    //
+    // Issue #115 precedence: Save/Load dialog > pause menu > ant-activity.
+    // Esc on the dialog is "Back" (return to pause menu); Esc on the pause
+    // menu is "Resume game". This keeps Esc as a consistent "close the
+    // topmost UI" gesture across both overlays.
     const escKey = this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
     if (escKey) {
       escKey.on('down', () => {
+        if (this.isSaveLoadDialogVisible()) {
+          const cb = this.saveLoadDialogCallbacks;
+          this.hideSaveLoadDialogOverlay();
+          cb?.onBack();
+          return;
+        }
         if (this.isPauseMenuVisible()) {
           const cb = this.pauseMenuCallbacks;
           this.hidePauseMenuOverlay();
@@ -384,6 +446,24 @@ export class UIScene extends Phaser.Scene {
 
     // Pointer events for HUD interactions.
     this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      // Issue #115 — Save/Load dialog absorbs every click while visible.
+      // Same guard rationale as the pause menu below; precedence here is
+      // strict (dialog > pause menu > HUD) so a click on a dialog button
+      // never falls through to a co-located pause-menu button rect.
+      if (this.isSaveLoadDialogVisible()) {
+        const items = this.saveLoadDialogVisibleItems;
+        const hit = saveLoadDialogItemAt(items, pointer.x, pointer.y);
+        if (hit !== null) {
+          this.dispatchSaveLoadDialogItem(hit.id);
+        } else {
+          // Click on the dialog background — clear any pending confirm flags
+          // so a stray miss doesn't leave a destructive button armed.
+          this.saveLoadDialogConfirming = { delete: false, newGame: false };
+          this.renderSaveLoadDialog();
+        }
+        return;
+      }
+
       // Issue #116 — pause menu absorbs every click. Buttons fire their own
       // callbacks via Phaser interactive handlers; this guard prevents a click
       // outside any button from falling through to HUD widgets / world input
@@ -519,6 +599,7 @@ export class UIScene extends Phaser.Scene {
     this.events.on('shutdown', () => {
       this.hideGameOverOverlay();
       this.hideSavePromptOverlay();
+      this.hideSaveLoadDialogOverlay();
       this.hidePauseMenuOverlay();
       hideAntActivityPanel();
       setActiveOverlay('none');
@@ -1041,6 +1122,190 @@ export class UIScene extends Phaser.Scene {
         this.renderPauseMenuPage();
         return;
       }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Issue #115 — Save/Load dialog overlay
+  //
+  // Reuses the Phaser-overlay pattern. Visually replaces the pause menu while
+  // open (GameScene hides the menu before showing the dialog and restores it
+  // on Back). The dialog reads save state via the save.ts API directly so
+  // GameScene doesn't have to plumb every read through callbacks; the
+  // callbacks only cover state changes that need scene-level coordination
+  // (loading a save into the running scene, restarting).
+  // ---------------------------------------------------------------------------
+
+  public showSaveLoadDialogOverlay(callbacks: SaveLoadDialogCallbacks): void {
+    this.hideSaveLoadDialogOverlay(); // idempotent — clear any prior instance
+    this.saveLoadDialogCallbacks = callbacks;
+    this.saveLoadDialogConfirming = { delete: false, newGame: false };
+    this.renderSaveLoadDialog();
+    setActiveOverlay('save-load');
+  }
+
+  public hideSaveLoadDialogOverlay(): void {
+    for (const obj of this.saveLoadDialogGroup) obj.destroy();
+    this.saveLoadDialogGroup = [];
+    this.saveLoadDialogVisibleItems = [];
+    this.saveLoadDialogCallbacks = null;
+    this.saveLoadDialogConfirming = { delete: false, newGame: false };
+    setActiveOverlay('none');
+  }
+
+  public isSaveLoadDialogVisible(): boolean {
+    return this.saveLoadDialogGroup.length > 0;
+  }
+
+  /** Render (or re-render) the dialog in place. Called on show, on confirm
+   *  flag flip, and after every state-changing action (Save Now, Delete) so
+   *  the info line and button enable states stay current. */
+  private renderSaveLoadDialog(): void {
+    for (const obj of this.saveLoadDialogGroup) obj.destroy();
+    this.saveLoadDialogGroup = [];
+
+    const ctx = {
+      hasCompatibleSave: hasSave(),
+      hasIncompatibleSave: hasIncompatibleSave(),
+      confirming: { ...this.saveLoadDialogConfirming },
+    };
+    const items = saveLoadDialogItems(ctx);
+    this.saveLoadDialogVisibleItems = items;
+    const info = getSaveInfo();
+
+    // Background scrim — slightly darker than the pause menu so the layered
+    // overlay reads as "deeper than the menu underneath."
+    const bg = this.add.rectangle(
+      PAUSE_MENU_CANVAS_W / 2,
+      PAUSE_MENU_CANVAS_H / 2,
+      PAUSE_MENU_CANVAS_W,
+      PAUSE_MENU_CANVAS_H,
+      0x000000,
+      0.85,
+    );
+    bg.setInteractive();
+    bg.setDepth(30);
+    this.saveLoadDialogGroup.push(bg);
+
+    // Title
+    const title = this.add.text(
+      PAUSE_MENU_CANVAS_W / 2,
+      DIALOG_TITLE_Y,
+      saveLoadDialogTitle(),
+      { fontSize: '28px', fontFamily: 'monospace', color: '#ffffff' },
+    );
+    title.setOrigin(0.5);
+    title.setDepth(31);
+    this.saveLoadDialogGroup.push(title);
+
+    // Info line — live state of saved-game (or "no save" / "incompatible save").
+    const infoLineColor = ctx.hasIncompatibleSave && info === null ? '#ffaa00' : '#aaaaaa';
+    const infoLine = this.add.text(
+      PAUSE_MENU_CANVAS_W / 2,
+      DIALOG_INFO_Y,
+      formatSaveInfoLine(info, ctx.hasIncompatibleSave),
+      { fontSize: '13px', fontFamily: 'monospace', color: infoLineColor },
+    );
+    infoLine.setOrigin(0.5);
+    infoLine.setDepth(31);
+    this.saveLoadDialogGroup.push(infoLine);
+
+    // Buttons. Confirming rows render in a warning color so the second-click
+    // target is unambiguous.
+    for (const item of items) {
+      const r = item.rect;
+      const fillColor = !item.enabled ? 0x202020
+        : item.confirming ? 0x884422
+        : 0x333333;
+      const labelColor = !item.enabled ? '#777777'
+        : item.confirming ? '#ffeecc'
+        : '#ffffff';
+      const btn = this.add.rectangle(
+        r.x + r.w / 2,
+        r.y + r.h / 2,
+        r.w,
+        r.h,
+        fillColor,
+        1,
+      );
+      btn.setInteractive();
+      btn.setDepth(31);
+      if (item.enabled) {
+        btn.on('pointerdown', () => this.dispatchSaveLoadDialogItem(item.id));
+      }
+      this.saveLoadDialogGroup.push(btn);
+
+      const label = this.add.text(
+        r.x + r.w / 2,
+        r.y + r.h / 2,
+        item.label,
+        { fontSize: '14px', fontFamily: 'monospace', color: labelColor },
+      );
+      label.setOrigin(0.5);
+      label.setDepth(32);
+      this.saveLoadDialogGroup.push(label);
+    }
+  }
+
+  /** Map dialog item id to its action. Destructive actions (delete, new-game
+   *  with an existing save) require a second click on the same row to commit. */
+  private dispatchSaveLoadDialogItem(id: SaveLoadDialogItemId): void {
+    const cb = this.saveLoadDialogCallbacks;
+    // Any non-confirm-target click clears the OTHER row's pending confirm so
+    // the player can't end up with both armed simultaneously.
+    if (id !== 'delete') this.saveLoadDialogConfirming.delete = false;
+    if (id !== 'new-game') this.saveLoadDialogConfirming.newGame = false;
+
+    switch (id) {
+      case 'continue':
+        // Continue path consumes both overlays — GameScene re-runs bootFromSave
+        // and resumes the loop. Hide the dialog locally first so the scene
+        // graph is clean before bootFromSave's resetSessionState fires.
+        this.hideSaveLoadDialogOverlay();
+        this.hidePauseMenuOverlay();
+        cb?.onContinue();
+        return;
+      case 'save-now': {
+        // GameScene owns (seed, inputLog, world) — the onSaveNow callback
+        // closes over those references and calls manualSave. Re-render so
+        // the info line picks up the new saved tick. We intentionally do
+        // not surface the boolean here: a storage failure leaves the prior
+        // save intact (info line stays valid) and a transient toast UI
+        // would add complexity without changing the player's recovery
+        // path (try again or check browser storage).
+        cb?.onSaveNow();
+        this.renderSaveLoadDialog();
+        return;
+      }
+      case 'delete': {
+        if (!this.saveLoadDialogConfirming.delete) {
+          this.saveLoadDialogConfirming.delete = true;
+          this.renderSaveLoadDialog();
+          return;
+        }
+        deleteSave();
+        this.saveLoadDialogConfirming.delete = false;
+        this.renderSaveLoadDialog();
+        return;
+      }
+      case 'new-game': {
+        // Confirm gate is only needed when a save exists — clicking New Game
+        // with no save is just "restart the running scenario" and has no
+        // hidden destructive consequence.
+        if (hasSave() && !this.saveLoadDialogConfirming.newGame) {
+          this.saveLoadDialogConfirming.newGame = true;
+          this.renderSaveLoadDialog();
+          return;
+        }
+        this.hideSaveLoadDialogOverlay();
+        this.hidePauseMenuOverlay();
+        cb?.onNewGame();
+        return;
+      }
+      case 'back':
+        this.hideSaveLoadDialogOverlay();
+        cb?.onBack();
+        return;
     }
   }
 

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -1206,15 +1206,25 @@ export class UIScene extends Phaser.Scene {
     for (const obj of this.saveLoadDialogGroup) obj.destroy();
     this.saveLoadDialogGroup = [];
 
+    // Cache hasIncompatibleSave once per render — round-5 made it run a
+    // full deserialize, so calling it twice for the ctx fields below
+    // would deserialize the entire WorldState twice per frame.
+    const incompatible = hasIncompatibleSave();
     const ctx = {
       // Round-3 (Codex P2): a future-sim save still passes parseSaveFile
       // (so hasSave returns true) but bootFromSave would reject it via
       // FutureSimVersionError. Treat the save as compatible only when
-      // BOTH envelope is parseable AND simVersion is loadable. The
-      // hasIncompatibleSave check covers both the parse-fails and the
-      // future-sim cases — see save.ts for the full classification.
-      hasCompatibleSave: hasSave() && !hasIncompatibleSave(),
-      hasIncompatibleSave: hasIncompatibleSave(),
+      // BOTH envelope is parseable AND deserialize succeeds. The
+      // hasIncompatibleSave check covers parse-fails, future-sim, and
+      // (round-4) any other shape error that would make Continue a
+      // silent fall-through to bootFresh. See save.ts for the full
+      // classification.
+      //
+      // Round-5 (cache): hasIncompatibleSave now performs a full
+      // deserialize on the saved envelope. Local-cache the result so
+      // a single renderSaveLoadDialog() doesn't pay the cost twice.
+      hasCompatibleSave: hasSave() && !incompatible,
+      hasIncompatibleSave: incompatible,
       confirming: { ...this.saveLoadDialogConfirming },
     };
     const items = saveLoadDialogItems(ctx);

--- a/tests/menu-and-dialog.spec.ts
+++ b/tests/menu-and-dialog.spec.ts
@@ -347,3 +347,107 @@ test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () =>
     expect(gone).toBeNull();
   });
 });
+
+test.describe('Round-5 (Codex P1) — Save Now respects autosaveSuspended', () => {
+  test('Save Now is a no-op when bootFromSave preserved a future-build save (does NOT overwrite the recoverable bytes)', async ({ page }) => {
+    // Bootstrap: populate localStorage with a future-sim save BEFORE the
+    // page loads. bootFromSave will deserialize, catch FutureSimVersionError,
+    // and set autosaveSuspended = true. We then verify Save Now refuses to
+    // write so the preserved future-build bytes survive for recovery.
+    await page.goto('/');
+    await page.locator('canvas').first().waitFor({ state: 'attached' });
+
+    // Build a serialized snapshot of a real scenario and bump simVersion
+    // past LATEST so bootFromSave throws FutureSimVersionError. We can't
+    // import save.ts inside page.evaluate (it's the test runner side), so
+    // pull the fresh envelope via a temporary boot first, then mutate.
+    await page.evaluate(() => localStorage.removeItem('subterrans:save:v3'));
+    await page.reload();
+    await page.locator('canvas').first().waitFor({ state: 'attached' });
+    await page.waitForTimeout(800); // let one autosave write a valid envelope
+    await page.evaluate(() => {
+      // After fresh-boot the autosave hasn't fired yet (30s interval). Hand-
+      // craft an envelope from a 1×1 minimal world that parseSaveFile accepts
+      // and bump simVersion. The Continue path is gated by hasIncompatibleSave
+      // → full deserialize anyway; the suspended state is the contract we
+      // care about.
+      const env = {
+        version: 3,
+        seed: 1,
+        inputLog: [],
+        snapshot: {
+          tick: 1,
+          rngState: 1,
+          nextEntityId: 0,
+          simVersion: 99999, // > LATEST → FutureSimVersionError on bootFromSave
+          commandQueue: [],
+          ants: { count: 0, posX: [], posY: [], colonyId: [], task: [], subTask: [],
+                  speed: [], foodCarrying: [], starvationTimer: [], age: [], alive: [],
+                  lifespan: [], zone: [], digTileX: [], digTileY: [], digTicksRemaining: [],
+                  targetPosX: [], targetPosY: [] },
+          colonies: {},
+          pheromoneGrids: {},
+          surface: { width: 1, height: 1, data: [0] },
+          undergroundGrids: {},
+          foodPiles: [],
+          pendingChambers: {},
+          recentlyDepletedFood: [],
+        },
+        savedAtMs: Date.now(),
+      };
+      localStorage.setItem('subterrans:save:v3', JSON.stringify(env));
+    });
+
+    // Reload — boot path now sees the future-sim save, SavePrompt shows.
+    await page.reload();
+    await page.locator('canvas').first().waitFor({ state: 'attached' });
+    await page.waitForFunction(() => {
+      const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
+      return ui !== undefined && ui.activeOverlay === 'save-prompt';
+    }, { timeout: 5_000 });
+
+    // Click Continue → bootFromSave → catches FutureSimVersionError →
+    // bootFresh + autosaveSuspended = true. The preserved bytes stay in
+    // localStorage; the running game is now a fresh scenario.
+    // SAVE_PROMPT_CONTINUE_RECT = { x: 300, y: 280, w: 120, h: 32 }
+    await page.locator('canvas').first().click({ position: { x: 360, y: 296 } });
+    await page.waitForFunction(() => {
+      const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
+      return ui !== undefined && ui.activeOverlay === 'none';
+    });
+
+    // Snapshot the preserved bytes BEFORE we touch the dialog.
+    const before = await page.evaluate(() => localStorage.getItem('subterrans:save:v3'));
+    expect(before).not.toBeNull();
+
+    // Open pause menu → Save/Load.
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    const saveLoadRect = await page.evaluate(() => {
+      const CANVAS_W = 800, CANVAS_H = 592;
+      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const n = 4;
+      const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
+      const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
+      const x = (CANVAS_W - BTN_W) / 2;
+      const slY = top + 1 * (BTN_H + GAP);
+      return { x: x + BTN_W / 2, y: slY + BTN_H / 2 };
+    });
+    await page.locator('canvas').first().click({ position: saveLoadRect });
+    await page.waitForTimeout(150);
+    expect(await page.evaluate(() => (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui?.activeOverlay)).toBe('save-load');
+
+    // Click Save Now (button index 1 in the dialog, BTN_W=280, BTN_H=36, GAP=8).
+    // firstY = DIALOG_INFO_Y(152) + DIALOG_INFO_TO_BUTTONS_GAP(24) = 176.
+    const saveNowY = 176 + 1 * (36 + 8) + 36 / 2;
+    const saveNowX = (800 - 280) / 2 + 280 / 2;
+    await page.locator('canvas').first().click({ position: { x: saveNowX, y: saveNowY } });
+    await page.waitForTimeout(200);
+
+    // The preserved bytes MUST be unchanged. Pre-fix this overwrote the
+    // future-build save with the fresh-session bytes, silently destroying
+    // the recoverable save.
+    const after = await page.evaluate(() => localStorage.getItem('subterrans:save:v3'));
+    expect(after).toBe(before);
+  });
+});

--- a/tests/menu-and-dialog.spec.ts
+++ b/tests/menu-and-dialog.spec.ts
@@ -116,11 +116,11 @@ test.describe('Issue #115/#116 — single click triggers single dispatch', () =>
     await page.locator('canvas').first().click({ position: settingsRect });
     await page.waitForTimeout(120);
 
-    // Settings sub-screen now has 2 buttons: pheromone-toggle and back.
+    // Settings sub-screen has 3 items: pheromone-toggle, speed-cycle, back.
     const toggleRect = await page.evaluate(() => {
       const CANVAS_W = 800, CANVAS_H = 592;
       const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
-      const n = 2;
+      const n = 3;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
       const x = (CANVAS_W - BTN_W) / 2;
@@ -345,6 +345,114 @@ test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () =>
     await page.waitForTimeout(150);
     const gone = await page.evaluate(() => localStorage.getItem('subterrans:save:v3'));
     expect(gone).toBeNull();
+  });
+});
+
+test.describe('Settings — Speed cycle row (UAT)', () => {
+  test('clicking the speed row cycles 1× → 2× → 4× → 1× (live, session-only)', async ({ page }) => {
+    await bootGame(page);
+
+    // Open menu → Settings.
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    const settingsRect = await page.evaluate(() => {
+      const CANVAS_W = 800, CANVAS_H = 592;
+      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const n = 4;
+      const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
+      const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
+      const x = (CANVAS_W - BTN_W) / 2;
+      const settingsY = top + 2 * (BTN_H + GAP);
+      return { x: x + BTN_W / 2, y: settingsY + BTN_H / 2 };
+    });
+    await page.locator('canvas').first().click({ position: settingsRect });
+    await page.waitForTimeout(120);
+
+    // On Settings page: [pheromone-toggle (i=0), speed-cycle (i=1), back (i=2)].
+    // Compute rect for i=1.
+    const speedRect = await page.evaluate(() => {
+      const CANVAS_W = 800, CANVAS_H = 592;
+      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const n = 3;
+      const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
+      const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
+      const x = (CANVAS_W - BTN_W) / 2;
+      const speedY = top + 1 * (BTN_H + GAP);
+      return { x: x + BTN_W / 2, y: speedY + BTN_H / 2 };
+    });
+
+    // We don't have a public hook for the speedMultiplier, but the dialog
+    // label encodes it visually. Sample the canvas pixels along the label
+    // baseline — only sanity-checking that consecutive clicks change the
+    // rendered text region (any change suffices: 1×→2×→4× all differ).
+    const sampleLabel = async () => {
+      return await page.locator('canvas').first().screenshot({
+        clip: { x: speedRect.x - 60, y: speedRect.y - 8, width: 120, height: 16 },
+      });
+    };
+
+    const at1x = await sampleLabel();
+    await page.locator('canvas').first().click({ position: speedRect });
+    await page.waitForTimeout(100);
+    const at2x = await sampleLabel();
+    await page.locator('canvas').first().click({ position: speedRect });
+    await page.waitForTimeout(100);
+    const at4x = await sampleLabel();
+    await page.locator('canvas').first().click({ position: speedRect });
+    await page.waitForTimeout(100);
+    const at1xAgain = await sampleLabel();
+
+    // Each step must differ from the previous (distinct labels render).
+    expect(at1x.equals(at2x)).toBe(false);
+    expect(at2x.equals(at4x)).toBe(false);
+    expect(at4x.equals(at1xAgain)).toBe(false);
+    // Cycle closes — back at 1× matches the initial 1× label.
+    expect(at1x.equals(at1xAgain)).toBe(true);
+  });
+});
+
+test.describe('Pheromone overlay actually renders (UAT P1 — pre-existing draw-order bug)', () => {
+  // The bug: GameScene called drawPheromoneOverlay BEFORE drawSurface, but
+  // drawSurface paints opaque terrain THEN entities. Pheromones got wiped
+  // by the terrain pass — invisible since 9f5b23f. Issue #114's toggle
+  // surfaced it (ON and OFF rendered identically because ON was always
+  // overpainted). Fix: split the orchestrator into terrain → pheromone →
+  // entities so the overlay lands between layers as the docstring intended.
+  test.setTimeout(120_000);
+
+  test('after sustained foraging at 4×, ON and OFF screenshots differ', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('canvas').first().waitFor({ state: 'attached' });
+    await page.evaluate(() => {
+      localStorage.removeItem('subterrans:save:v3');
+      localStorage.removeItem('subterrans:settings:v1');
+    });
+    await page.reload();
+    await page.locator('canvas').first().waitFor({ state: 'attached' });
+    await page.waitForFunction(() => {
+      const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
+      return ui !== undefined && ui.activeOverlay === 'none';
+    });
+
+    // Run at 4× tick rate for 30s wall-clock = 600 sim seconds. With the
+    // pre-fix draw order any non-zero pheromone would have been wiped by
+    // the terrain pass — ON and OFF were byte-identical. Post-fix the
+    // foraged FoodTrail cells ramp through alpha 0.6 max and are clearly
+    // visible. Assertion: PNGs must differ.
+    await page.keyboard.press('4');
+    await page.waitForTimeout(30000);
+
+    const onPng = await page.locator('canvas').first().screenshot();
+    await page.keyboard.press('p');
+    await page.waitForTimeout(500);
+    const offPng = await page.locator('canvas').first().screenshot();
+
+    // Pre-fix: ON and OFF rendered byte-identical because terrain overpainted
+    // the pheromone overlay. Post-fix: any non-zero pheromone cell renders
+    // and the buffers differ. We don't assert a byte-count delta because
+    // PNG compression sometimes coincidentally produces similar sizes for
+    // visually-distinct frames — the equals check is the load-bearing one.
+    expect(onPng.equals(offPng)).toBe(false);
   });
 });
 

--- a/tests/menu-and-dialog.spec.ts
+++ b/tests/menu-and-dialog.spec.ts
@@ -348,6 +348,73 @@ test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () =>
   });
 });
 
+test.describe('Round-6 (Codex P2) — pheromone toggle survives degraded storage', () => {
+  test('menu-clicked toggle keeps alternating when localStorage.setItem is blocked', async ({ page }) => {
+    await bootGame(page);
+
+    // Simulate quota-exceeded / private-mode: setItem throws. Reading is
+    // unaffected — only the write path is blocked.
+    await page.evaluate(() => {
+      window.localStorage.setItem = () => { throw new Error('QuotaExceeded (simulated)'); };
+    });
+
+    // Open pause menu → Settings sub-page. Stay there for the entire test
+    // so the underlying world doesn't tick between samples — pixel-level
+    // comparison of the toggle label is then deterministic.
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    const settingsRect = await page.evaluate(() => {
+      const CANVAS_W = 800, CANVAS_H = 592;
+      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const n = 4;
+      const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
+      const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
+      const x = (CANVAS_W - BTN_W) / 2;
+      const settingsY = top + 2 * (BTN_H + GAP);
+      return { x: x + BTN_W / 2, y: settingsY + BTN_H / 2 };
+    });
+    await page.locator('canvas').first().click({ position: settingsRect });
+    await page.waitForTimeout(120);
+
+    // Pheromone toggle is index 0 on the Settings sub-page.
+    const toggleClickPos = await page.evaluate(() => {
+      const CANVAS_W = 800, CANVAS_H = 592;
+      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const n = 3;
+      const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
+      const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
+      const x = (CANVAS_W - BTN_W) / 2;
+      const y = top + 0 * (BTN_H + GAP);
+      return { x: x + BTN_W / 2, y: y + BTN_H / 2 };
+    });
+    const labelClip = {
+      x: toggleClickPos.x - 60,
+      y: toggleClickPos.y - 8,
+      width: 120,
+      height: 16,
+    };
+
+    // Sample 1: initial state.
+    const before = await page.locator('canvas').first().screenshot({ clip: labelClip });
+    // Click toggle → flip to OFF in-mem (saveSettings drops the write silently).
+    await page.locator('canvas').first().click({ position: toggleClickPos });
+    await page.waitForTimeout(120);
+    const afterOne = await page.locator('canvas').first().screenshot({ clip: labelClip });
+    // Click again → flip back to ON.
+    await page.locator('canvas').first().click({ position: toggleClickPos });
+    await page.waitForTimeout(120);
+    const afterTwo = await page.locator('canvas').first().screenshot({ clip: labelClip });
+
+    // Pre-fix (degraded storage + loadSettings-derived flip): every click
+    // recomputes from DEFAULT_SETTINGS = {pheromoneOverlay: true}, so the
+    // label always ends at "OFF" after the first click and never flips
+    // back. Post-fix: in-mem state alternates regardless of storage.
+    expect(before.equals(afterOne)).toBe(false);       // 1 click changed it
+    expect(afterOne.equals(afterTwo)).toBe(false);     // 2nd click changed it back
+    expect(before.equals(afterTwo)).toBe(true);        // round trip
+  });
+});
+
 test.describe('Settings — Speed cycle row (UAT)', () => {
   test('clicking the speed row cycles 1× → 2× → 4× → 1× (live, session-only)', async ({ page }) => {
     await bootGame(page);
@@ -418,7 +485,13 @@ test.describe('Pheromone overlay actually renders (UAT P1 — pre-existing draw-
   // surfaced it (ON and OFF rendered identically because ON was always
   // overpainted). Fix: split the orchestrator into terrain → pheromone →
   // entities so the overlay lands between layers as the docstring intended.
-  test.setTimeout(120_000);
+  //
+  // This test runs ants long enough that *some* FoodTrail cells reach a
+  // visible alpha, then compares ON / OFF screenshots. Foraging is
+  // RNG-seeded (Date.now()-derived per bootFresh), so the wall-clock budget
+  // must be generous enough to cover unlucky seeds. 90s @ 4× = 1800 sim
+  // seconds (~30 sim-minutes) is well above the slowest seed observed.
+  test.setTimeout(180_000);
 
   test('after sustained foraging at 4×, ON and OFF screenshots differ', async ({ page }) => {
     await page.goto('/');
@@ -434,13 +507,8 @@ test.describe('Pheromone overlay actually renders (UAT P1 — pre-existing draw-
       return ui !== undefined && ui.activeOverlay === 'none';
     });
 
-    // Run at 4× tick rate for 30s wall-clock = 600 sim seconds. With the
-    // pre-fix draw order any non-zero pheromone would have been wiped by
-    // the terrain pass — ON and OFF were byte-identical. Post-fix the
-    // foraged FoodTrail cells ramp through alpha 0.6 max and are clearly
-    // visible. Assertion: PNGs must differ.
     await page.keyboard.press('4');
-    await page.waitForTimeout(30000);
+    await page.waitForTimeout(90_000);
 
     const onPng = await page.locator('canvas').first().screenshot();
     await page.keyboard.press('p');
@@ -448,10 +516,10 @@ test.describe('Pheromone overlay actually renders (UAT P1 — pre-existing draw-
     const offPng = await page.locator('canvas').first().screenshot();
 
     // Pre-fix: ON and OFF rendered byte-identical because terrain overpainted
-    // the pheromone overlay. Post-fix: any non-zero pheromone cell renders
-    // and the buffers differ. We don't assert a byte-count delta because
-    // PNG compression sometimes coincidentally produces similar sizes for
-    // visually-distinct frames — the equals check is the load-bearing one.
+    // the pheromone overlay. Post-fix: foraged FoodTrail cells render and
+    // the buffers differ. PNG-byte-count assertion is intentionally omitted
+    // (PNG compression sometimes coincidentally produces similar sizes for
+    // visually-distinct frames) — the equals check is the load-bearing one.
     expect(onPng.equals(offPng)).toBe(false);
   });
 });

--- a/tests/menu-and-dialog.spec.ts
+++ b/tests/menu-and-dialog.spec.ts
@@ -1,0 +1,349 @@
+// menu-and-dialog.spec.ts — issues #115/#116/#114 runtime regression tests.
+//
+// These cover the fixes from PR #118 round 2:
+//   - Esc opens pause menu (was racing between GameScene + UIScene handlers
+//     and ending up at activeOverlay === 'none')
+//   - Single click on a button dispatches ONCE (per-button + scene-level
+//     handlers were both firing → confirm gate bypassed, pheromone toggle
+//     no-op'd)
+//   - Save Now flash + savedAtMs timestamp surface
+
+import { test, expect, type Page } from '@playwright/test';
+
+async function bootGame(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.locator('canvas').first().waitFor({ state: 'attached' });
+  // Wait until the ready event has fired and the boot has dispatched —
+  // SavePrompt or Playing. window.__phase9_ui is published by setActiveOverlay.
+  await page.waitForFunction(() => typeof (window as { __phase9_ui?: unknown }).__phase9_ui !== 'undefined');
+  // Clear any prior save so we always boot into Playing (no SavePrompt).
+  await page.evaluate(() => localStorage.removeItem('subterrans:save:v3'));
+  await page.reload();
+  await page.locator('canvas').first().waitFor({ state: 'attached' });
+  await page.waitForFunction(() => {
+    const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
+    return ui !== undefined && ui.activeOverlay === 'none';
+  });
+}
+
+async function activeOverlay(page: Page): Promise<string> {
+  return await page.evaluate(() => {
+    const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
+    return ui?.activeOverlay ?? '<undefined>';
+  });
+}
+
+test.describe('Issue #116 — Esc opens / closes pause menu', () => {
+  test('Esc on a clean canvas opens the pause menu (single press, not racing closed)', async ({ page }) => {
+    await bootGame(page);
+    expect(await activeOverlay(page)).toBe('none');
+
+    // The bug Rob found: GameScene bound keydown-ESC AND UIScene bound an
+    // escKey 'down' listener, both firing on the same press. GameScene opened
+    // the menu, UIScene immediately closed it; activeOverlay ended at 'none'.
+    // After the fix, pressing Esc once should land at 'pause-menu'.
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    expect(await activeOverlay(page)).toBe('pause-menu');
+  });
+
+  test('Esc with menu open closes it (single press)', async ({ page }) => {
+    await bootGame(page);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    expect(await activeOverlay(page)).toBe('pause-menu');
+
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    expect(await activeOverlay(page)).toBe('none');
+  });
+
+  test('opening the menu pauses the game loop (no tick advances while menu is up)', async ({ page }) => {
+    await bootGame(page);
+    // Take two tick samples ~200ms apart with the menu OPEN; they should match.
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(150);
+    expect(await activeOverlay(page)).toBe('pause-menu');
+
+    const tick1 = await page.evaluate(() => {
+      // Phaser scenes are accessible via the scene plugin, but for a black-box
+      // smoke we read the autosave envelope which always carries snapshot.tick.
+      // (Forcing a save while paused isn't ideal — instead, sample _phase9_ui
+      // and check no overlay flicker / churn occurred.)
+      return (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui?.activeOverlay;
+    });
+    await page.waitForTimeout(300);
+    const tick2 = await page.evaluate(() => {
+      return (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui?.activeOverlay;
+    });
+    // Overlay state must be stable at 'pause-menu' across the wait — no
+    // flicker / re-open caused by handler races.
+    expect(tick1).toBe('pause-menu');
+    expect(tick2).toBe('pause-menu');
+  });
+});
+
+test.describe('Issue #115/#116 — single click triggers single dispatch', () => {
+  test('clicking the pheromone toggle once flips the persisted setting once (not twice → no-op)', async ({ page }) => {
+    await bootGame(page);
+    // Default pheromoneOverlay is true.
+    const before = await page.evaluate(() => {
+      try {
+        const raw = localStorage.getItem('subterrans:settings:v1');
+        return raw === null ? true : (JSON.parse(raw).settings?.pheromoneOverlay ?? true);
+      } catch { return true; }
+    });
+    expect(before).toBe(true);
+
+    // Open pause menu → Settings → toggle pheromone.
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    expect(await activeOverlay(page)).toBe('pause-menu');
+
+    // Layout from pause-menu-layout: Settings is the third button. Each button
+    // is 320×40 with 10px gap, stacked centered. We compute the rect to click.
+    const settingsRect = await page.evaluate(() => {
+      // Mirror pauseMenuItems('main', ...) layout for index=2 (Settings).
+      const CANVAS_W = 800, CANVAS_H = 592;
+      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const n = 4; // resume, save-load, settings, debug-snapshot
+      const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
+      const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
+      const x = (CANVAS_W - BTN_W) / 2;
+      const settingsY = top + 2 * (BTN_H + GAP);
+      return { x: x + BTN_W / 2, y: settingsY + BTN_H / 2 };
+    });
+    await page.locator('canvas').first().click({ position: settingsRect });
+    await page.waitForTimeout(120);
+
+    // Settings sub-screen now has 2 buttons: pheromone-toggle and back.
+    const toggleRect = await page.evaluate(() => {
+      const CANVAS_W = 800, CANVAS_H = 592;
+      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const n = 2;
+      const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
+      const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
+      const x = (CANVAS_W - BTN_W) / 2;
+      // pheromone-toggle is index 0
+      const toggleY = top + 0 * (BTN_H + GAP);
+      return { x: x + BTN_W / 2, y: toggleY + BTN_H / 2 };
+    });
+    await page.locator('canvas').first().click({ position: toggleRect });
+    await page.waitForTimeout(120);
+
+    const after = await page.evaluate(() => {
+      const raw = localStorage.getItem('subterrans:settings:v1');
+      return raw === null ? null : JSON.parse(raw).settings?.pheromoneOverlay;
+    });
+    // ONE click should flip the setting. The duplicate-dispatch bug fired
+    // dispatchPauseMenuItem twice → flipped on then off → 'after' would still
+    // be true. After the fix, after === false.
+    expect(after).toBe(false);
+  });
+});
+
+test.describe('Issue #114 — P key toggles pheromone overlay', () => {
+  test('pressing P flips the persisted pheromoneOverlay setting', async ({ page }) => {
+    await bootGame(page);
+    // Reset to a known starting state.
+    await page.evaluate(() => localStorage.removeItem('subterrans:settings:v1'));
+    await page.reload();
+    await page.locator('canvas').first().waitFor({ state: 'attached' });
+    await page.waitForTimeout(150);
+
+    await page.keyboard.press('p');
+    await page.waitForTimeout(100);
+
+    const persisted = await page.evaluate(() => {
+      const raw = localStorage.getItem('subterrans:settings:v1');
+      return raw === null ? null : JSON.parse(raw).settings?.pheromoneOverlay;
+    });
+    expect(persisted).toBe(false);
+
+    // Press again → back to true.
+    await page.keyboard.press('p');
+    await page.waitForTimeout(100);
+    const persisted2 = await page.evaluate(() => {
+      const raw = localStorage.getItem('subterrans:settings:v1');
+      return raw === null ? null : JSON.parse(raw).settings?.pheromoneOverlay;
+    });
+    expect(persisted2).toBe(true);
+  });
+});
+
+test.describe('Round-2 review — overlay observability stays coherent across transitions', () => {
+  test('Save/Load → Esc back to pause menu does NOT briefly publish activeOverlay = none', async ({ page }) => {
+    await bootGame(page);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    expect(await activeOverlay(page)).toBe('pause-menu');
+
+    // Open Save/Load (button index 1).
+    const saveLoadRect = await page.evaluate(() => {
+      const CANVAS_W = 800, CANVAS_H = 592;
+      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const n = 4;
+      const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
+      const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
+      const x = (CANVAS_W - BTN_W) / 2;
+      const slY = top + 1 * (BTN_H + GAP);
+      return { x: x + BTN_W / 2, y: slY + BTN_H / 2 };
+    });
+    await page.locator('canvas').first().click({ position: saveLoadRect });
+    await page.waitForTimeout(100);
+    expect(await activeOverlay(page)).toBe('save-load');
+
+    // Esc on dialog → onBack closes dialog and re-shows pause menu. The
+    // round-2 review found that hideSaveLoadDialogOverlay was unconditionally
+    // setting activeOverlay='none', so between the hide and the re-show the
+    // observable would briefly publish 'none' (Playwright + any external
+    // observer reading the global between paints sees the wrong state).
+    // After the recomputeActiveOverlay fix, the observable should never
+    // be 'none' during this transition — it goes save-load → pause-menu.
+    //
+    // We can't sample inside a single synchronous handler, but we CAN
+    // verify that after the transition completes, the overlay reads the
+    // correct final state. The bigger guarantee — "never observed 'none'"
+    // — would need a fast polling MutationObserver; this test is the
+    // best black-box proxy for catching a regression where someone
+    // re-introduces the 'none' flash.
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(50);
+    expect(await activeOverlay(page)).toBe('pause-menu');
+  });
+});
+
+test.describe('Round-2 review — keybinds gated on Playing phase', () => {
+  test('P pressed while pause menu is open does NOT flip the persisted setting', async ({ page }) => {
+    await bootGame(page);
+    // Verify default
+    const before = await page.evaluate(() => {
+      try {
+        const raw = localStorage.getItem('subterrans:settings:v1');
+        return raw === null ? true : (JSON.parse(raw).settings?.pheromoneOverlay ?? true);
+      } catch { return true; }
+    });
+    expect(before).toBe(true);
+
+    // Open menu, then press P.
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    expect(await activeOverlay(page)).toBe('pause-menu');
+    await page.keyboard.press('p');
+    await page.waitForTimeout(100);
+
+    // Setting should NOT have flipped — round-2 fix gates P on Playing only,
+    // so the menu's Settings sub-screen is the sole writer while paused.
+    const after = await page.evaluate(() => {
+      try {
+        const raw = localStorage.getItem('subterrans:settings:v1');
+        return raw === null ? true : (JSON.parse(raw).settings?.pheromoneOverlay ?? true);
+      } catch { return true; }
+    });
+    expect(after).toBe(true);
+  });
+});
+
+test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () => {
+  test('opening Save/Load row from menu lands at activeOverlay = save-load', async ({ page }) => {
+    await bootGame(page);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    expect(await activeOverlay(page)).toBe('pause-menu');
+
+    // Save/Load is the 2nd button (index 1) in the main menu.
+    const saveLoadRect = await page.evaluate(() => {
+      const CANVAS_W = 800, CANVAS_H = 592;
+      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const n = 4;
+      const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
+      const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
+      const x = (CANVAS_W - BTN_W) / 2;
+      const slY = top + 1 * (BTN_H + GAP);
+      return { x: x + BTN_W / 2, y: slY + BTN_H / 2 };
+    });
+    await page.locator('canvas').first().click({ position: saveLoadRect });
+    await page.waitForTimeout(150);
+    expect(await activeOverlay(page)).toBe('save-load');
+  });
+
+  test('clicking Delete once on a fresh save arms the confirm; second click commits (no one-click destruction)', async ({ page }) => {
+    await bootGame(page);
+    // Manually populate localStorage with a fresh save so Delete is enabled.
+    await page.evaluate(() => {
+      const env = {
+        version: 3,
+        seed: 1,
+        inputLog: [],
+        snapshot: {
+          tick: 1, rngState: 1, nextEntityId: 0, commandQueue: [],
+          ants: { count: 0, posX: [], posY: [], colonyId: [], task: [], subTask: [],
+                  speed: [], foodCarrying: [], starvationTimer: [], age: [], alive: [],
+                  lifespan: [], zone: [], digTileX: [], digTileY: [], digTicksRemaining: [],
+                  targetPosX: [], targetPosY: [], targetSet: [] },
+          colonies: {},
+          pheromoneGrids: {},
+          surface: { width: 1, height: 1, data: [0] },
+          undergroundGrids: {},
+          foodPiles: [],
+          pendingChambers: {},
+        },
+        savedAtMs: Date.now(),
+      };
+      localStorage.setItem('subterrans:save:v3', JSON.stringify(env));
+    });
+    await page.reload();
+    await page.locator('canvas').first().waitFor({ state: 'attached' });
+    await page.waitForFunction(() => {
+      const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
+      return ui !== undefined;
+    });
+    // Boot lands on SavePrompt — click Continue to enter Playing.
+    // SAVE_PROMPT_CONTINUE_RECT = { x: 300, y: 280, w: 120, h: 32 }
+    await page.locator('canvas').first().click({ position: { x: 360, y: 296 } });
+    await page.waitForTimeout(150);
+    // (Continue may fall back to bootFresh on the synthetic envelope —
+    // either way we're now in Playing without a SavePrompt.)
+    await page.waitForFunction(() => {
+      const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
+      return ui !== undefined && ui.activeOverlay !== 'save-prompt';
+    });
+
+    // Re-populate the save (Continue may have triggered an autosave that
+    // overwrote our synthetic one — that's fine; what matters is some valid
+    // save sits in storage so Delete enables).
+    await page.evaluate(() => {
+      const raw = localStorage.getItem('subterrans:save:v3');
+      if (raw === null) {
+        const env = { version: 3, seed: 1, inputLog: [], snapshot: { tick: 1, rngState: 1, nextEntityId: 0, commandQueue: [], ants: { count: 0, posX: [], posY: [], colonyId: [], task: [], subTask: [], speed: [], foodCarrying: [], starvationTimer: [], age: [], alive: [], lifespan: [], zone: [], digTileX: [], digTileY: [], digTicksRemaining: [], targetPosX: [], targetPosY: [], targetSet: [] }, colonies: {}, pheromoneGrids: {}, surface: { width: 1, height: 1, data: [0] }, undergroundGrids: {}, foodPiles: [], pendingChambers: {} }, savedAtMs: Date.now() };
+        localStorage.setItem('subterrans:save:v3', JSON.stringify(env));
+      }
+    });
+
+    // Open menu → Save/Load → Delete.
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(100);
+    expect(await activeOverlay(page)).toBe('pause-menu');
+    // Save/Load row.
+    await page.locator('canvas').first().click({ position: { x: 400, y: 312 } });
+    await page.waitForTimeout(150);
+    expect(await activeOverlay(page)).toBe('save-load');
+
+    // Delete row is index 2 in the dialog. CANVAS=800x592, BTN_W=280, BTN_H=36,
+    // GAP=8, firstY = DIALOG_INFO_Y + 24 = 152 + 24 = 176. Delete is index 2.
+    const deleteY = 176 + 2 * (36 + 8) + 36 / 2;
+    const deleteX = (800 - 280) / 2 + 280 / 2;
+
+    // First click — arms confirm (save still present).
+    await page.locator('canvas').first().click({ position: { x: deleteX, y: deleteY } });
+    await page.waitForTimeout(150);
+    const stillThere = await page.evaluate(() => localStorage.getItem('subterrans:save:v3'));
+    expect(stillThere).not.toBeNull();
+
+    // Second click — commits delete.
+    await page.locator('canvas').first().click({ position: { x: deleteX, y: deleteY } });
+    await page.waitForTimeout(150);
+    const gone = await page.evaluate(() => localStorage.getItem('subterrans:save:v3'));
+    expect(gone).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Bundles four small/medium feature requests into a single PR — three of them pivot off the new pause-menu shell, so they're naturally cohesive and share test/lint sweeps.

- **Closes #117** — round entrance holes with a dirt mound (render-only)
- **Closes #116** — pause menu overlay reachable via Esc; hosts Settings + Download debug log
- **Closes #114** — P key toggles pheromone overlay; persisted via settings; also exposed in the menu's Settings sub-screen
- **Closes #115** — Save/Load dialog reachable from the pause menu (Continue / Save Now / Delete / New Game)

Per-issue commits are atomic and reviewable independently:
- ` 574df7b` feat(render): round entrance holes with dirt mound (#117)
- ` 79deead` feat(render): pause menu overlay (Esc) (#116)
- ` 673abed` feat(render): pheromone overlay toggle key (P) (#114)
- ` ef32386` feat(save,render): in-game Save / Load dialog (#115)

## Highlights

**Esc replaces P-pause** — Esc now opens the pause menu (which itself pauses the game). P frees up for the pheromone toggle. Single mental model: "menu = pause."

**Pheromone overlay flag lives on `ViewState`**, hydrated from a new `subterrans:settings:v1` localStorage namespace. The settings store is a separate module from `save.ts` so cosmetic preferences survive `deleteSave()`.

**Save/Load dialog respects issue #66 path** — `hasIncompatibleSave()` detects "save bytes present but this build can't read them" and surfaces a warning info line. Delete stays enabled so the player can clear the leftovers without losing the dialog.

**Mound spills 2 px onto neighbor tiles** — viewport cull margin widened so the entrance reads as a 3-D bump, not a flat painted disc. Issue #14 enemy ring becomes a `strokeCircle` following the round silhouette.

## Architecture notes

- New pure modules: `pause-menu-layout.ts`, `save-load-dialog-layout.ts`, `platform/settings.ts` — all Phaser-free, fully unit-tested.
- UIScene gains the show/hide/dispatch methods; same overlay pattern as the existing SavePrompt + GameOver overlays.
- GameScene wires Esc → pause menu → save/load dialog as a layered chrome stack; game loop stays paused via `gameLoop.pause()` from menu open through dialog flows.
- No `src/sim/` changes. No determinism / replay impact.
- `ActiveOverlay` enum gains `'pause-menu'` and `'save-load'` for Playwright observability.

## Test plan

- [x] ` npm run typecheck` — clean
- [x] ` npm run lint` — matches main's pre-existing baseline (6 errors all pre-existing on main; PR introduces none)
- [x] ` npx vitest run` — **1998/1998 passing** (added 45 new tests across settings.ts, pause-menu-layout, save-load-dialog-layout, save.ts, draw-surface.ts, and camera.ts)
- [x] ` npm run build` — production bundle compiles
- [ ] Browser UAT (deferred to review): Esc opens menu, P toggles pheromone overlay, Save/Load dialog round-trips through Continue / Save Now / Delete / New Game / Back, round entrances render correctly at all zoom states, mound visible at viewport edges (cull margin)

## Out of scope

- Audio settings (no audio system yet)
- Key rebinding (deferred — Settings sub-screen is the placement, not the implementation)
- Animated dirt-spray on freshly-dug entrances (#117 follow-up)
- Per-entrance mound size variation by age / traffic (#117 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)