### PR TITLE
feat(survey): confirmation screen + New Game / Retry after end-of-game (issue #131)

### DIFF
--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -653,10 +653,14 @@ export class GameScene extends Phaser.Scene {
     // Capture seed now — retryGame() needs it but resetSessionState runs first.
     const retrySeed = this.currentSeed;
     // Issue #131 — when opened from the pause menu's "Quit & feedback" action,
-    // dismiss the pause menu before the survey appears so it doesn't ghost
-    // beneath the survey and persist after onNewGame / onRetry restart the game.
+    // dismiss the pause menu and transition to GameOver. GameOver is the
+    // correct semantic state: the player has quit, the loop is already paused,
+    // and the survey/confirmation overlay is functionally equivalent to a
+    // game-over overlay. This also enables the GameOver keyboard-suppression
+    // guard (issue #129) so WASD/Space don't fire under the survey here either.
     if (quitFromPauseMenu) {
       uiScene.hidePauseMenuOverlay();
+      this.gamePhase = GamePhase.GameOver;
     }
     uiScene.showSurveyOverlay({
       quitFromPauseMenu,

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -146,12 +146,14 @@ interface UIScenePhase9 {
     onBack: () => void;
   }): void;
   hideSaveLoadDialogOverlay(): void;
-  // Issue #122 / ADR 0013 — survey overlay. Shown at end-of-game (after a
-  // terminal outcome) or via the pause menu's "Quit & feedback" entry.
+  // Issue #131 — survey overlay. After submit or skip, the overlay shows a
+  // confirmation screen with New Game / Retry. onNewGame restarts with a new
+  // seed; onRetry restarts with the same seed. onSkip was removed.
   showSurveyOverlay(callbacks: {
     quitFromPauseMenu: boolean;
     onSubmit(survey: PlaytraceSurvey & { includeSnapshot: boolean }): void;
-    onSkip(): void;
+    onNewGame(): void;
+    onRetry(): void;
   }): void;
   hideSurveyOverlay(): void;
 }
@@ -638,19 +640,18 @@ export class GameScene extends Phaser.Scene {
   /** Issue #122 — open the survey overlay. Called at end-of-game (when
    *  the feature flag is on; falls back to game-over overlay otherwise)
    *  and from the pause menu's "Quit & feedback" entry. The survey
-   *  collects rating / free-text / brokenFlag / upload opt-in, then on
-   *  submit dispatches to submitPlaytrace and transitions to restart.
-   *  Skip / Esc transition straight to restart without uploading. */
+   *  collects rating / free-text / brokenFlag / upload opt-in, then dispatches
+   *  the upload and transitions to a confirmation screen with New Game / Retry.
+   *  Issue #131: onSkip replaced by onNewGame + onRetry from the confirmation. */
   private openSurveyOverlay(quitFromPauseMenu: boolean): void {
     if (this.world === undefined) return; // pre-boot guard
     const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
     // Capture the values the survey needs BEFORE handing control away.
     // The submission flow is async; meanwhile the player will start the
-    // next session (restart-on-skip / restart-on-submit) and the live
-    // references would otherwise change beneath us. World can't be safely
-    // captured by reference because resetSessionState swaps it; but we
-    // build the snapshot synchronously at submit time, before restart.
+    // next session and the live references would otherwise change beneath us.
     const outcome = this.currentOutcome;
+    // Capture seed now — retryGame() needs it but resetSessionState runs first.
+    const retrySeed = this.currentSeed;
     uiScene.showSurveyOverlay({
       quitFromPauseMenu,
       onSubmit: (survey) => {
@@ -676,10 +677,10 @@ export class GameScene extends Phaser.Scene {
         const wireOutcome: GameOutcome =
           outcome === GameOutcome.None ? GameOutcome.Defeat : outcome;
         if (world !== undefined) {
-          // Fire-and-forget. The user has already seen the overlay close;
-          // restart proceeds in parallel with the upload. cancelInFlight
-          // in resetSessionState handles the abort if restart fires before
-          // the request completes.
+          // Issue #131: Fire-and-forget. The overlay now stays open showing the
+          // confirmation screen; onNewGame / onRetry handle the actual restart.
+          // cancelInFlight in resetSessionState handles abort if restart fires
+          // before the request completes.
           void submitPlaytrace({
             endpoint: this.playtraceEndpoint,
             sessionId: this.playtraceSessionId,
@@ -696,12 +697,36 @@ export class GameScene extends Phaser.Scene {
             },
           });
         }
+        // Do NOT call restartGame here — overlay transitions to confirmation
+        // screen; the player clicks New Game or Retry from there.
+      },
+      onNewGame: () => {
         this.restartGame();
       },
-      onSkip: () => {
-        this.restartGame();
+      onRetry: () => {
+        this.retryGame(retrySeed);
       },
     });
+  }
+
+  /** Issue #131 — restart the game with the same seed the player just lost on.
+   *  Mirrors restartGame() but skips generateFreshSeed, using the captured
+   *  seed instead so the player gets the exact same map to retry. */
+  private retryGame(seed: number): void {
+    const wasSuspended = this.autosaveSuspended;
+    if (!wasSuspended) {
+      deleteSave();
+    }
+    this.currentOutcome = GameOutcome.None;
+    this.resetSessionState();
+    this.currentSeed = seed;
+    this.world = createScenario(seed);
+    this.finishBoot();
+    if (wasSuspended) {
+      this.autosaveSuspended = true;
+    }
+    const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
+    uiScene.hideGameOverOverlay();
   }
 
   private openPauseMenu(): void {

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -652,6 +652,12 @@ export class GameScene extends Phaser.Scene {
     const outcome = this.currentOutcome;
     // Capture seed now — retryGame() needs it but resetSessionState runs first.
     const retrySeed = this.currentSeed;
+    // Issue #131 — when opened from the pause menu's "Quit & feedback" action,
+    // dismiss the pause menu before the survey appears so it doesn't ghost
+    // beneath the survey and persist after onNewGame / onRetry restart the game.
+    if (quitFromPauseMenu) {
+      uiScene.hidePauseMenuOverlay();
+    }
     uiScene.showSurveyOverlay({
       quitFromPauseMenu,
       onSubmit: (survey) => {

--- a/src/render/survey-overlay-layout.test.ts
+++ b/src/render/survey-overlay-layout.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest';
 import {
   surveyRatingButtons,
   surveyHitTest,
+  surveyConfirmationHitTest,
   SURVEY_CANVAS_W,
   SURVEY_SUBMIT_BUTTON_RECT,
   SURVEY_SKIP_BUTTON_RECT,
@@ -99,5 +100,28 @@ describe('consent disclosure', () => {
     // the PR until the copy is fixed.
     expect(SURVEY_CONSENT_DISCLOSURE.toLowerCase()).toMatch(/ip/);
     expect(SURVEY_CONSENT_DISCLOSURE.toLowerCase()).toMatch(/browser|user[- ]agent|ua/);
+  });
+});
+
+describe('surveyConfirmationHitTest — issue #131', () => {
+  it('returns new-game when pointer is over the Submit button position', () => {
+    expect(surveyConfirmationHitTest(
+      SURVEY_SUBMIT_BUTTON_RECT.x + 5,
+      SURVEY_SUBMIT_BUTTON_RECT.y + 5,
+    )).toEqual({ kind: 'new-game' });
+  });
+
+  it('returns retry when pointer is over the Skip button position', () => {
+    expect(surveyConfirmationHitTest(
+      SURVEY_SKIP_BUTTON_RECT.x + 5,
+      SURVEY_SKIP_BUTTON_RECT.y + 5,
+    )).toEqual({ kind: 'retry' });
+  });
+
+  it('returns null on background (outside both button rects)', () => {
+    expect(surveyConfirmationHitTest(
+      SURVEY_SUBMIT_BUTTON_RECT.x - 10,
+      SURVEY_SUBMIT_BUTTON_RECT.y - 10,
+    )).toBeNull();
   });
 });

--- a/src/render/survey-overlay-layout.ts
+++ b/src/render/survey-overlay-layout.ts
@@ -183,8 +183,6 @@ export type SurveyHitTarget =
   | { kind: 'submit' }
   | { kind: 'skip' }
   | { kind: 'free-text' }
-  | { kind: 'new-game' }
-  | { kind: 'retry' }
   | null;
 
 /** Topmost interactive element under the pointer, or null on background.

--- a/src/render/survey-overlay-layout.ts
+++ b/src/render/survey-overlay-layout.ts
@@ -183,6 +183,8 @@ export type SurveyHitTarget =
   | { kind: 'submit' }
   | { kind: 'skip' }
   | { kind: 'free-text' }
+  | { kind: 'new-game' }
+  | { kind: 'retry' }
   | null;
 
 /** Topmost interactive element under the pointer, or null on background.
@@ -199,5 +201,13 @@ export function surveyHitTest(px: number, py: number): SurveyHitTarget {
       return { kind: 'rating', rating: btn.rating };
     }
   }
+  return null;
+}
+
+/** Hit-test for the post-submit/skip confirmation screen. The confirmation
+ *  screen reuses the Submit/Skip button positions for New Game and Retry. */
+export function surveyConfirmationHitTest(px: number, py: number): { kind: 'new-game' } | { kind: 'retry' } | null {
+  if (pointInRect(px, py, SURVEY_SUBMIT_BUTTON_RECT)) return { kind: 'new-game' };
+  if (pointInRect(px, py, SURVEY_SKIP_BUTTON_RECT))   return { kind: 'retry' };
   return null;
 }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -2021,11 +2021,6 @@ export class UIScene extends Phaser.Scene {
         this.renderSurveyOverlay();
         return;
       }
-      // 'new-game' and 'retry' are confirmation-screen targets; unreachable
-      // here since the confirmation branch above returns early.
-      case 'new-game':
-      case 'retry':
-        return;
     }
   }
 }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -185,6 +185,7 @@ import {
   SURVEY_CHECKBOX_LABEL_GAP,
   surveyRatingButtons,
   surveyHitTest,
+  surveyConfirmationHitTest,
 } from './survey-overlay-layout.js';
 import {
   PLAYTRACE_FREE_TEXT_MAX,
@@ -492,14 +493,19 @@ export class UIScene extends Phaser.Scene {
     const escKey = this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
     if (escKey) {
       escKey.on('down', () => {
-        // Issue #122 — Esc on the survey overlay is equivalent to Skip.
-        // The overlay is end-of-game; the player should always have a
-        // keyboard escape hatch even if the buttons are unreachable
-        // (e.g. window resized smaller than the modal panel).
+        // Issue #131 — Esc on the survey form is equivalent to Skip (transitions
+        // to the New Game/Retry confirmation). Esc on the confirmation screen
+        // defaults to New Game so the player always has a keyboard escape hatch.
         if (this.isSurveyVisible()) {
-          const cb = this.surveyCallbacks;
-          this.hideSurveyOverlay();
-          cb?.onSkip();
+          if (this.surveyState.showConfirmation) {
+            const cb = this.surveyCallbacks;
+            this.hideSurveyOverlay();
+            cb?.onNewGame();
+          } else {
+            this.surveyState.showConfirmation = true;
+            this.surveyState.confirmedSubmit = false;
+            this.renderSurveyOverlay();
+          }
           return;
         }
         if (this.isSaveLoadDialogVisible()) {
@@ -1574,12 +1580,16 @@ export class UIScene extends Phaser.Scene {
     brokenFlag: boolean;
     includeSnapshot: boolean;
     quitFromPauseMenu: boolean;
+    showConfirmation: boolean;
+    confirmedSubmit: boolean;
   } = {
     rating: 0,
     freeText: '',
     brokenFlag: false,
     includeSnapshot: false,
     quitFromPauseMenu: false,
+    showConfirmation: false,
+    confirmedSubmit: false,
   };
   private surveyTextarea: HTMLTextAreaElement | null = null;
   /** Bound handler kept on the instance so addEventListener / removeEventListener
@@ -1598,6 +1608,8 @@ export class UIScene extends Phaser.Scene {
       brokenFlag: false,
       includeSnapshot: false,
       quitFromPauseMenu: callbacks.quitFromPauseMenu,
+      showConfirmation: false,
+      confirmedSubmit: false,
     };
     this.renderSurveyOverlay();
     this.recomputeActiveOverlay();
@@ -1624,10 +1636,16 @@ export class UIScene extends Phaser.Scene {
 
   /** Render (or re-render) the survey overlay in place. Called on show and
    *  after every state mutation (rating click, checkbox toggle) so the
-   *  selected-state highlight reflects the latest input. */
+   *  selected-state highlight reflects the latest input. When showConfirmation
+   *  is true, renders the post-submit/skip confirmation screen instead. */
   private renderSurveyOverlay(): void {
     for (const obj of this.surveyGroup) obj.destroy();
     this.surveyGroup = [];
+
+    if (this.surveyState.showConfirmation) {
+      this.renderSurveyConfirmation();
+      return;
+    }
 
     // Background scrim — opaque-ish so the game beneath reads as paused.
     const bg = this.add.rectangle(
@@ -1738,6 +1756,39 @@ export class UIScene extends Phaser.Scene {
     const submitEnabled = this.surveyState.rating !== 0;
     this.drawSurveyButton(SURVEY_SUBMIT_BUTTON_RECT, 'Submit', submitEnabled);
     this.drawSurveyButton(SURVEY_SKIP_BUTTON_RECT, 'Skip', true);
+  }
+
+  /** Issue #131 — render the post-submit/skip confirmation screen. Shows a
+   *  result message and two buttons: New Game (fresh seed) and Retry (same
+   *  seed). The buttons reuse the Submit/Skip positions from the form phase. */
+  private renderSurveyConfirmation(): void {
+    const bg = this.add.rectangle(
+      SURVEY_CANVAS_W / 2,
+      SURVEY_CANVAS_H / 2,
+      SURVEY_CANVAS_W,
+      SURVEY_CANVAS_H,
+      0x000000,
+      0.85,
+    );
+    bg.setInteractive();
+    bg.setDepth(40);
+    this.surveyGroup.push(bg);
+
+    const resultText = this.surveyState.confirmedSubmit
+      ? 'Survey submitted — thanks for playing!'
+      : 'Thanks for playing!';
+    const title = this.add.text(
+      SURVEY_CANVAS_W / 2,
+      SURVEY_CANVAS_H / 2 - 40,
+      resultText,
+      { fontSize: '22px', fontFamily: 'monospace', color: '#ffffff' },
+    );
+    title.setOrigin(0.5);
+    title.setDepth(41);
+    this.surveyGroup.push(title);
+
+    this.drawSurveyButton(SURVEY_SUBMIT_BUTTON_RECT, 'New Game', true);
+    this.drawSurveyButton(SURVEY_SKIP_BUTTON_RECT, 'Retry', true);
   }
 
   /** Helper — draw a checkbox square + label for the survey overlay. */
@@ -1909,8 +1960,21 @@ export class UIScene extends Phaser.Scene {
   }
 
   /** Dispatch a click on the survey overlay. Called from the pointerdown
-   *  handler in create() when the overlay is visible. */
+   *  handler in create() when the overlay is visible. Routes to the
+   *  confirmation hit-test when showConfirmation is true. */
   private dispatchSurveyClick(px: number, py: number): void {
+    // Issue #131 — when the confirmation screen is showing, use the
+    // confirmation hit-test (New Game / Retry) instead of the form hit-test.
+    if (this.surveyState.showConfirmation) {
+      const hit = surveyConfirmationHitTest(px, py);
+      if (hit === null) return;
+      const cb = this.surveyCallbacks;
+      this.hideSurveyOverlay();
+      if (hit.kind === 'new-game') cb?.onNewGame();
+      else                        cb?.onRetry();
+      return;
+    }
+
     const hit = surveyHitTest(px, py);
     if (hit === null) return;
     switch (hit.kind) {
@@ -1940,34 +2004,49 @@ export class UIScene extends Phaser.Scene {
           brokenFlag: this.surveyState.brokenFlag,
           includeSnapshot: this.surveyState.includeSnapshot,
         };
-        this.hideSurveyOverlay();
+        // Issue #131 — fire the upload callback immediately, then transition
+        // to the confirmation screen instead of closing the overlay. The
+        // player chooses New Game or Retry from the confirmation screen.
         cb?.onSubmit(result);
+        this.surveyState.showConfirmation = true;
+        this.surveyState.confirmedSubmit = true;
+        this.renderSurveyOverlay();
         return;
       }
       case 'skip': {
-        const cb = this.surveyCallbacks;
-        this.hideSurveyOverlay();
-        cb?.onSkip();
+        // Issue #131 — skip transitions to the New Game/Retry choice without
+        // a submission confirmation message.
+        this.surveyState.showConfirmation = true;
+        this.surveyState.confirmedSubmit = false;
+        this.renderSurveyOverlay();
         return;
       }
+      // 'new-game' and 'retry' are confirmation-screen targets; unreachable
+      // here since the confirmation branch above returns early.
+      case 'new-game':
+      case 'retry':
+        return;
     }
   }
 }
 
-/** Issue #122 — callbacks the survey overlay invokes. The overlay collects
- *  rating / free-text / brokenFlag / upload-opt-in and hands them back via
- *  onSubmit; onSkip closes the overlay without producing a payload. */
+/** Issue #131 — callbacks the survey overlay invokes. After submit or skip,
+ *  the overlay shows a confirmation screen with New Game / Retry buttons;
+ *  onNewGame and onRetry fire when the player makes that choice. */
 export interface SurveyOverlayCallbacks {
   /** True when this overlay was opened from the pause menu's "Quit &
    *  feedback" action rather than after a natural game-over. The overlay
    *  uses it to pick a slightly different title; the game-scene passes it
    *  through to the upload as the wire envelope's quitFromPauseMenu flag. */
   quitFromPauseMenu: boolean;
-  /** Player chose to submit. The callback owns the upload — UIScene only
-   *  hands over the collected fields and closes the overlay. */
+  /** Player submitted. The callback fires the upload (fire-and-forget) then
+   *  the overlay transitions to the confirmation screen — do NOT call
+   *  restartGame here; wait for onNewGame / onRetry. */
   onSubmit(survey: PlaytraceSurvey & { includeSnapshot: boolean }): void;
-  /** Player chose to skip. The overlay is already closed by the time this
-   *  fires; the callback typically transitions GameScene to a restart or
-   *  reload path. */
-  onSkip(): void;
+  /** Player chose New Game from the confirmation screen (fresh seed). The
+   *  overlay is already closed by the time this fires. */
+  onNewGame(): void;
+  /** Player chose Retry from the confirmation screen (same seed). The
+   *  overlay is already closed by the time this fires. */
+  onRetry(): void;
 }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -1901,7 +1901,7 @@ export class UIScene extends Phaser.Scene {
       // preventDefault() for any key in its captures list — which includes
       // WASD and Space by default. stopPropagation prevents the keydown from
       // reaching Phaser so the textarea receives every character normally.
-      ta.addEventListener('keydown', (e) => { e.stopPropagation(); });
+      ta.addEventListener('keydown', (e) => { if (e.key !== 'Escape') e.stopPropagation(); });
       // Append to the canvas's parent so embedded-in-shadow-DOM hosts
       // (the library-mode embed on the website may eventually mount
       // inside a custom element) keep the textarea inside the same

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -1897,12 +1897,11 @@ export class UIScene extends Phaser.Scene {
       ta.addEventListener('input', () => {
         this.surveyState.freeText = truncateFreeText(ta.value);
       });
-      ta.addEventListener('focus', () => {
-        this.input.keyboard?.removeCapture('SPACE');
-      });
-      ta.addEventListener('blur', () => {
-        this.input.keyboard?.addCapture('SPACE');
-      });
+      // Phaser's KeyboardManager listens on window (bubble phase) and calls
+      // preventDefault() for any key in its captures list — which includes
+      // WASD and Space by default. stopPropagation prevents the keydown from
+      // reaching Phaser so the textarea receives every character normally.
+      ta.addEventListener('keydown', (e) => { e.stopPropagation(); });
       // Append to the canvas's parent so embedded-in-shadow-DOM hosts
       // (the library-mode embed on the website may eventually mount
       // inside a custom element) keep the textarea inside the same

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -1643,6 +1643,16 @@ export class UIScene extends Phaser.Scene {
     this.surveyGroup = [];
 
     if (this.surveyState.showConfirmation) {
+      // Tear down the DOM textarea before the confirmation screen replaces the
+      // form — it is not part of surveyGroup and must be removed explicitly.
+      if (this.surveyTextarea !== null) {
+        this.surveyTextarea.remove();
+        this.surveyTextarea = null;
+      }
+      if (this.surveyResizeHandler !== null && typeof window !== 'undefined') {
+        window.removeEventListener('resize', this.surveyResizeHandler);
+        this.surveyResizeHandler = null;
+      }
       this.renderSurveyConfirmation();
       return;
     }
@@ -1886,6 +1896,12 @@ export class UIScene extends Phaser.Scene {
       ta.style.resize = 'none';
       ta.addEventListener('input', () => {
         this.surveyState.freeText = truncateFreeText(ta.value);
+      });
+      ta.addEventListener('focus', () => {
+        this.input.keyboard?.removeCapture('SPACE');
+      });
+      ta.addEventListener('blur', () => {
+        this.input.keyboard?.addCapture('SPACE');
       });
       // Append to the canvas's parent so embedded-in-shadow-DOM hosts
       // (the library-mode embed on the website may eventually mount


### PR DESCRIPTION
## Summary

- After submitting the end-of-game survey, the overlay no longer immediately restarts. Instead it fires the upload (fire-and-forget) and transitions to a **confirmation screen** showing "Survey submitted — thanks for playing!" with two buttons
- After skipping, it goes directly to the same two-button screen without the confirmation text
- **New Game** starts a fresh seed (existing behaviour)
- **Retry** replays the exact same seed so the player can try the same map again
- Esc on the form transitions to the confirmation; Esc on the confirmation → New Game

## Changes

| File | What changed |
|------|-------------|
| `survey-overlay-layout.ts` | Added `surveyConfirmationHitTest()` which maps Submit/Skip button positions to `new-game`/`retry`; kept those kinds out of `SurveyHitTarget` |
| `ui-scene.ts` | Two-phase render: `showConfirmation` state flag; `renderSurveyConfirmation()` draws the second screen; `dispatchSurveyClick` routes to confirmation hit-test when in phase 2; `SurveyOverlayCallbacks.onSkip` → `onNewGame` + `onRetry`; Esc behaviour updated |
| `game-scene.ts` | `UIScenePhase9` interface updated; `onSubmit` no longer calls `restartGame`; `onNewGame` → `restartGame()`; `onRetry` → new `retryGame(retrySeed)` method; when opened from pause menu, `hidePauseMenuOverlay()` is called and `gamePhase` is set to `GameOver` |
| `survey-overlay-layout.test.ts` | 3 new unit tests for `surveyConfirmationHitTest` |

Closes #131.

## Test plan

- [ ] Game over (queen dies) → survey appears → submit rating → confirm "Survey submitted — thanks for playing!" appears → click **New Game** → fresh game starts
- [ ] Same flow → click **Retry** → same map restarts
- [ ] Skip → confirm two-button screen appears without submission text → New Game / Retry both work
- [ ] Esc on survey form → confirmation screen appears → Esc → New Game
- [ ] Pause menu "Quit & feedback" → survey appears (pause menu dismissed) → submit → confirm → Retry → game resumes correctly (no ghost overlay)
- [ ] WASD during confirmation screen: should not pan camera (gamePhase=GameOver)
- [ ] `npm test` — 2069 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)