### PR TITLE
fix(input): suppress WASD/drag-pan during GameOver overlay (issue #129)

### DIFF
--- a/src/input/camera-input.ts
+++ b/src/input/camera-input.ts
@@ -325,7 +325,7 @@ export interface DragState {
  * HUD-zone pointerdown and HUD-zone pointermove are ignored so a drag
  * starting inside a HUD widget never pans the camera.
  */
-export function registerDragPan(scene: Phaser.Scene, viewState: ViewState): DragState {
+export function registerDragPan(scene: Phaser.Scene, viewState: ViewState, isBlocked?: () => boolean): DragState {
   const dragState: DragState = {
     isDragging: false,
     lastX: 0,
@@ -361,6 +361,7 @@ export function registerDragPan(scene: Phaser.Scene, viewState: ViewState): Drag
   };
 
   scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+    if (isBlocked?.()) return;
     if (!isPanTriggerDown(pointer)) return;
     if (isPointerOverHUD(pointer.x, pointer.y, viewState)) return;
     dragState.active = true;
@@ -372,6 +373,7 @@ export function registerDragPan(scene: Phaser.Scene, viewState: ViewState): Drag
 
   scene.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
     if (!dragState.active) return;
+    if (isBlocked?.()) { releaseDrag(); return; }
     // Continue pan only while the originating trigger is still held.
     if (!isPanTriggerDown(pointer)) return;
     // Issue #73 — when the pointer is over a HUD widget mid-drag, suppress

--- a/src/input/camera-input.ts
+++ b/src/input/camera-input.ts
@@ -372,8 +372,8 @@ export function registerDragPan(scene: Phaser.Scene, viewState: ViewState, isBlo
   });
 
   scene.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
-    if (!dragState.active) return;
     if (isBlocked?.()) { releaseDrag(); return; }
+    if (!dragState.active) return;
     // Continue pan only while the originating trigger is still held.
     if (!isPanTriggerDown(pointer)) return;
     // Issue #73 — when the pointer is over a HUD widget mid-drag, suppress

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -812,8 +812,17 @@ export class GameScene extends Phaser.Scene {
     // SavePrompt phase: overlay handles input; no tick updates expected.
     if (this.gamePhase === GamePhase.SavePrompt) return;
 
+    // Issue #129 — suppress keyboard input while the GameOver overlay (survey or
+    // game-over panel) is visible. WASD/Space/Tab fire through to the world
+    // beneath the modal otherwise, which the player can feel even though the
+    // canvas is obscured. Tab and processCameraInput are the two per-frame
+    // keyboard consumers; both are skipped in GameOver. The Paused phase is
+    // intentionally left untouched: the pause menu is not full-screen and
+    // panning while paused is expected behaviour.
+    const keyboardActive = this.gamePhase !== GamePhase.GameOver;
+
     // Tab toggles view (JustDown handles key-press edge, not held).
-    if (Phaser.Input.Keyboard.JustDown(this.tabKey)) {
+    if (keyboardActive && Phaser.Input.Keyboard.JustDown(this.tabKey)) {
       toggleView(this.viewState);
     }
 
@@ -827,11 +836,13 @@ export class GameScene extends Phaser.Scene {
     this.gameLoop.update(delta);
 
     // Apply keyboard-pan + final clamp.
-    processCameraInput(this.viewState, {
-      cursors: this.cursors,
-      wasd: this.wasd,
-      dragState: this.dragState,
-    });
+    if (keyboardActive) {
+      processCameraInput(this.viewState, {
+        cursors: this.cursors,
+        wasd: this.wasd,
+        dragState: this.dragState,
+      });
+    }
 
     const cam = this.viewState.activeView === 'surface' ? this.viewState.surfaceCamera : this.viewState.undergroundCamera;
     const worldW = this.viewState.activeView === 'surface' ? SURFACE_GRID_WIDTH : UNDERGROUND_GRID_WIDTH;

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -272,7 +272,7 @@ export class GameScene extends Phaser.Scene {
     this.input.mouse!.disableContextMenu();
 
     // Drag-pan registration — returns dragState ref for processCameraInput
-    this.dragState = registerDragPan(this, this.viewState);
+    this.dragState = registerDragPan(this, this.viewState, () => this.gamePhase === GamePhase.GameOver);
 
     // Issue #116 — Esc opens the pause menu overlay (which also pauses the
     // sim). The Esc keybinding itself lives in UIScene (which already owned
@@ -563,6 +563,11 @@ export class GameScene extends Phaser.Scene {
         this.gamePhase = GamePhase.GameOver;
         // W2: first-class pause via Plan 06 Task 1 API — no setMsPerTick(Infinity)
         this.gameLoop.pause();
+        // Issue #129 — clear any in-flight pan/drag so spaceHeld and dragState.active
+        // don't leak into the GameOver overlay state (drag-pan event handlers are
+        // independent of processCameraInput and otherwise fire unguarded).
+        resetPanInputState();
+        resetDragState(this.dragState);
         const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
         // Issue #122 — when the playtrace feature is enabled, the survey
         // overlay replaces the bare game-over panel at end-of-game. Skip


### PR DESCRIPTION
## Summary

- WASD, arrow keys, and Space+drag could move the camera beneath the end-of-game survey/game-over overlay because the per-frame input handlers had no `GameOver` guard
- Added `keyboardActive = gamePhase !== GameOver` flag in `update()` and gated both `processCameraInput` and the Tab view-toggle on it
- Added optional `isBlocked?: () => boolean` parameter to `registerDragPan`; GameScene passes `() => gamePhase === GameOver` so drag-pan `pointerdown` and `pointermove` are also suppressed
- Added `resetPanInputState()` + `resetDragState()` call in `onTickOutcome` so any Space key held at the moment of game-over doesn't leave `spaceHeld` stuck true into the overlay phase

`Paused` phase is intentionally unchanged — the pause menu is not full-screen and camera pan while paused is expected.

Closes #129.

## Test plan

- [ ] Play until loss, confirm WASD/arrows no longer pan camera while survey is visible
- [ ] Hold Space and left-drag on the survey canvas area — confirm no camera movement
- [ ] Resume normal gameplay after survey dismissal — confirm camera pan still works
- [ ] Pause menu: confirm arrow keys and WASD still pan while the pause menu is open (intentional)
- [ ] `npm test` — 2066 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)