### PR TITLE
feat(render,platform): playtrace upload — survey overlay + opt-in snapshot POST (#122)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# .env.example — copy to `.env.local` and edit as needed.
+#
+# Local dev defaults to feature-OFF. To enable the issue #122 / ADR 0013
+# playtrace upload flow on localhost, set:
+#
+#     VITE_PLAYTRACE_ENDPOINT=/api/playtrace
+#
+# Then `npm run dev` and play to game-over (or use the pause menu's
+# "Quit & feedback" entry). The dev server has a built-in mock for
+# `POST /api/playtrace` that decodes the gzipped payload and logs it to
+# the terminal — see vite.config.ts (playtraceMockPlugin) for what gets
+# printed and how to inspect the full envelope.
+#
+# Leave this commented out or empty to disable the survey overlay
+# entirely (the open-source default).
+# VITE_PLAYTRACE_ENDPOINT=/api/playtrace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,21 @@ node --experimental-transform-types scripts/analyze-snapshot.ts <snapshot.json>
 
 The CLI replays the recorded inputLog from seed and byte-compares the result against the captured snapshot (a free SCEN-06 determinism check — exits 1 on regression), then reports tile-occupancy clusters, underground ants stuck on non-Open tiles, and stationary / oscillating ants from a per-ant motion history sampled during replay. Each motion group is annotated with its dominant `(task, subTask)` so a real bug stands out from expected stuck cases. See PR #121 for the design notes.
 
+## Playtrace upload (issue #122 / ADR 0013)
+
+End-of-game survey overlay with an opt-in debug-snapshot upload. **Disabled by default** — the survey overlay and the pause menu's "Quit & feedback" row are hidden when the `VITE_PLAYTRACE_ENDPOINT` env var is unset or empty, and `npm run build` produces a bundle with the feature off.
+
+To exercise the upload flow on localhost without standing up the website's Lambda + S3 stack:
+
+```bash
+cd code/
+cp .env.example .env.local
+# uncomment VITE_PLAYTRACE_ENDPOINT=/api/playtrace in .env.local
+npm run dev
+```
+
+The dev server has a built-in mock for `POST /api/playtrace` (see `vite.config.ts` — `playtraceMockPlugin`). Play to game-over (or use the pause menu's "Quit & feedback" entry), fill in the survey, and hit Submit. The dev-server terminal prints a one-line summary of the received envelope plus a pretty-printed JSON dump (snapshot elided). The mock returns the same `202 + { accepted, sessionId }` body the production Lambda will return.
+
 ## Note
 
 This repository is the public, open-source portion of a larger project. Research, planning, and internal design documents live in a separate private repository.

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,12 +94,17 @@ function normalizeAssetsBase(raw: string | undefined): string {
 export function mount(target: HTMLElement, options?: MountOptions): MountedGame {
   const assetsBase = normalizeAssetsBase(options?.assetsBase);
   // Playtrace endpoint resolution: explicit option wins; otherwise fall back
-  // to the build-time env var. Empty string = feature disabled, per the
-  // ADR 0013 convention — survey overlay is hidden, no network calls.
-  const playtraceEndpoint =
+  // to the build-time env var. Trim whitespace before deciding feature on/off
+  // — a value like `'   '` (templated env var that resolved blank) would
+  // otherwise pass the `=== ''` check inside submitPlaytrace, fire a fetch
+  // against an invalid URL, and fail silently. The trim mirrors the
+  // assetsBase normalization so both env-var-derived options share the same
+  // empty-string convention.
+  const playtraceEndpointRaw =
     options?.playtraceEndpoint
     ?? (import.meta.env.VITE_PLAYTRACE_ENDPOINT as string | undefined)
     ?? '';
+  const playtraceEndpoint = playtraceEndpointRaw.trim();
 
   const config: Phaser.Types.Core.GameConfig = {
     type: Phaser.AUTO,

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,24 @@ export interface MountOptions {
    * Default: `${import.meta.env.BASE_URL}assets/`.
    */
   assetsBase?: string;
+
+  /**
+   * Override the endpoint URL for the end-of-game playtrace upload (issue
+   * #122 / ADR 0013). When set to a non-empty string, the survey overlay
+   * appears at end-of-game (and as a "Quit & feedback" entry on the pause
+   * menu) and submissions POST to this URL.
+   *
+   * Default: the build-time `VITE_PLAYTRACE_ENDPOINT` env var, or `''` if
+   * unset. The empty-string convention is load-bearing: a missing env var
+   * (typical for local dev and the open-source build) disables the feature
+   * entirely — no overlay, no network traffic.
+   *
+   * Embedders on third-party origins can override here to point at a
+   * different deployment (currently a deferred CORS item per ADR 0013 §"Open
+   * items"; if you set this to a cross-origin URL the request will be
+   * blocked until the server adds the appropriate CORS headers).
+   */
+  playtraceEndpoint?: string;
 }
 
 export interface MountedGame {
@@ -75,6 +93,13 @@ function normalizeAssetsBase(raw: string | undefined): string {
 
 export function mount(target: HTMLElement, options?: MountOptions): MountedGame {
   const assetsBase = normalizeAssetsBase(options?.assetsBase);
+  // Playtrace endpoint resolution: explicit option wins; otherwise fall back
+  // to the build-time env var. Empty string = feature disabled, per the
+  // ADR 0013 convention — survey overlay is hidden, no network calls.
+  const playtraceEndpoint =
+    options?.playtraceEndpoint
+    ?? (import.meta.env.VITE_PLAYTRACE_ENDPOINT as string | undefined)
+    ?? '';
 
   const config: Phaser.Types.Core.GameConfig = {
     type: Phaser.AUTO,
@@ -98,6 +123,7 @@ export function mount(target: HTMLElement, options?: MountOptions): MountedGame 
       // its sprite URLs.
       preBoot: (game) => {
         game.registry.set('assetsBase', assetsBase);
+        game.registry.set('playtraceEndpoint', playtraceEndpoint);
       },
     },
   };

--- a/src/platform/debug-snapshot.test.ts
+++ b/src/platform/debug-snapshot.test.ts
@@ -469,3 +469,58 @@ describe('buildDebugSnapshot — envelope + filtering', () => {
     expect(name.endsWith('.json')).toBe(true);
   });
 });
+
+describe('buildDebugSnapshot — BuildDebugSnapshotOptions (issue #122)', () => {
+  function makeWorldWithAnts() {
+    const { world } = setupWorldWithColony(COLONY_ID);
+    setupSurfaceGrid(world, COLONY_ID);
+    for (let i = 0; i < 4; i++) {
+      const id = allocateEntityId(world);
+      initAnt(world.ants, id, {
+        colonyId: COLONY_ID,
+        posX: (10 + i) << FP_SHIFT,
+        posY: (10 + i) << FP_SHIFT,
+        task: AntTask.Foraging,
+        subTask: ForagingSubState.SearchingFood,
+      });
+    }
+    return world;
+  }
+
+  it('default options include both antTrace and inputLog (F9 path is unchanged)', () => {
+    const world = makeWorldWithAnts();
+    const log = [{ type: 'SetBehaviorRatio', colonyId: COLONY_ID, ratio: { forage: 50, fight: 50 }, issuedAtTick: 0 }] as never;
+    const snap = buildDebugSnapshot(world, 1, log);
+    expect(snap.antTrace.length).toBeGreaterThan(0);
+    expect(snap.inputLog.length).toBe(1);
+  });
+
+  it('includeAntTrace=false emits an empty trace array (downgrade stage 1)', () => {
+    const world = makeWorldWithAnts();
+    const log = [{ type: 'SetBehaviorRatio', colonyId: COLONY_ID, ratio: { forage: 50, fight: 50 }, issuedAtTick: 0 }] as never;
+    const snap = buildDebugSnapshot(world, 1, log, { includeAntTrace: false });
+    expect(snap.antTrace).toEqual([]);
+    // inputLog must still be present at this stage.
+    expect(snap.inputLog.length).toBe(1);
+  });
+
+  it('includeInputLog=false drops the input log (downgrade stage 2)', () => {
+    const world = makeWorldWithAnts();
+    const log = [{ type: 'SetBehaviorRatio', colonyId: COLONY_ID, ratio: { forage: 50, fight: 50 }, issuedAtTick: 0 }] as never;
+    const snap = buildDebugSnapshot(world, 1, log, { includeAntTrace: false, includeInputLog: false });
+    expect(snap.antTrace).toEqual([]);
+    expect(snap.inputLog).toEqual([]);
+  });
+
+  it('legacy colonyFilter array signature still works', () => {
+    const world = makeWorldWithAnts();
+    const snap = buildDebugSnapshot(world, 1, [], [COLONY_ID]);
+    expect(snap.antTrace.every(r => r.colonyId === COLONY_ID)).toBe(true);
+  });
+
+  it('options.colonyFilter narrows the trace to the listed colonies', () => {
+    const world = makeWorldWithAnts();
+    const snap = buildDebugSnapshot(world, 1, [], { colonyFilter: [OTHER_COLONY_ID] });
+    expect(snap.antTrace).toEqual([]);
+  });
+});

--- a/src/platform/debug-snapshot.ts
+++ b/src/platform/debug-snapshot.ts
@@ -306,6 +306,32 @@ export function buildAntTrace(world: WorldState, antId: number): AntTraceRow {
 }
 
 /**
+ * Optional shape parameters for {@link buildDebugSnapshot}. All fields are
+ * additive — omitting the argument (or passing `{}`) reproduces the original
+ * "include everything" payload that the F9 export path depends on.
+ *
+ * The `includeAntTrace` / `includeInputLog` flags exist for the playtrace
+ * upload's graceful-downgrade fallback (ADR 0013): when the gzipped body
+ * would exceed the 5 MB API Gateway cap, the uploader rebuilds the snapshot
+ * with antTrace omitted, then with inputLog omitted, before falling back to
+ * a survey-only submission with `snapshot: null`.
+ */
+export interface BuildDebugSnapshotOptions {
+  /** Restrict the trace to ants belonging to the listed colonies. Defaults
+   *  to all live ants. Useful to scope exports to the player colony. */
+  colonyFilter?: readonly number[];
+  /** When false, `antTrace` is emitted as an empty array. The world snapshot
+   *  still carries the raw per-ant component state; only the derived per-ant
+   *  trace rows are dropped. Defaults to true. */
+  includeAntTrace?: boolean;
+  /** When false, `inputLog` is emitted as an empty array. The receiver loses
+   *  replay value (the input sequence is what reproduces the recorded run)
+   *  but the snapshot itself is still a valid point-in-time observation.
+   *  Defaults to true. */
+  includeInputLog?: boolean;
+}
+
+/**
  * Build a full debug snapshot for export. Captures every LIVE ant (alive === 1)
  * in the trace. Dead slots are skipped — the world snapshot preserves their
  * raw array state already, so duplicating them in the trace is noise.
@@ -315,36 +341,46 @@ export function buildAntTrace(world: WorldState, antId: number): AntTraceRow {
  * @param inputLog  The session's accumulated command log (shared reference —
  *                  caller-side is responsible for NOT mutating after the call;
  *                  each command is shallow-copied into the payload).
- * @param colonyFilter  Optional: when provided, only ants in the listed
- *                  colonies appear in the trace. Defaults to all live ants.
- *                  Useful to scope exports to the player colony.
+ * @param options   Optional payload-shape controls. See {@link BuildDebugSnapshotOptions}.
+ *                  Back-compat: a bare `readonly number[]` is accepted in this
+ *                  slot for legacy callers that previously passed `colonyFilter`
+ *                  directly. New code should pass an options object.
  */
 export function buildDebugSnapshot(
   world: WorldState,
   seed: number,
   inputLog: readonly SimCommand[],
-  colonyFilter?: readonly number[],
+  options?: BuildDebugSnapshotOptions | readonly number[],
 ): DebugSnapshot {
+  // Back-compat: a bare array argument was the legacy colonyFilter signature.
+  const opts: BuildDebugSnapshotOptions = Array.isArray(options)
+    ? { colonyFilter: options as readonly number[] }
+    : ((options as BuildDebugSnapshotOptions | undefined) ?? {});
+  const includeAntTrace = opts.includeAntTrace ?? true;
+  const includeInputLog = opts.includeInputLog ?? true;
+
   const trace: AntTraceRow[] = [];
-  const filter = colonyFilter ? new Set(colonyFilter) : null;
-  // Queens are stored as AntTask.Idle with a queenEntityId reference on the
-  // colony record — collect those entity IDs up front so the trace can skip
-  // them (a queen's posX/posY never moves, so its trace row is noise).
-  const queenIds = new Set<number>();
-  for (const [, colony] of Object.entries(world.colonies)) {
-    if (colony.queenEntityId >= 0) queenIds.add(colony.queenEntityId);
-  }
-  for (let id = 0; id < world.nextEntityId; id++) {
-    if (world.ants.alive[id] !== 1) continue;
-    if (queenIds.has(id)) continue;
-    if (filter !== null && !filter.has(world.ants.colonyId[id]!)) continue;
-    trace.push(buildAntTrace(world, id));
+  if (includeAntTrace) {
+    const filter = opts.colonyFilter ? new Set(opts.colonyFilter) : null;
+    // Queens are stored as AntTask.Idle with a queenEntityId reference on the
+    // colony record — collect those entity IDs up front so the trace can skip
+    // them (a queen's posX/posY never moves, so its trace row is noise).
+    const queenIds = new Set<number>();
+    for (const [, colony] of Object.entries(world.colonies)) {
+      if (colony.queenEntityId >= 0) queenIds.add(colony.queenEntityId);
+    }
+    for (let id = 0; id < world.nextEntityId; id++) {
+      if (world.ants.alive[id] !== 1) continue;
+      if (queenIds.has(id)) continue;
+      if (filter !== null && !filter.has(world.ants.colonyId[id]!)) continue;
+      trace.push(buildAntTrace(world, id));
+    }
   }
   return {
     version: DEBUG_SNAPSHOT_VERSION,
     seed,
     tick: world.tick,
-    inputLog: inputLog.map((c) => ({ ...c })),
+    inputLog: includeInputLog ? inputLog.map((c) => ({ ...c })) : [],
     snapshot: serializeWorldState(world),
     antTrace: trace,
   };

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -258,7 +258,10 @@ export class GameScene extends Phaser.Scene {
     // off" so a programming error in main.ts doesn't accidentally turn the
     // overlay on with an undefined endpoint and 404 the submission.
     const endpointRaw = this.registry.get('playtraceEndpoint');
-    this.playtraceEndpoint = typeof endpointRaw === 'string' ? endpointRaw : '';
+    // Trim whitespace so a templated env var that resolved to spaces
+    // is treated as feature-off here too. main.ts normalizes at the
+    // boundary; this is defense-in-depth for the registry value.
+    this.playtraceEndpoint = typeof endpointRaw === 'string' ? endpointRaw.trim() : '';
 
     // Input registration — keyboard is GameScene-only (Pitfall 2).
     this.cursors = this.input.keyboard!.createCursorKeys();

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -38,7 +38,6 @@ import { buildDebugSnapshot } from '../platform/debug-snapshot.js';
 import { downloadDebugSnapshot } from './debug-snapshot-download.js';
 import {
   submitPlaytrace,
-  cancelInFlightUpload,
   type PlaytraceSurvey,
 } from './playtrace-upload.js';
 import {
@@ -453,11 +452,16 @@ export class GameScene extends Phaser.Scene {
     // would lock a freshly-spawned ant into the prior ant's direction until
     // the smoothing relaxes. Clearing here keeps boot visually clean.
     this.antFacingCache.reset();
-    // Issue #122 — cancel any upload from the prior session that may still
-    // be in flight (long network tails, slow uplink) so the new session's
-    // submission doesn't race the old one server-side, and rotate the
-    // session UUID so each (re)start gets its own telemetry row.
-    cancelInFlightUpload();
+    // Issue #122 — rotate the session UUID so each (re)start gets its own
+    // telemetry row server-side.
+    //
+    // Note: we intentionally do NOT cancel any in-flight playtrace upload
+    // here. The end-of-game survey flow is fire-and-forget: onSubmit kicks
+    // off submitPlaytrace AND then calls restartGame, which routes through
+    // this method. Cancelling the upload here would race-cancel the very
+    // request we just dispatched, dropping the survey row server-side.
+    // The single-in-flight discipline is instead enforced inside
+    // submitPlaytrace itself — each new submission cancels its predecessor.
     this.playtraceSessionId =
       typeof crypto !== 'undefined' && 'randomUUID' in crypto
         ? crypto.randomUUID()
@@ -653,9 +657,13 @@ export class GameScene extends Phaser.Scene {
         // live world reference there.
         const world = this.world;
         const seed = this.currentSeed;
-        // Defensive copy of the inputLog — the live array is owned by
-        // GameScene and will be cleared by restartGame's resetSessionState.
-        const inputLogCopy: SimCommand[] = this.inputLog.map((c) => ({ ...c }));
+        // Deep copy of the inputLog. `structuredClone` covers nested
+        // objects (e.g. SetBehaviorRatio.ratio: { forage, fight }) that a
+        // shallow `{...c}` would still share by reference with the live
+        // array. resetSessionState clears the live array shortly after;
+        // a shared nested reference would let that clear corrupt the
+        // in-flight payload.
+        const inputLogCopy: SimCommand[] = this.inputLog.map((c) => structuredClone(c));
         // The ADR contract requires outcome to be one of Victory / Defeat /
         // MutualDestruction on the wire — `None` is not a valid value. The
         // pause-menu-quit path may fire with a live queen (outcome=None), so

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -37,6 +37,11 @@ import { runAIController } from './ai-controller.js';
 import { buildDebugSnapshot } from '../platform/debug-snapshot.js';
 import { downloadDebugSnapshot } from './debug-snapshot-download.js';
 import {
+  submitPlaytrace,
+  cancelInFlightUpload,
+  type PlaytraceSurvey,
+} from './playtrace-upload.js';
+import {
   GamePhase,
   deriveAIColonyIds,
   appendInputLog,
@@ -128,6 +133,7 @@ interface UIScenePhase9 {
     onResume: () => void;
     onDownloadDebug: () => void;
     onOpenSaveLoad?: () => void;
+    onQuitAndSurvey?: () => void;
   }): void;
   hidePauseMenuOverlay(): void;
   isPauseMenuVisible(): boolean;
@@ -141,6 +147,14 @@ interface UIScenePhase9 {
     onBack: () => void;
   }): void;
   hideSaveLoadDialogOverlay(): void;
+  // Issue #122 / ADR 0013 — survey overlay. Shown at end-of-game (after a
+  // terminal outcome) or via the pause menu's "Quit & feedback" entry.
+  showSurveyOverlay(callbacks: {
+    quitFromPauseMenu: boolean;
+    onSubmit(survey: PlaytraceSurvey & { includeSnapshot: boolean }): void;
+    onSkip(): void;
+  }): void;
+  hideSurveyOverlay(): void;
 }
 import type { SimCommand } from '../sim/commands.js';
 
@@ -191,6 +205,14 @@ export class GameScene extends Phaser.Scene {
   // type aligns with PauseMenuLayout's SpeedMultiplier.
   private speedMultiplier: 1 | 2 | 4 = 1;
 
+  // Issue #122 / ADR 0013 — playtrace upload state. The endpoint string is
+  // sourced from the registry (set by main.ts from VITE_PLAYTRACE_ENDPOINT
+  // or MountOptions.playtraceEndpoint); empty string = feature off. The
+  // sessionId is a per-session UUID generated render-side via crypto;
+  // regenerated on restart so each session has its own row server-side.
+  private playtraceEndpoint: string = '';
+  private playtraceSessionId: string = '';
+
   constructor() { super({ key: 'GameScene' }); }
 
   preload() {
@@ -231,6 +253,13 @@ export class GameScene extends Phaser.Scene {
     this.viewState = createViewState(PLAYER_START_X, PLAYER_START_Y);
     this.gfx = this.add.graphics();
     this.antSprites = new AntSpritePool(this);
+
+    // Issue #122 — pull the playtrace endpoint out of the registry (set by
+    // main.ts in callbacks.preBoot). Treat any non-string value as "feature
+    // off" so a programming error in main.ts doesn't accidentally turn the
+    // overlay on with an undefined endpoint and 404 the submission.
+    const endpointRaw = this.registry.get('playtraceEndpoint');
+    this.playtraceEndpoint = typeof endpointRaw === 'string' ? endpointRaw : '';
 
     // Input registration — keyboard is GameScene-only (Pitfall 2).
     this.cursors = this.input.keyboard!.createCursorKeys();
@@ -424,6 +453,15 @@ export class GameScene extends Phaser.Scene {
     // would lock a freshly-spawned ant into the prior ant's direction until
     // the smoothing relaxes. Clearing here keeps boot visually clean.
     this.antFacingCache.reset();
+    // Issue #122 — cancel any upload from the prior session that may still
+    // be in flight (long network tails, slow uplink) so the new session's
+    // submission doesn't race the old one server-side, and rotate the
+    // session UUID so each (re)start gets its own telemetry row.
+    cancelInFlightUpload();
+    this.playtraceSessionId =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : '';
   }
 
   private bootFresh(): void {
@@ -519,7 +557,16 @@ export class GameScene extends Phaser.Scene {
         // W2: first-class pause via Plan 06 Task 1 API — no setMsPerTick(Infinity)
         this.gameLoop.pause();
         const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
-        uiScene.showGameOverOverlay(outcome, () => this.restartGame());
+        // Issue #122 — when the playtrace feature is enabled, the survey
+        // overlay replaces the bare game-over panel at end-of-game. Skip
+        // from the survey transitions to restart, matching the prior UX.
+        // When the feature is off, fall back to the original game-over
+        // overlay so the open-source build's behavior is unchanged.
+        if (this.playtraceEndpoint !== '') {
+          this.openSurveyOverlay(false /* quitFromPauseMenu */);
+        } else {
+          uiScene.showGameOverOverlay(outcome, () => this.restartGame());
+        }
       },
       getMsPerTick: () => MS_PER_TICK / this.speedMultiplier,
     });
@@ -555,8 +602,9 @@ export class GameScene extends Phaser.Scene {
     onOpenSaveLoad: () => void;
     getSpeedMultiplier: () => 1 | 2 | 4;
     onCycleSpeed: (next: 1 | 2 | 4) => void;
+    onQuitAndSurvey?: () => void;
   } {
-    return {
+    const cb: ReturnType<GameScene['buildPauseMenuCallbacks']> = {
       onResume: () => this.closePauseMenu(),
       onDownloadDebug: () => {
         if (this.world === undefined) return;
@@ -571,6 +619,78 @@ export class GameScene extends Phaser.Scene {
       getSpeedMultiplier: () => this.speedMultiplier,
       onCycleSpeed: (next: 1 | 2 | 4) => { this.speedMultiplier = next; },
     };
+    // Issue #122 — only attach onQuitAndSurvey when the feature flag is on.
+    // The pause menu treats `undefined` as "hide the row" so an open-source
+    // build with no endpoint set never even sees the affordance.
+    if (this.playtraceEndpoint !== '') {
+      cb.onQuitAndSurvey = () => this.openSurveyOverlay(true /* quitFromPauseMenu */);
+    }
+    return cb;
+  }
+
+  /** Issue #122 — open the survey overlay. Called at end-of-game (when
+   *  the feature flag is on; falls back to game-over overlay otherwise)
+   *  and from the pause menu's "Quit & feedback" entry. The survey
+   *  collects rating / free-text / brokenFlag / upload opt-in, then on
+   *  submit dispatches to submitPlaytrace and transitions to restart.
+   *  Skip / Esc transition straight to restart without uploading. */
+  private openSurveyOverlay(quitFromPauseMenu: boolean): void {
+    if (this.world === undefined) return; // pre-boot guard
+    const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
+    // Capture the values the survey needs BEFORE handing control away.
+    // The submission flow is async; meanwhile the player will start the
+    // next session (restart-on-skip / restart-on-submit) and the live
+    // references would otherwise change beneath us. World can't be safely
+    // captured by reference because resetSessionState swaps it; but we
+    // build the snapshot synchronously at submit time, before restart.
+    const outcome = this.currentOutcome;
+    uiScene.showSurveyOverlay({
+      quitFromPauseMenu,
+      onSubmit: (survey) => {
+        // Capture the live world / seed / inputLog right now, before the
+        // restart path overwrites them. The snapshot is built lazily
+        // inside submitPlaytrace's downgrade loop, so we still need the
+        // live world reference there.
+        const world = this.world;
+        const seed = this.currentSeed;
+        // Defensive copy of the inputLog — the live array is owned by
+        // GameScene and will be cleared by restartGame's resetSessionState.
+        const inputLogCopy: SimCommand[] = this.inputLog.map((c) => ({ ...c }));
+        // The ADR contract requires outcome to be one of Victory / Defeat /
+        // MutualDestruction on the wire — `None` is not a valid value. The
+        // pause-menu-quit path may fire with a live queen (outcome=None), so
+        // treat that as a concession and map to Defeat. quitFromPauseMenu
+        // remains true on the envelope so the receiver can distinguish a
+        // "player abandoned" run from an actual queen-death defeat.
+        const wireOutcome: GameOutcome =
+          outcome === GameOutcome.None ? GameOutcome.Defeat : outcome;
+        if (world !== undefined) {
+          // Fire-and-forget. The user has already seen the overlay close;
+          // restart proceeds in parallel with the upload. cancelInFlight
+          // in resetSessionState handles the abort if restart fires before
+          // the request completes.
+          void submitPlaytrace({
+            endpoint: this.playtraceEndpoint,
+            sessionId: this.playtraceSessionId,
+            outcome: wireOutcome,
+            quitFromPauseMenu,
+            includeSnapshot: survey.includeSnapshot,
+            world,
+            seed,
+            inputLog: inputLogCopy,
+            survey: {
+              rating: survey.rating,
+              freeText: survey.freeText,
+              brokenFlag: survey.brokenFlag,
+            },
+          });
+        }
+        this.restartGame();
+      },
+      onSkip: () => {
+        this.restartGame();
+      },
+    });
   }
 
   private openPauseMenu(): void {

--- a/src/render/pause-menu-layout.test.ts
+++ b/src/render/pause-menu-layout.test.ts
@@ -40,6 +40,28 @@ describe('pauseMenuItems — main page', () => {
     expect(items.find(i => i.id === 'save-load')!.enabled).toBe(true);
   });
 
+  it('Quit & feedback row is hidden when quitAndSurveyEnabled=false (issue #122 default)', () => {
+    const items = pauseMenuItems('main', { ...ctx, quitAndSurveyEnabled: false });
+    expect(items.find(i => i.id === 'quit-and-survey')).toBeUndefined();
+    // The default-off path keeps the original 4-row main menu.
+    expect(items).toHaveLength(4);
+  });
+
+  it('Quit & feedback row is emitted when quitAndSurveyEnabled=true (issue #122)', () => {
+    const items = pauseMenuItems('main', { ...ctx, quitAndSurveyEnabled: true });
+    const row = items.find(i => i.id === 'quit-and-survey');
+    expect(row).toBeDefined();
+    expect(row!.enabled).toBe(true);
+    expect(items).toHaveLength(5);
+    // Layout invariant: every row including the new one keeps the
+    // documented w×h and the stack-gap (rebuilt against new item count).
+    for (let i = 1; i < items.length; i++) {
+      const prevBottom = items[i - 1]!.rect.y + items[i - 1]!.rect.h;
+      const currTop = items[i]!.rect.y;
+      expect(currTop - prevBottom).toBe(PAUSE_MENU_BUTTON_GAP);
+    }
+  });
+
   it('every button has the documented w×h dimensions', () => {
     const items = pauseMenuItems('main', ctx);
     for (const i of items) {

--- a/src/render/pause-menu-layout.test.ts
+++ b/src/render/pause-menu-layout.test.ts
@@ -18,6 +18,7 @@ const ctx: PauseMenuRenderContext = {
   saveLoadEnabled: true,
   currentPheromoneOverlay: true,
   currentSpeedMultiplier: 1,
+  quitAndSurveyEnabled: false,
 };
 
 describe('pauseMenuItems — main page', () => {

--- a/src/render/pause-menu-layout.ts
+++ b/src/render/pause-menu-layout.ts
@@ -49,7 +49,11 @@ export type PauseMenuItemId =
   | 'debug-snapshot'
   | 'back'
   | 'pheromone-toggle'
-  | 'speed-cycle';
+  | 'speed-cycle'
+  // Issue #122 / ADR 0013 — "Quit & feedback" entry. Only emitted when the
+  // playtrace feature is enabled (caller passes ctx.quitAndSurveyEnabled);
+  // hidden otherwise so the open-source build's pause menu is unchanged.
+  | 'quit-and-survey';
 
 /** Allowed speedMultiplier values. Cycled by the Settings sub-screen
  *  speed-cycle row in the order 1 → 2 → 4 → 1. */
@@ -88,6 +92,11 @@ export interface PauseMenuRenderContext {
    *  settings persistence — matches the Phase 4 fresh-boot contract that
    *  speed resets to 1× on restart). */
   currentSpeedMultiplier: SpeedMultiplier;
+  /** Issue #122 / ADR 0013 — true when the playtrace upload feature is
+   *  active (VITE_PLAYTRACE_ENDPOINT non-empty). Adds a "Quit & feedback"
+   *  row to the main menu; hidden when the feature is off so the open-
+   *  source build's menu stays identical to pre-#122. */
+  quitAndSurveyEnabled: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -135,6 +144,9 @@ export function pauseMenuItems(
       { id: 'settings',       label: 'Settings  >',        enabled: true },
       { id: 'debug-snapshot', label: 'Download debug log', enabled: true },
     ];
+    if (ctx.quitAndSurveyEnabled) {
+      labels.push({ id: 'quit-and-survey', label: 'Quit & feedback', enabled: true });
+    }
     const rects = stackRects(labels.length);
     return labels.map((l, i) => ({
       id: l.id,

--- a/src/render/playtrace-upload.test.ts
+++ b/src/render/playtrace-upload.test.ts
@@ -267,7 +267,7 @@ describe('submitPlaytrace — timing invariant (load-bearing)', () => {
   // world.simVersion immediately after `void submitPlaytrace(...)`
   // returns, then waits for the upload to land and asserts the body
   // reflects the pre-mutation state.
-  it('captures world.tick / simVersion before yielding control to the caller', async () => {
+  it('captures world.tick / simVersion before yielding control to the caller (stage-1 fit)', async () => {
     const input = makeInput();
     input.world.tick = 9999;
     input.world.simVersion = 7;
@@ -298,6 +298,70 @@ describe('submitPlaytrace — timing invariant (load-bearing)', () => {
       expect(bodies[0]).toEqual({ tick: 9999, simVersion: 7 });
     } finally {
       fetchSpy.mockRestore();
+    }
+  });
+
+  // Codex P1 regression: the downgrade loop's stages 2/3 used to
+  // re-call buildDebugSnapshot(input.world, ...) AFTER suspending on
+  // stage 1's gzip — by that point restartGame() had mutated the world.
+  // This test forces the downgrade loop to walk all the way to stage 4
+  // by stubbing CompressionStream to identity-encode, then mutates the
+  // world between submit and final resolution and asserts the body
+  // reflects pre-mutation state at every wire-visible field.
+  it('downgrade stages derive from the stage-1 envelope, not the live world (codex P1)', async () => {
+    const origCS = globalThis.CompressionStream;
+    // Identity CompressionStream — passes input bytes through unchanged
+    // so the downgrade loop is forced to walk all stages by JSON-encoded
+    // body size, not by real gzip ratio.
+    const IdentityCS = function (this: unknown, _format: string) {
+      return new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) { controller.enqueue(chunk); },
+      });
+    };
+    (globalThis as unknown as { CompressionStream: unknown }).CompressionStream = IdentityCS;
+
+    // Inflate the inputLog so stages 1 and 2 exceed the 5 MB cap and the
+    // downgrade walks past them. Stage 3 (no antTrace, no inputLog)
+    // shrinks below 5 MB and lands at fetch.
+    const fat = 'a'.repeat(2 * 1024 * 1024);
+    const input = makeInput({
+      inputLog: Array.from({ length: 3 }, () => ({
+        type: 'SetBehaviorRatio',
+        colonyId: 1,
+        ratio: { forage: 50, fight: 50 },
+        issuedAtTick: 0,
+        _padding: fat,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)),
+    });
+    input.world.tick = 5555;
+    input.world.simVersion = 9;
+
+    const bodies: Array<{ tick: number; simVersion: number }> = [];
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      // Identity-encoded body: bytes ARE the JSON. Skip DecompressionStream
+      // (it would reject non-gzip input).
+      const blob = init!.body as Blob;
+      const text = await blob.text();
+      const env = JSON.parse(text) as { tick: number; simVersion: number };
+      bodies.push({ tick: env.tick, simVersion: env.simVersion });
+      return new Response(JSON.stringify({ accepted: true }), { status: 202 });
+    });
+
+    try {
+      const pending = submitPlaytrace(input);
+      // Same synchronous-tick mutation as the stage-1 test. This must NOT
+      // leak into the final body even though the downgrade loop awaits
+      // multiple times before sending.
+      input.world.tick = 0;
+      input.world.simVersion = 0;
+      const result = await pending;
+      expect(result.status, JSON.stringify(result)).toBe('ok');
+      expect(bodies).toHaveLength(1);
+      expect(bodies[0]).toEqual({ tick: 5555, simVersion: 9 });
+    } finally {
+      fetchSpy.mockRestore();
+      (globalThis as unknown as { CompressionStream: unknown }).CompressionStream = origCS;
     }
   });
 });

--- a/src/render/playtrace-upload.test.ts
+++ b/src/render/playtrace-upload.test.ts
@@ -107,6 +107,24 @@ describe('submitPlaytrace — feature flag gating', () => {
       fetchSpy.mockRestore();
     }
   });
+
+  it('treats whitespace-only endpoint as feature-off (codex P2)', async () => {
+    // A templated env var that resolved to whitespace (`'   '`,
+    // `'\t\n'`) would otherwise pass the `=== ''` check and fire fetch
+    // against an invalid URL. Trim before gating.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      throw new Error('fetch should not be called for a whitespace-only endpoint');
+    });
+    try {
+      for (const endpoint of ['   ', '\t', '\n', ' \t\n  ']) {
+        const result = await submitPlaytrace(makeInput({ endpoint }));
+        expect(result).toEqual({ status: 'feature-off' });
+      }
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });
 
 describe('submitPlaytrace — wire framing', () => {

--- a/src/render/playtrace-upload.test.ts
+++ b/src/render/playtrace-upload.test.ts
@@ -259,6 +259,49 @@ describe('submitPlaytrace — graceful downgrade', () => {
   });
 });
 
+describe('submitPlaytrace — timing invariant (load-bearing)', () => {
+  // game-scene.ts:onSubmit fires `void submitPlaytrace(...)` and then
+  // synchronously calls restartGame(), which mutates the live world.
+  // The wire envelope MUST be fully captured into JSON-safe primitives
+  // before that mutation can happen. This test mutates world.tick and
+  // world.simVersion immediately after `void submitPlaytrace(...)`
+  // returns, then waits for the upload to land and asserts the body
+  // reflects the pre-mutation state.
+  it('captures world.tick / simVersion before yielding control to the caller', async () => {
+    const input = makeInput();
+    input.world.tick = 9999;
+    input.world.simVersion = 7;
+
+    const bodies: Array<{ tick: number; simVersion: number }> = [];
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      // Decompress the body and capture the envelope fields we care about.
+      const blob = init!.body as Blob;
+      const buf = new Uint8Array(await blob.arrayBuffer());
+      const stream = new Blob([buf]).stream().pipeThrough(new DecompressionStream('gzip'));
+      const text = await new Response(stream).text();
+      const env = JSON.parse(text) as { tick: number; simVersion: number };
+      bodies.push({ tick: env.tick, simVersion: env.simVersion });
+      return new Response(JSON.stringify({ accepted: true }), { status: 202 });
+    });
+
+    try {
+      // Fire-and-forget exactly as game-scene does.
+      const pending = submitPlaytrace(input);
+      // Mutate the live world IMMEDIATELY — same synchronous tick as the
+      // caller. This simulates restartGame() running right after the void
+      // submitPlaytrace expression. If the envelope were captured lazily
+      // (after the first await), these mutations would corrupt the body.
+      input.world.tick = 0;
+      input.world.simVersion = 0;
+      await pending;
+      expect(bodies).toHaveLength(1);
+      expect(bodies[0]).toEqual({ tick: 9999, simVersion: 7 });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
 describe('cancelInFlightUpload', () => {
   beforeEach(() => {
     cancelInFlightUpload();

--- a/src/render/playtrace-upload.test.ts
+++ b/src/render/playtrace-upload.test.ts
@@ -1,0 +1,296 @@
+// playtrace-upload.test.ts — issue #122 / ADR 0013 coverage for the
+// upload module. Three concerns:
+//
+//   1. Graceful downgrade — when the gzipped body exceeds the cap, the
+//      module retries with reduced snapshot shape (antTrace off → inputLog
+//      off → survey-only). This is the headline correctness property.
+//   2. Feature-flag gating — an empty endpoint string must short-circuit
+//      without touching `fetch`. Defense-in-depth against an overlay that
+//      forgot to gate on the same flag.
+//   3. Wire framing — Content-Type / Content-Encoding / X-Schema-Version
+//      headers match the contract, body is the gzipped envelope.
+//
+// The fetch + CompressionStream APIs are present in Vitest's node-environment
+// runtime (Node 22+); these tests do NOT require jsdom. Where the body Blob
+// needs to be inspected we read it back via arrayBuffer().
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  submitPlaytrace,
+  buildPlaytraceEnvelope,
+  outcomeToWire,
+  truncateFreeText,
+  cancelInFlightUpload,
+  PLAYTRACE_FREE_TEXT_MAX,
+  PLAYTRACE_SCHEMA_VERSION,
+  type PlaytraceSubmissionInput,
+} from './playtrace-upload.js';
+import { GameOutcome } from '../sim/game-over.js';
+import { createWorldState } from '../sim/types.js';
+import * as debugSnapshot from '../platform/debug-snapshot.js';
+
+const MAX_TEST_ENTITIES = 16;
+
+function makeInput(overrides: Partial<PlaytraceSubmissionInput> = {}): PlaytraceSubmissionInput {
+  const world = createWorldState(123, MAX_TEST_ENTITIES);
+  return {
+    endpoint: '/api/playtrace',
+    sessionId: 'test-uuid-0000',
+    outcome: GameOutcome.Victory,
+    quitFromPauseMenu: false,
+    includeSnapshot: true,
+    world,
+    seed: 123,
+    inputLog: [],
+    survey: { rating: 5, freeText: '', brokenFlag: false },
+    ...overrides,
+  };
+}
+
+describe('outcomeToWire', () => {
+  it('maps the three terminal outcomes to their string forms', () => {
+    expect(outcomeToWire(GameOutcome.Victory)).toBe('Victory');
+    expect(outcomeToWire(GameOutcome.Defeat)).toBe('Defeat');
+    expect(outcomeToWire(GameOutcome.MutualDestruction)).toBe('MutualDestruction');
+  });
+
+  it('throws on None — the contract forbids it on the wire', () => {
+    expect(() => outcomeToWire(GameOutcome.None)).toThrow(/None should never reach the wire/);
+  });
+});
+
+describe('truncateFreeText', () => {
+  it('passes through short input unchanged', () => {
+    expect(truncateFreeText('hello')).toBe('hello');
+  });
+
+  it('trims trailing whitespace', () => {
+    expect(truncateFreeText('hello   \n')).toBe('hello');
+  });
+
+  it('truncates to PLAYTRACE_FREE_TEXT_MAX', () => {
+    const long = 'a'.repeat(PLAYTRACE_FREE_TEXT_MAX + 50);
+    const out = truncateFreeText(long);
+    expect(out.length).toBe(PLAYTRACE_FREE_TEXT_MAX);
+  });
+});
+
+describe('buildPlaytraceEnvelope', () => {
+  it('produces a wire envelope with the contracted fields', () => {
+    const input = makeInput();
+    const env = buildPlaytraceEnvelope(input, null);
+    expect(env.sessionId).toBe(input.sessionId);
+    expect(env.schemaVersion).toBe(PLAYTRACE_SCHEMA_VERSION);
+    expect(env.outcome).toBe('Victory');
+    expect(env.snapshot).toBeNull();
+    expect(env.survey.rating).toBe(5);
+  });
+
+  it('echoes the live world simVersion (per ADR §"Schema versioning")', () => {
+    const input = makeInput();
+    input.world.simVersion = 42;
+    const env = buildPlaytraceEnvelope(input, null);
+    expect(env.simVersion).toBe(42);
+  });
+});
+
+describe('submitPlaytrace — feature flag gating', () => {
+  it('short-circuits when endpoint is the empty string without calling fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      throw new Error('fetch should not be called when feature flag is off');
+    });
+    try {
+      const result = await submitPlaytrace(makeInput({ endpoint: '' }));
+      expect(result).toEqual({ status: 'feature-off' });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe('submitPlaytrace — wire framing', () => {
+  it('sends a same-origin POST with the contracted headers and gzipped body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ accepted: true }), { status: 202 }),
+    );
+    try {
+      await submitPlaytrace(makeInput());
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchSpy.mock.calls[0]!;
+      expect(url).toBe('/api/playtrace');
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      expect(headers['Content-Type']).toBe('application/octet-stream');
+      expect(headers['Content-Encoding']).toBe('gzip');
+      expect(headers['X-Schema-Version']).toBe('1');
+      // Body should be a Blob of non-zero size — the gzipped envelope.
+      const body = init?.body as Blob;
+      expect(body).toBeInstanceOf(Blob);
+      expect(body.size).toBeGreaterThan(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('reports server-side disable (HTTP 503) cleanly so the UI silently skips', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 503 }),
+    );
+    try {
+      const result = await submitPlaytrace(makeInput());
+      expect(result).toEqual({ status: 'server-disabled' });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('surfaces a Retry-After header on HTTP 429', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 429, headers: { 'Retry-After': '30' } }),
+    );
+    try {
+      const result = await submitPlaytrace(makeInput());
+      expect(result).toEqual({ status: 'rate-limited', retryAfterSeconds: 30 });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe('submitPlaytrace — graceful downgrade', () => {
+  it('walks the antTrace → inputLog → survey-only stages when the body exceeds the cap', async () => {
+    // Force the downgrade loop by making gzipString return artificial sizes
+    // depending on which downgrade stage the envelope reflects. We can't
+    // spy on the internal gzipString (it's a module-local helper); instead
+    // we observe stage transitions indirectly by capturing every fetch
+    // call's body and asserting that the final body corresponds to a
+    // survey-only envelope (snapshot: null).
+    //
+    // Strategy: stub global CompressionStream so each compressed Blob is
+    // sized proportionally to the input. The default CompressionStream
+    // shrinks our test payloads to bytes; making the gzip-result size
+    // grow linearly with input length gives us a deterministic way to
+    // make stage 1+2+3 oversize.
+    const origCS = globalThis.CompressionStream;
+    // Custom CompressionStream that emits the input UTF-8 bytes unchanged
+    // (no compression). That way a JSON envelope >5 MB stays >5 MB on the
+    // "gzipped" side, and the downgrade loop is forced to walk forward.
+    class IdentityCompressionStream extends TransformStream<Uint8Array, Uint8Array> {
+      constructor(_format: string) {
+        super({
+          transform(chunk, controller) {
+            controller.enqueue(chunk);
+          },
+        });
+      }
+    }
+    (globalThis as unknown as { CompressionStream: unknown }).CompressionStream =
+      IdentityCompressionStream;
+
+    // Inflate the input so stage 1 (full snapshot) breaches the 5 MB cap.
+    // The world has no ants but we shove a fat free-text string in the
+    // survey envelope to make the JSON body grow past the threshold.
+    const fat = 'a'.repeat(2 * 1024 * 1024); // 2 MB
+    const input = makeInput({
+      // Free text capped at 2000 chars — irrelevant for body size; instead
+      // we inflate the inputLog with fake commands so the envelope JSON
+      // crosses 5 MB on stages 1 and 2.
+      inputLog: Array.from({ length: 3 }, () => ({
+        type: 'SetBehaviorRatio',
+        colonyId: 1,
+        ratio: { forage: 50, fight: 50 },
+        issuedAtTick: 0,
+        // The padding pushes each command's stringified form past 2 MB —
+        // three of them = 6 MB stage-1 body. Stage 2 keeps the inputLog
+        // (still 6 MB). Stage 3 drops the inputLog and survives. Stage 4
+        // is the survey-only fallback (always fits).
+        _padding: fat,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)),
+    });
+
+    const bodies: Array<Blob> = [];
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      bodies.push(init!.body as Blob);
+      return new Response(JSON.stringify({ accepted: true }), { status: 202 });
+    });
+
+    try {
+      const result = await submitPlaytrace(input);
+      expect(result.status).toBe('ok');
+      // Exactly one fetch — the module performs the downgrade locally and
+      // only calls fetch once with the final, fitting body.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      // The final body must be ≤ 5 MB (the cap).
+      const finalBody = bodies[0]!;
+      expect(finalBody.size).toBeLessThanOrEqual(5 * 1024 * 1024);
+    } finally {
+      fetchSpy.mockRestore();
+      (globalThis as unknown as { CompressionStream: unknown }).CompressionStream = origCS;
+    }
+  });
+
+  it('skips snapshot construction when includeSnapshot is false', async () => {
+    // Use vi.mock at the module boundary so the import binding in
+    // playtrace-upload.ts is replaced (vi.spyOn on a namespace object
+    // doesn't reach a direct import). Defer to a dynamic import after
+    // the mock is registered.
+    vi.resetModules();
+    const buildSpy = vi.fn(() => ({
+      version: 1, seed: 0, tick: 0, inputLog: [], snapshot: {} as never, antTrace: [],
+    }));
+    vi.doMock('../platform/debug-snapshot.js', async (importOriginal) => {
+      const orig = await importOriginal<typeof debugSnapshot>();
+      return { ...orig, buildDebugSnapshot: buildSpy };
+    });
+    const mod = await import('./playtrace-upload.js');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ accepted: true }), { status: 202 }),
+    );
+    try {
+      await mod.submitPlaytrace(makeInput({ includeSnapshot: false }));
+      expect(buildSpy).not.toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchSpy.mockRestore();
+      vi.doUnmock('../platform/debug-snapshot.js');
+      vi.resetModules();
+    }
+  });
+});
+
+describe('cancelInFlightUpload', () => {
+  beforeEach(() => {
+    cancelInFlightUpload();
+  });
+
+  it('aborts an in-flight submission, surfacing { status: cancelled }', async () => {
+    // Mock fetch as a long-running promise that rejects with AbortError
+    // when the signal aborts. We resolve `fetchStarted` from inside the
+    // mock so the test knows when to call cancelInFlightUpload(); a bare
+    // `await Promise.resolve()` doesn't yield long enough for the gzip
+    // pipeline + fetch dispatch to complete.
+    let resolveFetchStarted!: () => void;
+    const fetchStarted = new Promise<void>((resolve) => { resolveFetchStarted = resolve; });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((_url, init) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = (init as RequestInit | undefined)?.signal;
+        if (signal !== undefined && signal !== null) {
+          signal.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        }
+        resolveFetchStarted();
+      });
+    });
+    try {
+      const pending = submitPlaytrace(makeInput());
+      await fetchStarted;
+      cancelInFlightUpload();
+      const result = await pending;
+      expect(result.status).toBe('cancelled');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/src/render/playtrace-upload.ts
+++ b/src/render/playtrace-upload.ts
@@ -197,6 +197,10 @@ export function buildPlaytraceEnvelope(
     quitFromPauseMenu: input.quitFromPauseMenu,
     survey: {
       rating: input.survey.rating,
+      // truncateFreeText is idempotent; running it here guarantees the
+      // contract bound even if a caller passed an unsanitized survey
+      // straight to buildPlaytraceEnvelope (bypassing submitPlaytrace's
+      // hoist). The hoist still saves repeated work in the downgrade loop.
       freeText: truncateFreeText(input.survey.freeText),
       brokenFlag: input.survey.brokenFlag,
     },
@@ -234,6 +238,17 @@ export async function gzipString(s: string): Promise<Blob> {
  * `feature-off` without touching the network. Errors are normalized into
  * the {@link PlaytraceUploadResult} discriminated union so the caller
  * doesn't need to inspect raw Response objects.
+ *
+ * Timing invariant — load-bearing: the entire snapshot construction
+ * (buildDebugSnapshot → serializeWorldState) and envelope build run in
+ * this function's SYNCHRONOUS PREFIX, before the first true `await`
+ * suspension point (which is inside `gzipString`'s `new Response(...).blob()`).
+ * Callers may therefore mutate the live `world` reference immediately
+ * after `void submitPlaytrace(...)` returns — game-scene.ts depends on
+ * this so its end-of-game `restartGame()` doesn't race the in-flight
+ * payload. The downgrade rebuild path stays inside the same async tail
+ * after suspension, but by then every world read has already happened
+ * into JSON-safe primitives via serializeWorldState (see save.ts:569).
  */
 export async function submitPlaytrace(
   input: PlaytraceSubmissionInput,
@@ -251,12 +266,23 @@ export async function submitPlaytrace(
   const controller = new AbortController();
   inFlightController = controller;
 
-  try {
-    const body = input.includeSnapshot
-      ? await buildPayloadWithDowngrade(input)
-      : await buildSurveyOnlyPayload(input);
+  // Pre-truncate the free-text once. The downgrade loop rebuilds the
+  // envelope up to four times; running truncateFreeText each time would
+  // re-allocate the (possibly large) string on every rebuild for no value.
+  // Hoisting it also keeps the cleaned form stable across stages so the
+  // server sees identical bytes regardless of which downgrade landed.
+  const truncatedFreeText = truncateFreeText(input.survey.freeText);
+  const preparedInput: PlaytraceSubmissionInput = {
+    ...input,
+    survey: { ...input.survey, freeText: truncatedFreeText },
+  };
 
-    const response = await fetch(input.endpoint, {
+  try {
+    const body = preparedInput.includeSnapshot
+      ? await buildPayloadWithDowngrade(preparedInput)
+      : await buildSurveyOnlyPayload(preparedInput);
+
+    const response = await fetch(preparedInput.endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/octet-stream',

--- a/src/render/playtrace-upload.ts
+++ b/src/render/playtrace-upload.ts
@@ -1,0 +1,362 @@
+// playtrace-upload.ts — issue #122 / ADR 0013 playtrace upload module.
+//
+// Browser-only glue that gzips and POSTs a survey + (optional) debug-snapshot
+// payload to the website's `/api/playtrace` endpoint. Sibling to
+// debug-snapshot-download.ts: that file handles the F9 local-file path; this
+// one handles the same payload going to the cloud receiver for diagnostics.
+//
+// Boundary rules (ADR 0013):
+//   - No src/sim/ imports — sessionId comes from crypto.randomUUID(), the
+//     gameVersion from the build-time __APP_VERSION__ define, simVersion from
+//     world.simVersion (read by the caller, not us).
+//   - One outbound POST per submission. Body is gzipped JSON; framing matches
+//     the contract verbatim (Content-Type: application/octet-stream,
+//     Content-Encoding: gzip, X-Schema-Version: 1).
+//   - Client cap: gzipped body ≤ 5 MB. Downgrade fallback rebuilds the
+//     snapshot with antTrace omitted, then with inputLog omitted, then
+//     submits survey-only (snapshot: null).
+//   - Feature flag: an empty endpoint string disables the upload entirely.
+//     The caller (main.ts via VITE_PLAYTRACE_ENDPOINT) is expected to feature-
+//     gate the survey overlay too, but a defensive check here keeps a missed
+//     gating from sending traffic to the wrong origin.
+//
+// Concurrency: a single in-flight controller is tracked at module scope so
+// `cancelInFlightUpload()` can abort a still-running submission when the
+// game restarts mid-upload. The contract is fire-and-forget from the player's
+// perspective (the survey overlay closes immediately on submit), but if the
+// game restarts before the request completes, the abort prevents the new
+// session from racing the old one through the network.
+
+import type { WorldState } from '../sim/types.js';
+import type { SimCommand } from '../sim/commands.js';
+import { buildDebugSnapshot, type DebugSnapshot } from '../platform/debug-snapshot.js';
+import { GameOutcome } from '../sim/game-over.js';
+
+// Build-time-injected by vite.config.ts / vite.lib.config.ts `define`. The
+// ambient declaration keeps the playtrace module self-contained — no
+// global.d.ts shim required for a single-consumer define.
+declare const __APP_VERSION__: string;
+
+/** Wire-level schema version. Bumped on any breaking change to the envelope
+ *  shape. Mirrored in the `X-Schema-Version` header so the server can reject
+ *  unknown versions without paying the cost of decompressing the body. */
+export const PLAYTRACE_SCHEMA_VERSION = 1 as const;
+
+/** Hard ceiling on the gzipped body. Defense-in-depth — the server also
+ *  enforces this and returns 413. Picked to fit comfortably inside the
+ *  API Gateway HTTP API + Lambda binary-invoke effective payload cap. */
+export const PLAYTRACE_MAX_GZIPPED_BYTES = 5 * 1024 * 1024;
+
+/** Free-text survey field cap (per ADR §"Decision → Wire shape"). Enforced
+ *  client-side so the server doesn't need to truncate. */
+export const PLAYTRACE_FREE_TEXT_MAX = 2000;
+
+/** Survey contents collected by the overlay. Mirrors the wire envelope's
+ *  `survey` object 1:1 — keep these in sync if the contract changes. */
+export interface PlaytraceSurvey {
+  /** Player rating, 1-5 inclusive. Validated at the overlay layer; this
+   *  module trusts the caller to have clamped already. */
+  rating: number;
+  /** Free-text feedback. Truncated to PLAYTRACE_FREE_TEXT_MAX before send. */
+  freeText: string;
+  /** "Report as broken" flag — orthogonal to the rating so a 5-star "great
+   *  game but X is broken" report is expressible. */
+  brokenFlag: boolean;
+}
+
+/** Inputs the caller (game-scene) supplies to issue a submission. The module
+ *  builds the snapshot internally so the downgrade rebuild can re-call
+ *  buildDebugSnapshot with reduced options without forcing the caller to
+ *  carry the world reference across the await. */
+export interface PlaytraceSubmissionInput {
+  /** Endpoint URL — `''` means feature off, the call no-ops. Typically
+   *  `/api/playtrace` in production, threaded via VITE_PLAYTRACE_ENDPOINT. */
+  endpoint: string;
+  /** Stable per-session client UUID. Generated render-side via
+   *  `crypto.randomUUID()` — never read off the sim PRNG. */
+  sessionId: string;
+  /** Terminal outcome for the run. `None` is rejected (the overlay only
+   *  opens on a terminal outcome); the caller should never pass it. */
+  outcome: GameOutcome;
+  /** UI flag — true when the survey was reached via the pause menu's
+   *  "Quit & feedback" path rather than after a natural game-over. */
+  quitFromPauseMenu: boolean;
+  /** Whether to include the debug snapshot in the submission. False =
+   *  survey-only; the wire envelope's `snapshot` becomes null. */
+  includeSnapshot: boolean;
+  /** Live world reference, used only to build the snapshot. The module
+   *  does not retain the reference beyond the synchronous build call. */
+  world: WorldState;
+  /** Session seed (matches the SaveFile envelope). */
+  seed: number;
+  /** Session-accumulated command log. Caller-owned reference; the upload
+   *  shallow-copies each command into the payload. */
+  inputLog: readonly SimCommand[];
+  /** Survey contents from the overlay. */
+  survey: PlaytraceSurvey;
+}
+
+/** Result of a submission attempt. The caller surfaces a toast based on
+ *  `status` (the survey overlay has already closed by this point). */
+export type PlaytraceUploadResult =
+  | { status: 'ok'; httpStatus: number }
+  | { status: 'feature-off' }
+  | { status: 'cancelled' }
+  /** Server rejected the body (400/413) or transport failed (offline / DNS).
+   *  Both produce the same UI: "feedback failed, please try again". */
+  | { status: 'error'; reason: string; httpStatus?: number }
+  /** Rate-limited. UI shows "try again later"; client does not auto-retry. */
+  | { status: 'rate-limited'; retryAfterSeconds?: number }
+  /** Server-side feature flag is off (PLAYTRACE_ENABLED=false → 503).
+   *  Treated the same as `feature-off` by the UI — silent skip. */
+  | { status: 'server-disabled' };
+
+/** Envelope as it goes over the wire (pre-gzip). Exported so tests can
+ *  reconstruct expectations against the same shape. */
+export interface PlaytraceEnvelope {
+  sessionId: string;
+  schemaVersion: typeof PLAYTRACE_SCHEMA_VERSION;
+  gameVersion: string;
+  simVersion: number;
+  seed: number;
+  tick: number;
+  outcome: 'Victory' | 'Defeat' | 'MutualDestruction';
+  quitFromPauseMenu: boolean;
+  survey: PlaytraceSurvey;
+  snapshot: DebugSnapshot | null;
+}
+
+// ---------------------------------------------------------------------------
+// Internal state — single in-flight controller for cancel-on-restart
+// ---------------------------------------------------------------------------
+
+let inFlightController: AbortController | null = null;
+
+/** Aborts any in-flight upload. Idempotent — safe to call when no upload
+ *  is in flight. Called from game restart paths so an upload from the
+ *  previous session can't race the new session through the network. */
+export function cancelInFlightUpload(): void {
+  if (inFlightController !== null) {
+    inFlightController.abort();
+    inFlightController = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for unit tests
+// ---------------------------------------------------------------------------
+
+/** Map the sim's numeric GameOutcome to the contract's string name. The
+ *  string form decouples the wire from the sim's internal numbering so the
+ *  enum can be renumbered without breaking on-disk telemetry. `None` is
+ *  invalid input — the survey only opens on a terminal outcome. */
+export function outcomeToWire(
+  outcome: GameOutcome,
+): 'Victory' | 'Defeat' | 'MutualDestruction' {
+  switch (outcome) {
+    case GameOutcome.Victory:           return 'Victory';
+    case GameOutcome.Defeat:            return 'Defeat';
+    case GameOutcome.MutualDestruction: return 'MutualDestruction';
+    case GameOutcome.None:
+      throw new Error('playtrace-upload: outcome=None should never reach the wire');
+  }
+}
+
+/** Sanitize the free-text response: trim, then truncate to the contract's
+ *  cap. Exported so the overlay can show a live char counter against the
+ *  same cap. */
+export function truncateFreeText(s: string): string {
+  // Trim only trailing whitespace — leading spaces in feedback ("  this is
+  // broken because…") are usually a paste artifact and dropping them keeps
+  // the stored row readable; we don't strip leading meaningful chars.
+  const trimmed = s.replace(/\s+$/, '');
+  if (trimmed.length <= PLAYTRACE_FREE_TEXT_MAX) return trimmed;
+  return trimmed.slice(0, PLAYTRACE_FREE_TEXT_MAX);
+}
+
+/** Build a fully-typed envelope from the submission input + a pre-built
+ *  snapshot (or null for survey-only). Pure — no fetch, no compression.
+ *  Exported for the downgrade-fallback unit test. */
+export function buildPlaytraceEnvelope(
+  input: PlaytraceSubmissionInput,
+  snapshot: DebugSnapshot | null,
+): PlaytraceEnvelope {
+  return {
+    sessionId: input.sessionId,
+    schemaVersion: PLAYTRACE_SCHEMA_VERSION,
+    gameVersion: __APP_VERSION__,
+    // Sourced from the LIVE snapshot's own simVersion (per ADR §"Schema
+    // versioning"). For loaded older saves, that field reflects what the
+    // save was written as — accurate even though the running build is
+    // newer. The current world.simVersion is the right field to read; we
+    // do not import LATEST_SIM_VERSION at build time.
+    simVersion: input.world.simVersion,
+    seed: input.seed,
+    tick: input.world.tick,
+    outcome: outcomeToWire(input.outcome),
+    quitFromPauseMenu: input.quitFromPauseMenu,
+    survey: {
+      rating: input.survey.rating,
+      freeText: truncateFreeText(input.survey.freeText),
+      brokenFlag: input.survey.brokenFlag,
+    },
+    snapshot,
+  };
+}
+
+/** Gzip a UTF-8 string using the native CompressionStream API. Returns the
+ *  compressed bytes as a Blob so the caller can read `.size` for the cap
+ *  check before deciding whether to retry with a smaller payload. */
+export async function gzipString(s: string): Promise<Blob> {
+  const stream = new Blob([s], { type: 'application/json' })
+    .stream()
+    .pipeThrough(new CompressionStream('gzip'));
+  return new Response(stream).blob();
+}
+
+// ---------------------------------------------------------------------------
+// Submission flow — graceful downgrade + fetch POST
+// ---------------------------------------------------------------------------
+
+/**
+ * Submit a playtrace. Handles the full ADR §"Size limits and graceful
+ * downgrade" sequence:
+ *
+ *   1. Build the full snapshot (or null if includeSnapshot=false) and
+ *      gzip the envelope. If it fits the 5 MB cap, send it.
+ *   2. Else rebuild with `includeAntTrace: false` (typically dominant
+ *      contribution to size), re-gzip, retry.
+ *   3. Else also drop the inputLog. Replay value is gone — caller's
+ *      overlay should have warned the player when the box was ticked.
+ *   4. Else fall back to a survey-only submission (snapshot: null).
+ *
+ * Feature flag handling: an empty endpoint string short-circuits to
+ * `feature-off` without touching the network. Errors are normalized into
+ * the {@link PlaytraceUploadResult} discriminated union so the caller
+ * doesn't need to inspect raw Response objects.
+ */
+export async function submitPlaytrace(
+  input: PlaytraceSubmissionInput,
+): Promise<PlaytraceUploadResult> {
+  if (input.endpoint === '') {
+    // Feature flag is off — silent skip. The overlay should already be
+    // gated on the same check; this guard is defense-in-depth.
+    return { status: 'feature-off' };
+  }
+
+  // Cancel any prior in-flight upload before starting a new one. Two
+  // submissions in flight simultaneously would race the server's per-route
+  // throttle (5 burst / 1 rps) for no benefit — only one survey per game.
+  cancelInFlightUpload();
+  const controller = new AbortController();
+  inFlightController = controller;
+
+  try {
+    const body = input.includeSnapshot
+      ? await buildPayloadWithDowngrade(input)
+      : await buildSurveyOnlyPayload(input);
+
+    const response = await fetch(input.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Encoding': 'gzip',
+        'X-Schema-Version': String(PLAYTRACE_SCHEMA_VERSION),
+      },
+      body,
+      // No credentials, no referrer policy override — same-origin POST.
+      signal: controller.signal,
+    });
+
+    if (response.status === 202) {
+      return { status: 'ok', httpStatus: 202 };
+    }
+    if (response.status === 429) {
+      const retryAfter = parseRetryAfter(response.headers.get('Retry-After'));
+      return retryAfter !== undefined
+        ? { status: 'rate-limited', retryAfterSeconds: retryAfter }
+        : { status: 'rate-limited' };
+    }
+    if (response.status === 503) {
+      return { status: 'server-disabled' };
+    }
+    return {
+      status: 'error',
+      reason: `HTTP ${response.status}`,
+      httpStatus: response.status,
+    };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      return { status: 'cancelled' };
+    }
+    return {
+      status: 'error',
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    // Only clear the module-level controller if it still points to ours —
+    // a concurrent cancelInFlightUpload + new submit may have rotated it
+    // while this submission was awaiting the network.
+    if (inFlightController === controller) inFlightController = null;
+  }
+}
+
+/** ADR §"Size limits and graceful downgrade" sequence for snapshot-included
+ *  submissions. Tries full → no-antTrace → no-antTrace-no-inputLog → null.
+ *  Each stage rebuilds the envelope with the reduced snapshot, re-gzips,
+ *  and checks size before falling through. Returns the first body that
+ *  fits the cap, or the final survey-only body which always fits. */
+async function buildPayloadWithDowngrade(
+  input: PlaytraceSubmissionInput,
+): Promise<Blob> {
+  // Stage 1 — full snapshot.
+  let snapshot = buildDebugSnapshot(input.world, input.seed, input.inputLog);
+  let body = await encodeEnvelope(input, snapshot);
+  if (body.size <= PLAYTRACE_MAX_GZIPPED_BYTES) return body;
+
+  // Stage 2 — drop antTrace (typically dominant size contribution).
+  snapshot = buildDebugSnapshot(input.world, input.seed, input.inputLog, {
+    includeAntTrace: false,
+  });
+  body = await encodeEnvelope(input, snapshot);
+  if (body.size <= PLAYTRACE_MAX_GZIPPED_BYTES) return body;
+
+  // Stage 3 — also drop inputLog. Replay value is now gone.
+  snapshot = buildDebugSnapshot(input.world, input.seed, input.inputLog, {
+    includeAntTrace: false,
+    includeInputLog: false,
+  });
+  body = await encodeEnvelope(input, snapshot);
+  if (body.size <= PLAYTRACE_MAX_GZIPPED_BYTES) return body;
+
+  // Stage 4 — survey-only. Always fits (envelope is a handful of fields).
+  return encodeEnvelope(input, null);
+}
+
+/** Build a survey-only payload directly, skipping the snapshot construction.
+ *  Used when the player did not opt in to upload. */
+async function buildSurveyOnlyPayload(
+  input: PlaytraceSubmissionInput,
+): Promise<Blob> {
+  return encodeEnvelope(input, null);
+}
+
+/** Stringify the envelope and gzip it. Shared helper across all four
+ *  downgrade stages so the wire framing stays identical between them. */
+async function encodeEnvelope(
+  input: PlaytraceSubmissionInput,
+  snapshot: DebugSnapshot | null,
+): Promise<Blob> {
+  const envelope = buildPlaytraceEnvelope(input, snapshot);
+  return gzipString(JSON.stringify(envelope));
+}
+
+/** Parse a Retry-After header value as integer seconds. Returns undefined on
+ *  unparseable input (the contract specifies seconds; HTTP-date form is
+ *  accepted by some servers but the contract pins it to seconds). */
+function parseRetryAfter(raw: string | null): number | undefined {
+  if (raw === null) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return Math.floor(n);
+}

--- a/src/render/playtrace-upload.ts
+++ b/src/render/playtrace-upload.ts
@@ -253,7 +253,13 @@ export async function gzipString(s: string): Promise<Blob> {
 export async function submitPlaytrace(
   input: PlaytraceSubmissionInput,
 ): Promise<PlaytraceUploadResult> {
-  if (input.endpoint === '') {
+  // Trim before checking so a whitespace-only endpoint (e.g. an embedder
+  // passing `playtraceEndpoint: '   '`, or a templated env var that
+  // resolved blank) is treated as feature-off rather than firing a fetch
+  // against an invalid URL. main.ts also normalizes at the boundary; this
+  // is defense-in-depth for direct submitPlaytrace callers.
+  const endpoint = input.endpoint.trim();
+  if (endpoint === '') {
     // Feature flag is off — silent skip. The overlay should already be
     // gated on the same check; this guard is defense-in-depth.
     return { status: 'feature-off' };
@@ -274,6 +280,7 @@ export async function submitPlaytrace(
   const truncatedFreeText = truncateFreeText(input.survey.freeText);
   const preparedInput: PlaytraceSubmissionInput = {
     ...input,
+    endpoint,
     survey: { ...input.survey, freeText: truncatedFreeText },
   };
 

--- a/src/render/playtrace-upload.ts
+++ b/src/render/playtrace-upload.ts
@@ -329,51 +329,69 @@ export async function submitPlaytrace(
 
 /** ADR §"Size limits and graceful downgrade" sequence for snapshot-included
  *  submissions. Tries full → no-antTrace → no-antTrace-no-inputLog → null.
- *  Each stage rebuilds the envelope with the reduced snapshot, re-gzips,
- *  and checks size before falling through. Returns the first body that
- *  fits the cap, or the final survey-only body which always fits. */
+ *
+ *  **World capture happens exactly once, in this function's synchronous
+ *  prefix.** Both the wire envelope's top-level fields (`tick`, `simVersion`,
+ *  ...) AND the nested snapshot field are read off `input.world` here, then
+ *  the downgrade stages emit derivatives of the captured envelope via plain
+ *  object manipulation — no further world reads. Codex P1 finding: the
+ *  caller's pattern is `void submitPlaytrace(...)` followed by an immediate
+ *  synchronous `restartGame()`, which mutates the live world. The first
+ *  `await` here yields control to that restart, so any later
+ *  `buildPlaytraceEnvelope(input, ...)` or `buildDebugSnapshot(input.world, ...)`
+ *  would race a post-restart world and produce a payload with mixed
+ *  sessions on the very oversized path this loop exists to handle. */
 async function buildPayloadWithDowngrade(
   input: PlaytraceSubmissionInput,
 ): Promise<Blob> {
-  // Stage 1 — full snapshot.
-  let snapshot = buildDebugSnapshot(input.world, input.seed, input.inputLog);
-  let body = await encodeEnvelope(input, snapshot);
+  // Capture the world ONCE, synchronously, into a JSON-safe full envelope.
+  // serializeWorldState (see save.ts:569) materializes every TypedArray and
+  // grid into plain primitives/arrays; buildPlaytraceEnvelope copies the
+  // remaining world-dependent primitives (tick, simVersion). After this
+  // returns, the envelope has no live references back into `input.world`.
+  const fullSnap = buildDebugSnapshot(input.world, input.seed, input.inputLog);
+  const fullEnvelope = buildPlaytraceEnvelope(input, fullSnap);
+
+  // Stage 1 — full envelope.
+  let body = await gzipEnvelope(fullEnvelope);
   if (body.size <= PLAYTRACE_MAX_GZIPPED_BYTES) return body;
 
   // Stage 2 — drop antTrace (typically dominant size contribution).
-  snapshot = buildDebugSnapshot(input.world, input.seed, input.inputLog, {
-    includeAntTrace: false,
-  });
-  body = await encodeEnvelope(input, snapshot);
+  const stage2: PlaytraceEnvelope = {
+    ...fullEnvelope,
+    snapshot: { ...fullSnap, antTrace: [] },
+  };
+  body = await gzipEnvelope(stage2);
   if (body.size <= PLAYTRACE_MAX_GZIPPED_BYTES) return body;
 
   // Stage 3 — also drop inputLog. Replay value is now gone.
-  snapshot = buildDebugSnapshot(input.world, input.seed, input.inputLog, {
-    includeAntTrace: false,
-    includeInputLog: false,
-  });
-  body = await encodeEnvelope(input, snapshot);
+  const stage3: PlaytraceEnvelope = {
+    ...fullEnvelope,
+    snapshot: { ...fullSnap, antTrace: [], inputLog: [] },
+  };
+  body = await gzipEnvelope(stage3);
   if (body.size <= PLAYTRACE_MAX_GZIPPED_BYTES) return body;
 
   // Stage 4 — survey-only. Always fits (envelope is a handful of fields).
-  return encodeEnvelope(input, null);
+  const stage4: PlaytraceEnvelope = { ...fullEnvelope, snapshot: null };
+  return gzipEnvelope(stage4);
 }
 
 /** Build a survey-only payload directly, skipping the snapshot construction.
- *  Used when the player did not opt in to upload. */
+ *  Used when the player did not opt in to upload. Same world-capture
+ *  property as the downgrade path: the envelope is built in this function's
+ *  synchronous prefix before the first await. */
 async function buildSurveyOnlyPayload(
   input: PlaytraceSubmissionInput,
 ): Promise<Blob> {
-  return encodeEnvelope(input, null);
+  const envelope = buildPlaytraceEnvelope(input, null);
+  return gzipEnvelope(envelope);
 }
 
-/** Stringify the envelope and gzip it. Shared helper across all four
- *  downgrade stages so the wire framing stays identical between them. */
-async function encodeEnvelope(
-  input: PlaytraceSubmissionInput,
-  snapshot: DebugSnapshot | null,
-): Promise<Blob> {
-  const envelope = buildPlaytraceEnvelope(input, snapshot);
+/** Stringify a fully-built envelope and gzip it. The envelope is already
+ *  decoupled from the live world at this point — this function does no
+ *  further world reads. */
+async function gzipEnvelope(envelope: PlaytraceEnvelope): Promise<Blob> {
   return gzipString(JSON.stringify(envelope));
 }
 

--- a/src/render/survey-overlay-layout.test.ts
+++ b/src/render/survey-overlay-layout.test.ts
@@ -54,6 +54,18 @@ describe('surveyHitTest — disjoint targets', () => {
     )).toEqual({ kind: 'upload-checkbox' });
   });
 
+  it('checkbox-row clicks register over the label area too (codex P3)', () => {
+    // The visible checkbox square is only 20×20, but the row also renders
+    // a long label to the right. A click on the label must toggle the
+    // checkbox — otherwise users (especially on touch) aim at the obvious
+    // target and nothing happens.
+    const labelX = SURVEY_BROKEN_CHECKBOX_RECT.x + SURVEY_BROKEN_CHECKBOX_RECT.w + 50;
+    expect(surveyHitTest(labelX, SURVEY_BROKEN_CHECKBOX_RECT.y + 5))
+      .toEqual({ kind: 'broken-checkbox' });
+    expect(surveyHitTest(labelX, SURVEY_UPLOAD_CHECKBOX_RECT.y + 5))
+      .toEqual({ kind: 'upload-checkbox' });
+  });
+
   it('returns submit / skip hits on the respective buttons', () => {
     expect(surveyHitTest(
       SURVEY_SUBMIT_BUTTON_RECT.x + 5,

--- a/src/render/survey-overlay-layout.test.ts
+++ b/src/render/survey-overlay-layout.test.ts
@@ -1,0 +1,91 @@
+// survey-overlay-layout.test.ts — issue #122 layout smoke coverage.
+//
+// Pure-data tests for the survey overlay's geometry + hit-testing. The
+// Phaser scene integration is covered separately (manually + via the
+// E2E suite in tests/); this file makes sure the layout module is
+// internally consistent before the scene ever consumes it.
+
+import { describe, it, expect } from 'vitest';
+import {
+  surveyRatingButtons,
+  surveyHitTest,
+  SURVEY_CANVAS_W,
+  SURVEY_SUBMIT_BUTTON_RECT,
+  SURVEY_SKIP_BUTTON_RECT,
+  SURVEY_BROKEN_CHECKBOX_RECT,
+  SURVEY_UPLOAD_CHECKBOX_RECT,
+  SURVEY_FREE_TEXT_RECT,
+  SURVEY_CONSENT_DISCLOSURE,
+} from './survey-overlay-layout.js';
+
+describe('surveyRatingButtons', () => {
+  it('emits exactly five buttons numbered 1..5 in order', () => {
+    const btns = surveyRatingButtons();
+    expect(btns.map(b => b.rating)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('button row is centered horizontally on the canvas', () => {
+    const btns = surveyRatingButtons();
+    const first = btns[0]!.rect;
+    const last  = btns[4]!.rect;
+    const leftMargin  = first.x;
+    const rightMargin = SURVEY_CANVAS_W - (last.x + last.w);
+    // Allow a 1px slack for rounding.
+    expect(Math.abs(leftMargin - rightMargin)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('surveyHitTest — disjoint targets', () => {
+  it('returns a rating hit when the pointer is inside a rating button', () => {
+    const btns = surveyRatingButtons();
+    const r = btns[2]!.rect; // rating 3
+    const hit = surveyHitTest(r.x + 5, r.y + 5);
+    expect(hit).toEqual({ kind: 'rating', rating: 3 });
+  });
+
+  it('returns broken-checkbox / upload-checkbox hits on the respective rects', () => {
+    expect(surveyHitTest(
+      SURVEY_BROKEN_CHECKBOX_RECT.x + 5,
+      SURVEY_BROKEN_CHECKBOX_RECT.y + 5,
+    )).toEqual({ kind: 'broken-checkbox' });
+    expect(surveyHitTest(
+      SURVEY_UPLOAD_CHECKBOX_RECT.x + 5,
+      SURVEY_UPLOAD_CHECKBOX_RECT.y + 5,
+    )).toEqual({ kind: 'upload-checkbox' });
+  });
+
+  it('returns submit / skip hits on the respective buttons', () => {
+    expect(surveyHitTest(
+      SURVEY_SUBMIT_BUTTON_RECT.x + 5,
+      SURVEY_SUBMIT_BUTTON_RECT.y + 5,
+    )).toEqual({ kind: 'submit' });
+    expect(surveyHitTest(
+      SURVEY_SKIP_BUTTON_RECT.x + 5,
+      SURVEY_SKIP_BUTTON_RECT.y + 5,
+    )).toEqual({ kind: 'skip' });
+  });
+
+  it('returns free-text on the textarea rect', () => {
+    expect(surveyHitTest(
+      SURVEY_FREE_TEXT_RECT.x + 5,
+      SURVEY_FREE_TEXT_RECT.y + 5,
+    )).toEqual({ kind: 'free-text' });
+  });
+
+  it('returns null on the panel background', () => {
+    // A point in the title gap above the rating buttons should not hit
+    // any interactive element.
+    expect(surveyHitTest(SURVEY_CANVAS_W / 2, 30)).toBeNull();
+  });
+});
+
+describe('consent disclosure', () => {
+  it('mentions both IP and browser/UA leakage per ADR 0013 §"Privacy"', () => {
+    // The exact wording is allowed to drift, but the two pieces of
+    // information the player needs to consent to MUST be named. Failing
+    // this assertion is a privacy-disclosure regression and should block
+    // the PR until the copy is fixed.
+    expect(SURVEY_CONSENT_DISCLOSURE.toLowerCase()).toMatch(/ip/);
+    expect(SURVEY_CONSENT_DISCLOSURE.toLowerCase()).toMatch(/browser|user[- ]agent|ua/);
+  });
+});

--- a/src/render/survey-overlay-layout.ts
+++ b/src/render/survey-overlay-layout.ts
@@ -62,6 +62,8 @@ export const SURVEY_UPLOAD_CHECKBOX_Y =
 export const SURVEY_CONSENT_TEXT_Y =
   SURVEY_UPLOAD_CHECKBOX_Y + SURVEY_CHECKBOX_SIZE + 6;
 
+/** Visible checkbox square rendered by UIScene. The clickable row hit
+ *  zone is wider — see {@link SURVEY_BROKEN_ROW_HIT_RECT}. */
 export const SURVEY_BROKEN_CHECKBOX_RECT = {
   x: PANEL_INSET_X,
   y: SURVEY_BROKEN_CHECKBOX_Y,
@@ -69,10 +71,35 @@ export const SURVEY_BROKEN_CHECKBOX_RECT = {
   h: SURVEY_CHECKBOX_SIZE,
 } as const;
 
+/** Visible checkbox square rendered by UIScene. The clickable row hit
+ *  zone is wider — see {@link SURVEY_UPLOAD_ROW_HIT_RECT}. */
 export const SURVEY_UPLOAD_CHECKBOX_RECT = {
   x: PANEL_INSET_X,
   y: SURVEY_UPLOAD_CHECKBOX_Y,
   w: SURVEY_CHECKBOX_SIZE,
+  h: SURVEY_CHECKBOX_SIZE,
+} as const;
+
+/** Codex P3: the visible checkbox square is only 20×20 but the row also
+ *  renders a long label to the right ("Report this as a bug", "Upload
+ *  diagnostic snapshot to help us debug…"). The label IS the affordance
+ *  most users will aim for — especially on touch devices. These row hit
+ *  rects cover the full row width so clicks on the label register as
+ *  checkbox toggles. The visible square is drawn off the narrower
+ *  ..._CHECKBOX_RECT constants above. */
+const ROW_HIT_W = SURVEY_CANVAS_W - 2 * PANEL_INSET_X;
+
+export const SURVEY_BROKEN_ROW_HIT_RECT = {
+  x: PANEL_INSET_X,
+  y: SURVEY_BROKEN_CHECKBOX_Y,
+  w: ROW_HIT_W,
+  h: SURVEY_CHECKBOX_SIZE,
+} as const;
+
+export const SURVEY_UPLOAD_ROW_HIT_RECT = {
+  x: PANEL_INSET_X,
+  y: SURVEY_UPLOAD_CHECKBOX_Y,
+  w: ROW_HIT_W,
   h: SURVEY_CHECKBOX_SIZE,
 } as const;
 
@@ -158,12 +185,14 @@ export type SurveyHitTarget =
   | { kind: 'free-text' }
   | null;
 
-/** Topmost interactive element under the pointer, or null on background. */
+/** Topmost interactive element under the pointer, or null on background.
+ *  Note: checkbox rows hit-test against the wider ROW_HIT rects so clicks
+ *  on the label text register the same as clicks on the visible square. */
 export function surveyHitTest(px: number, py: number): SurveyHitTarget {
   if (pointInRect(px, py, SURVEY_SUBMIT_BUTTON_RECT)) return { kind: 'submit' };
   if (pointInRect(px, py, SURVEY_SKIP_BUTTON_RECT))   return { kind: 'skip' };
-  if (pointInRect(px, py, SURVEY_BROKEN_CHECKBOX_RECT)) return { kind: 'broken-checkbox' };
-  if (pointInRect(px, py, SURVEY_UPLOAD_CHECKBOX_RECT)) return { kind: 'upload-checkbox' };
+  if (pointInRect(px, py, SURVEY_BROKEN_ROW_HIT_RECT)) return { kind: 'broken-checkbox' };
+  if (pointInRect(px, py, SURVEY_UPLOAD_ROW_HIT_RECT)) return { kind: 'upload-checkbox' };
   if (pointInRect(px, py, SURVEY_FREE_TEXT_RECT))     return { kind: 'free-text' };
   for (const btn of surveyRatingButtons()) {
     if (pointInRect(px, py, btn.rect)) {

--- a/src/render/survey-overlay-layout.ts
+++ b/src/render/survey-overlay-layout.ts
@@ -1,0 +1,174 @@
+// survey-overlay-layout.ts — issue #122 end-of-game survey overlay layout.
+//
+// Pure-TypeScript module (no Phaser, no DOM) mirroring the pattern in
+// pause-menu-layout.ts and save-load-dialog-layout.ts: defines geometry +
+// hit-testing for the overlay so UIScene can spin up Phaser game objects
+// against fixed rects and Vitest can exercise hit-testing headlessly.
+//
+// Visual layout (canvas-local pixels, 800×592):
+//
+//   Title:              "Thanks for playing" / "Tell us what you think"
+//   Rating row:         five rating buttons 1..5, horizontal stack
+//   Free-text:          single-line edit affordance (full editing happens
+//                       via a DOM input — see ui-scene.ts; this layout
+//                       reserves the rect)
+//   "Report as broken" checkbox row
+//   "Upload diagnostic snapshot" checkbox row + consent disclosure text
+//   Buttons:            [ Submit ] [ Skip ]
+//
+// The overlay is shown either at game-over (replacing the bare GameOver
+// overlay) or after the pause menu's "Quit & feedback" action. Layout is
+// identical between the two — only the title string differs slightly so
+// the player can tell the two paths apart (handled in UIScene at draw time).
+
+export const SURVEY_CANVAS_W = 800;
+export const SURVEY_CANVAS_H = 592;
+
+/** Overall modal panel inset from the canvas edges. */
+const PANEL_INSET_X = 80;
+const PANEL_TOP_Y = 60;
+const PANEL_BOTTOM_Y = SURVEY_CANVAS_H - 60;
+
+/** Title baseline Y — fixed offset from the panel top so the title doesn't
+ *  drift when other rows resize. */
+export const SURVEY_TITLE_Y = PANEL_TOP_Y + 30;
+
+/** Vertical anchor for the rating row — five buttons across, centered. */
+export const SURVEY_RATING_ROW_Y = PANEL_TOP_Y + 80;
+export const SURVEY_RATING_BUTTON_W = 56;
+export const SURVEY_RATING_BUTTON_H = 56;
+export const SURVEY_RATING_BUTTON_GAP = 12;
+
+/** Free-text input rect — a single-line affordance. DOM input element is
+ *  positioned over this rect at runtime by UIScene. */
+export const SURVEY_FREE_TEXT_RECT = {
+  x: PANEL_INSET_X,
+  y: SURVEY_RATING_ROW_Y + SURVEY_RATING_BUTTON_H + 30,
+  w: SURVEY_CANVAS_W - 2 * PANEL_INSET_X,
+  h: 100,
+} as const;
+
+/** Checkbox row constants — used by both the "Report as broken" and
+ *  "Upload diagnostic snapshot" rows. */
+export const SURVEY_CHECKBOX_SIZE = 20;
+export const SURVEY_CHECKBOX_LABEL_GAP = 12;
+
+export const SURVEY_BROKEN_CHECKBOX_Y =
+  SURVEY_FREE_TEXT_RECT.y + SURVEY_FREE_TEXT_RECT.h + 20;
+export const SURVEY_UPLOAD_CHECKBOX_Y =
+  SURVEY_BROKEN_CHECKBOX_Y + SURVEY_CHECKBOX_SIZE + 16;
+/** Two-line consent disclosure sits below the upload checkbox, indented to
+ *  align with the label text. */
+export const SURVEY_CONSENT_TEXT_Y =
+  SURVEY_UPLOAD_CHECKBOX_Y + SURVEY_CHECKBOX_SIZE + 6;
+
+export const SURVEY_BROKEN_CHECKBOX_RECT = {
+  x: PANEL_INSET_X,
+  y: SURVEY_BROKEN_CHECKBOX_Y,
+  w: SURVEY_CHECKBOX_SIZE,
+  h: SURVEY_CHECKBOX_SIZE,
+} as const;
+
+export const SURVEY_UPLOAD_CHECKBOX_RECT = {
+  x: PANEL_INSET_X,
+  y: SURVEY_UPLOAD_CHECKBOX_Y,
+  w: SURVEY_CHECKBOX_SIZE,
+  h: SURVEY_CHECKBOX_SIZE,
+} as const;
+
+/** Button row at the bottom of the panel. */
+const BUTTON_W = 120;
+const BUTTON_H = 36;
+const BUTTON_GAP = 16;
+const BUTTON_ROW_Y = PANEL_BOTTOM_Y - BUTTON_H - 20;
+
+/** Submit button — primary action, left side of the pair (centered as
+ *  a 2-button group). */
+export const SURVEY_SUBMIT_BUTTON_RECT = {
+  x: SURVEY_CANVAS_W / 2 - BUTTON_W - BUTTON_GAP / 2,
+  y: BUTTON_ROW_Y,
+  w: BUTTON_W,
+  h: BUTTON_H,
+} as const;
+
+/** Skip button — secondary action, right side. */
+export const SURVEY_SKIP_BUTTON_RECT = {
+  x: SURVEY_CANVAS_W / 2 + BUTTON_GAP / 2,
+  y: BUTTON_ROW_Y,
+  w: BUTTON_W,
+  h: BUTTON_H,
+} as const;
+
+/** Consent disclosure text. ADR 0013 §"Privacy" requires the overlay to
+ *  warn the player that an upload leaks client IP + User-Agent at the edge.
+ *  Centralized here so the wording is reviewable and only changes via this
+ *  module (matching the same approach for the contract's wire shape). */
+export const SURVEY_CONSENT_DISCLOSURE =
+  'Uploading sends your IP and browser version to the server alongside the diagnostic snapshot.';
+
+// ---------------------------------------------------------------------------
+// Rating buttons — five rects across, centered, indexed 1..5 left→right
+// ---------------------------------------------------------------------------
+
+export interface SurveyRatingButton {
+  rating: 1 | 2 | 3 | 4 | 5;
+  rect: { x: number; y: number; w: number; h: number };
+}
+
+/** Build the five rating-button rects. Computed lazily (called once on
+ *  overlay open) — the values are constant for the fixed canvas size so
+ *  caching is not warranted. */
+export function surveyRatingButtons(): SurveyRatingButton[] {
+  const totalW =
+    5 * SURVEY_RATING_BUTTON_W + 4 * SURVEY_RATING_BUTTON_GAP;
+  const startX = (SURVEY_CANVAS_W - totalW) / 2;
+  const out: SurveyRatingButton[] = [];
+  for (let i = 0; i < 5; i++) {
+    out.push({
+      rating: (i + 1) as 1 | 2 | 3 | 4 | 5,
+      rect: {
+        x: startX + i * (SURVEY_RATING_BUTTON_W + SURVEY_RATING_BUTTON_GAP),
+        y: SURVEY_RATING_ROW_Y,
+        w: SURVEY_RATING_BUTTON_W,
+        h: SURVEY_RATING_BUTTON_H,
+      },
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Hit testing
+// ---------------------------------------------------------------------------
+
+function pointInRect(
+  px: number,
+  py: number,
+  r: { x: number; y: number; w: number; h: number },
+): boolean {
+  return px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h;
+}
+
+export type SurveyHitTarget =
+  | { kind: 'rating'; rating: 1 | 2 | 3 | 4 | 5 }
+  | { kind: 'broken-checkbox' }
+  | { kind: 'upload-checkbox' }
+  | { kind: 'submit' }
+  | { kind: 'skip' }
+  | { kind: 'free-text' }
+  | null;
+
+/** Topmost interactive element under the pointer, or null on background. */
+export function surveyHitTest(px: number, py: number): SurveyHitTarget {
+  if (pointInRect(px, py, SURVEY_SUBMIT_BUTTON_RECT)) return { kind: 'submit' };
+  if (pointInRect(px, py, SURVEY_SKIP_BUTTON_RECT))   return { kind: 'skip' };
+  if (pointInRect(px, py, SURVEY_BROKEN_CHECKBOX_RECT)) return { kind: 'broken-checkbox' };
+  if (pointInRect(px, py, SURVEY_UPLOAD_CHECKBOX_RECT)) return { kind: 'upload-checkbox' };
+  if (pointInRect(px, py, SURVEY_FREE_TEXT_RECT))     return { kind: 'free-text' };
+  for (const btn of surveyRatingButtons()) {
+    if (pointInRect(px, py, btn.rect)) {
+      return { kind: 'rating', rating: btn.rating };
+    }
+  }
+  return null;
+}

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -683,7 +683,7 @@ export class UIScene extends Phaser.Scene {
 
     // Belt-and-suspenders: clear overlay window state on scene shutdown to
     // prevent stale __phase9_ui surviving a scene restart.
-    this.events.on('shutdown', () => {
+    const teardown = () => {
       this.hideGameOverOverlay();
       this.hideSavePromptOverlay();
       this.hideSaveLoadDialogOverlay();
@@ -691,7 +691,14 @@ export class UIScene extends Phaser.Scene {
       this.hideSurveyOverlay();
       hideAntActivityPanel();
       setActiveOverlay('none');
-    });
+    };
+    this.events.on('shutdown', teardown);
+    // Defensive: Phaser fires `shutdown` before `destroy`, but a race
+    // between game.destroy(true) and a pending overlay state could leave
+    // the DOM textarea or its resize listener attached if `shutdown`
+    // didn't reach hideSurveyOverlay. Wiring `destroy` too costs nothing
+    // and guarantees the DOM leak doesn't outlive the game instance.
+    this.events.on('destroy', teardown);
 
     this.input.on('pointerup', () => {
       if (this.dragState.isDragging) {
@@ -1575,6 +1582,12 @@ export class UIScene extends Phaser.Scene {
     quitFromPauseMenu: false,
   };
   private surveyTextarea: HTMLTextAreaElement | null = null;
+  /** Bound handler kept on the instance so addEventListener / removeEventListener
+   *  observe the same function reference. Window resize while the survey is
+   *  open repositions the DOM textarea over the canvas; without this the
+   *  textarea drifts off-canvas after a layout change (sidebar collapse,
+   *  devtools open, mobile orientation flip). */
+  private surveyResizeHandler: (() => void) | null = null;
 
   public showSurveyOverlay(callbacks: SurveyOverlayCallbacks): void {
     this.hideSurveyOverlay(); // idempotent clear
@@ -1597,6 +1610,10 @@ export class UIScene extends Phaser.Scene {
     if (this.surveyTextarea !== null) {
       this.surveyTextarea.remove();
       this.surveyTextarea = null;
+    }
+    if (this.surveyResizeHandler !== null && typeof window !== 'undefined') {
+      window.removeEventListener('resize', this.surveyResizeHandler);
+      this.surveyResizeHandler = null;
     }
     this.recomputeActiveOverlay();
   }
@@ -1819,8 +1836,22 @@ export class UIScene extends Phaser.Scene {
       ta.addEventListener('input', () => {
         this.surveyState.freeText = truncateFreeText(ta.value);
       });
-      document.body.appendChild(ta);
+      // Append to the canvas's parent so embedded-in-shadow-DOM hosts
+      // (the library-mode embed on the website may eventually mount
+      // inside a custom element) keep the textarea inside the same
+      // stacking context as the canvas. Fall back to document.body only
+      // when the canvas has no parent yet (defensive — shouldn't happen
+      // after Phaser's create()).
+      const parent = canvas.parentElement ?? document.body;
+      parent.appendChild(ta);
       this.surveyTextarea = ta;
+    }
+    // Bind the resize handler once per overlay open so a window-resize
+    // mid-overlay (devtools open, sidebar toggle, mobile rotate) keeps the
+    // textarea aligned with the canvas. Removed in hideSurveyOverlay.
+    if (this.surveyResizeHandler === null && typeof window !== 'undefined') {
+      this.surveyResizeHandler = () => this.positionSurveyTextarea();
+      window.addEventListener('resize', this.surveyResizeHandler);
     }
     this.positionSurveyTextarea();
   }
@@ -1829,12 +1860,24 @@ export class UIScene extends Phaser.Scene {
     if (this.surveyTextarea === null) return;
     const canvas = this.game.canvas;
     if (canvas === null) return;
-    const r = canvas.getBoundingClientRect();
-    const scaleX = r.width / SURVEY_CANVAS_W;
-    const scaleY = r.height / SURVEY_CANVAS_H;
+    const canvasRect = canvas.getBoundingClientRect();
+    const scaleX = canvasRect.width / SURVEY_CANVAS_W;
+    const scaleY = canvasRect.height / SURVEY_CANVAS_H;
     const ta = this.surveyTextarea;
-    ta.style.left = `${r.left + SURVEY_FREE_TEXT_RECT.x * scaleX}px`;
-    ta.style.top = `${r.top + SURVEY_FREE_TEXT_RECT.y * scaleY}px`;
+    // The textarea is now appended to canvas.parentElement (when present),
+    // so positioning relative to the canvas's offset within that parent
+    // avoids drift when the parent is itself positioned, scrolled, or
+    // inside a shadow root. Fall back to viewport-relative positioning
+    // when the textarea ended up on document.body (no canvas parent).
+    if (ta.parentElement === canvas.parentElement && ta.parentElement !== null) {
+      // Parent-relative: use canvas offsetLeft/Top within the shared parent.
+      ta.style.left = `${canvas.offsetLeft + SURVEY_FREE_TEXT_RECT.x * scaleX}px`;
+      ta.style.top = `${canvas.offsetTop + SURVEY_FREE_TEXT_RECT.y * scaleY}px`;
+    } else {
+      // Viewport-relative fallback for the document.body case.
+      ta.style.left = `${canvasRect.left + SURVEY_FREE_TEXT_RECT.x * scaleX}px`;
+      ta.style.top = `${canvasRect.top + SURVEY_FREE_TEXT_RECT.y * scaleY}px`;
+    }
     ta.style.width = `${SURVEY_FREE_TEXT_RECT.w * scaleX}px`;
     ta.style.height = `${SURVEY_FREE_TEXT_RECT.h * scaleY}px`;
   }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -35,7 +35,17 @@ export { formatOutcomeTitle, formatKillStatsSubtitle };
 // Plan 07 Playwright observability contract
 // ---------------------------------------------------------------------------
 
-export type ActiveOverlay = 'none' | 'save-prompt' | 'game-over' | 'pause-menu' | 'save-load';
+export type ActiveOverlay =
+  | 'none'
+  | 'save-prompt'
+  | 'game-over'
+  | 'pause-menu'
+  | 'save-load'
+  // Issue #122 / ADR 0013 — end-of-game survey overlay. Shown either after
+  // a terminal outcome (taking precedence over the bare game-over panel
+  // when the feature flag is on) or via the pause menu's "Quit & feedback"
+  // action. See showSurveyOverlay / hideSurveyOverlay for the lifecycle.
+  | 'survey';
 
 // Phase 09.1 Chunk 2 — enemy underground observability. Exposed via the same
 // __phase9_ui global so Playwright can read which colony the underground view
@@ -161,6 +171,26 @@ import {
   type SaveLoadDialogItem,
   type SaveLoadDialogItemId,
 } from './save-load-dialog-layout.js';
+import {
+  SURVEY_CANVAS_W,
+  SURVEY_CANVAS_H,
+  SURVEY_TITLE_Y,
+  SURVEY_FREE_TEXT_RECT,
+  SURVEY_BROKEN_CHECKBOX_RECT,
+  SURVEY_UPLOAD_CHECKBOX_RECT,
+  SURVEY_CONSENT_TEXT_Y,
+  SURVEY_CONSENT_DISCLOSURE,
+  SURVEY_SUBMIT_BUTTON_RECT,
+  SURVEY_SKIP_BUTTON_RECT,
+  SURVEY_CHECKBOX_LABEL_GAP,
+  surveyRatingButtons,
+  surveyHitTest,
+} from './survey-overlay-layout.js';
+import {
+  PLAYTRACE_FREE_TEXT_MAX,
+  truncateFreeText,
+  type PlaytraceSurvey,
+} from './playtrace-upload.js';
 
 /** Issue #115 — duration of the post-Save-Now "Saved" / "Save failed" flash
  *  rendered above the dialog's info line. 1500 ms is long enough to be
@@ -198,6 +228,11 @@ export interface PauseMenuCallbacks {
    *  clicked. The 1/2/4 keyboard shortcuts on GameScene call the same
    *  setter under the hood; both paths converge on speedMultiplier writes. */
   onCycleSpeed?(next: SpeedMultiplier): void;
+  /** Issue #122 / ADR 0013 — invoked when the player picks the "Quit &
+   *  feedback" entry, taking them to the survey overlay before they
+   *  abandon the session. Only present when the feature flag is enabled
+   *  (empty VITE_PLAYTRACE_ENDPOINT → undefined → row hidden). */
+  onQuitAndSurvey?(): void;
 }
 
 /** Issue #115 — callbacks the Save/Load dialog invokes. The dialog reads
@@ -457,6 +492,16 @@ export class UIScene extends Phaser.Scene {
     const escKey = this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
     if (escKey) {
       escKey.on('down', () => {
+        // Issue #122 — Esc on the survey overlay is equivalent to Skip.
+        // The overlay is end-of-game; the player should always have a
+        // keyboard escape hatch even if the buttons are unreachable
+        // (e.g. window resized smaller than the modal panel).
+        if (this.isSurveyVisible()) {
+          const cb = this.surveyCallbacks;
+          this.hideSurveyOverlay();
+          cb?.onSkip();
+          return;
+        }
         if (this.isSaveLoadDialogVisible()) {
           const cb = this.saveLoadDialogCallbacks;
           this.hideSaveLoadDialogOverlay();
@@ -480,6 +525,14 @@ export class UIScene extends Phaser.Scene {
 
     // Pointer events for HUD interactions.
     this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      // Issue #122 — survey overlay takes top priority. Once it's open the
+      // game is over (or about to be — quit-from-pause path) and no HUD
+      // interaction should leak through.
+      if (this.isSurveyVisible()) {
+        this.dispatchSurveyClick(pointer.x, pointer.y);
+        return;
+      }
+
       // Issue #115 — Save/Load dialog absorbs every click while visible.
       // Same guard rationale as the pause menu below; precedence here is
       // strict (dialog > pause menu > HUD) so a click on a dialog button
@@ -635,6 +688,7 @@ export class UIScene extends Phaser.Scene {
       this.hideSavePromptOverlay();
       this.hideSaveLoadDialogOverlay();
       this.hidePauseMenuOverlay();
+      this.hideSurveyOverlay();
       hideAntActivityPanel();
       setActiveOverlay('none');
     });
@@ -1071,6 +1125,10 @@ export class UIScene extends Phaser.Scene {
       // reflects writes from EITHER the row click OR the live 1/2/4
       // keyboard shortcuts on GameScene.
       currentSpeedMultiplier: this.pauseMenuCallbacks?.getSpeedMultiplier?.() ?? 1,
+      // Issue #122 — only show the Quit & feedback row when GameScene
+      // supplied the callback. Empty VITE_PLAYTRACE_ENDPOINT → undefined
+      // callback → row hidden.
+      quitAndSurveyEnabled: this.pauseMenuCallbacks?.onQuitAndSurvey !== undefined,
     };
     const items = pauseMenuItems(page, ctx);
     this.pauseMenuVisibleItems = items;
@@ -1190,6 +1248,14 @@ export class UIScene extends Phaser.Scene {
         this.renderPauseMenuPage();
         return;
       }
+      case 'quit-and-survey':
+        // Issue #122 — close the menu and hand control to GameScene's
+        // callback, which opens the survey overlay. The menu was already
+        // gated on `onQuitAndSurvey !== undefined` to even render this
+        // row, so the `?` here is defensive against state desync.
+        this.hidePauseMenuOverlay();
+        cb?.onQuitAndSurvey?.();
+        return;
     }
   }
 
@@ -1465,10 +1531,374 @@ export class UIScene extends Phaser.Scene {
    *  re-show — exactly the kind of observability lie round 1 was supposed
    *  to fix. This recompute reflects whatever overlay is still on screen. */
   private recomputeActiveOverlay(): void {
-    if (this.saveLoadDialogGroup.length > 0) setActiveOverlay('save-load');
+    // Survey takes precedence over the bare game-over overlay so the
+    // end-of-game flow lands on the highest-value screen for diagnostics.
+    if (this.surveyGroup.length > 0) setActiveOverlay('survey');
+    else if (this.saveLoadDialogGroup.length > 0) setActiveOverlay('save-load');
     else if (this.pauseMenuGroup.length > 0) setActiveOverlay('pause-menu');
     else if (this.gameOverGroup.length > 0) setActiveOverlay('game-over');
     else if (this.savePromptGroup.length > 0) setActiveOverlay('save-prompt');
     else setActiveOverlay('none');
   }
+
+  // ---------------------------------------------------------------------------
+  // Issue #122 / ADR 0013 — survey overlay
+  //
+  // End-of-game survey overlay with optional debug-snapshot upload. Same
+  // Phaser-overlay-on-UIScene pattern as the other panels: a semi-transparent
+  // input-blocking background, rating buttons, a DOM <textarea> overlaid at
+  // SURVEY_FREE_TEXT_RECT for native text entry, two checkbox rows
+  // ("Report as broken", "Upload diagnostic snapshot" + consent disclosure),
+  // and Submit / Skip buttons.
+  //
+  // The DOM textarea is added because Phaser does not ship a text input
+  // primitive; rolling one over the canvas via keyboard events would
+  // require us to reimplement caret, selection, IME composition, paste, and
+  // accessibility. Anchoring a real `<textarea>` over the canvas defers all
+  // of that to the browser. The textarea is removed in hideSurveyOverlay
+  // (cleanup is also wired into the scene shutdown handler).
+  // ---------------------------------------------------------------------------
+
+  private surveyGroup: Phaser.GameObjects.GameObject[] = [];
+  private surveyCallbacks: SurveyOverlayCallbacks | null = null;
+  private surveyState: {
+    rating: 0 | 1 | 2 | 3 | 4 | 5;
+    freeText: string;
+    brokenFlag: boolean;
+    includeSnapshot: boolean;
+    quitFromPauseMenu: boolean;
+  } = {
+    rating: 0,
+    freeText: '',
+    brokenFlag: false,
+    includeSnapshot: false,
+    quitFromPauseMenu: false,
+  };
+  private surveyTextarea: HTMLTextAreaElement | null = null;
+
+  public showSurveyOverlay(callbacks: SurveyOverlayCallbacks): void {
+    this.hideSurveyOverlay(); // idempotent clear
+    this.surveyCallbacks = callbacks;
+    this.surveyState = {
+      rating: 0,
+      freeText: '',
+      brokenFlag: false,
+      includeSnapshot: false,
+      quitFromPauseMenu: callbacks.quitFromPauseMenu,
+    };
+    this.renderSurveyOverlay();
+    this.recomputeActiveOverlay();
+  }
+
+  public hideSurveyOverlay(): void {
+    for (const obj of this.surveyGroup) obj.destroy();
+    this.surveyGroup = [];
+    this.surveyCallbacks = null;
+    if (this.surveyTextarea !== null) {
+      this.surveyTextarea.remove();
+      this.surveyTextarea = null;
+    }
+    this.recomputeActiveOverlay();
+  }
+
+  public isSurveyVisible(): boolean {
+    return this.surveyGroup.length > 0;
+  }
+
+  /** Render (or re-render) the survey overlay in place. Called on show and
+   *  after every state mutation (rating click, checkbox toggle) so the
+   *  selected-state highlight reflects the latest input. */
+  private renderSurveyOverlay(): void {
+    for (const obj of this.surveyGroup) obj.destroy();
+    this.surveyGroup = [];
+
+    // Background scrim — opaque-ish so the game beneath reads as paused.
+    const bg = this.add.rectangle(
+      SURVEY_CANVAS_W / 2,
+      SURVEY_CANVAS_H / 2,
+      SURVEY_CANVAS_W,
+      SURVEY_CANVAS_H,
+      0x000000,
+      0.85,
+    );
+    bg.setInteractive();
+    bg.setDepth(40);
+    this.surveyGroup.push(bg);
+
+    // Title — wording differs slightly based on which path opened the
+    // overlay so the player can tell "game ended, share thoughts" apart
+    // from "you chose to quit and give feedback".
+    const titleText = this.surveyState.quitFromPauseMenu
+      ? 'Quitting — tell us what you think'
+      : 'Thanks for playing — tell us what you think';
+    const title = this.add.text(
+      SURVEY_CANVAS_W / 2,
+      SURVEY_TITLE_Y,
+      titleText,
+      { fontSize: '22px', fontFamily: 'monospace', color: '#ffffff' },
+    );
+    title.setOrigin(0.5, 0);
+    title.setDepth(41);
+    this.surveyGroup.push(title);
+
+    // Rating row — five buttons. Selected button renders with a green
+    // fill so the choice is visible at a glance.
+    const ratings = surveyRatingButtons();
+    for (const btn of ratings) {
+      const selected = this.surveyState.rating === btn.rating;
+      const fillColor = selected ? 0x22aa22 : 0x333333;
+      const r = btn.rect;
+      const rect = this.add.rectangle(
+        r.x + r.w / 2,
+        r.y + r.h / 2,
+        r.w,
+        r.h,
+        fillColor,
+        1,
+      );
+      rect.setInteractive();
+      rect.setDepth(41);
+      this.surveyGroup.push(rect);
+      const label = this.add.text(
+        r.x + r.w / 2,
+        r.y + r.h / 2,
+        String(btn.rating),
+        { fontSize: '20px', fontFamily: 'monospace', color: '#ffffff' },
+      );
+      label.setOrigin(0.5);
+      label.setDepth(42);
+      this.surveyGroup.push(label);
+    }
+
+    // Free-text rect background (the actual editable surface is a DOM
+    // textarea positioned over the canvas below — see ensureSurveyTextarea).
+    const ft = SURVEY_FREE_TEXT_RECT;
+    const ftBg = this.add.rectangle(
+      ft.x + ft.w / 2,
+      ft.y + ft.h / 2,
+      ft.w,
+      ft.h,
+      0x222222,
+      1,
+    );
+    ftBg.setDepth(41);
+    this.surveyGroup.push(ftBg);
+    this.ensureSurveyTextarea();
+
+    // Checkbox rows. Each row is a small square + label; the row's full
+    // horizontal span is treated as the click target via surveyHitTest.
+    this.drawCheckboxRow(
+      SURVEY_BROKEN_CHECKBOX_RECT,
+      this.surveyState.brokenFlag,
+      'Report this as a bug',
+    );
+    this.drawCheckboxRow(
+      SURVEY_UPLOAD_CHECKBOX_RECT,
+      this.surveyState.includeSnapshot,
+      'Upload diagnostic snapshot to help us debug',
+    );
+
+    // Consent disclosure — only meaningful when the upload checkbox is
+    // ticked, but always rendered so the player sees the privacy
+    // implication BEFORE deciding to tick. ADR 0013 §"Privacy" requires
+    // the overlay to disclose IP + UA leakage at the edge.
+    const consent = this.add.text(
+      SURVEY_BROKEN_CHECKBOX_RECT.x + SURVEY_BROKEN_CHECKBOX_RECT.w + SURVEY_CHECKBOX_LABEL_GAP,
+      SURVEY_CONSENT_TEXT_Y,
+      SURVEY_CONSENT_DISCLOSURE,
+      {
+        fontSize: '11px',
+        fontFamily: 'monospace',
+        color: '#aaaaaa',
+        wordWrap: { width: SURVEY_CANVAS_W - 2 * SURVEY_BROKEN_CHECKBOX_RECT.x },
+      },
+    );
+    consent.setDepth(42);
+    this.surveyGroup.push(consent);
+
+    // Submit + Skip buttons. Submit is disabled until a rating is picked
+    // so the survey row always carries a 1-5 value; Skip is always live.
+    const submitEnabled = this.surveyState.rating !== 0;
+    this.drawSurveyButton(SURVEY_SUBMIT_BUTTON_RECT, 'Submit', submitEnabled);
+    this.drawSurveyButton(SURVEY_SKIP_BUTTON_RECT, 'Skip', true);
+  }
+
+  /** Helper — draw a checkbox square + label for the survey overlay. */
+  private drawCheckboxRow(
+    rect: { x: number; y: number; w: number; h: number },
+    checked: boolean,
+    label: string,
+  ): void {
+    const box = this.add.rectangle(
+      rect.x + rect.w / 2,
+      rect.y + rect.h / 2,
+      rect.w,
+      rect.h,
+      checked ? 0x22aa22 : 0x333333,
+      1,
+    );
+    box.setInteractive();
+    box.setDepth(41);
+    this.surveyGroup.push(box);
+    if (checked) {
+      // Simple check mark — a Phaser-Text "✓" reads more cleanly than
+      // drawing line segments at this resolution.
+      const tick = this.add.text(
+        rect.x + rect.w / 2,
+        rect.y + rect.h / 2,
+        '✓',
+        { fontSize: '16px', fontFamily: 'monospace', color: '#ffffff' },
+      );
+      tick.setOrigin(0.5);
+      tick.setDepth(42);
+      this.surveyGroup.push(tick);
+    }
+    const text = this.add.text(
+      rect.x + rect.w + SURVEY_CHECKBOX_LABEL_GAP,
+      rect.y + rect.h / 2,
+      label,
+      { fontSize: '14px', fontFamily: 'monospace', color: '#ffffff' },
+    );
+    text.setOrigin(0, 0.5);
+    text.setDepth(42);
+    this.surveyGroup.push(text);
+  }
+
+  /** Helper — draw a Submit/Skip button. Disabled buttons render dimmer
+   *  and do not register clicks (caller checks via surveyHitTest + state). */
+  private drawSurveyButton(
+    rect: { x: number; y: number; w: number; h: number },
+    label: string,
+    enabled: boolean,
+  ): void {
+    const fillColor = enabled ? 0x335577 : 0x202020;
+    const labelColor = enabled ? '#ffffff' : '#777777';
+    const btn = this.add.rectangle(
+      rect.x + rect.w / 2,
+      rect.y + rect.h / 2,
+      rect.w,
+      rect.h,
+      fillColor,
+      1,
+    );
+    btn.setInteractive();
+    btn.setDepth(41);
+    this.surveyGroup.push(btn);
+    const text = this.add.text(
+      rect.x + rect.w / 2,
+      rect.y + rect.h / 2,
+      label,
+      { fontSize: '16px', fontFamily: 'monospace', color: labelColor },
+    );
+    text.setOrigin(0.5);
+    text.setDepth(42);
+    this.surveyGroup.push(text);
+  }
+
+  /** Mount a <textarea> over the canvas at SURVEY_FREE_TEXT_RECT for free-
+   *  text input. Created once per overlay open and torn down in
+   *  hideSurveyOverlay. Position is recomputed each render so a canvas
+   *  resize between renders is handled correctly. */
+  private ensureSurveyTextarea(): void {
+    if (typeof document === 'undefined') return; // headless Vitest path
+    const canvas = this.game.canvas;
+    if (canvas === null) return;
+    if (this.surveyTextarea === null) {
+      const ta = document.createElement('textarea');
+      ta.placeholder = 'What stood out? (optional)';
+      ta.maxLength = PLAYTRACE_FREE_TEXT_MAX;
+      ta.style.position = 'absolute';
+      ta.style.zIndex = '1000';
+      ta.style.background = '#222222';
+      ta.style.color = '#ffffff';
+      ta.style.border = '1px solid #444444';
+      ta.style.fontFamily = 'monospace';
+      ta.style.fontSize = '13px';
+      ta.style.padding = '6px';
+      ta.style.resize = 'none';
+      ta.addEventListener('input', () => {
+        this.surveyState.freeText = truncateFreeText(ta.value);
+      });
+      document.body.appendChild(ta);
+      this.surveyTextarea = ta;
+    }
+    this.positionSurveyTextarea();
+  }
+
+  private positionSurveyTextarea(): void {
+    if (this.surveyTextarea === null) return;
+    const canvas = this.game.canvas;
+    if (canvas === null) return;
+    const r = canvas.getBoundingClientRect();
+    const scaleX = r.width / SURVEY_CANVAS_W;
+    const scaleY = r.height / SURVEY_CANVAS_H;
+    const ta = this.surveyTextarea;
+    ta.style.left = `${r.left + SURVEY_FREE_TEXT_RECT.x * scaleX}px`;
+    ta.style.top = `${r.top + SURVEY_FREE_TEXT_RECT.y * scaleY}px`;
+    ta.style.width = `${SURVEY_FREE_TEXT_RECT.w * scaleX}px`;
+    ta.style.height = `${SURVEY_FREE_TEXT_RECT.h * scaleY}px`;
+  }
+
+  /** Dispatch a click on the survey overlay. Called from the pointerdown
+   *  handler in create() when the overlay is visible. */
+  private dispatchSurveyClick(px: number, py: number): void {
+    const hit = surveyHitTest(px, py);
+    if (hit === null) return;
+    switch (hit.kind) {
+      case 'rating':
+        this.surveyState.rating = hit.rating;
+        this.renderSurveyOverlay();
+        return;
+      case 'broken-checkbox':
+        this.surveyState.brokenFlag = !this.surveyState.brokenFlag;
+        this.renderSurveyOverlay();
+        return;
+      case 'upload-checkbox':
+        this.surveyState.includeSnapshot = !this.surveyState.includeSnapshot;
+        this.renderSurveyOverlay();
+        return;
+      case 'free-text':
+        // Focus the underlying DOM textarea so the player can start typing
+        // immediately without a second click.
+        this.surveyTextarea?.focus();
+        return;
+      case 'submit': {
+        if (this.surveyState.rating === 0) return; // disabled — defensive
+        const cb = this.surveyCallbacks;
+        const result: PlaytraceSurvey & { includeSnapshot: boolean } = {
+          rating: this.surveyState.rating,
+          freeText: this.surveyState.freeText,
+          brokenFlag: this.surveyState.brokenFlag,
+          includeSnapshot: this.surveyState.includeSnapshot,
+        };
+        this.hideSurveyOverlay();
+        cb?.onSubmit(result);
+        return;
+      }
+      case 'skip': {
+        const cb = this.surveyCallbacks;
+        this.hideSurveyOverlay();
+        cb?.onSkip();
+        return;
+      }
+    }
+  }
+}
+
+/** Issue #122 — callbacks the survey overlay invokes. The overlay collects
+ *  rating / free-text / brokenFlag / upload-opt-in and hands them back via
+ *  onSubmit; onSkip closes the overlay without producing a payload. */
+export interface SurveyOverlayCallbacks {
+  /** True when this overlay was opened from the pause menu's "Quit &
+   *  feedback" action rather than after a natural game-over. The overlay
+   *  uses it to pick a slightly different title; the game-scene passes it
+   *  through to the upload as the wire envelope's quitFromPauseMenu flag. */
+  quitFromPauseMenu: boolean;
+  /** Player chose to submit. The callback owns the upload — UIScene only
+   *  hands over the collected fields and closes the overlay. */
+  onSubmit(survey: PlaytraceSurvey & { includeSnapshot: boolean }): void;
+  /** Player chose to skip. The overlay is already closed by the time this
+   *  fires; the callback typically transitions GameScene to a restart or
+   *  reload path. */
+  onSkip(): void;
 }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -1864,20 +1864,46 @@ export class UIScene extends Phaser.Scene {
     const scaleX = canvasRect.width / SURVEY_CANVAS_W;
     const scaleY = canvasRect.height / SURVEY_CANVAS_H;
     const ta = this.surveyTextarea;
-    // The textarea is now appended to canvas.parentElement (when present),
-    // so positioning relative to the canvas's offset within that parent
-    // avoids drift when the parent is itself positioned, scrolled, or
-    // inside a shadow root. Fall back to viewport-relative positioning
-    // when the textarea ended up on document.body (no canvas parent).
-    if (ta.parentElement === canvas.parentElement && ta.parentElement !== null) {
-      // Parent-relative: use canvas offsetLeft/Top within the shared parent.
-      ta.style.left = `${canvas.offsetLeft + SURVEY_FREE_TEXT_RECT.x * scaleX}px`;
-      ta.style.top = `${canvas.offsetTop + SURVEY_FREE_TEXT_RECT.y * scaleY}px`;
+    // The textarea is absolutely-positioned and sits in `document.body` or
+    // in `canvas.parentElement` (see ensureSurveyTextarea). For an
+    // absolutely-positioned element, the `left`/`top` values are measured
+    // against the nearest positioned ancestor (i.e. the same offsetParent
+    // resolution the browser uses). We compute the canvas's position in
+    // that same coordinate space by taking the bounding-rect delta against
+    // the textarea's own offsetParent — which is guaranteed to be the
+    // coordinate space `left`/`top` are interpreted in. This survives a
+    // scrolled page, an embedder whose canvas-parent isn't positioned, and
+    // shadow-DOM hosts. Codex P1 (round 3) — earlier `canvas.offsetLeft`
+    // approach landed in the wrong coordinate space when canvas.parentElement
+    // wasn't a positioned ancestor; the textarea drifted off-canvas.
+    const offsetParent = ta.offsetParent as HTMLElement | null;
+    let originX = 0;
+    let originY = 0;
+    if (offsetParent !== null) {
+      const opRect = offsetParent.getBoundingClientRect();
+      // Bounding-client-rect deltas use viewport coordinates; add the
+      // offsetParent's scrollLeft/Top so a scrolled overflow container
+      // (rare for the game canvas, but defensible) is handled too.
+      //
+      // Subtract clientLeft/Top — these equal the offsetParent's
+      // left/top border width. getBoundingClientRect() returns the
+      // border-box rect, but absolutely-positioned children's left/top
+      // are measured from the parent's PADDING-box (i.e. inside the
+      // border). Without this, an embedder whose canvas wrapper has a
+      // non-zero CSS border would see the textarea shift by the border
+      // width. (Codex round-3 review follow-up.)
+      originX = canvasRect.left - opRect.left - offsetParent.clientLeft + offsetParent.scrollLeft;
+      originY = canvasRect.top - opRect.top - offsetParent.clientTop + offsetParent.scrollTop;
     } else {
-      // Viewport-relative fallback for the document.body case.
-      ta.style.left = `${canvasRect.left + SURVEY_FREE_TEXT_RECT.x * scaleX}px`;
-      ta.style.top = `${canvasRect.top + SURVEY_FREE_TEXT_RECT.y * scaleY}px`;
+      // Textarea is positioned relative to the viewport (e.g. when its
+      // offsetParent is the initial containing block / document.body
+      // with no positioned ancestor in between). Fall back to viewport
+      // coordinates from canvasRect directly.
+      originX = canvasRect.left;
+      originY = canvasRect.top;
     }
+    ta.style.left = `${originX + SURVEY_FREE_TEXT_RECT.x * scaleX}px`;
+    ta.style.top = `${originY + SURVEY_FREE_TEXT_RECT.y * scaleY}px`;
     ta.style.width = `${SURVEY_FREE_TEXT_RECT.w * scaleX}px`;
     ta.style.height = `${SURVEY_FREE_TEXT_RECT.h * scaleY}px`;
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,7 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import { readFileSync } from 'node:fs';
+import { gunzipSync } from 'node:zlib';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 // Read package.json at config-evaluation time so __APP_VERSION__ in the built
 // bundle reflects the version on disk when `npm run build` ran. Used by the
@@ -8,10 +10,119 @@ import { readFileSync } from 'node:fs';
 // so version bumps flow through to telemetry automatically.
 const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as { version: string };
 
+/**
+ * Issue #122 — dev-server mock for the playtrace upload endpoint.
+ *
+ * In `npm run dev`, attaches a middleware that handles
+ * `POST /api/playtrace`: decodes the gzipped JSON body, logs a one-line
+ * summary to the dev console (sessionId, outcome, gzipped bytes, rating,
+ * brokenFlag, hasSnapshot, free-text preview), and returns the same
+ * `{ accepted: true, sessionId: <echo> }` body the production Lambda
+ * returns. Lets you exercise the full upload flow end-to-end on localhost
+ * without standing up the website's Lambda + S3 stack.
+ *
+ * Enable with:
+ *
+ *     # in .env.local
+ *     VITE_PLAYTRACE_ENDPOINT=/api/playtrace
+ *
+ * Then `npm run dev` → play to game-over (or use the pause menu's
+ * "Quit & feedback" entry) → fill the survey → Submit. The dev-server
+ * terminal logs the decoded envelope summary; failing requests log a
+ * stack trace.
+ *
+ * Production builds NEVER include this middleware: Vite plugins with only
+ * `configureServer` hooks are dev-only by construction.
+ */
+const playtraceMockPlugin = (): Plugin => ({
+  name: 'subterrans-playtrace-mock',
+  configureServer(server) {
+    server.middlewares.use('/api/playtrace', (req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) => {
+      if (req.method !== 'POST') {
+        // Let the dev server's default 404 handle GET/HEAD/etc.
+        next();
+        return;
+      }
+      // Sanity cap on the mock's incoming body — dev-only, but a runaway
+      // client (or a misconfigured browser-side test) could otherwise OOM
+      // the dev server. 10 MB is comfortably above the production 5 MB
+      // gzipped cap, so legitimate submissions always fit.
+      const MAX_MOCK_BODY = 10 * 1024 * 1024;
+      const chunks: Buffer[] = [];
+      let received = 0;
+      let oversized = false;
+      req.on('data', (chunk: Buffer) => {
+        received += chunk.length;
+        if (received > MAX_MOCK_BODY) {
+          if (!oversized) {
+            oversized = true;
+            // eslint-disable-next-line no-console
+            console.warn(`[playtrace-mock] body exceeded ${MAX_MOCK_BODY} bytes — discarding`);
+            res.statusCode = 413;
+            res.end('Payload Too Large');
+            req.destroy();
+          }
+          return;
+        }
+        chunks.push(chunk);
+      });
+      req.on('end', () => {
+        if (oversized) return; // response already sent
+        try {
+          const raw = Buffer.concat(chunks);
+          let envelope: Record<string, unknown> = {};
+          let parseError: string | null = null;
+          // The wire format is gzip-encoded JSON. Decompress + parse, but
+          // tolerate parse failures so the mock surfaces *what* the client
+          // sent even when the JSON is malformed — diagnosing a bad
+          // serialization is the whole point of having this middleware.
+          try {
+            const decompressed = gunzipSync(raw);
+            envelope = JSON.parse(decompressed.toString('utf8')) as Record<string, unknown>;
+          } catch (err) {
+            parseError = err instanceof Error ? err.message : String(err);
+          }
+          const survey = envelope['survey'] as Record<string, unknown> | undefined;
+          const freeText = typeof survey?.['freeText'] === 'string' ? survey['freeText'] as string : '';
+          const freeTextPreview = freeText.length > 80 ? `${freeText.slice(0, 80)}…` : freeText;
+          // One-line summary keeps the dev-server log readable. The full
+          // envelope is also logged below for offline inspection.
+          // eslint-disable-next-line no-console
+          console.log(
+            `[playtrace-mock] received: sessionId=${envelope['sessionId'] ?? '?'} `
+            + `outcome=${envelope['outcome'] ?? '?'} `
+            + `gzippedBytes=${raw.length} `
+            + `rating=${survey?.['rating'] ?? '?'} `
+            + `brokenFlag=${survey?.['brokenFlag'] ?? '?'} `
+            + `hasSnapshot=${envelope['snapshot'] !== null} `
+            + `freeText=${JSON.stringify(freeTextPreview)}`
+            + (parseError !== null ? ` PARSE_ERROR=${parseError}` : ''),
+          );
+          // Full envelope dump (without the snapshot payload — the snapshot
+          // is large and noisy in the terminal; if you need it, change
+          // `null` → the actual snapshot block).
+          // eslint-disable-next-line no-console
+          console.log('[playtrace-mock] envelope:', JSON.stringify({ ...envelope, snapshot: envelope['snapshot'] === null ? null : '<elided>' }, null, 2));
+
+          res.statusCode = 202;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ accepted: true, sessionId: envelope['sessionId'] ?? null }));
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error('[playtrace-mock] handler error:', err);
+          res.statusCode = 500;
+          res.end('mock middleware error');
+        }
+      });
+    });
+  },
+});
+
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
+  plugins: [playtraceMockPlugin()],
   server: {
     port: 5173,
     open: false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from 'vite';
+import { readFileSync } from 'node:fs';
+
+// Read package.json at config-evaluation time so __APP_VERSION__ in the built
+// bundle reflects the version on disk when `npm run build` ran. Used by the
+// playtrace upload module (issue #122) as the `gameVersion` field on the
+// submission envelope — sourced from package.json rather than hand-maintained
+// so version bumps flow through to telemetry automatically.
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as { version: string };
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   server: {
     port: 5173,
     open: false,

--- a/vite.lib.config.ts
+++ b/vite.lib.config.ts
@@ -19,9 +19,15 @@
 // type-only imports in the host project.
 
 import { defineConfig, type Plugin } from 'vite';
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import ts from 'typescript';
+
+// Package version — exposed to the bundle as the __APP_VERSION__ define so
+// the playtrace upload module (issue #122) can report `gameVersion` on the
+// submission envelope. Same source-of-truth as the standalone build's
+// vite.config.ts; keeping the two configs in sync is a manual review check.
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as { version: string };
 
 /** Emit dist-lib/manifest.json after the bundle is written, so the website
  *  deploy can read `entry` and inject the right hashed <script src=…>.
@@ -136,6 +142,9 @@ function generateMainDts(): string {
 }
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   // Suppress copying public/* into dist-lib/. Sprite assets live in the
   // website's deploy at /demo/play/assets/sprites/* — the library bundle
   // doesn't need to ship duplicates.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from 'vitest/config';
+import { readFileSync } from 'node:fs';
+
+// Mirror the build-time __APP_VERSION__ define from vite.config.ts so the
+// playtrace upload module (issue #122) can read it under Vitest the same
+// way it will at runtime in production. Same package.json source-of-truth.
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as { version: string };
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   test: {
     include: ['src/**/*.test.ts'],
     environment: 'node',


### PR DESCRIPTION
## Summary

Implements the **game-side** slice of [ADR 0013 — Playtrace Upload Contract](https://github.com/LightAxe/subterrans/issues/122) (private). Adds an end-of-game survey overlay and an opt-in debug-snapshot upload that POSTs gzipped JSON to `/api/playtrace` per the contract. The receiving Lambda + S3 bucket are the website-side agent's scope, against the same contract.

The feature is **gated by `VITE_PLAYTRACE_ENDPOINT`** — empty string (the open-source default and `npm run build` default) disables the overlay and prevents any network calls. The pause menu's new "Quit & feedback" row only renders when the feature is enabled.

## Game-side deliverables (per ADR §"Consequences → Game side")

- `BuildDebugSnapshotOptions` on `buildDebugSnapshot()` — `{ includeAntTrace?, includeInputLog?, colonyFilter? }`, defaults preserve F9 behavior. Legacy bare-array signature still works.
- New `src/render/playtrace-upload.ts` — `CompressionStream('gzip')` + single `fetch` POST, graceful downgrade (antTrace → inputLog → survey-only) under the 5 MB cap, in-flight cancel on restart, normalized result union.
- New `src/render/survey-overlay-layout.ts` — pure geometry + hit-testing module (mirrors `pause-menu-layout.ts`).
- New `'survey'` member on `ActiveOverlay` union in `ui-scene.ts` with full show/hide lifecycle, DOM `<textarea>` overlay for free-text, Esc-to-skip.
- `onQuitAndSurvey?` callback on `PauseMenuCallbacks`; wired through `buildPauseMenuCallbacks` in `game-scene.ts`. Pause-quit with live queen maps to `Defeat` on the wire (with `quitFromPauseMenu: true` preserved); never extends the sim's `GameOutcome` enum.
- `VITE_PLAYTRACE_ENDPOINT` plumbing in `main.ts` + `MountOptions.playtraceEndpoint` override.
- `__APP_VERSION__` define in both `vite.config.ts` and `vite.lib.config.ts` (and `vitest.config.ts`) sourced from `package.json#version`.
- Session UUID via `crypto.randomUUID()` in `render` only — no sim/render boundary violation.

## What is NOT in this PR

- `src/sim/` is untouched.
- `website/` is untouched — that's the parallel agent's scope.
- Snapshot privacy was already verified against `debug-snapshot.ts:88-95` and `save.ts:422-458` per the ADR; no PII regressions.

## Tests

- **`debug-snapshot.test.ts`** — `BuildDebugSnapshotOptions` (each downgrade stage, legacy array signature, colony filter).
- **`playtrace-upload.test.ts`** (14 tests) — feature-flag gating, wire framing (headers + body), HTTP 429/503 paths, graceful downgrade walk, `includeSnapshot=false` skip, in-flight cancel via `AbortController`.
- **`survey-overlay-layout.test.ts`** — geometry smoke + a privacy-disclosure regression test (the consent string MUST mention IP and browser/UA per ADR §"Privacy").

All **2051** vitest tests pass (was 2024 before this PR + 27 new). `tsc --noEmit` clean. `npm run build` and `npm run build:lib` clean.

## Step 1 review (binding)

The ADR was given a binding review against the current `code/` tree before any code landed: file paths, hook points, `world.simVersion`, `GameOutcome` enum form, and the downgrade order all check out. No blockers — full notes in the agent transcript.

## Test plan

- [ ] CI green (lint pre-existing issues unchanged; sim-boundary script unchanged)
- [ ] Manual: with `VITE_PLAYTRACE_ENDPOINT=` (empty) — no survey overlay appears at game-over; pause menu has no "Quit & feedback" row.
- [ ] Manual: with `VITE_PLAYTRACE_ENDPOINT=/api/playtrace` — survey overlay appears at game-over; rating + free-text + checkboxes work; Submit closes overlay and triggers restart.
- [ ] Manual: pause menu → "Quit & feedback" → survey overlay opens; Submit while queen is alive results in the wire envelope reporting `outcome: "Defeat"`, `quitFromPauseMenu: true`.
- [ ] Cross-repo: confirm website-side endpoint accepts the contracted shape once that PR lands.

Refs LightAxe/subterrans#122. Owner-only merge per `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)