### PR TITLE
feat(s0b): Playtrace Contract v2 — SimEvent pipeline + schemaVersion 2 envelope

### DIFF
--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -430,6 +430,10 @@ export interface SerializedWorldState {
    * sticky on load to preserve SCEN-06 replay determinism.
    */
   simVersion?: number;
+  /** S0b — overflow counters (persisted; events are NOT). Pre-V15 saves omit
+   *  these fields; deserializeWorldState defaults both to 0. */
+  droppedCombatKillCount?: number;
+  droppedStructuralCount?: number;
   /**
    * Issue #44 — terrain decoration seed (independent of `rngState` and
    * `simVersion`). Optional for backward compatibility: pre-#44 saves omit
@@ -600,6 +604,9 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
     foodPiles: world.foodPiles.map((p) => ({ ...p })),
     recentlyDepletedFood: world.recentlyDepletedFood.map((r) => ({ ...r })),
     pendingChambers: pendingOut,
+    // S0b: persist overflow counters; skip events (transient per design).
+    droppedCombatKillCount: world.droppedCombatKillCount,
+    droppedStructuralCount: world.droppedStructuralCount,
   };
 }
 
@@ -1135,6 +1142,21 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     foodPiles: s.foodPiles.map((p) => ({ ...p })),
     recentlyDepletedFood: validatedRecentlyDepleted.map((r) => ({ ...r })),
     pendingChambers,
+    // S0b — telemetry fields. events is always fresh (transient); counters
+    // load from save with 0 default for pre-V15 saves.
+    events: [],
+    droppedCombatKillCount:
+      typeof s.droppedCombatKillCount === 'number' &&
+      Number.isInteger(s.droppedCombatKillCount) &&
+      s.droppedCombatKillCount >= 0
+        ? s.droppedCombatKillCount
+        : 0,
+    droppedStructuralCount:
+      typeof s.droppedStructuralCount === 'number' &&
+      Number.isInteger(s.droppedStructuralCount) &&
+      s.droppedStructuralCount >= 0
+        ? s.droppedStructuralCount
+        : 0,
   };
 }
 

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -199,6 +199,7 @@ export class GameScene extends Phaser.Scene {
    * Cleared on resetSessionState so an explicit restartGame re-enables it.
    */
   private autosaveSuspended: boolean = false;
+  private resumedFromSave: boolean = false;
   private currentSeed: number = 0;
   // Issue #114 UAT — Settings sub-screen has a "Speed: N×" cycle row that
   // reads/writes this field via callbacks. The 1/2/4 keyboard shortcuts
@@ -445,6 +446,7 @@ export class GameScene extends Phaser.Scene {
     // bootFromSave's deserialize-throw catch (see issue #66 in the field
     // doc); a fresh start via restartGame should resume normal autosave.
     this.autosaveSuspended = false;
+    this.resumedFromSave = false;
     // tick.ts caches entrance/dig/chamber flow-fields at module scope keyed by
     // colonyId. bootFresh/bootFromSave replace `world` but those singletons
     // survive, so a new session with the same colony IDs would otherwise route
@@ -533,6 +535,7 @@ export class GameScene extends Phaser.Scene {
     }
     this.currentSeed = loaded.seed;
     this.world = nextWorld;
+    this.resumedFromSave = true;
     // SCEN-06 replay truth: restore inputLog completely so the continued session
     // can be replayed byte-for-byte from (seed, inputLog) per Plan 04 Task 1.
     for (const c of loaded.inputLog) this.inputLog.push(c);
@@ -705,6 +708,7 @@ export class GameScene extends Phaser.Scene {
             world,
             seed,
             inputLog: inputLogCopy,
+            resumedFromSave: this.resumedFromSave,
             survey: {
               rating: survey.rating,
               freeText: survey.freeText,

--- a/src/render/playtrace-upload.test.ts
+++ b/src/render/playtrace-upload.test.ts
@@ -43,6 +43,7 @@ function makeInput(overrides: Partial<PlaytraceSubmissionInput> = {}): Playtrace
     seed: 123,
     inputLog: [],
     survey: { rating: 5, freeText: '', brokenFlag: false },
+    resumedFromSave: false,
     ...overrides,
   };
 }
@@ -140,7 +141,7 @@ describe('submitPlaytrace — wire framing', () => {
       const headers = (init?.headers ?? {}) as Record<string, string>;
       expect(headers['Content-Type']).toBe('application/octet-stream');
       expect(headers['Content-Encoding']).toBe('gzip');
-      expect(headers['X-Schema-Version']).toBe('1');
+      expect(headers['X-Schema-Version']).toBe('2');
       // Body should be a Blob of non-zero size — the gzipped envelope.
       const body = init?.body as Blob;
       expect(body).toBeInstanceOf(Blob);

--- a/src/render/playtrace-upload.ts
+++ b/src/render/playtrace-upload.ts
@@ -435,11 +435,19 @@ async function buildPayloadWithDowngrade(
 /** Build a survey-only payload directly, skipping the snapshot construction.
  *  Used when the player did not opt in to upload. Same world-capture
  *  property as the downgrade path: the envelope is built in this function's
- *  synchronous prefix before the first await. */
+ *  synchronous prefix before the first await.
+ *
+ *  Capture events synchronously so roundEndReason is derived from the
+ *  pre-restart event buffer (world.events may be mutated after the first
+ *  await if restartGame fires immediately). */
 async function buildSurveyOnlyPayload(
   input: PlaytraceSubmissionInput,
 ): Promise<Blob> {
-  const envelope = buildPlaytraceEnvelope(input, null);
+  const capturedEvents: SimEvent[] = input.world.events.slice();
+  // survey-only: snapshot is null, so events+summary are omitted from the
+  // envelope body (per spec). roundEndReason IS included — it's a top-level
+  // field present on all submissions.
+  const envelope = buildPlaytraceEnvelope(input, null, capturedEvents);
   return gzipEnvelope(envelope);
 }
 

--- a/src/render/playtrace-upload.ts
+++ b/src/render/playtrace-upload.ts
@@ -29,8 +29,10 @@
 
 import type { WorldState } from '../sim/types.js';
 import type { SimCommand } from '../sim/commands.js';
+import type { SimEvent } from '../sim/telemetry.js';
 import { buildDebugSnapshot, type DebugSnapshot } from '../platform/debug-snapshot.js';
 import { GameOutcome } from '../sim/game-over.js';
+import { buildPlaytraceSummary, type PlaytraceSummary } from './summary-builder.js';
 
 // Build-time-injected by vite.config.ts / vite.lib.config.ts `define`. The
 // ambient declaration keeps the playtrace module self-contained — no
@@ -40,7 +42,7 @@ declare const __APP_VERSION__: string;
 /** Wire-level schema version. Bumped on any breaking change to the envelope
  *  shape. Mirrored in the `X-Schema-Version` header so the server can reject
  *  unknown versions without paying the cost of decompressing the body. */
-export const PLAYTRACE_SCHEMA_VERSION = 1 as const;
+export const PLAYTRACE_SCHEMA_VERSION = 2 as const;
 
 /** Hard ceiling on the gzipped body. Defense-in-depth — the server also
  *  enforces this and returns 413. Picked to fit comfortably inside the
@@ -94,6 +96,10 @@ export interface PlaytraceSubmissionInput {
   inputLog: readonly SimCommand[];
   /** Survey contents from the overlay. */
   survey: PlaytraceSurvey;
+  /** True when the session was booted from a saved file rather than a fresh
+   *  game. Causes summary.eventsCoverage to be 'since_load' instead of
+   *  'full_round', flagging that events before the save tick are missing. */
+  resumedFromSave: boolean;
 }
 
 /** Result of a submission attempt. The caller surfaces a toast based on
@@ -111,8 +117,21 @@ export type PlaytraceUploadResult =
    *  Treated the same as `feature-off` by the UI — silent skip. */
   | { status: 'server-disabled' };
 
+/** Round end reason — orthogonal to outcome; lets telemetry join outcome ×
+ *  end-reason for D-30 distribution. 'QueenDeath' is the only reason in
+ *  S0b-S4; TimeoutTiebreak and StalemateTiebreak land in S5. */
+export type RoundEndReason =
+  | 'QueenDeath'
+  | 'TimeoutTiebreak'
+  | 'StalemateTiebreak';
+
 /** Envelope as it goes over the wire (pre-gzip). Exported so tests can
- *  reconstruct expectations against the same shape. */
+ *  reconstruct expectations against the same shape.
+ *
+ *  v2 additions: events, summary, roundEndReason.
+ *  - events + summary are omitted on survey-only submissions (snapshot: null).
+ *  - roundEndReason is always present but may be null (quit from pause menu,
+ *    or a game-over without a detectable queen-death event). */
 export interface PlaytraceEnvelope {
   sessionId: string;
   schemaVersion: typeof PLAYTRACE_SCHEMA_VERSION;
@@ -121,9 +140,13 @@ export interface PlaytraceEnvelope {
   seed: number;
   tick: number;
   outcome: 'Victory' | 'Defeat' | 'MutualDestruction';
+  roundEndReason: RoundEndReason | null;
   quitFromPauseMenu: boolean;
   survey: PlaytraceSurvey;
   snapshot: DebugSnapshot | null;
+  // Present only when snapshot is non-null (survey-only uploads omit both).
+  events?: SimEvent[];
+  summary?: PlaytraceSummary;
 }
 
 // ---------------------------------------------------------------------------
@@ -177,35 +200,53 @@ export function truncateFreeText(s: string): string {
 /** Build a fully-typed envelope from the submission input + a pre-built
  *  snapshot (or null for survey-only). Pure — no fetch, no compression.
  *  Exported for the downgrade-fallback unit test. */
+/** Derive the RoundEndReason from the event buffer. Returns null when no
+ *  queen_death event was emitted (quit from pause menu, or pre-S1 round). */
+function deriveRoundEndReason(events: SimEvent[]): RoundEndReason | null {
+  for (const ev of events) {
+    if (ev.type === 'queen_death') return 'QueenDeath';
+  }
+  return null;
+}
+
 export function buildPlaytraceEnvelope(
   input: PlaytraceSubmissionInput,
   snapshot: DebugSnapshot | null,
+  // v2: pre-captured events and summary (must be provided in synchronous
+  // prefix to avoid racing a post-restart world mutation).
+  capturedEvents?: SimEvent[],
+  capturedSummary?: PlaytraceSummary,
 ): PlaytraceEnvelope {
-  return {
+  const roundEndReason = capturedEvents
+    ? deriveRoundEndReason(capturedEvents)
+    : null;
+
+  const envelope: PlaytraceEnvelope = {
     sessionId: input.sessionId,
     schemaVersion: PLAYTRACE_SCHEMA_VERSION,
     gameVersion: __APP_VERSION__,
-    // Sourced from the LIVE snapshot's own simVersion (per ADR §"Schema
-    // versioning"). For loaded older saves, that field reflects what the
-    // save was written as — accurate even though the running build is
-    // newer. The current world.simVersion is the right field to read; we
-    // do not import LATEST_SIM_VERSION at build time.
     simVersion: input.world.simVersion,
     seed: input.seed,
     tick: input.world.tick,
     outcome: outcomeToWire(input.outcome),
+    roundEndReason,
     quitFromPauseMenu: input.quitFromPauseMenu,
     survey: {
       rating: input.survey.rating,
-      // truncateFreeText is idempotent; running it here guarantees the
-      // contract bound even if a caller passed an unsanitized survey
-      // straight to buildPlaytraceEnvelope (bypassing submitPlaytrace's
-      // hoist). The hoist still saves repeated work in the downgrade loop.
       freeText: truncateFreeText(input.survey.freeText),
       brokenFlag: input.survey.brokenFlag,
     },
     snapshot,
   };
+
+  // Attach events + summary only when a snapshot is present (spec: survey-only
+  // uploads omit both fields entirely).
+  if (snapshot !== null && capturedEvents !== undefined && capturedSummary !== undefined) {
+    envelope.events = capturedEvents;
+    envelope.summary = capturedSummary;
+  }
+
+  return envelope;
 }
 
 /** Gzip a UTF-8 string using the native CompressionStream API. Returns the
@@ -351,13 +392,16 @@ export async function submitPlaytrace(
 async function buildPayloadWithDowngrade(
   input: PlaytraceSubmissionInput,
 ): Promise<Blob> {
-  // Capture the world ONCE, synchronously, into a JSON-safe full envelope.
-  // serializeWorldState (see save.ts:569) materializes every TypedArray and
-  // grid into plain primitives/arrays; buildPlaytraceEnvelope copies the
-  // remaining world-dependent primitives (tick, simVersion). After this
-  // returns, the envelope has no live references back into `input.world`.
+  // Capture the world ONCE, synchronously, into JSON-safe primitives.
+  // world.events.slice() and buildPlaytraceSummary must happen here (in
+  // the sync prefix) before the first await yields control back to the
+  // caller — game-scene.ts fires restartGame() immediately after
+  // void-casting submitPlaytrace, so the live world is mutated during the
+  // async tail of this function.
+  const capturedEvents: SimEvent[] = input.world.events.slice();
+  const capturedSummary = buildPlaytraceSummary(input.world, input.resumedFromSave);
   const fullSnap = buildDebugSnapshot(input.world, input.seed, input.inputLog);
-  const fullEnvelope = buildPlaytraceEnvelope(input, fullSnap);
+  const fullEnvelope = buildPlaytraceEnvelope(input, fullSnap, capturedEvents, capturedSummary);
 
   // Stage 1 — full envelope.
   let body = await gzipEnvelope(fullEnvelope);
@@ -379,8 +423,9 @@ async function buildPayloadWithDowngrade(
   body = await gzipEnvelope(stage3);
   if (body.size <= PLAYTRACE_MAX_GZIPPED_BYTES) return body;
 
-  // Stage 4 — survey-only. Always fits (envelope is a handful of fields).
-  const stage4: PlaytraceEnvelope = { ...fullEnvelope, snapshot: null };
+  // Stage 4 — survey-only. Events and summary are omitted when snapshot is
+  // null (spec: survey-only uploads omit both v2 fields entirely).
+  const stage4: PlaytraceEnvelope = buildPlaytraceEnvelope(input, null);
   return gzipEnvelope(stage4);
 }
 

--- a/src/render/playtrace-upload.ts
+++ b/src/render/playtrace-upload.ts
@@ -423,9 +423,12 @@ async function buildPayloadWithDowngrade(
   body = await gzipEnvelope(stage3);
   if (body.size <= PLAYTRACE_MAX_GZIPPED_BYTES) return body;
 
-  // Stage 4 — survey-only. Events and summary are omitted when snapshot is
-  // null (spec: survey-only uploads omit both v2 fields entirely).
-  const stage4: PlaytraceEnvelope = buildPlaytraceEnvelope(input, null);
+  // Stage 4 — survey-only. Derive from the pre-captured fullEnvelope
+  // (not from input.world directly) to avoid reading mutated world state
+  // after the awaits above — restartGame() may have fired. Events and
+  // summary are excluded per spec (survey-only uploads omit both).
+  const { events: _ev, summary: _sm, ...stage4Base } = fullEnvelope;
+  const stage4: PlaytraceEnvelope = { ...stage4Base, snapshot: null };
   return gzipEnvelope(stage4);
 }
 

--- a/src/render/summary-builder.ts
+++ b/src/render/summary-builder.ts
@@ -1,0 +1,241 @@
+// summary-builder.ts — S0b: render-side PlaytraceSummary builder.
+//
+// Called once at game-over / upload time. Reads world + world.events;
+// produces the v2 wire envelope's top-level `summary` block.
+// This module is render-side: it may read world state but must NOT mutate
+// it. It is NOT in src/sim/.
+//
+// S6 loss-screen attribution reuses buildPlaytraceSummary to derive the
+// one-line narrative without uploading. Keep it import-friendly from render code.
+
+import type { WorldState } from '../sim/types.js';
+import type { SimEvent } from '../sim/telemetry.js';
+import { ChamberType } from '../sim/enums.js';
+import type { ColonyId } from '../sim/colony/colony-store.js';
+import { AntTask } from '../sim/enums.js';
+
+// Player colony is always ColonyId 1 per scenario.ts convention.
+const PLAYER_COLONY_ID = 1 as ColonyId;
+
+// ---------------------------------------------------------------------------
+// PlaytraceSummary — top-level v2 wire field
+// ---------------------------------------------------------------------------
+
+export interface StrategySignals {
+  chamberCounts: { Queen: number; Nursery: number; FoodStorage: number };
+  nurseryTileCount: number;
+  fighterPeak: number;
+  workerPeak: number;
+  forageFightRatioHistory: Array<{ tick: number; forage: number; fight: number }>;
+}
+
+export interface OutcomeAttribution {
+  primaryCause: string | null;
+  narrativeSeed: string | null;
+}
+
+export interface CombatAggregate {
+  killsByColony: Record<string, number>;
+  killLocationBuckets: {
+    surface: number;
+    playerUnderground: number;
+    enemyUnderground: number;
+  };
+  peakContestedTiles: number;
+}
+
+export interface TunableObserved {
+  defenderHomegroundWinRate: number | null;
+  invasionDefenderSurvival: number | null;
+  spiderRampageThisRound: number;
+  totalSpiderHunts: number;
+  totalProbes: number;
+  totalInvasions: number;
+}
+
+export interface EventOverflow {
+  totalEmitted: number;
+  stored: number;
+  droppedCombatKill: number;
+  droppedStructural: number;
+}
+
+export interface PlaytraceSummary {
+  strategySignals: StrategySignals;
+  outcomeAttribution: OutcomeAttribution;
+  combatAggregate: CombatAggregate;
+  tunableObserved: TunableObserved;
+  eventOverflow: EventOverflow;
+  difficulty: 'Easy' | 'Normal' | 'Hard' | null;
+  eventsCoverage: 'full_round' | 'since_load' | 'unknown';
+  eventsStartTick: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+function buildStrategySignals(world: WorldState): StrategySignals {
+  const colony = world.colonies[PLAYER_COLONY_ID];
+  const chamberCounts = { Queen: 0, Nursery: 0, FoodStorage: 0 };
+  let nurseryTileCount = 0;
+
+  if (colony) {
+    for (const ch of colony.chambers) {
+      if (ch.chamberType === ChamberType.Queen) {
+        chamberCounts.Queen += 1;
+      } else if (ch.chamberType === ChamberType.Nursery) {
+        chamberCounts.Nursery += 1;
+        // 4×3 tiles per nursery (per CHAMBER_DIMENSIONS)
+        nurseryTileCount += 12;
+      } else if (ch.chamberType === ChamberType.FoodStorage) {
+        chamberCounts.FoodStorage += 1;
+      }
+    }
+  }
+
+  // Count current workers and fighters (snapshot at game-over; S0b has no
+  // per-tick peak tracking yet — peaks will be wired in a follow-up stage).
+  let workerPeak = 0;
+  let fighterPeak = 0;
+  if (colony) {
+    const count = world.ants.alive.length;
+    for (let i = 0; i < count; i++) {
+      if (!world.ants.alive[i]) continue;
+      if (world.ants.colonyId[i] !== PLAYER_COLONY_ID) continue;
+      const task = world.ants.task[i];
+      if (task === AntTask.Fighting) fighterPeak += 1;
+      else if (task !== AntTask.Idle) workerPeak += 1;
+    }
+  }
+
+  // Emit current slider position as the sole history entry.
+  const ratio = colony?.targetRatio ?? { forage: 10, fight: 0 };
+  const forageFightRatioHistory = [
+    { tick: 0, forage: ratio.forage, fight: ratio.fight },
+  ];
+
+  return {
+    chamberCounts,
+    nurseryTileCount,
+    fighterPeak,
+    workerPeak,
+    forageFightRatioHistory,
+  };
+}
+
+function buildOutcomeAttribution(events: SimEvent[]): OutcomeAttribution {
+  for (const ev of events) {
+    if (ev.type === 'queen_death') {
+      const cause = ev.payload.cause;
+      if (cause === null) {
+        return { primaryCause: null, narrativeSeed: null };
+      }
+      const narratives: Record<string, string> = {
+        InvasionKill: 'The enemy colony overran your nest',
+        SpiderRampage: 'A spider rampage reached your queen',
+        Starvation: 'Your colony starved',
+        MutualDestruction: 'Both queens fell at the same time',
+      };
+      return {
+        primaryCause: cause,
+        narrativeSeed: narratives[cause] ?? null,
+      };
+    }
+  }
+  return { primaryCause: null, narrativeSeed: null };
+}
+
+function buildCombatAggregate(events: SimEvent[]): CombatAggregate {
+  const killsByColony: Record<string, number> = {};
+  const buckets = { surface: 0, playerUnderground: 0, enemyUnderground: 0 };
+
+  for (const ev of events) {
+    if (ev.type !== 'combat_kill') continue;
+    const killerCid = ev.payload.killer.colonyId;
+    if (killerCid !== null) {
+      const key = String(killerCid);
+      killsByColony[key] = (killsByColony[key] ?? 0) + 1;
+    }
+    const loc = ev.payload.location;
+    if (loc.grid === 'surface') {
+      buckets.surface += 1;
+    } else if (killerCid === PLAYER_COLONY_ID || ev.payload.victim.colonyId !== PLAYER_COLONY_ID) {
+      buckets.enemyUnderground += 1;
+    } else {
+      buckets.playerUnderground += 1;
+    }
+  }
+
+  return {
+    killsByColony,
+    killLocationBuckets: buckets,
+    peakContestedTiles: 0, // surface contested tile tracking added in S1
+  };
+}
+
+function buildTunableObserved(events: SimEvent[]): TunableObserved {
+  let totalSpiderHunts = 0;
+  let spiderRampageThisRound = 0;
+  let totalProbes = 0;
+  let totalInvasions = 0;
+
+  for (const ev of events) {
+    if (ev.type === 'spider_hunt_start') totalSpiderHunts += 1;
+    if (ev.type === 'spider_rampage_start') spiderRampageThisRound += 1;
+    if (ev.type === 'invasion_start') {
+      totalInvasions += 1;
+      // Probing is a sub-type of invasion in S2's AI state; for now every
+      // invasion_start is also counted as a probe until S2 distinguishes them.
+      totalProbes += 1;
+    }
+  }
+
+  return {
+    defenderHomegroundWinRate: null, // populated once combat data exists (S1)
+    invasionDefenderSurvival: null,  // populated once combat data exists (S1)
+    spiderRampageThisRound,
+    totalSpiderHunts,
+    totalProbes,
+    totalInvasions,
+  };
+}
+
+/**
+ * Build the PlaytraceSummary for the completed session.
+ *
+ * @param world          - The terminal WorldState (post-outcome).
+ * @param resumedFromSave - True if the session was loaded from a save; causes
+ *                         eventsCoverage to be 'since_load'.
+ */
+export function buildPlaytraceSummary(
+  world: WorldState,
+  resumedFromSave: boolean,
+): PlaytraceSummary {
+  const events = world.events;
+
+  const stored = events.length;
+  const droppedCombatKill = world.droppedCombatKillCount;
+  const droppedStructural = world.droppedStructuralCount;
+  const totalEmitted = stored + droppedCombatKill + droppedStructural;
+
+  return {
+    strategySignals: buildStrategySignals(world),
+    outcomeAttribution: buildOutcomeAttribution(events),
+    combatAggregate: buildCombatAggregate(events),
+    tunableObserved: buildTunableObserved(events),
+    eventOverflow: {
+      totalEmitted,
+      stored,
+      droppedCombatKill,
+      droppedStructural,
+    },
+    difficulty: null, // difficulty tiers land in S5
+    eventsCoverage: resumedFromSave
+      ? 'since_load'
+      : totalEmitted > 0
+        ? 'full_round'
+        : 'unknown',
+    eventsStartTick: events.length > 0 ? (events[0]?.tick ?? null) : null,
+  };
+}

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -1,4 +1,6 @@
 // Phase 5 scope: outcome enum only. checkQueenDeath is Phase 9 scope — see Phase 4 PRD §5a.
+// S0b: emits queen_death SimEvent on first detection (cause: null — S1/S2 will fill cause
+// from kill-site context when those stages land, per RC-P1-003).
 
 export const GameOutcome = {
   None: 0,
@@ -10,6 +12,7 @@ export type GameOutcome = typeof GameOutcome[keyof typeof GameOutcome];
 
 import type { WorldState } from './types.js';
 import type { ColonyId, ColonyRecord } from './colony/colony-store.js';
+import { emitEvent } from './telemetry.js';
 
 /**
  * Returns true if the colony's queen is alive per world.ants.
@@ -19,7 +22,25 @@ function isQueenAlive(world: WorldState, colony: ColonyRecord): boolean {
   const qid = colony.queenEntityId;
   const alive = world.ants.alive[qid] === 1;
   if (!alive) {
-    colony.defeated = true;
+    if (!colony.defeated) {
+      // Set before emitting (defensive guard against hypothetical re-entrancy).
+      colony.defeated = true;
+      emitEvent(world, {
+        tick: world.tick,
+        type: 'queen_death',
+        payload: {
+          cause: null,
+          location: {
+            x: world.ants.posX[qid] ?? 0,
+            y: world.ants.posY[qid] ?? 0,
+            grid: 'underground',
+          },
+          aiStateAtTime: null,
+        },
+      });
+    } else {
+      colony.defeated = true;
+    }
     return false;
   }
   return true;

--- a/src/sim/telemetry.test.ts
+++ b/src/sim/telemetry.test.ts
@@ -1,0 +1,202 @@
+// telemetry.test.ts — S0b: emitEvent cap enforcement + V15 migration
+//
+// Run: npx vitest run src/sim/telemetry.test.ts
+
+import { describe, it, expect } from 'vitest';
+import { emitEvent, PLAYTRACE_EVENT_CAP_PER_ROUND, type SimEvent } from './telemetry.js';
+import { createScenario } from './scenario.js';
+import { serializeWorldState, deserializeWorldState } from '../platform/save.js';
+import { SIM_VERSION_V15_TELEMETRY } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCombatKill(tick: number): SimEvent {
+  return {
+    tick,
+    type: 'combat_kill',
+    payload: {
+      killer: { kind: 'Ant', id: 1, colonyId: 2 as any },
+      victim: { kind: 'Ant', id: 2, colonyId: 1 as any },
+      location: { x: 0, y: 0, grid: 'surface' },
+    },
+  };
+}
+
+function makeQueenDeath(tick: number): SimEvent {
+  return {
+    tick,
+    type: 'queen_death',
+    payload: {
+      cause: null,
+      location: { x: 5, y: 5, grid: 'underground' },
+      aiStateAtTime: null,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cap enforcement tests
+// ---------------------------------------------------------------------------
+
+describe('emitEvent — under cap', () => {
+  it('appends events normally when under cap', () => {
+    const world = createScenario(1);
+    expect(world.events).toHaveLength(0);
+    emitEvent(world, makeCombatKill(1));
+    emitEvent(world, makeCombatKill(2));
+    expect(world.events).toHaveLength(2);
+    expect(world.droppedCombatKillCount).toBe(0);
+    expect(world.droppedStructuralCount).toBe(0);
+  });
+});
+
+describe('emitEvent — combat_kill eviction at cap', () => {
+  it('evicts oldest combat_kill and increments droppedCombatKillCount', () => {
+    const world = createScenario(1);
+    // Fill to cap with combat_kills (tick 0..CAP-1)
+    for (let i = 0; i < PLAYTRACE_EVENT_CAP_PER_ROUND; i++) {
+      world.events.push(makeCombatKill(i));
+    }
+    expect(world.events).toHaveLength(PLAYTRACE_EVENT_CAP_PER_ROUND);
+
+    // Emit one more combat_kill: should evict tick=0, append tick=CAP
+    const newKill = makeCombatKill(PLAYTRACE_EVENT_CAP_PER_ROUND);
+    emitEvent(world, newKill);
+
+    expect(world.events).toHaveLength(PLAYTRACE_EVENT_CAP_PER_ROUND);
+    expect(world.droppedCombatKillCount).toBe(1);
+    expect(world.droppedStructuralCount).toBe(0);
+    // The evicted event was tick=0; tick=1 is now the oldest
+    expect(world.events[0]!.tick).toBe(1);
+    // The new event is last
+    expect(world.events[PLAYTRACE_EVENT_CAP_PER_ROUND - 1]!.tick).toBe(PLAYTRACE_EVENT_CAP_PER_ROUND);
+  });
+
+  it('evicts oldest combat_kill when a structural event pushes over cap', () => {
+    const world = createScenario(1);
+    for (let i = 0; i < PLAYTRACE_EVENT_CAP_PER_ROUND; i++) {
+      world.events.push(makeCombatKill(i));
+    }
+
+    const queenDeath = makeQueenDeath(9999);
+    emitEvent(world, queenDeath);
+
+    expect(world.events).toHaveLength(PLAYTRACE_EVENT_CAP_PER_ROUND);
+    expect(world.droppedCombatKillCount).toBe(1);
+    expect(world.droppedStructuralCount).toBe(0);
+    // queen_death should be last
+    const last = world.events[PLAYTRACE_EVENT_CAP_PER_ROUND - 1]!;
+    expect(last.type).toBe('queen_death');
+  });
+});
+
+describe('emitEvent — structural drop when no combat_kill available', () => {
+  it('drops new structural event and increments droppedStructuralCount when buffer full with no combat_kills', () => {
+    const world = createScenario(1);
+    // Fill with structural events (queen_death, not evictable)
+    for (let i = 0; i < PLAYTRACE_EVENT_CAP_PER_ROUND; i++) {
+      world.events.push(makeQueenDeath(i));
+    }
+
+    // Try to emit one more structural event
+    emitEvent(world, makeQueenDeath(9999));
+
+    expect(world.events).toHaveLength(PLAYTRACE_EVENT_CAP_PER_ROUND);
+    expect(world.droppedStructuralCount).toBe(1);
+    expect(world.droppedCombatKillCount).toBe(0);
+    // Last event should NOT be tick=9999 (was dropped)
+    expect(world.events[PLAYTRACE_EVENT_CAP_PER_ROUND - 1]!.tick).toBe(PLAYTRACE_EVENT_CAP_PER_ROUND - 1);
+  });
+
+  it('evicts combat_kills before falling back to structural drop', () => {
+    const world = createScenario(1);
+    // Half structural, half combat_kill
+    for (let i = 0; i < PLAYTRACE_EVENT_CAP_PER_ROUND / 2; i++) {
+      world.events.push(makeQueenDeath(i));
+    }
+    for (let i = 0; i < PLAYTRACE_EVENT_CAP_PER_ROUND / 2; i++) {
+      world.events.push(makeCombatKill(i + 1000));
+    }
+    expect(world.events).toHaveLength(PLAYTRACE_EVENT_CAP_PER_ROUND);
+
+    // Structural event: should evict a combat_kill, not drop
+    emitEvent(world, makeQueenDeath(9999));
+    expect(world.droppedCombatKillCount).toBe(1);
+    expect(world.droppedStructuralCount).toBe(0);
+    expect(world.events).toHaveLength(PLAYTRACE_EVENT_CAP_PER_ROUND);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V15 save migration — events + counters
+// ---------------------------------------------------------------------------
+
+describe('V15 migration — deserializeWorldState', () => {
+  it('V15 sentinel constant has value 15', () => {
+    expect(SIM_VERSION_V15_TELEMETRY).toBe(15);
+  });
+
+  it('pre-V15 save (missing droppedCombatKillCount/droppedStructuralCount) loads with counters = 0', () => {
+    const world = createScenario(42);
+    const serialized = serializeWorldState(world);
+
+    // Simulate a pre-V15 save by deleting the new fields
+    const raw = JSON.parse(JSON.stringify(serialized)) as Record<string, unknown>;
+    delete raw['droppedCombatKillCount'];
+    delete raw['droppedStructuralCount'];
+
+    const restored = deserializeWorldState(raw as unknown as Parameters<typeof deserializeWorldState>[0]);
+    expect(restored.events).toEqual([]);
+    expect(restored.droppedCombatKillCount).toBe(0);
+    expect(restored.droppedStructuralCount).toBe(0);
+  });
+
+  it('round-trips events field not serialized (events always empty after load)', () => {
+    const world = createScenario(42);
+    // Add some events to the live world
+    emitEvent(world, makeCombatKill(1));
+    emitEvent(world, makeQueenDeath(2));
+    expect(world.events).toHaveLength(2);
+
+    // Serialize -> events should not appear in snapshot
+    const serialized = serializeWorldState(world);
+    expect((serialized as unknown as Record<string, unknown>)['events']).toBeUndefined();
+
+    // Deserialize -> events reset to []
+    const restored = deserializeWorldState(serialized);
+    expect(restored.events).toEqual([]);
+  });
+
+  it('droppedCombatKillCount and droppedStructuralCount survive round-trip', () => {
+    const world = createScenario(42);
+    world.droppedCombatKillCount = 7;
+    world.droppedStructuralCount = 3;
+
+    const restored = deserializeWorldState(serializeWorldState(world));
+    expect(restored.droppedCombatKillCount).toBe(7);
+    expect(restored.droppedStructuralCount).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// queen_death emission
+// ---------------------------------------------------------------------------
+
+describe('queen_death emission format', () => {
+  it('emits a well-formed queen_death event', () => {
+    const world = createScenario(1);
+    const ev = makeQueenDeath(42);
+    emitEvent(world, ev);
+
+    expect(world.events).toHaveLength(1);
+    const emitted = world.events[0]!;
+    expect(emitted.type).toBe('queen_death');
+    if (emitted.type === 'queen_death') {
+      expect(emitted.payload.cause).toBeNull();
+      expect(emitted.payload.location.grid).toBe('underground');
+      expect(emitted.payload.aiStateAtTime).toBeNull();
+    }
+  });
+});

--- a/src/sim/telemetry.ts
+++ b/src/sim/telemetry.ts
@@ -1,0 +1,170 @@
+// telemetry.ts — S0b: SimEvent discriminated union, emitEvent helper,
+// and cap enforcement (ADR-0013 v2 / D-31 / D-34).
+//
+// This is a SIM-SIDE module (src/sim/). It mutates WorldState.events and
+// the two overflow counters. Render-side code must NOT import emitEvent;
+// instead it calls narrow sim helpers (e.g. transitionAIState in S2)
+// that perform both the state mutation and the event emission atomically.
+//
+// Cap policy (D-34):
+//   - Hard cap: WorldState.events never exceeds PLAYTRACE_EVENT_CAP_PER_ROUND.
+//   - combat_kill is the only evictable event type (lowest priority).
+//   - New structural event over cap: evict oldest combat_kill, append new.
+//   - New combat_kill over cap: evict oldest combat_kill, append new.
+//   - Over cap with no combat_kill to evict: drop and increment
+//     droppedStructuralCount. Expected to stay 0 in a 7-minute round.
+
+import type { WorldState } from './types.js';
+import type { ColonyId } from './colony/colony-store.js';
+
+export const PLAYTRACE_EVENT_CAP_PER_ROUND = 2000;
+
+// AIState alias — real union defined in S2; string covers all legal values
+// until then. The names are the canonical PascalCase strings that appear in
+// the wire envelope.
+export type AIState =
+  | 'Peacetime'
+  | 'WarFooting'
+  | 'Probing'
+  | 'Invading'
+  | 'Recovery';
+
+// ---------------------------------------------------------------------------
+// SimEvent discriminated union (9 types — CF-P1-005)
+// ---------------------------------------------------------------------------
+
+export type SimEvent =
+  | {
+      tick: number;
+      type: 'ai_state_transition';
+      payload: {
+        colonyId: ColonyId;
+        from: AIState;
+        to: AIState;
+        triggerValues: {
+          aiFighterCount: number;
+          aiFoodStorageFrac100: number;
+          playerWorkerCount: number;
+        };
+      };
+    }
+  | {
+      tick: number;
+      type: 'invasion_start';
+      payload: {
+        colonyId: ColonyId;
+        rallyTile: { x: number; y: number; grid: 'surface' };
+        fighterCount: number;
+        targetGrid: ColonyId;
+      };
+    }
+  | {
+      tick: number;
+      type: 'invasion_end';
+      payload: {
+        colonyId: ColonyId;
+        outcome: 'queen_kill' | 'fighter_rout' | 'timeout';
+        attackerLosses: number;
+        defenderLosses: number;
+      };
+    }
+  | {
+      tick: number;
+      type: 'spider_hunt_start';
+      payload: {
+        reticleTile: { x: number; y: number; grid: 'surface' };
+        targetWorkers: number;
+      };
+    }
+  | {
+      tick: number;
+      type: 'spider_hunt_end';
+      payload: { outcome: 'kill' | 'swarm_retreat' | 'scatter'; deaths: number };
+    }
+  | {
+      tick: number;
+      type: 'spider_rampage_start';
+      payload: { lairTile: { x: number; y: number }; hungerTicks: number };
+    }
+  | {
+      tick: number;
+      type: 'spider_rampage_end';
+      payload: {
+        outcome:
+          | 'killed_in_nest'
+          | 'killed_by_player'
+          | 'killed_by_ai'
+          | 'quota_met'
+          | 'retreated';
+        broodKilled: number;
+        queenKilled: boolean;
+      };
+    }
+  | {
+      tick: number;
+      type: 'queen_death';
+      payload: {
+        // cause is null in V15 traces (S0b proof-of-concept). S1/S2 will fill
+        // this in from the kill-site context when those stages land (RC-P1-003).
+        cause:
+          | 'InvasionKill'
+          | 'SpiderRampage'
+          | 'Starvation'
+          | 'MutualDestruction'
+          | null;
+        location: { x: number; y: number; grid: 'surface' | 'underground' };
+        aiStateAtTime: AIState | null;
+      };
+    }
+  | {
+      // combat_kill is the ONLY evictable (low-priority) event type.
+      // The cap policy preferentially drops oldest combat_kills when the
+      // buffer is full, preserving structural events.
+      tick: number;
+      type: 'combat_kill';
+      payload: {
+        killer: {
+          kind: 'Ant' | 'Spider';
+          id: number | null;
+          colonyId: ColonyId | null;
+        };
+        victim: {
+          kind: 'Ant' | 'Spider' | 'Brood' | 'Queen';
+          id: number | null;
+          colonyId: ColonyId | null;
+        };
+        location: { x: number; y: number; grid: 'surface' | 'underground' };
+      };
+    };
+
+// ---------------------------------------------------------------------------
+// Cap enforcement helpers
+// ---------------------------------------------------------------------------
+
+function findOldestCombatKillIndex(events: SimEvent[]): number {
+  for (let i = 0; i < events.length; i++) {
+    if (events[i]!.type === 'combat_kill') return i;
+  }
+  return -1;
+}
+
+// ---------------------------------------------------------------------------
+// emitEvent — the single write path into world.events
+// ---------------------------------------------------------------------------
+
+export function emitEvent(world: WorldState, event: SimEvent): void {
+  if (world.events.length < PLAYTRACE_EVENT_CAP_PER_ROUND) {
+    world.events.push(event);
+    return;
+  }
+  // Cap reached: evict oldest combat_kill if available, then append new event.
+  const evictIdx = findOldestCombatKillIndex(world.events);
+  if (evictIdx >= 0) {
+    world.events.splice(evictIdx, 1);
+    world.events.push(event);
+    world.droppedCombatKillCount += 1;
+  } else {
+    // No combat_kill to evict; structural overflow — hard cap honored.
+    world.droppedStructuralCount += 1;
+  }
+}

--- a/src/sim/types.test.ts
+++ b/src/sim/types.test.ts
@@ -29,10 +29,10 @@ describe('WorldState', () => {
       expect(world.rngState).toBe(4294967295);
     });
 
-    it('has exactly fourteen fields (4 Phase 5 + 3 Phase 6 + 4 Phase 7 + 1 issue #27 + 1 issue #44 + 1 issue #112)', () => {
+    it('has exactly seventeen fields (4 Phase 5 + 3 Phase 6 + 4 Phase 7 + 1 issue #27 + 1 issue #44 + 1 issue #112 + 3 S0b telemetry)', () => {
       const world = createWorldState(0);
       const keys = Object.keys(world);
-      expect(keys).toHaveLength(14);
+      expect(keys).toHaveLength(17);
       expect(keys).toContain('tick');
       expect(keys).toContain('rngState');
       expect(keys).toContain('nextEntityId');
@@ -47,6 +47,9 @@ describe('WorldState', () => {
       expect(keys).toContain('foodPiles');
       expect(keys).toContain('recentlyDepletedFood'); // issue #112
       expect(keys).toContain('pendingChambers');
+      expect(keys).toContain('events'); // S0b
+      expect(keys).toContain('droppedCombatKillCount'); // S0b
+      expect(keys).toContain('droppedStructuralCount'); // S0b
     });
 
     it('issue #44: terrainSeed is a deterministic, non-zero, non-rngState mix of the input seed', () => {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -403,7 +403,12 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   dst.simVersion = src.simVersion;
   dst.terrainSeed = src.terrainSeed;
   dst.commandQueue = src.commandQueue.slice(); // small in practice (user-input rate) — PRD §3 accepts this as the only Phase 1 allocation
-  dst.events = src.events.slice();
+  // events: intentionally not copied into the render double-buffer (prevState).
+  // prevState.events is never read for interpolation; the only consumers of
+  // events (buildPaytraceSummary, buildPayloadWithDowngrade) read the live
+  // world directly. Skipping the copy avoids a per-tick O(n) allocation that
+  // could grow to ~2,000 entries.
+  // droppedCombatKillCount / droppedStructuralCount are also telemetry-only.
   dst.droppedCombatKillCount = src.droppedCombatKillCount;
   dst.droppedStructuralCount = src.droppedStructuralCount;
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -57,6 +57,8 @@ export type EntityId = number; // incrementing counter from 0, no recycling per 
  * preserves SCEN-06 replay determinism — a save recorded before a given
  * fix keeps producing identical ticks across reload under the old algorithm.
  */
+import type { SimEvent } from './telemetry.js';
+
 export const LEGACY_SIM_VERSION = 2 as const;
 export const SIM_VERSION_V3 = 3 as const;
 export const SIM_VERSION_V4_DIAGONAL_MOTION = 4 as const;
@@ -210,7 +212,14 @@ export const SIM_VERSION_V13_INVARIANT_FIXES = 13 as const;
  *          deposit (same as the surface path).
  */
 export const SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX = 14 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX;
+/**
+ * V15 (S0b) — adds WorldState.events (SimEvent[]) + overflow counters for the
+ * playtrace telemetry pipeline. Sticky-on-load: pre-V15 saves replay with
+ * events=[] and counters=0, which is correct (no events to re-emit from a
+ * pre-telemetry save).
+ */
+export const SIM_VERSION_V15_TELEMETRY = 15 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V15_TELEMETRY;
 
 export interface WorldState {
   tick: number;             // 0 at creation; incremented once per tick
@@ -327,6 +336,15 @@ export interface WorldState {
   recentlyDepletedFood: DepletionRecord[];
 
   pendingChambers: Record<string, PendingChamber>;         // keyed by `${colonyId}:${anchorTileX}:${anchorTileY}` (PRD §2d)
+
+  // S0b — playtrace telemetry (ADR-0013 v2 / D-31 / D-34).
+  // events: accumulated this session; NOT serialized to saves (transient —
+  // reset to [] on load; deterministic replay re-generates from inputLog).
+  // Counters ARE persisted so a resumed-from-save upload produces a truthful
+  // eventOverflow block reflecting drops that happened before the save.
+  events: SimEvent[];
+  droppedCombatKillCount: number;
+  droppedStructuralCount: number;
 }
 
 /**
@@ -357,6 +375,10 @@ export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIE
     foodPiles: [],
     recentlyDepletedFood: [],   // issue #112 — empty until first depletion
     pendingChambers: {},    // empty Record; PlaceChamberCommand creates entries
+    // S0b — telemetry fields.
+    events: [],
+    droppedCombatKillCount: 0,
+    droppedStructuralCount: 0,
   };
 }
 
@@ -381,6 +403,9 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   dst.simVersion = src.simVersion;
   dst.terrainSeed = src.terrainSeed;
   dst.commandQueue = src.commandQueue.slice(); // small in practice (user-input rate) — PRD §3 accepts this as the only Phase 1 allocation
+  dst.events = src.events.slice();
+  dst.droppedCombatKillCount = src.droppedCombatKillCount;
+  dst.droppedStructuralCount = src.droppedStructuralCount;
 
   // --- AntComponents: 19 TypedArray.set calls (zero allocation) ---
   dst.ants.posX.set(src.ants.posX);


### PR DESCRIPTION
## Summary

- **New `src/sim/telemetry.ts`**: SimEvent discriminated union (9 types), `emitEvent` with 2,000-event hard cap; evicts oldest `combat_kill` on overflow, drops new structural events (increments `droppedStructuralCount`) when no evictable events remain.
- **`src/sim/types.ts`**: `WorldState` gains `events: SimEvent[]`, `droppedCombatKillCount`, `droppedStructuralCount`; `SIM_VERSION_V15_TELEMETRY = 15`.
- **`src/sim/game-over.ts`**: emits `queen_death` SimEvent on first queen death detection (cause: null in S0b; S1/S2 will back-fill from kill context per RC-P1-003).
- **`src/platform/save.ts`**: persists overflow counters; `events` is always transient (reset to `[]` on load). Pre-V15 saves default counters to 0.
- **New `src/render/summary-builder.ts`**: builds `PlaytraceSummary` from `WorldState` (strategy signals, outcome attribution, combat aggregate, tunable observed, event overflow). `eventsCoverage: 'since_load'` when resumed from save.
- **`src/render/playtrace-upload.ts`**: schema version bumped to 2; envelope gains `roundEndReason`, `events?`, `summary?`; `capturedEvents`/`capturedSummary` captured synchronously before first `await` to avoid post-restart world mutation race.
- **`src/render/game-scene.ts`**: tracks `resumedFromSave` flag; passes it to `submitPlaytrace`.

## Test plan

- [ ] `npx vitest run` passes (2080 tests, 70 files)
- [ ] `npx tsc --noEmit` clean
- [ ] `src/sim/telemetry.test.ts`: cap enforcement (eviction, structural drop, mixed buffer), V15 migration (pre-V15 save defaults counters to 0, events not serialized, counters round-trip), queen_death emission format
- [ ] `src/render/playtrace-upload.test.ts`: `X-Schema-Version: 2` header; `resumedFromSave: false` in fixture
- [ ] `src/sim/types.test.ts`: 17 WorldState fields (was 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)