### PR TITLE
feat(s1): HP/damage/cooldown combat system (D-32 / simVersion V16)

### DIFF
--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -393,6 +393,15 @@ interface SerializedAnts {
    */
   carryingBroodId?: number[];
   carriedBy?: number[];
+  /**
+   * S1 / D-32 — per-ant combat HP fields. Optional for backward-compat with
+   * pre-S1 saves; deserializer defaults hp=COMBAT_HP_BASE, homeGroundBonusHp
+   * from isHomeGround check, attackCooldown=0. Pre-V16 saves replay on the
+   * V15 coin-flip path so these fields are never read in-tick.
+   */
+  hp?: number[];
+  homeGroundBonusHp?: number[];
+  attackCooldown?: number[];
 }
 
 interface SerializedColony {
@@ -529,6 +538,10 @@ function serializeAnts(a: AntComponents): SerializedAnts {
     // Issue #17 Phase 1 — visible brood carry slot + reverse pointer.
     carryingBroodId: Array.from(a.carryingBroodId),
     carriedBy:       Array.from(a.carriedBy),
+    // S1 — combat HP/damage/cooldown fields.
+    hp:               Array.from(a.hp),
+    homeGroundBonusHp:Array.from(a.homeGroundBonusHp),
+    attackCooldown:   Array.from(a.attackCooldown),
   };
 }
 
@@ -811,6 +824,32 @@ function deserializeAnts(saved: SerializedAnts, capacity: number): AntComponents
   if (saved.carriedBy !== undefined) {
     copyIntoInt32(a.carriedBy, saved.carriedBy);
   }
+  // S1 — combat HP fields. Pre-S1 saves omit; migrate from world state
+  // (hp=COMBAT_HP_BASE, homeGroundBonusHp based on current grid occupancy,
+  // attackCooldown=0). Since save.ts cannot import sim constants without
+  // a circular dep, we inline the literal values here (COMBAT_HP_BASE=16,
+  // COMBAT_HP_HOMEGROUND_BONUS=4) — these are load-time migration defaults
+  // and do NOT affect simulation determinism (pre-V16 saves stay on V15 path).
+  if (saved.hp !== undefined) {
+    copyIntoInt32(a.hp, saved.hp);
+  } else {
+    a.hp.fill(16); // COMBAT_HP_BASE — migrated ants start at full health
+  }
+  if (saved.homeGroundBonusHp !== undefined) {
+    copyIntoInt32(a.homeGroundBonusHp, saved.homeGroundBonusHp);
+  } else {
+    // Migration: set bonus for ants on their own colony grid.
+    // currentGridColonyId is already populated at this point.
+    for (let i = 0; i < a.alive.length; i++) {
+      if (a.alive[i] === 1 && a.currentGridColonyId[i] === a.colonyId[i]) {
+        a.homeGroundBonusHp[i] = 4; // COMBAT_HP_HOMEGROUND_BONUS
+      }
+    }
+  }
+  if (saved.attackCooldown !== undefined) {
+    copyIntoInt32(a.attackCooldown, saved.attackCooldown);
+  }
+  // attackCooldown defaults to 0 (not in combat) via createAntComponents zero-init.
   return a;
 }
 
@@ -1145,6 +1184,8 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     // S0b — telemetry fields. events is always fresh (transient); counters
     // load from save with 0 default for pre-V15 saves.
     events: [],
+    // S1 — transient; always fresh on load (cleared between ticks).
+    pendingQueenDeathContexts: [],
     droppedCombatKillCount:
       typeof s.droppedCombatKillCount === 'number' &&
       Number.isInteger(s.droppedCombatKillCount) &&

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -402,6 +402,8 @@ interface SerializedAnts {
   hp?: number[];
   homeGroundBonusHp?: number[];
   attackCooldown?: number[];
+  /** S1 / D-32 — combatOpponentId (-1 = not paired). Absent on pre-S1 saves; defaults to all-(-1). */
+  combatOpponentId?: number[];
 }
 
 interface SerializedColony {
@@ -542,6 +544,7 @@ function serializeAnts(a: AntComponents): SerializedAnts {
     hp:               Array.from(a.hp),
     homeGroundBonusHp:Array.from(a.homeGroundBonusHp),
     attackCooldown:   Array.from(a.attackCooldown),
+    combatOpponentId: Array.from(a.combatOpponentId),
   };
 }
 
@@ -850,6 +853,10 @@ function deserializeAnts(saved: SerializedAnts, capacity: number): AntComponents
     copyIntoInt32(a.attackCooldown, saved.attackCooldown);
   }
   // attackCooldown defaults to 0 (not in combat) via createAntComponents zero-init.
+  if (saved.combatOpponentId !== undefined) {
+    copyIntoInt32(a.combatOpponentId, saved.combatOpponentId);
+  }
+  // combatOpponentId defaults to -1 (not paired) via createAntComponents -1 fill.
   return a;
 }
 

--- a/src/render/ant-sprite-layer.ts
+++ b/src/render/ant-sprite-layer.ts
@@ -26,6 +26,9 @@ export interface AntSpriteDrawOptions {
    * rather than jittering frame-to-frame.
    */
   rotation?: number;
+  /** S1 — uniform scale multiplier. 1.0 = natural size; >1 = larger sprite.
+   *  Used to render fighter ants slightly larger than workers. */
+  scale?: number;
 }
 
 /** Static (non-moving) entities drawn through the same sprite pool. */

--- a/src/render/ant-sprite-pool.ts
+++ b/src/render/ant-sprite-pool.ts
@@ -63,6 +63,7 @@ export class AntSpritePool implements AntSpriteLayer {
     sprite.setPosition(opts.x, opts.y);
     sprite.setTint(opts.tint);
     sprite.setRotation(opts.rotation ?? 0);
+    sprite.setScale(opts.scale ?? 1);
     sprite.setDepth(ANT_SPRITE_DEPTH);
     sprite.setVisible(true);
   }

--- a/src/render/ant-sprite-pool.ts
+++ b/src/render/ant-sprite-pool.ts
@@ -72,9 +72,11 @@ export class AntSpritePool implements AntSpriteLayer {
     const sprite = this.acquire();
     sprite.setTexture(STATIC_TEXTURES[opts.kind]);
     sprite.setPosition(opts.x, opts.y);
-    // Clear any tint / rotation inherited from a recycled ant slot.
+    // Clear any tint / rotation / scale inherited from a recycled ant slot (e.g. a
+    // fighter at 1.25× reused as an egg/food-cache would remain oversized).
     sprite.setTint(opts.tint ?? 0xffffff);
     sprite.setRotation(0);
+    sprite.setScale(1);
     sprite.setDepth(STATIC_SPRITE_DEPTH);
     sprite.setVisible(true);
   }

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -14,6 +14,7 @@
 // between terrain and entities per RESEARCH §Architecture draw-order diagram.
 
 import { sgGet } from '../sim/terrain.js';
+import { AntTask } from '../sim/enums.js';
 import { isAlive } from '../sim/ant/ant-store.js';
 import { FP_ONE } from '../sim/fixed.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
@@ -29,6 +30,8 @@ import {
   COLOR_ENEMY_COLONY,
   COLOR_QUEEN_OUTLINE,
   COLOR_RALLY_POINT,
+  COLOR_FIGHTER_TINT,
+  COLOR_CONTESTED_TILE,
 } from './sprites.js';
 import {
   drawBarrenEarthTile,
@@ -234,6 +237,35 @@ export function drawSurfaceEntities(
     }
   }
 
+  // --- Contested tile glow (S1) ---
+  // Draw a faint orange tint under ants on tiles where 2+ colonies meet.
+  // Two-pass: first collect contested surface tiles, then draw glows before ants.
+  {
+    const tileColony = new Map<number, number>(); // tileKey → first colonyId
+    const contested  = new Set<number>();
+    const n = curr.ants.alive.length;
+    for (let id = 0; id < n; id++) {
+      if (!isAlive(curr.ants, id)) continue;
+      if (curr.ants.zone[id] !== 0) continue;
+      const tx = curr.ants.posX[id]! >> 8;
+      const ty = curr.ants.posY[id]! >> 8;
+      const key = (ty << 16) | tx;
+      const cid = curr.ants.colonyId[id]!;
+      const existing = tileColony.get(key);
+      if (existing === undefined) tileColony.set(key, cid);
+      else if (existing !== cid) contested.add(key);
+    }
+    for (const key of contested) {
+      const tx = key & 0xffff;
+      const ty = (key >> 16) & 0xffff;
+      const sx = (tx - left) * TILE_SIZE_PX;
+      const sy = (ty - top)  * TILE_SIZE_PX;
+      if (sx < -TILE_SIZE_PX || sx > canvasW || sy < -TILE_SIZE_PX || sy > canvasH) continue;
+      gfx.fillStyle(COLOR_CONTESTED_TILE, 0.25);
+      gfx.fillRect(sx, sy, TILE_SIZE_PX, TILE_SIZE_PX);
+    }
+  }
+
   // --- Ants on surface (zone === 0) ---
   // Wrong-plane flicker guard (09 render polish): when an ant's zone flipped
   // between prev and curr (e.g. queen descending through an entrance), OR when
@@ -285,12 +317,16 @@ export function drawSurfaceEntities(
     const dy = currPxY - prevPxY;
     const rotation = computeAntRotation(facing, id, curr.ants.zone[id]!, dx, dy, useInterp);
 
+    const isFighter = curr.ants.task[id] === AntTask.Fighting;
     sprites.drawAnt({
       kind: isQueen ? 'queen' : 'worker',
       x: screenX,
       y: screenY,
-      tint: color,
+      // S1: fighters get a red tint blended over their colony color.
+      tint: isFighter && !isQueen ? COLOR_FIGHTER_TINT : color,
       rotation,
+      // S1: fighters render slightly larger (+1px equivalent at TILE_SIZE_PX=16).
+      scale: isFighter && !isQueen ? 1.25 : 1.0,
     });
   }
 

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -32,6 +32,7 @@ import {
   COLOR_RALLY_POINT,
   COLOR_FIGHTER_TINT,
   COLOR_CONTESTED_TILE,
+  lerpColor,
 } from './sprites.js';
 import {
   drawBarrenEarthTile,
@@ -323,7 +324,7 @@ export function drawSurfaceEntities(
       x: screenX,
       y: screenY,
       // S1: fighters get a red tint blended over their colony color.
-      tint: isFighter && !isQueen ? COLOR_FIGHTER_TINT : color,
+      tint: isFighter && !isQueen ? lerpColor(color, COLOR_FIGHTER_TINT, 0.45) : color,
       rotation,
       // S1: fighters render slightly larger (+1px equivalent at TILE_SIZE_PX=16).
       scale: isFighter && !isQueen ? 1.25 : 1.0,

--- a/src/render/draw-underground.ts
+++ b/src/render/draw-underground.ts
@@ -29,6 +29,7 @@ import { ChamberType } from '../sim/enums.js';
 import { CHAMBER_DIMENSIONS } from '../sim/colony/chamber.js';
 import type { WorldState } from '../sim/types.js';
 import type { ColonyRecord } from '../sim/colony/colony-store.js';
+import { AntTask } from '../sim/enums.js';
 import {
   TILE_SIZE_PX,
   COLOR_MARKED_TILE_OVERLAY,
@@ -41,6 +42,8 @@ import {
   COLOR_PLAYER_COLONY,
   COLOR_ENEMY_COLONY,
   COLOR_QUEEN_OUTLINE,
+  COLOR_FIGHTER_TINT,
+  COLOR_CONTESTED_TILE,
 } from './sprites.js';
 import {
   drawBarrenEarthSubstrate,
@@ -471,12 +474,14 @@ export function drawUndergroundEntities(
     // distinction — grid-of-occupancy vs colony identity).
     const owningColonyId = curr.ants.colonyId[id];
     const tint = owningColonyId === PLAYER_COLONY_ID ? COLOR_PLAYER_COLONY : COLOR_ENEMY_COLONY;
+    const isFighter2 = curr.ants.task[id] === AntTask.Fighting;
     sprites.drawAnt({
       kind: isQueen ? 'queen' : 'worker',
       x: screenX,
       y: screenY,
-      tint,
+      tint: isFighter2 && !isQueen ? COLOR_FIGHTER_TINT : tint,
       rotation,
+      scale: isFighter2 && !isQueen ? 1.25 : 1.0,
     });
   }
 

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -51,6 +51,12 @@ export const COLOR_SURFACE_ENTRANCE_HOLE = 0x1a0f00;
 /** PRD §7g — Rally point marker color. */
 export const COLOR_RALLY_POINT = 0xffffff;
 
+/** S1 — Red tint overlay applied to fighter-caste ants (tinted on top of colony color). */
+export const COLOR_FIGHTER_TINT = 0xff4444;
+
+/** S1 — Faint tile tint drawn under ants on contested tiles (alpha < 0.3). */
+export const COLOR_CONTESTED_TILE = 0xff6600;
+
 /** PRD §7g — Underground solid (unexcavated) tile color. */
 export const COLOR_UNDERGROUND_SOLID = 0x2d1a0a;
 

--- a/src/sim/ant/ant-store.ts
+++ b/src/sim/ant/ant-store.ts
@@ -241,6 +241,14 @@ export interface AntComponents {
   readonly homeGroundBonusHp: Int32Array;
   /** S1 / D-32 — Ticks until next strike (0 = not in active combat). Windup on first engagement. */
   readonly attackCooldown: Int32Array;
+  /**
+   * S1 / D-32 — Entity index of the ant's current combat opponent (-1 = not paired).
+   * Used by resolveCombatOnTile_v16 to detect new pairings: a pairing is new when
+   * combatOpponentId[antA] !== antB, which correctly handles veteran-veteran first
+   * contacts (both have non-zero cooldowns from prior fights but are new to each other).
+   * Set to the opponent's index on windup; reset to -1 on kill or death.
+   */
+  readonly combatOpponentId: Int32Array;
 }
 
 /**
@@ -344,6 +352,8 @@ export function createAntComponents(maxEntities: number = MAX_ENTITIES): AntComp
     hp:               new Int32Array(maxEntities),
     homeGroundBonusHp:new Int32Array(maxEntities),
     attackCooldown:   new Int32Array(maxEntities),
+    // S1 — combat opponent tracking. -1 = not paired.
+    combatOpponentId: (() => { const a = new Int32Array(maxEntities); a.fill(-1); return a; })(),
   };
 }
 
@@ -436,6 +446,7 @@ export function initAnt(ants: AntComponents, id: EntityId, spec: InitAntSpec): v
   ants.hp[id]               = COMBAT_HP_BASE;
   ants.homeGroundBonusHp[id]= 0;
   ants.attackCooldown[id]   = 0;
+  ants.combatOpponentId[id] = -1;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sim/ant/ant-store.ts
+++ b/src/sim/ant/ant-store.ts
@@ -39,6 +39,7 @@ import {
   MAX_ENTITIES,
   WORKER_BASE_SPEED,
   WORKER_LIFESPAN_TICKS,
+  COMBAT_HP_BASE,
 } from '../constants.js';
 
 // ---------------------------------------------------------------------------
@@ -233,6 +234,13 @@ export interface AntComponents {
    * save/load (optional; defaults to all-(-1) on pre-v10 saves).
    */
   readonly carriedBy: Int32Array;
+  // S1 — combat HP/damage/cooldown fields.
+  /** S1 / D-32 — Current base HP. Death when hp <= 0 (after homeGroundBonusHp depleted). */
+  readonly hp: Int32Array;
+  /** S1 / D-32 — Home-ground HP buffer; depletes first before hp. 0 when on away ground. */
+  readonly homeGroundBonusHp: Int32Array;
+  /** S1 / D-32 — Ticks until next strike (0 = not in active combat). Windup on first engagement. */
+  readonly attackCooldown: Int32Array;
 }
 
 /**
@@ -331,6 +339,11 @@ export function createAntComponents(maxEntities: number = MAX_ENTITIES): AntComp
     // Issue #17 Phase 1 — visible brood carry. -1 = not carrying / not carried.
     carryingBroodId,
     carriedBy,
+    // S1 — combat fields. hp zero-init would be wrong (dead ants have hp=0);
+    // initAnt sets hp=COMBAT_HP_BASE on spawn.
+    hp:               new Int32Array(maxEntities),
+    homeGroundBonusHp:new Int32Array(maxEntities),
+    attackCooldown:   new Int32Array(maxEntities),
   };
 }
 
@@ -418,6 +431,11 @@ export function initAnt(ants: AntComponents, id: EntityId, spec: InitAntSpec): v
   // Issue #17 Phase 1 — fresh ant is not carrying / not carried.
   ants.carryingBroodId[id]   = -1;
   ants.carriedBy[id]         = -1;
+  // S1 — fresh ant starts at full base HP; home-ground bonus is set by
+  // the combat resolver on first engagement on home ground.
+  ants.hp[id]               = COMBAT_HP_BASE;
+  ants.homeGroundBonusHp[id]= 0;
+  ants.attackCooldown[id]   = 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -7878,13 +7878,17 @@ describe('Issue #106 — ascent uses currentGridColonyId (V13+)', () => {
     // at tileY=0 in the enemy grid would find the enemy's entrance at the
     // same tileX (which is exactly where it descended) and ascend through
     // it, then descend again next tick — bouncing forever and never fighting.
+    // Note: skipAscent only fires for ACTIVE invaders (fight ratio > 0 AND rally
+    // set). Recalled invaders (fight=0 or rally cleared) intentionally ascend.
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     world.simVersion = 13;
     const playerColonyId = 1;
     const enemyColonyId = 2;
     const playerColony = createColonyRecord(playerColonyId, 0);
     playerColony.entrances = [{ entranceId: 10, surfaceTileX: 5, surfaceTileY: 5, isOpen: true }];
-    playerColony.rallyPoint = null;
+    // Active invader: rally set + fight ratio > 0 (not a recall situation).
+    playerColony.rallyPoint = { tileX: 5, tileY: 50 };
+    playerColony.targetRatio.fight = 5;
     playerColony.digFlowFieldDirty = false;
     world.colonies[playerColonyId] = playerColony;
     const enemyColony = createColonyRecord(enemyColonyId, 0);

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -1976,6 +1976,21 @@ export function updateFightAntTargets(world: WorldState): void {
     const entrances = colony.entrances;
     const hasEntrances = entrances != null && entrances.length > 0;
 
+    // Invader in enemy underground: recall or active-fight — both handled by tickAntMovement.
+    // Recall (fight===0 or rp==null): isForeignGridUnderground routes toward the enemy
+    //   entrance exit; skipAscent is cleared so the ant can ascend at tileY=0.
+    // Active: isForeignGridUnderground routes via pickNearestHostileUnderground.
+    // This block must run before the rp==null and zone===Underground blocks so invaders
+    // don't get routed to their own colony's entrance inside a foreign grid.
+    const currentGridColonyId = ants.currentGridColonyId[id]!;
+    if (world.simVersion >= SIM_VERSION_V13_INVARIANT_FIXES
+        && ants.zone[id] === 1 /* Underground */ && currentGridColonyId !== colonyId) {
+      // Always clear stale targets — tickAntMovement computes the correct direction.
+      ants.targetPosX[id] = -1;
+      ants.targetPosY[id] = -1;
+      continue;
+    }
+
     // No rally point (null or uninitialized): fall back to first entrance (idle-at-nest).
     if (rp == null) {
       if (hasEntrances) {
@@ -4167,14 +4182,45 @@ export function tickAntMovement(
       let haveTarget = false;
 
       if (isForeignGridUnderground) {
-        const hostile = pickNearestHostileUnderground(ants, id, gridColonyId);
-        if (hostile !== null) {
-          rawDx = hostile.targetX - posX;
-          rawDy = hostile.targetY - posY;
-          haveTarget = true;
+        const ownColony = world.colonies[ownColonyId];
+        // null colony is treated as NOT recalled (matches isRecallingFromForeign guard
+        // in skipAscent) — missing colony record is a defensive fallback, not a recall.
+        const isRecalling = ownColony != null
+          && (ownColony.targetRatio.fight === 0 || ownColony.rallyPoint == null);
+
+        if (isRecalling) {
+          // Recalled invader: navigate toward the nearest foreign entrance exit
+          // (underground tileY=0 at the shaft column) so skipAscent=false allows ascent.
+          const foreignColony = world.colonies[gridColonyId];
+          const fEnts = foreignColony?.entrances;
+          if (fEnts != null && fEnts.length > 0) {
+            // Pick nearest open entrance; fall back to nearest any entrance.
+            const antTileX = posX >> FP_SHIFT;
+            const antTileY = posY >> FP_SHIFT;
+            let bestEnt = fEnts[0]!;
+            let bestDist = Math.abs(bestEnt.surfaceTileX - antTileX) + antTileY;
+            let bestIsOpen = bestEnt.isOpen;
+            for (let ei = 1; ei < fEnts.length; ei++) {
+              const candidate = fEnts[ei]!;
+              const dist = Math.abs(candidate.surfaceTileX - antTileX) + antTileY;
+              const improves = candidate.isOpen && !bestIsOpen
+                || (candidate.isOpen === bestIsOpen && dist < bestDist);
+              if (improves) { bestEnt = candidate; bestDist = dist; bestIsOpen = candidate.isOpen; }
+            }
+            rawDx = (bestEnt.surfaceTileX << FP_SHIFT) - posX;
+            rawDy = -posY; // target underground Y=0 (entrance row)
+            haveTarget = true;
+          }
+          // else: no enemy entrance → hold (dx=dy=0 fallback)
+        } else {
+          const hostile = pickNearestHostileUnderground(ants, id, gridColonyId);
+          if (hostile !== null) {
+            rawDx = hostile.targetX - posX;
+            rawDy = hostile.targetY - posY;
+            haveTarget = true;
+          }
+          // hostile === null → idle fallback: dx=dy=0 (haveTarget stays false)
         }
-        // hostile === null → idle fallback: dx=dy=0 (haveTarget stays false,
-        // axis-step block below leaves dx/dy at their defaults of 0).
       } else {
         const targetX = ants.targetPosX[id]!;
         const targetY = ants.targetPosY[id]!;
@@ -4709,7 +4755,13 @@ export function tickAntMovement(
           //       coincidental tileX alignment.
           const useGridColony = world.simVersion >= SIM_VERSION_V13_INVARIANT_FIXES;
           const inOwnGrid = ants.currentGridColonyId[id] === ants.colonyId[id];
-          const skipAscent = useGridColony && task === AntTask.Fighting && !inOwnGrid;
+          // Recalled invaders (fight ratio zeroed or rally cleared) must be able to
+          // exit the enemy underground, so skipAscent is cleared for them.
+          const ownColonyForAscent = useGridColony ? world.colonies[ants.colonyId[id]!] : undefined;
+          const isRecallingFromForeign = useGridColony && !inOwnGrid
+            && ownColonyForAscent != null
+            && (ownColonyForAscent.targetRatio.fight === 0 || ownColonyForAscent.rallyPoint == null);
+          const skipAscent = useGridColony && task === AntTask.Fighting && !inOwnGrid && !isRecallingFromForeign;
           if (!skipAscent) {
             const lookupColonyId = useGridColony
               ? ants.currentGridColonyId[id]!

--- a/src/sim/combat-cross-grid.test.ts
+++ b/src/sim/combat-cross-grid.test.ts
@@ -165,7 +165,9 @@ describe('combat cross-grid — tile-key gridColonyId extension (REQ-C4)', () =>
 
     // Act --------------------------------------------------------------------
     // Pin rngState to the known-player-wins seed value immediately before combat.
+    // Use V15 resolver: this test verifies cross-grid tile-key bucketing, not V16 HP math.
     world.rngState = 3;
+    world.simVersion = 15;
     detectAndResolveCombat(world, new Rng(world.rngState));
 
     // MANDATORY t=N outcome assertions ---------------------------------------

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -47,6 +47,13 @@ function spawnAnt(world: WorldState, colonyId: ColonyId, tileX: number, tileY: n
   return id;
 }
 
+// Helper: spawn a fighting ant (AntTask.Fighting) for V16 combat tests.
+function spawnFighter(world: WorldState, colonyId: ColonyId, tileX: number, tileY: number, zone: Zone): number {
+  const id = spawnAnt(world, colonyId, tileX, tileY, zone);
+  world.ants.task[id] = AntTask.Fighting;
+  return id;
+}
+
 describe('detectAndResolveCombat (V15 coin-flip path)', () => {
   it('does nothing when no two ants share a tile', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
@@ -292,8 +299,8 @@ function runCombatTicks(world: WorldState, n: number): void {
 describe('V16 combat resolver', () => {
   it('windup: no ant dies on first contested tick', () => {
     const { world, cid1, cid2 } = makeV16World();
-    const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
-    const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    const a = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const b = spawnFighter(world, cid2, 5, 7, Zone.Surface);
     runCombatTicks(world, 1);
     // Windup tick — no strike, both alive
     expect(world.ants.alive[a]).toBe(1);
@@ -305,8 +312,8 @@ describe('V16 combat resolver', () => {
 
   it('no strike until cooldown decrements to 0 (first strike at T=6)', () => {
     const { world, cid1, cid2 } = makeV16World();
-    const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
-    const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    const a = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const b = spawnFighter(world, cid2, 5, 7, Zone.Surface);
     runCombatTicks(world, 4); // windup + 3 decrements → cooldown = 2
     expect(world.ants.alive[a]).toBe(1);
     expect(world.ants.alive[b]).toBe(1);
@@ -319,8 +326,8 @@ describe('V16 combat resolver', () => {
     // 4 strikes kill (4×4=16). Strikes at T=6,11,16,21 (windup T=1, decrement 5 ticks).
     // Both deal same damage → both reach hp=0 simultaneously on strike 4 (mutual kill).
     const { world, cid1, cid2 } = makeV16World();
-    const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
-    const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    const a = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const b = spawnFighter(world, cid2, 5, 7, Zone.Surface);
     runCombatTicks(world, 21);
     // Symmetric fight = mutual kill: both dead
     expect(world.ants.alive[a]).toBe(0);
@@ -336,10 +343,10 @@ describe('V16 combat resolver', () => {
     // T=20: strike 4. Defender hp=8-4=4. Attacker hp=1-5=-4 → DEAD.
     const { world, cid1, cid2 } = makeV16World();
     // Defender (cid1) on their own grid (currentGridColonyId=cid1, zone=Underground)
-    const defender = spawnAnt(world, cid1, 5, 7, Zone.Underground);
+    const defender = spawnFighter(world, cid1, 5, 7, Zone.Underground);
     world.ants.currentGridColonyId[defender] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
     // Attacker (cid2) on cid1's grid (invasion)
-    const attacker = spawnAnt(world, cid2, 5, 7, Zone.Underground);
+    const attacker = spawnFighter(world, cid2, 5, 7, Zone.Underground);
     world.ants.currentGridColonyId[attacker] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
 
     // Run exactly COMBAT_COOLDOWN_TICKS+1 = 6 ticks per round, 4 rounds = 24 ticks total
@@ -360,8 +367,8 @@ describe('V16 combat resolver', () => {
   it('simultaneous kills: both ants die on same tick when both hp<=0', () => {
     // Force both ants to have hp=4 (one strike kills) and no homeground bonus.
     const { world, cid1, cid2 } = makeV16World();
-    const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
-    const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    const a = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const b = spawnFighter(world, cid2, 5, 7, Zone.Surface);
     // Wind up both (1 tick), then set hp to low value
     runCombatTicks(world, 1); // windup tick
     world.ants.hp[a] = 4; // will die on next strike
@@ -377,9 +384,9 @@ describe('V16 combat resolver', () => {
 
   it('2v1: only one attacker is active; replacement winds up fresh after first dies', () => {
     const { world, cid1, cid2 } = makeV16World();
-    const a1 = spawnAnt(world, cid1, 5, 7, Zone.Surface);
-    const a2 = spawnAnt(world, cid1, 5, 7, Zone.Surface); // backup
-    const b  = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    const a1 = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const a2 = spawnFighter(world, cid1, 5, 7, Zone.Surface); // backup
+    const b  = spawnFighter(world, cid2, 5, 7, Zone.Surface);
     // After windup, a1 and b are in combat; a2 should NOT have cooldown set
     runCombatTicks(world, 1);
     expect(world.ants.attackCooldown[a1]).toBe(COMBAT_COOLDOWN_TICKS); // active
@@ -390,9 +397,9 @@ describe('V16 combat resolver', () => {
   it('replacement ant winds up fresh after first ally dies', () => {
     // a1 and b fight. b kills a1. a2 (backup) should wind up against b on the next tick.
     const { world, cid1, cid2 } = makeV16World();
-    const a1 = spawnAnt(world, cid1, 5, 7, Zone.Surface);
-    const a2 = spawnAnt(world, cid1, 5, 7, Zone.Surface); // backup (higher slot)
-    const b  = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    const a1 = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const a2 = spawnFighter(world, cid1, 5, 7, Zone.Surface); // backup (higher slot)
+    const b  = spawnFighter(world, cid2, 5, 7, Zone.Surface);
     // Force a1 to die quickly: set hp=4 so one strike kills.
     runCombatTicks(world, 1); // windup tick (a1 vs b paired, a2 unpaired)
     world.ants.hp[a1] = 4;
@@ -409,9 +416,9 @@ describe('V16 combat resolver', () => {
 
   it('home-ground bonus HP depletes first before base HP', () => {
     const { world, cid1, cid2 } = makeV16World();
-    const defender = spawnAnt(world, cid1, 5, 7, Zone.Underground);
+    const defender = spawnFighter(world, cid1, 5, 7, Zone.Underground);
     world.ants.currentGridColonyId[defender] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
-    const attacker = spawnAnt(world, cid2, 5, 7, Zone.Underground);
+    const attacker = spawnFighter(world, cid2, 5, 7, Zone.Underground);
     world.ants.currentGridColonyId[attacker] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
     // After windup, set defender's hp/bonus to known state
     runCombatTicks(world, 1); // windup
@@ -422,5 +429,48 @@ describe('V16 combat resolver', () => {
     // Attacker deals COMBAT_DAMAGE_BASE=4; defender bonus=4 → bonus absorbs all 4 → bonus=0, hp=16
     expect(world.ants.homeGroundBonusHp[defender]).toBe(0);
     expect(world.ants.hp[defender]).toBe(COMBAT_HP_BASE);
+  });
+});
+
+// =============================================================================
+// S1 — 2v2 two-tile chamber frontage (spec validation target)
+// =============================================================================
+
+describe('V16 2v2 two-tile chamber frontage', () => {
+  it('two adjacent tiles each resolve one independent pair; both defenders survive at hp=4', () => {
+    // Spec: "two adjacent chamber/open tiles each contain one home defender and one invader.
+    // Two active pairs resolve in parallel (one per tile). Both home defenders survive at HP 4;
+    // both invaders die at T+20."
+    const { world, cid1, cid2 } = makeV16World();
+
+    // Tile A (5,7): defender from cid1 (home-ground) vs invader from cid2
+    const defA = spawnFighter(world, cid1, 5, 7, Zone.Underground);
+    const invA = spawnFighter(world, cid2, 5, 7, Zone.Underground);
+    // Tile B (6,7): defender from cid1 (home-ground) vs invader from cid2
+    const defB = spawnFighter(world, cid1, 6, 7, Zone.Underground);
+    const invB = spawnFighter(world, cid2, 6, 7, Zone.Underground);
+
+    // Place all four on cid1's grid (defenders are on home ground).
+    const COLONY1 = 1;
+    world.ants.currentGridColonyId[defA] = COLONY1;
+    world.ants.currentGridColonyId[invA] = COLONY1;
+    world.ants.currentGridColonyId[defB] = COLONY1;
+    world.ants.currentGridColonyId[invB] = COLONY1;
+
+    // Run 21 ticks: windup at T=1, strikes at T=6, T=11, T=16, T=21.
+    runCombatTicks(world, 21);
+
+    // Both invaders dead (defender deals 5 home-ground damage × 4 strikes = 20 total).
+    expect(world.ants.alive[invA]).toBe(0);
+    expect(world.ants.alive[invB]).toBe(0);
+    // Both defenders alive (invader deals 4 damage × 4 strikes = 16; bonus absorbs first 4).
+    expect(world.ants.alive[defA]).toBe(1);
+    expect(world.ants.alive[defB]).toBe(1);
+    // Each defender ends at hp=4 (took 16 total damage: 4 absorbed by bonus, 12 from hp=16).
+    expect(world.ants.hp[defA]).toBe(4);
+    expect(world.ants.hp[defB]).toBe(4);
+    // Pairs are independent — each tile resolved its own fight.
+    expect(world.colonies[cid1]!.killCount).toBe(2);
+    expect(world.colonies[cid2]!.killCount).toBe(0);
   });
 });

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -47,9 +47,10 @@ function spawnAnt(world: WorldState, colonyId: ColonyId, tileX: number, tileY: n
   return id;
 }
 
-describe('detectAndResolveCombat', () => {
+describe('detectAndResolveCombat (V15 coin-flip path)', () => {
   it('does nothing when no two ants share a tile', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
+    world.simVersion = 15; // pin to V15 coin-flip path
     const a = spawnAnt(world, cid1, 5, 5, Zone.Surface);
     const b = spawnAnt(world, cid2, 10, 10, Zone.Surface);
     detectAndResolveCombat(world, new Rng(world.rngState));
@@ -70,6 +71,7 @@ describe('detectAndResolveCombat', () => {
 
   it('resolves combat when 2 ants from different colonies share a tile — one dies, winner killCount increments', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
+    world.simVersion = 15;
     const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
     const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
     detectAndResolveCombat(world, new Rng(world.rngState));
@@ -93,6 +95,7 @@ describe('detectAndResolveCombat', () => {
   it('is deterministic: same rngState + same placements produces the same survivor', () => {
     const build = () => {
       const x = makeWorldWith2Colonies(42);
+      x.world.simVersion = 15;
       const a = spawnAnt(x.world, x.cid1, 5, 7, Zone.Surface);
       const b = spawnAnt(x.world, x.cid2, 5, 7, Zone.Surface);
       return { ...x, a, b };
@@ -106,9 +109,10 @@ describe('detectAndResolveCombat', () => {
   });
 });
 
-describe('resolveCombatOnTile', () => {
+describe('resolveCombatOnTile_v15 (legacy coin-flip)', () => {
   it('resolves 3-way combat until one colony remains', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
+    world.simVersion = 15;
     // Add a 3rd colony — queen placed at tile (2,0) to avoid collision with queens 1,2 at tiles (0,0)/(1,0).
     const queen3 = allocateEntityId(world);
     initAnt(world.ants, queen3, { colonyId: 3, posX: 2 << FP_SHIFT, posY: 0, task: AntTask.Idle, subTask: 0, speed: 0 });
@@ -132,6 +136,7 @@ describe('resolveCombatOnTile', () => {
     // This test pins the new contract: combat advances the rng IT was given,
     // not world.rngState directly.
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
+    world.simVersion = 15;
     spawnAnt(world, cid1, 5, 7, Zone.Surface);
     spawnAnt(world, cid2, 5, 7, Zone.Surface);
     const rng = new Rng(world.rngState);
@@ -148,7 +153,7 @@ describe('killAnt', () => {
   it('zeroes alive flag on victim', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
     const v = spawnAnt(world, cid1, 5, 7, Zone.Surface);
-    killAnt(world, v, cid2);
+    killAnt(world, v, cid2, null, 'Ant');
     expect(world.ants.alive[v]).toBe(0);
   });
 
@@ -156,23 +161,24 @@ describe('killAnt', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
     const v = spawnAnt(world, cid1, 5, 7, Zone.Surface);
     expect(world.colonies[cid2]!.killCount).toBe(0);
-    killAnt(world, v, cid2);
+    killAnt(world, v, cid2, null, 'Ant');
     expect(world.colonies[cid2]!.killCount).toBe(1);
   });
 
-  it('does not increment killCount when killerColonyId is 0', () => {
+  it('does not increment killCount when killerColonyId is null', () => {
     const { world, cid1 } = makeWorldWith2Colonies();
     const v = spawnAnt(world, cid1, 5, 7, Zone.Surface);
-    killAnt(world, v, 0 as ColonyId);
+    killAnt(world, v, null, null, 'Ant');
     expect(world.ants.alive[v]).toBe(0);
     expect(world.colonies[cid1]!.killCount).toBe(0);
   });
 
   it('does NOT remove entity from roster (tickDeathCleanup owns roster swap-remove)', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
+    world.simVersion = 15; // avoid combat_kill emit on V16
     const v = spawnAnt(world, cid1, 5, 7, Zone.Surface);
     expect(world.colonies[cid1]!.workers).toContain(v);
-    killAnt(world, v, cid2);
+    killAnt(world, v, cid2, null, 'Ant');
     // Combat.killAnt intentionally does NOT cleanup the roster. The alive=0 flag is enough;
     // tickDeathCleanup (colony-system.ts:165) handles the roster next tick.
     expect(world.colonies[cid1]!.workers).toContain(v);
@@ -189,7 +195,7 @@ describe('killAnt', () => {
     const brood = spawnAnt(world, cid1, 5, 7, Zone.Underground);
     world.ants.carryingBroodId[carrier] = brood;
     world.ants.carriedBy[brood] = carrier;
-    killAnt(world, carrier, cid2);
+    killAnt(world, carrier, cid2, null, 'Ant');
     expect(world.ants.alive[carrier]).toBe(0);
     expect(world.ants.carryingBroodId[carrier]).toBe(-1);
     expect(world.ants.carriedBy[brood]).toBe(-1);
@@ -202,7 +208,7 @@ describe('killAnt', () => {
     const brood = spawnAnt(world, cid1, 5, 7, Zone.Underground);
     world.ants.carryingBroodId[carrier] = brood;
     world.ants.carriedBy[brood] = carrier;
-    killAnt(world, brood, cid2);
+    killAnt(world, brood, cid2, null, 'Ant');
     expect(world.ants.alive[brood]).toBe(0);
     expect(world.ants.carryingBroodId[carrier]).toBe(-1);
     expect(world.ants.carriedBy[brood]).toBe(-1);
@@ -215,7 +221,7 @@ describe('killAnt', () => {
     const brood = spawnAnt(world, cid1, 5, 7, Zone.Underground);
     world.ants.carryingBroodId[carrier] = brood;
     world.ants.carriedBy[brood] = carrier;
-    killAnt(world, carrier, cid2);
+    killAnt(world, carrier, cid2, null, 'Ant');
     expect(world.ants.alive[carrier]).toBe(0);
     // Legacy: pointers persist past death — the bug this V13 fix addresses.
     expect(world.ants.carryingBroodId[carrier]).toBe(brood);
@@ -227,20 +233,21 @@ describe('killAnt', () => {
     world.simVersion = 13;
     const v = spawnAnt(world, cid1, 5, 7, Zone.Surface);
     // Default state: carryingBroodId = -1, carriedBy = -1.
-    killAnt(world, v, cid2);
+    killAnt(world, v, cid2, null, 'Ant');
     expect(world.ants.alive[v]).toBe(0);
     expect(world.ants.carryingBroodId[v]).toBe(-1);
     expect(world.ants.carriedBy[v]).toBe(-1);
   });
 });
 
-describe('coin flip distribution (CMBT-05)', () => {
+describe('coin flip distribution (CMBT-05, V15 path)', () => {
   it('over 1000 fights, A-wins is within ±3σ of 500 (approx 453..547)', () => {
     // Issue #58 — combat now advances the rng instance the caller passes,
     // not world.rngState. Pass ONE shared rng across all iterations so the
     // sequence advances naturally between fights (the prior test relied on
     // combat's now-removed writeback to world.rngState).
     const { world, cid1, cid2 } = makeWorldWith2Colonies(42);
+    world.simVersion = 15; // pin to V15 coin-flip path
     const rng = new Rng(world.rngState);
     let aWins = 0;
     for (let i = 0; i < 1000; i++) {
@@ -259,5 +266,161 @@ describe('coin flip distribution (CMBT-05)', () => {
     }
     expect(aWins).toBeGreaterThanOrEqual(453);
     expect(aWins).toBeLessThanOrEqual(547);
+  });
+});
+
+// =============================================================================
+// S1 — V16 HP/damage/cooldown combat tests
+// =============================================================================
+
+import { COMBAT_HP_BASE, COMBAT_HP_HOMEGROUND_BONUS, COMBAT_COOLDOWN_TICKS } from './constants.js';
+
+function makeV16World(seed = 42): { world: WorldState; cid1: ColonyId; cid2: ColonyId } {
+  const r = makeWorldWith2Colonies(seed);
+  r.world.simVersion = 16;
+  return r;
+}
+
+/** Run N ticks of combat on a world where ants are already on a contested tile. */
+function runCombatTicks(world: WorldState, n: number): void {
+  const rng = new Rng(world.rngState);
+  for (let t = 0; t < n; t++) {
+    detectAndResolveCombat(world, rng);
+  }
+}
+
+describe('V16 combat resolver', () => {
+  it('windup: no ant dies on first contested tick', () => {
+    const { world, cid1, cid2 } = makeV16World();
+    const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
+    const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    runCombatTicks(world, 1);
+    // Windup tick — no strike, both alive
+    expect(world.ants.alive[a]).toBe(1);
+    expect(world.ants.alive[b]).toBe(1);
+    // cooldown set to COMBAT_COOLDOWN_TICKS
+    expect(world.ants.attackCooldown[a]).toBe(COMBAT_COOLDOWN_TICKS);
+    expect(world.ants.attackCooldown[b]).toBe(COMBAT_COOLDOWN_TICKS);
+  });
+
+  it('no strike until cooldown decrements to 0 (first strike at T=6)', () => {
+    const { world, cid1, cid2 } = makeV16World();
+    const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
+    const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    runCombatTicks(world, 4); // windup + 3 decrements → cooldown = 2
+    expect(world.ants.alive[a]).toBe(1);
+    expect(world.ants.alive[b]).toBe(1);
+    expect(world.ants.attackCooldown[a]).toBe(2);
+    expect(world.ants.attackCooldown[b]).toBe(2);
+  });
+
+  it('1v1 surface: symmetric fight produces mutual kill (both die after 4 strikes)', () => {
+    // Surface fight: no home-ground bonus. HP=16, damage=4 per side.
+    // 4 strikes kill (4×4=16). Strikes at T=6,11,16,21 (windup T=1, decrement 5 ticks).
+    // Both deal same damage → both reach hp=0 simultaneously on strike 4 (mutual kill).
+    const { world, cid1, cid2 } = makeV16World();
+    const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
+    const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    runCombatTicks(world, 21);
+    // Symmetric fight = mutual kill: both dead
+    expect(world.ants.alive[a]).toBe(0);
+    expect(world.ants.alive[b]).toBe(0);
+  });
+
+  it('1v1 underground home defender vs attacker: home defender wins with HP=4 remaining at T=20 (D-32 TTK)', () => {
+    // Home defender: on own colony grid → homeGroundBonusHp=4, hp=16, deals COMBAT_DAMAGE_HOMEGROUND=5.
+    // Attacker: on enemy grid → homeGroundBonusHp=0, hp=16, deals COMBAT_DAMAGE_BASE=4.
+    // T=5 (windup+5 ticks): strike 1. Defender takes 4→hp=16 (bonus absorbs). Attacker takes 5→hp=11.
+    // T=10: strike 2. Defender bonus=0, hp=16-4=12. Attacker hp=11-5=6.
+    // T=15: strike 3. Defender hp=12-4=8. Attacker hp=6-5=1.
+    // T=20: strike 4. Defender hp=8-4=4. Attacker hp=1-5=-4 → DEAD.
+    const { world, cid1, cid2 } = makeV16World();
+    // Defender (cid1) on their own grid (currentGridColonyId=cid1, zone=Underground)
+    const defender = spawnAnt(world, cid1, 5, 7, Zone.Underground);
+    world.ants.currentGridColonyId[defender] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
+    // Attacker (cid2) on cid1's grid (invasion)
+    const attacker = spawnAnt(world, cid2, 5, 7, Zone.Underground);
+    world.ants.currentGridColonyId[attacker] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
+
+    // Run exactly COMBAT_COOLDOWN_TICKS+1 = 6 ticks per round, 4 rounds = 24 ticks total
+    // But windup is on tick 1, first strike at tick 1+5=6. So T=6, T=12, T=18, T=24?
+    // Wait - let me recount: windup happens when cooldown=0. T=1: windup, cooldown=5.
+    // T=2: decrement to 4. T=3: 3. T=4: 2. T=5: 1. T=6: decrement to 0 → strike 1, reset to 5.
+    // T=7: 4. ... T=11: 0 → strike 2. T=12: reset. ... T=16: 0 → strike 3. T=17: reset. ... T=21: 0 → strike 4.
+    // So 4 strikes at T=6, T=11, T=16, T=21 with COMBAT_COOLDOWN_TICKS=5.
+    runCombatTicks(world, 21);
+    // Attacker should be dead, defender should be alive
+    expect(world.ants.alive[attacker]).toBe(0);
+    expect(world.ants.alive[defender]).toBe(1);
+    // Defender's hp should be 4 after 4 strikes absorbed: bonus(4-4=0)+hp(16-4*3=4)
+    // Wait: Strike 1: bonus depletes (4-4=0), hp=16. Strike 2: hp=16-4=12. Strike 3: hp=12-4=8. Strike 4: hp=8-4=4.
+    expect(world.ants.hp[defender]).toBe(4);
+  });
+
+  it('simultaneous kills: both ants die on same tick when both hp<=0', () => {
+    // Force both ants to have hp=4 (one strike kills) and no homeground bonus.
+    const { world, cid1, cid2 } = makeV16World();
+    const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
+    const b = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    // Wind up both (1 tick), then set hp to low value
+    runCombatTicks(world, 1); // windup tick
+    world.ants.hp[a] = 4; // will die on next strike
+    world.ants.hp[b] = 4;
+    world.ants.homeGroundBonusHp[a] = 0;
+    world.ants.homeGroundBonusHp[b] = 0;
+    // One more full round (5 ticks) to reach the strike
+    runCombatTicks(world, 5);
+    // Both should die (4 damage each, both at hp=4)
+    expect(world.ants.alive[a]).toBe(0);
+    expect(world.ants.alive[b]).toBe(0);
+  });
+
+  it('2v1: only one attacker is active; replacement winds up fresh after first dies', () => {
+    const { world, cid1, cid2 } = makeV16World();
+    const a1 = spawnAnt(world, cid1, 5, 7, Zone.Surface);
+    const a2 = spawnAnt(world, cid1, 5, 7, Zone.Surface); // backup
+    const b  = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    // After windup, a1 and b are in combat; a2 should NOT have cooldown set
+    runCombatTicks(world, 1);
+    expect(world.ants.attackCooldown[a1]).toBe(COMBAT_COOLDOWN_TICKS); // active
+    expect(world.ants.attackCooldown[a2]).toBe(0); // NOT active (not paired)
+    expect(world.ants.attackCooldown[b]).toBe(COMBAT_COOLDOWN_TICKS);
+  });
+
+  it('replacement ant winds up fresh after first ally dies', () => {
+    // a1 and b fight. b kills a1. a2 (backup) should wind up against b on the next tick.
+    const { world, cid1, cid2 } = makeV16World();
+    const a1 = spawnAnt(world, cid1, 5, 7, Zone.Surface);
+    const a2 = spawnAnt(world, cid1, 5, 7, Zone.Surface); // backup (higher slot)
+    const b  = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    // Force a1 to die quickly: set hp=4 so one strike kills.
+    runCombatTicks(world, 1); // windup tick (a1 vs b paired, a2 unpaired)
+    world.ants.hp[a1] = 4;
+    world.ants.homeGroundBonusHp[a1] = 0;
+    runCombatTicks(world, 5); // first strike tick: b hits a1 for 4 → a1 dies
+    expect(world.ants.alive[a1]).toBe(0); // a1 is dead
+    // a1's kill resets a2's cooldown (via cooldown=0 on replacement side).
+    // On next tick, a2 (now lowest slot from cid1) winds up against b.
+    expect(world.ants.attackCooldown[a2]).toBe(0); // not yet in combat
+    runCombatTicks(world, 1); // windup tick for a2 vs b
+    expect(world.ants.attackCooldown[a2]).toBe(COMBAT_COOLDOWN_TICKS); // now wound up
+    expect(world.ants.alive[b]).toBe(1); // b still alive (just wound up together)
+  });
+
+  it('home-ground bonus HP depletes first before base HP', () => {
+    const { world, cid1, cid2 } = makeV16World();
+    const defender = spawnAnt(world, cid1, 5, 7, Zone.Underground);
+    world.ants.currentGridColonyId[defender] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
+    const attacker = spawnAnt(world, cid2, 5, 7, Zone.Underground);
+    world.ants.currentGridColonyId[attacker] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
+    // After windup, set defender's hp/bonus to known state
+    runCombatTicks(world, 1); // windup
+    expect(world.ants.homeGroundBonusHp[defender]).toBe(COMBAT_HP_HOMEGROUND_BONUS);
+    expect(world.ants.hp[defender]).toBe(COMBAT_HP_BASE);
+    // Run one more round (5 ticks) to trigger first strike
+    runCombatTicks(world, 5);
+    // Attacker deals COMBAT_DAMAGE_BASE=4; defender bonus=4 → bonus absorbs all 4 → bonus=0, hp=16
+    expect(world.ants.homeGroundBonusHp[defender]).toBe(0);
+    expect(world.ants.hp[defender]).toBe(COMBAT_HP_BASE);
   });
 });

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -187,12 +187,23 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
   if (aNew || bNew) {
     ants.attackCooldown[antA] = COMBAT_COOLDOWN_TICKS;
     ants.attackCooldown[antB] = COMBAT_COOLDOWN_TICKS;
-    // Always recompute homeGroundBonusHp for both ants when windup fires. This prevents
-    // stale bonus HP from prior engagements carrying into off-home fights (Codex P1).
+    // New ants get a fresh bonus based on their current position. Veteran ants
+    // (forced into re-windup because their opponent is new) keep their depleted bonus
+    // if still on home ground; it's zeroed if they've since moved off home ground.
+    // This prevents both unintended healing (bonus restored on replacement) and
+    // stale bonus (bonus persists after leaving home ground).
     const aOnHome = ants.zone[antA] === 1 && ants.currentGridColonyId[antA] === ants.colonyId[antA]!;
-    ants.homeGroundBonusHp[antA] = aOnHome ? COMBAT_HP_HOMEGROUND_BONUS : 0;
     const bOnHome = ants.zone[antB] === 1 && ants.currentGridColonyId[antB] === ants.colonyId[antB]!;
-    ants.homeGroundBonusHp[antB] = bOnHome ? COMBAT_HP_HOMEGROUND_BONUS : 0;
+    if (aNew) {
+      ants.homeGroundBonusHp[antA] = aOnHome ? COMBAT_HP_HOMEGROUND_BONUS : 0;
+    } else if (!aOnHome) {
+      ants.homeGroundBonusHp[antA] = 0;
+    }
+    if (bNew) {
+      ants.homeGroundBonusHp[antB] = bOnHome ? COMBAT_HP_HOMEGROUND_BONUS : 0;
+    } else if (!bOnHome) {
+      ants.homeGroundBonusHp[antB] = 0;
+    }
     return;
   }
 
@@ -231,10 +242,11 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
   if (bDies) killAnt(world, antB, cidA as ColonyId, antA, 'Ant');
   if (aDies) killAnt(world, antA, cidB as ColonyId, antB, 'Ant');
 
-  // Clear cooldowns for survivors so they wind up fresh in their next engagement.
-  // This also re-enables the home-ground HP buffer check on the next windup tick.
-  if (bDies && !aDies) ants.attackCooldown[antA] = 0;
-  if (aDies && !bDies) ants.attackCooldown[antB] = 0;
+  // After a kill, survivors retain their current cooldown (set to COMBAT_COOLDOWN_TICKS
+  // above on their strike tick). When a new opponent joins on the next tick, the
+  // "reset both when either is new" rule synchronizes their cooldowns — no separate
+  // reset needed here. Zeroing cooldown here would falsely mark the survivor as "new"
+  // on the next tick, which would reset their home-ground bonus (unintended healing).
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -1,48 +1,41 @@
 // src/sim/combat.ts
-// Phase 9 / CMBT-04..07 — pure-sim combat detection and resolution (instant-kill model).
+// Phase 9 / CMBT-04..07 — pure-sim combat detection and resolution.
 //
-// Model: two ants from DIFFERENT colonies sharing the same (zone, posX>>FP_SHIFT, posY>>FP_SHIFT) fight.
-// Each round: deterministic coin flip via world.rngState picks a winner; loser's alive flag is zeroed.
-// tickDeathCleanup (step 5 next tick) performs roster cleanup — combat.ts never calls swap-remove.
+// V15 (legacy): coin-flip instant-kill resolver (resolveCombatOnTile_v15).
+// V16 (S1): HP/damage/cooldown resolver (resolveCombatOnTile_v16).
+//   - One active pair per contested tile per tick (lowest slot indices).
+//   - Windup on first contested tick: attackCooldown=COMBAT_COOLDOWN_TICKS, no strike.
+//   - Strike when cooldown decrements to 0; resets to COMBAT_COOLDOWN_TICKS.
+//   - Strikes are simultaneous: both ants can die the same tick.
+//   - Home-ground damage bonus: COMBAT_DAMAGE_HOMEGROUND on own grid (underground only).
+//   - Home-ground HP buffer: homeGroundBonusHp depletes before hp.
 //
-// Determinism: iterate tileKeys ascending; within a tile, iterate ant slot indices ascending;
-// between colonies, pick the two lowest colonyIds first.
-//
-// No HP field — the existing AntComponents SoA has no hp slot and adding one would require a
-// Phase-wide data model change. Instant-kill matches PRD §4 "fight rounds resolve in a single coin flip".
+// killAnt now emits combat_kill and writes pendingQueenDeathContexts when victim is queen.
+// checkQueenDeath (game-over.ts) reads and clears pendingQueenDeathContexts each tick.
 
 import { Rng } from './rng.js';
 import { makeTileKey } from './tile-key.js';
-import type { WorldState } from './types.js';
-import { SIM_VERSION_V13_INVARIANT_FIXES } from './types.js';
+import type { WorldState, KillerKind, QueenDeathContext } from './types.js';
+import { SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V16_COMBAT_HPDPS } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 import type { Zone } from './terrain.js';
 import { FP_SHIFT } from './fixed.js';
+import { emitEvent } from './telemetry.js';
+import {
+  COMBAT_HP_BASE,
+  COMBAT_HP_HOMEGROUND_BONUS,
+  COMBAT_DAMAGE_BASE,
+  COMBAT_DAMAGE_HOMEGROUND,
+  COMBAT_COOLDOWN_TICKS,
+} from './constants.js';
 
 /**
  * Sweep all live ants, bucket by tile, and resolve combat on tiles shared by 2+ colonies.
- * Mutates: world.ants.alive (instant-kills losers), world.colonies[*].killCount (increments
- * winners), world.rngState (advances once per round).
- */
-/**
- * Issue #58 — caller passes the rng instance.
- *
- * Pre-fix this function was `(world)`-only and constructed a fresh Rng from
- * `world.rngState` internally. That state was still the tick-start value
- * (tickAntMovement mutates a separate rng_tick instance and only writes
- * back at end-of-tick), so combat's RNG sequence was effectively a
- * parallel stream that the end-of-tick writeback discarded — the
- * `world.rngState = rng.getState()` line we used to do here was overwritten
- * by tick.ts step 19. Functionally byte-deterministic (same seed → same
- * outcomes) but contradicts the design intent that "rng pulls accumulate."
- *
- * v11+: caller passes `rng_tick` so combat shares the tick's stream.
- * pre-v11: caller passes a fresh `Rng(world.rngState)` to preserve the
- *          dead-writeback behaviour for byte-identical replay of older saves.
+ * Dispatches to V15 (coin-flip) or V16 (HP/damage/cooldown) based on world.simVersion.
  */
 export function detectAndResolveCombat(world: WorldState, rng: Rng): void {
   const { ants } = world;
-  const count = ants.alive.length; // capacity; iterate all slots (alive/colonyId guard)
+  const count = ants.alive.length;
 
   // Bucket live ants by tileKey.
   const bucket = new Map<number, number[]>();
@@ -51,10 +44,6 @@ export function detectAndResolveCombat(world: WorldState, rng: Rng): void {
     if (ants.colonyId[i] === 0) continue;
     const tileX = ants.posX[i]! >> FP_SHIFT;
     const tileY = ants.posY[i]! >> FP_SHIFT;
-    // Phase 09.1 Chunk 4: pass currentGridColonyId so underground ants in
-    // different grids at the same (tileX, tileY) bucket separately. makeTileKey
-    // internally zeroes the gridByte for Surface, so passing this
-    // unconditionally is safe and preserves surface bucketing byte-for-byte.
     const key = makeTileKey(
       ants.zone[i] as unknown as Zone,
       tileX,
@@ -71,7 +60,6 @@ export function detectAndResolveCombat(world: WorldState, rng: Rng): void {
   for (const key of keys) {
     const participants = bucket.get(key)!;
     if (participants.length < 2) continue;
-    // Quick exit: all participants from one colony.
     const firstCid = ants.colonyId[participants[0]!]!;
     let multiColony = false;
     for (let j = 1; j < participants.length; j++) {
@@ -81,25 +69,32 @@ export function detectAndResolveCombat(world: WorldState, rng: Rng): void {
       }
     }
     if (!multiColony) continue;
-    resolveCombatOnTile(world, key, participants, rng);
+    if (world.simVersion >= SIM_VERSION_V16_COMBAT_HPDPS) {
+      resolveCombatOnTile_v16(world, key, participants);
+    } else {
+      resolveCombatOnTile_v15(world, key, participants, rng);
+    }
   }
+
+  // Clear pendingQueenDeathContexts for ants that survived (i.e., where the queen kill
+  // context was never consumed because the queen is alive). checkQueenDeath will consume
+  // valid contexts the same tick. Reset transient array for next tick.
+  // NOTE: actual clearing happens in checkQueenDeath per-colony; we leave the array
+  // intact here so checkQueenDeath can read it after combat resolves.
 }
 
+// ---------------------------------------------------------------------------
+// V15 legacy resolver — coin-flip instant-kill (frozen, byte-identical replay)
+// ---------------------------------------------------------------------------
+
 /**
- * Resolve combat on a single tile. Runs rounds until fewer than 2 distinct colonies remain.
- * Mutates world.ants.alive, world.colonies[*].killCount, and the passed rng instance.
- *
- * Issue #58 — caller passes rng. Previously constructed `new Rng(world.rngState)`
- * internally and did `world.rngState = rng.getState()` at the bottom; both
- * removed because tick.ts step 19 owns the world.rngState writeback.
+ * Resolve combat on a single tile using the pre-V16 coin-flip model.
+ * Called only when world.simVersion < SIM_VERSION_V16_COMBAT_HPDPS.
  */
-export function resolveCombatOnTile(world: WorldState, _tileKey: number, participants: readonly number[], rng: Rng): void {
+export function resolveCombatOnTile_v15(world: WorldState, _tileKey: number, participants: readonly number[], rng: Rng): void {
   const { ants } = world;
 
-  // Loop until only one colony remains among alive participants.
-  // Each round guarantees one death → provably terminates in ≤ participants.length - 1 rounds.
   for (let iter = 0; iter < participants.length; iter++) {
-    // Group alive participants by colonyId; sort colony ids ascending for determinism.
     const byColony = new Map<ColonyId, number[]>();
     for (const idx of participants) {
       if (ants.alive[idx] !== 1) continue;
@@ -113,8 +108,6 @@ export function resolveCombatOnTile(world: WorldState, _tileKey: number, partici
     const cids = Array.from(byColony.keys()).sort((a, b) => a - b);
     const cidA = cids[0]!;
     const cidB = cids[1]!;
-    // Sort each group's slot indices ascending (was inserted in iteration order which is already ascending)
-    // but be defensive in case caller passed arbitrary order.
     const groupA = byColony.get(cidA)!;
     const groupB = byColony.get(cidB)!;
     groupA.sort((a, b) => a - b);
@@ -122,30 +115,152 @@ export function resolveCombatOnTile(world: WorldState, _tileKey: number, partici
     const antA = groupA[0]!;
     const antB = groupB[0]!;
 
-    const flip = rng.nextInt(2); // 0 → A wins, 1 → B wins
+    const flip = rng.nextInt(2);
     if (flip === 0) {
-      killAnt(world, antB, cidA);
+      killAnt(world, antB, cidA, antA, 'Ant');
     } else {
-      killAnt(world, antA, cidB);
+      killAnt(world, antA, cidB, antB, 'Ant');
     }
   }
-  // Issue #58 — no writeback. The pre-fix `world.rngState = rng.getState()`
-  // was always overwritten by tick.ts step 19 (rng_tick.getState()) so it
-  // was dead code. Caller (tick.ts) owns the single end-of-tick writeback.
+}
+
+// ---------------------------------------------------------------------------
+// V16 resolver — HP / damage / cooldown (S1 / D-32)
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply `damage` to `antIdx`, depleting homeGroundBonusHp first, then hp.
+ * Returns true if the ant should die (hp <= 0 after depletion).
+ */
+function applyDamage(world: WorldState, antIdx: number, damage: number): boolean {
+  const { ants } = world;
+  let bonus = ants.homeGroundBonusHp[antIdx]!;
+  if (bonus > 0) {
+    if (damage <= bonus) {
+      ants.homeGroundBonusHp[antIdx] = bonus - damage;
+      return false;
+    }
+    // Damage overflows bonus into hp
+    damage -= bonus;
+    ants.homeGroundBonusHp[antIdx] = 0;
+  }
+  ants.hp[antIdx] = (ants.hp[antIdx]! - damage);
+  return ants.hp[antIdx]! <= 0;
 }
 
 /**
- * Instant-kill: zero alive flag, increment killer killCount.
- * Roster cleanup is the responsibility of tickDeathCleanup at step 5 next tick.
- *
- * Issue #107 (v13+) — atomically clear bidirectional carry pointers BEFORE
- * zeroing alive so the (`carryingBroodId[X] === Y` ⇔ `carriedBy[Y] === X`)
- * invariant holds across a combat death. Pre-v13 a nurse killed mid-Feeding
- * left the brood's `carriedBy` pointing at a dead ant; if the carrier died
- * on a Marked or Solid tile, the brood was unreclaimable (chamber-flow.ts
- * pickup-field seeds Open/BeingDug only).
+ * Resolve combat on a single tile using the V16 HP/damage/cooldown model.
+ * One active pair per tick (lowest slot from each colony). Strikes are simultaneous.
  */
-export function killAnt(world: WorldState, antIndex: number, killerColonyId: ColonyId): void {
+function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participants: readonly number[]): void {
+  const { ants } = world;
+
+  // Group alive participants by colony; sort colony ids ascending for determinism.
+  const byColony = new Map<ColonyId, number[]>();
+  for (const idx of participants) {
+    if (ants.alive[idx] !== 1) continue;
+    const cid = ants.colonyId[idx]! as ColonyId;
+    const list = byColony.get(cid);
+    if (list === undefined) byColony.set(cid, [idx]);
+    else list.push(idx);
+  }
+  if (byColony.size < 2) return;
+
+  const cids = Array.from(byColony.keys()).sort((a, b) => a - b);
+  const cidA = cids[0]!;
+  const cidB = cids[1]!;
+  const groupA = byColony.get(cidA)!;
+  const groupB = byColony.get(cidB)!;
+  groupA.sort((a, b) => a - b);
+  groupB.sort((a, b) => a - b);
+  // Active pair: lowest slot from each colony.
+  const antA = groupA[0]!;
+  const antB = groupB[0]!;
+
+  // Windup: if either ant is not yet in combat (cooldown=0), both wind up together.
+  // Resetting the veteran's cooldown prevents a cooldown phase lock when a replacement
+  // opponent joins mid-cycle (otherwise the two cooldowns could cycle out of phase forever).
+  const aNew = ants.attackCooldown[antA] === 0;
+  const bNew = ants.attackCooldown[antB] === 0;
+
+  if (aNew || bNew) {
+    ants.attackCooldown[antA] = COMBAT_COOLDOWN_TICKS;
+    ants.attackCooldown[antB] = COMBAT_COOLDOWN_TICKS;
+    // Home-ground bonus is only granted to ants that are newly entering combat
+    // (not to veterans whose opponent was replaced — they keep whatever bonus remains).
+    if (aNew) {
+      const aOnHome = ants.zone[antA] === 1 && ants.currentGridColonyId[antA] === ants.colonyId[antA]!;
+      if (aOnHome) ants.homeGroundBonusHp[antA] = COMBAT_HP_HOMEGROUND_BONUS;
+    }
+    if (bNew) {
+      const bOnHome = ants.zone[antB] === 1 && ants.currentGridColonyId[antB] === ants.colonyId[antB]!;
+      if (bOnHome) ants.homeGroundBonusHp[antB] = COMBAT_HP_HOMEGROUND_BONUS;
+    }
+    return;
+  }
+
+  // Decrement cooldowns. Strike when either reaches 0.
+  ants.attackCooldown[antA] = ants.attackCooldown[antA]! - 1;
+  ants.attackCooldown[antB] = ants.attackCooldown[antB]! - 1;
+
+  const aStrikes = ants.attackCooldown[antA] === 0;
+  const bStrikes = ants.attackCooldown[antB] === 0;
+
+  if (!aStrikes && !bStrikes) return;
+
+  // Compute damage dealt by each striker (home-ground bonus on own underground grid).
+  const aDamage = aStrikes
+    ? ((ants.zone[antA] === 1 && ants.currentGridColonyId[antA] === ants.colonyId[antA]!)
+        ? COMBAT_DAMAGE_HOMEGROUND
+        : COMBAT_DAMAGE_BASE)
+    : 0;
+  const bDamage = bStrikes
+    ? ((ants.zone[antB] === 1 && ants.currentGridColonyId[antB] === ants.colonyId[antB]!)
+        ? COMBAT_DAMAGE_HOMEGROUND
+        : COMBAT_DAMAGE_BASE)
+    : 0;
+
+  // Simultaneous damage: compute both death results before killing either.
+  const aDies = bDamage > 0 && applyDamage(world, antA, bDamage);
+  const bDies = aDamage > 0 && applyDamage(world, antB, aDamage);
+
+  // Reset cooldowns for survivors (dead ants' cooldowns are irrelevant).
+  if (aStrikes && !aDies) ants.attackCooldown[antA] = COMBAT_COOLDOWN_TICKS;
+  if (bStrikes && !bDies) ants.attackCooldown[antB] = COMBAT_COOLDOWN_TICKS;
+
+  // Kill dead ants. Event ordering: combat_kill emitted first (in killAnt),
+  // then queen_death (in checkQueenDeath after this resolver returns).
+  if (bDies) killAnt(world, antB, cidA as ColonyId, antA, 'Ant');
+  if (aDies) killAnt(world, antA, cidB as ColonyId, antB, 'Ant');
+
+  // Clear cooldowns for survivors so they wind up fresh in their next engagement.
+  // This also re-enables the home-ground HP buffer check on the next windup tick.
+  if (bDies && !aDies) ants.attackCooldown[antA] = 0;
+  if (aDies && !bDies) ants.attackCooldown[antB] = 0;
+}
+
+// ---------------------------------------------------------------------------
+// killAnt — single write path for ant death
+// ---------------------------------------------------------------------------
+
+/**
+ * Kill ant at `antIndex`. Emits a combat_kill event (S1). Writes
+ * pendingQueenDeathContexts if the victim is a queen (read by checkQueenDeath
+ * later the same tick to fill in queen_death cause). Increments killer killCount.
+ *
+ * killerColonyId: colony that made the kill (null for environmental kills).
+ * killerId: entity slot of the killing ant (null for non-ant kills).
+ * killerKind: 'Ant' in S1/S2; 'Spider' in S5; 'Environment' reserved.
+ *
+ * Issue #107 (v13+) — atomically clears bidirectional carry pointers.
+ */
+export function killAnt(
+  world: WorldState,
+  antIndex: number,
+  killerColonyId: ColonyId | null,
+  killerId: number | null,
+  killerKind: KillerKind,
+): void {
   const ants = world.ants;
   if (world.simVersion >= SIM_VERSION_V13_INVARIANT_FIXES) {
     const carrying = ants.carryingBroodId[antIndex]!;
@@ -159,8 +274,55 @@ export function killAnt(world: WorldState, antIndex: number, killerColonyId: Col
       ants.carriedBy[antIndex] = -1;
     }
   }
+
+  const victimColonyId = ants.colonyId[antIndex]! as ColonyId;
+  const tileX = ants.posX[antIndex]! >> FP_SHIFT;
+  const tileY = ants.posY[antIndex]! >> FP_SHIFT;
+  const currentGridColonyId = ants.currentGridColonyId[antIndex]! as ColonyId;
+
+  // Emit combat_kill event and write queen death context (S1 telemetry, V16+ only).
+  if (world.simVersion >= SIM_VERSION_V16_COMBAT_HPDPS) {
+    // combat_kill is only emitted for Ant/Spider kills; Environment is reserved (no event).
+    if (killerKind !== 'Environment') {
+      emitEvent(world, {
+        tick: world.tick,
+        type: 'combat_kill',
+        payload: {
+          killer: { kind: killerKind, id: killerId, colonyId: killerColonyId },
+          victim: {
+            kind: 'Ant',
+            id: antIndex,
+            colonyId: victimColonyId,
+          },
+          location: {
+            x: tileX,
+            y: tileY,
+            grid: ants.zone[antIndex] === 0 ? 'surface' : 'underground',
+          },
+        },
+      });
+    }
+
+    // Write queen death context regardless of killerKind so checkQueenDeath can
+    // fill in the cause field for queen_death events from any kill source.
+    const victimColony = world.colonies[victimColonyId];
+    if (victimColony !== undefined && antIndex === victimColony.queenEntityId) {
+      const ctx: QueenDeathContext = {
+        tile: { x: tileX, y: tileY },
+        currentGridColonyId,
+        killerColonyId,
+        killerId,
+        killerKind,
+      };
+      world.pendingQueenDeathContexts[victimColonyId] = ctx;
+    }
+  }
+
   ants.alive[antIndex] = 0;
-  if (killerColonyId !== 0) {
+  // Reset combat state so replacement ants wind up fresh.
+  ants.attackCooldown[antIndex] = 0;
+
+  if (killerColonyId !== null && killerColonyId !== 0) {
     const killerColony = world.colonies[killerColonyId];
     if (killerColony !== undefined) {
       killerColony.killCount += 1;

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -186,16 +186,12 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
   if (aNew || bNew) {
     ants.attackCooldown[antA] = COMBAT_COOLDOWN_TICKS;
     ants.attackCooldown[antB] = COMBAT_COOLDOWN_TICKS;
-    // Home-ground bonus is only granted to ants that are newly entering combat
-    // (not to veterans whose opponent was replaced — they keep whatever bonus remains).
-    if (aNew) {
-      const aOnHome = ants.zone[antA] === 1 && ants.currentGridColonyId[antA] === ants.colonyId[antA]!;
-      if (aOnHome) ants.homeGroundBonusHp[antA] = COMBAT_HP_HOMEGROUND_BONUS;
-    }
-    if (bNew) {
-      const bOnHome = ants.zone[antB] === 1 && ants.currentGridColonyId[antB] === ants.colonyId[antB]!;
-      if (bOnHome) ants.homeGroundBonusHp[antB] = COMBAT_HP_HOMEGROUND_BONUS;
-    }
+    // Always recompute homeGroundBonusHp for both ants when windup fires. This prevents
+    // stale bonus HP from prior engagements carrying into off-home fights (Codex P1).
+    const aOnHome = ants.zone[antA] === 1 && ants.currentGridColonyId[antA] === ants.colonyId[antA]!;
+    ants.homeGroundBonusHp[antA] = aOnHome ? COMBAT_HP_HOMEGROUND_BONUS : 0;
+    const bOnHome = ants.zone[antB] === 1 && ants.currentGridColonyId[antB] === ants.colonyId[antB]!;
+    ants.homeGroundBonusHp[antB] = bOnHome ? COMBAT_HP_HOMEGROUND_BONUS : 0;
     return;
   }
 

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -58,6 +58,31 @@ export function detectAndResolveCombat(world: WorldState, rng: Rng): void {
 
   // Deterministic iteration: sort tileKeys ascending.
   const keys = Array.from(bucket.keys()).sort((a, b) => a - b);
+
+  // First pass: collect all ants that are currently on multi-colony contested tiles.
+  // Any live ant NOT in this set has disengaged; its combatOpponentId is stale and
+  // must be cleared so the next encounter triggers a fresh windup (Codex P1 finding).
+  if (world.simVersion >= SIM_VERSION_V16_COMBAT_HPDPS) {
+    const contestedSet = new Set<number>();
+    for (const key of keys) {
+      const participants = bucket.get(key)!;
+      if (participants.length < 2) continue;
+      const firstCid = ants.colonyId[participants[0]!]!;
+      let multiColony = false;
+      for (let j = 1; j < participants.length; j++) {
+        if (ants.colonyId[participants[j]!]! !== firstCid) { multiColony = true; break; }
+      }
+      if (multiColony) {
+        for (const idx of participants) contestedSet.add(idx);
+      }
+    }
+    for (let i = 0; i < count; i++) {
+      if (ants.alive[i] === 1 && !contestedSet.has(i)) {
+        ants.combatOpponentId[i] = -1;
+      }
+    }
+  }
+
   for (const key of keys) {
     const participants = bucket.get(key)!;
     if (participants.length < 2) continue;

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -14,6 +14,7 @@
 // checkQueenDeath (game-over.ts) reads and clears pendingQueenDeathContexts each tick.
 
 import { Rng } from './rng.js';
+import { AntTask } from './enums.js';
 import { makeTileKey } from './tile-key.js';
 import type { WorldState, KillerKind, QueenDeathContext } from './types.js';
 import { SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V16_COMBAT_HPDPS } from './types.js';
@@ -204,13 +205,14 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
 
   if (!aStrikes && !bStrikes) return;
 
-  // Compute damage dealt by each striker (home-ground bonus on own underground grid).
-  const aDamage = aStrikes
+  // Compute damage dealt by each striker. Only AntTask.Fighting ants deal damage;
+  // workers, nurses, and queens caught in combat do not strike back (spec Part A §3).
+  const aDamage = aStrikes && ants.task[antA] === AntTask.Fighting
     ? ((ants.zone[antA] === 1 && ants.currentGridColonyId[antA] === ants.colonyId[antA]!)
         ? COMBAT_DAMAGE_HOMEGROUND
         : COMBAT_DAMAGE_BASE)
     : 0;
-  const bDamage = bStrikes
+  const bDamage = bStrikes && ants.task[antB] === AntTask.Fighting
     ? ((ants.zone[antB] === 1 && ants.currentGridColonyId[antB] === ants.colonyId[antB]!)
         ? COMBAT_DAMAGE_HOMEGROUND
         : COMBAT_DAMAGE_BASE)
@@ -278,6 +280,9 @@ export function killAnt(
 
   // Emit combat_kill event and write queen death context (S1 telemetry, V16+ only).
   if (world.simVersion >= SIM_VERSION_V16_COMBAT_HPDPS) {
+    const victimColony = world.colonies[victimColonyId];
+    const isQueenVictim = victimColony !== undefined && antIndex === victimColony.queenEntityId;
+
     // combat_kill is only emitted for Ant/Spider kills; Environment is reserved (no event).
     if (killerKind !== 'Environment') {
       emitEvent(world, {
@@ -286,7 +291,8 @@ export function killAnt(
         payload: {
           killer: { kind: killerKind, id: killerId, colonyId: killerColonyId },
           victim: {
-            kind: 'Ant',
+            // Queen victims use kind 'Queen' so analytics can filter without re-deriving role.
+            kind: isQueenVictim ? 'Queen' : 'Ant',
             id: antIndex,
             colonyId: victimColonyId,
           },
@@ -301,8 +307,7 @@ export function killAnt(
 
     // Write queen death context regardless of killerKind so checkQueenDeath can
     // fill in the cause field for queen_death events from any kill source.
-    const victimColony = world.colonies[victimColonyId];
-    if (victimColony !== undefined && antIndex === victimColony.queenEntityId) {
+    if (isQueenVictim) {
       const ctx: QueenDeathContext = {
         tile: { x: tileX, y: tileY },
         currentGridColonyId,

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -178,28 +178,37 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
   const antA = groupA[0]!;
   const antB = groupB[0]!;
 
-  // Windup: if either ant is not yet in combat (cooldown=0), both wind up together.
-  // Resetting the veteran's cooldown prevents a cooldown phase lock when a replacement
-  // opponent joins mid-cycle (otherwise the two cooldowns could cycle out of phase forever).
-  const aNew = ants.attackCooldown[antA] === 0;
-  const bNew = ants.attackCooldown[antB] === 0;
+  // New-pairing detection: compare current opponent to the stored one.
+  // This correctly handles veteran-veteran first contacts (both have non-zero
+  // cooldowns from prior fights but combatOpponentId differs from the new match).
+  const aNew = ants.combatOpponentId[antA] !== antB;
+  const bNew = ants.combatOpponentId[antB] !== antA;
+
+  // aFresh/bFresh: ant has never entered V16 combat (cooldown still 0 from initAnt
+  // or save migration). Used to decide whether to grant a fresh home-ground bonus.
+  // Distinct from aNew (new pairing) — a post-kill survivor has aNew=true (new
+  // opponent) but aFresh=false (cooldown was COMBAT_COOLDOWN_TICKS, not 0).
+  const aFresh = ants.attackCooldown[antA] === 0;
+  const bFresh = ants.attackCooldown[antB] === 0;
 
   if (aNew || bNew) {
     ants.attackCooldown[antA] = COMBAT_COOLDOWN_TICKS;
     ants.attackCooldown[antB] = COMBAT_COOLDOWN_TICKS;
-    // New ants get a fresh bonus based on their current position. Veteran ants
-    // (forced into re-windup because their opponent is new) keep their depleted bonus
-    // if still on home ground; it's zeroed if they've since moved off home ground.
-    // This prevents both unintended healing (bonus restored on replacement) and
-    // stale bonus (bonus persists after leaving home ground).
+    ants.combatOpponentId[antA] = antB;
+    ants.combatOpponentId[antB] = antA;
+    // Fresh ants get a full bonus based on current location.
+    // Veteran ants (new pairing, but were already in combat) keep their depleted
+    // bonus if still on home ground; it's zeroed if they've moved off home ground.
+    // This prevents unintended healing (bonus restored on replacement) while
+    // also clearing stale bonus after a position change.
     const aOnHome = ants.zone[antA] === 1 && ants.currentGridColonyId[antA] === ants.colonyId[antA]!;
     const bOnHome = ants.zone[antB] === 1 && ants.currentGridColonyId[antB] === ants.colonyId[antB]!;
-    if (aNew) {
+    if (aFresh) {
       ants.homeGroundBonusHp[antA] = aOnHome ? COMBAT_HP_HOMEGROUND_BONUS : 0;
     } else if (!aOnHome) {
       ants.homeGroundBonusHp[antA] = 0;
     }
-    if (bNew) {
+    if (bFresh) {
       ants.homeGroundBonusHp[antB] = bOnHome ? COMBAT_HP_HOMEGROUND_BONUS : 0;
     } else if (!bOnHome) {
       ants.homeGroundBonusHp[antB] = 0;
@@ -242,11 +251,13 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
   if (bDies) killAnt(world, antB, cidA as ColonyId, antA, 'Ant');
   if (aDies) killAnt(world, antA, cidB as ColonyId, antB, 'Ant');
 
-  // After a kill, survivors retain their current cooldown (set to COMBAT_COOLDOWN_TICKS
-  // above on their strike tick). When a new opponent joins on the next tick, the
-  // "reset both when either is new" rule synchronizes their cooldowns — no separate
-  // reset needed here. Zeroing cooldown here would falsely mark the survivor as "new"
-  // on the next tick, which would reset their home-ground bonus (unintended healing).
+  // After a kill, clear the survivor's opponent tracking so the next encounter
+  // is detected as a new pairing (triggering proper windup and home-ground bonus
+  // normalization). The survivor's cooldown stays at COMBAT_COOLDOWN_TICKS (set
+  // at the strike tick above), so aFresh=false on the next windup — the depleted
+  // bonus is preserved for home-ground survivors and zeroed for off-home ones.
+  if (bDies && !aDies) ants.combatOpponentId[antA] = -1;
+  if (aDies && !bDies) ants.combatOpponentId[antB] = -1;
 }
 
 // ---------------------------------------------------------------------------
@@ -334,6 +345,7 @@ export function killAnt(
   ants.alive[antIndex] = 0;
   // Reset combat state so replacement ants wind up fresh.
   ants.attackCooldown[antIndex] = 0;
+  ants.combatOpponentId[antIndex] = -1;
 
   if (killerColonyId !== null && killerColonyId !== 0) {
     const killerColony = world.colonies[killerColonyId];

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -520,3 +520,23 @@ export const EXCURSION_WOBBLE_PERCENT = 20;
  * meaningful outbound trail (4+ tiles out, along the path toward food) intact.
  */
 export const ENTRANCE_DEPOSIT_SUPPRESS_RADIUS = 3;
+
+// ---------------------------------------------------------------------------
+// S1 — Combat math (HP / damage / cooldown)
+// ---------------------------------------------------------------------------
+
+/** S1 / D-32 — Base HP for any ant. Home-ground HP = HP_BASE + HP_HOMEGROUND_BONUS = 20. */
+export const COMBAT_HP_BASE = 16 as const;
+
+/** S1 / D-32 — Extra HP buffer for ants fighting on their own colony's grid.
+ *  Depletes before the base HP pool (takes damage first). */
+export const COMBAT_HP_HOMEGROUND_BONUS = 4 as const;
+
+/** S1 / D-32 — Damage dealt per strike by an ant fighting on away ground. */
+export const COMBAT_DAMAGE_BASE = 4 as const;
+
+/** S1 / D-32 — Damage dealt per strike by an ant fighting on home ground (+25%, integer-clean). */
+export const COMBAT_DAMAGE_HOMEGROUND = 5 as const;
+
+/** S1 / D-32 — Ticks between strikes; also the windup length (first contested tick). */
+export const COMBAT_COOLDOWN_TICKS = 5 as const;

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -707,6 +707,10 @@ function buildCrossGridCombatWorld(seed: number): WorldState {
   });
   world.colonies[PLAYER_COLONY_ID]!.workers.push(playerAntId);
   world.colonies[PLAYER_COLONY_ID]!.workerCount += 1;
+  // Model real game state: rally + fight ratio > 0 so recall logic doesn't
+  // fire immediately after descent (which would break the divergence guard).
+  world.colonies[PLAYER_COLONY_ID]!.rallyPoint = { tileX: ENEMY_START_X, tileY: ENEMY_START_Y };
+  world.colonies[PLAYER_COLONY_ID]!.targetRatio.fight = 5;
 
   // Pin an enemy hostile a few tiles east + below the entrance shaft.
   const hostileTileX = ENEMY_START_X + 3;

--- a/src/sim/fighter-rally-hold.test.ts
+++ b/src/sim/fighter-rally-hold.test.ts
@@ -395,6 +395,10 @@ function buildInvasionRallyWorld(
     fighterIds.push(id);
   }
 
+  // Model real game state: fight ratio > 0 so recall logic doesn't fire
+  // immediately after descent (recall triggers when targetRatio.fight===0).
+  world.colonies[PLAYER_COLONY_ID]!.targetRatio.fight = Math.max(5, fighterIds.length);
+
   return { world, fighterIds, rallyTileX, rallyTileY };
 }
 

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -33,11 +33,11 @@ function isQueenAlive(world: WorldState, colony: ColonyRecord): boolean {
         ? (world.pendingQueenDeathContexts[colony.colonyId] ?? null)
         : null;
 
-      // Determine cause: InvasionKill when the killer is from a different colony
-      // than the grid the queen was in when killed (RC-P1-003).
+      // Determine cause: InvasionKill when the killer is from outside the grid where
+      // the queen died — i.e. the killer was the invader in that grid (RC-P1-003).
       let cause: 'InvasionKill' | 'SpiderRampage' | 'Starvation' | 'MutualDestruction' | null = null;
       if (ctx !== null) {
-        if (ctx.killerColonyId !== null && ctx.killerColonyId !== colony.colonyId) {
+        if (ctx.killerColonyId !== null && ctx.killerColonyId !== ctx.currentGridColonyId) {
           cause = 'InvasionKill';
         }
         // SpiderRampage, Starvation, MutualDestruction: S2/S5/S6 will extend this.

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -1,6 +1,6 @@
 // Phase 5 scope: outcome enum only. checkQueenDeath is Phase 9 scope — see Phase 4 PRD §5a.
-// S0b: emits queen_death SimEvent on first detection (cause: null — S1/S2 will fill cause
-// from kill-site context when those stages land, per RC-P1-003).
+// S0b: emits queen_death SimEvent on first detection (cause: null for pre-V16 saves).
+// S1: reads pendingQueenDeathContexts (written by killAnt) to fill in cause=InvasionKill.
 
 export const GameOutcome = {
   None: 0,
@@ -13,10 +13,12 @@ export type GameOutcome = typeof GameOutcome[keyof typeof GameOutcome];
 import type { WorldState } from './types.js';
 import type { ColonyId, ColonyRecord } from './colony/colony-store.js';
 import { emitEvent } from './telemetry.js';
+import { SIM_VERSION_V16_COMBAT_HPDPS } from './types.js';
 
 /**
  * Returns true if the colony's queen is alive per world.ants.
  * Side effect (idempotent): sets colony.defeated = true when queen is dead.
+ * S1: reads world.pendingQueenDeathContexts to fill in queen_death cause.
  */
 function isQueenAlive(world: WorldState, colony: ColonyRecord): boolean {
   const qid = colony.queenEntityId;
@@ -25,19 +27,41 @@ function isQueenAlive(world: WorldState, colony: ColonyRecord): boolean {
     if (!colony.defeated) {
       // Set before emitting (defensive guard against hypothetical re-entrancy).
       colony.defeated = true;
+
+      // S1: read kill-site context written by combat.killAnt this same tick.
+      const ctx = world.simVersion >= SIM_VERSION_V16_COMBAT_HPDPS
+        ? (world.pendingQueenDeathContexts[colony.colonyId] ?? null)
+        : null;
+
+      // Determine cause: InvasionKill when the killer is from a different colony
+      // than the grid the queen was in when killed (RC-P1-003).
+      let cause: 'InvasionKill' | 'SpiderRampage' | 'Starvation' | 'MutualDestruction' | null = null;
+      if (ctx !== null) {
+        if (ctx.killerColonyId !== null && ctx.killerColonyId !== colony.colonyId) {
+          cause = 'InvasionKill';
+        }
+        // SpiderRampage, Starvation, MutualDestruction: S2/S5/S6 will extend this.
+      }
+
+      // Location from kill-site context when available; fall back to queen's current tile.
+      const locX = ctx ? ctx.tile.x : (world.ants.posX[qid] ?? 0) >> 8;
+      const locY = ctx ? ctx.tile.y : (world.ants.posY[qid] ?? 0) >> 8;
+      const grid: 'surface' | 'underground' = (world.ants.zone[qid] ?? 1) === 0 ? 'surface' : 'underground';
+
       emitEvent(world, {
         tick: world.tick,
         type: 'queen_death',
         payload: {
-          cause: null,
-          location: {
-            x: world.ants.posX[qid] ?? 0,
-            y: world.ants.posY[qid] ?? 0,
-            grid: 'underground',
-          },
-          aiStateAtTime: null,
+          cause,
+          location: { x: locX, y: locY, grid },
+          aiStateAtTime: null, // S2 fills this
         },
       });
+
+      // Clear the context so it's not re-read if isQueenAlive is called again.
+      if (ctx !== null) {
+        world.pendingQueenDeathContexts[colony.colonyId] = null;
+      }
     } else {
       colony.defeated = true;
     }

--- a/src/sim/invasion-routing.test.ts
+++ b/src/sim/invasion-routing.test.ts
@@ -89,6 +89,10 @@ function buildInvasionWorld(seed = 42): InvasionWorld {
   });
   world.colonies[PLAYER_COLONY_ID]!.workers.push(playerAntId);
   world.colonies[PLAYER_COLONY_ID]!.workerCount += 1;
+  // Model real game state: player rallied fighters to enemy entrance with fight ratio > 0.
+  // Without these, recall logic fires immediately after descent (targetRatio.fight=0, rp=null).
+  world.colonies[PLAYER_COLONY_ID]!.rallyPoint = { tileX: enemyEntTileX, tileY: enemyEntTileY };
+  world.colonies[PLAYER_COLONY_ID]!.targetRatio.fight = 5;
 
   return { world, playerAntId, enemyEntTileX, enemyEntTileY };
 }

--- a/src/sim/types.test.ts
+++ b/src/sim/types.test.ts
@@ -29,10 +29,10 @@ describe('WorldState', () => {
       expect(world.rngState).toBe(4294967295);
     });
 
-    it('has exactly seventeen fields (4 Phase 5 + 3 Phase 6 + 4 Phase 7 + 1 issue #27 + 1 issue #44 + 1 issue #112 + 3 S0b telemetry)', () => {
+    it('has exactly eighteen fields (4 Phase 5 + 3 Phase 6 + 4 Phase 7 + 1 issue #27 + 1 issue #44 + 1 issue #112 + 3 S0b telemetry + 1 S1 pendingQueenDeathContexts)', () => {
       const world = createWorldState(0);
       const keys = Object.keys(world);
-      expect(keys).toHaveLength(17);
+      expect(keys).toHaveLength(18);
       expect(keys).toContain('tick');
       expect(keys).toContain('rngState');
       expect(keys).toContain('nextEntityId');

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -59,6 +59,18 @@ export type EntityId = number; // incrementing counter from 0, no recycling per 
  */
 import type { SimEvent } from './telemetry.js';
 
+/** S1 — Who killed an ant. 'Environment' reserved for future hazards (S5+). */
+export type KillerKind = 'Ant' | 'Spider' | 'Environment';
+
+/** S1 — Context written by killAnt when a queen dies; read+cleared by checkQueenDeath same tick. */
+export interface QueenDeathContext {
+  tile: { x: number; y: number };
+  currentGridColonyId: ColonyId;
+  killerColonyId: ColonyId | null;
+  killerId: number | null;
+  killerKind: KillerKind;
+}
+
 export const LEGACY_SIM_VERSION = 2 as const;
 export const SIM_VERSION_V3 = 3 as const;
 export const SIM_VERSION_V4_DIAGONAL_MOTION = 4 as const;
@@ -219,7 +231,12 @@ export const SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX = 14 as const;
  * pre-telemetry save).
  */
 export const SIM_VERSION_V15_TELEMETRY = 15 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V15_TELEMETRY;
+/**
+ * V16 (S1) — Combat math: HP/damage/cooldown replaces coin-flip resolver.
+ * QueenDeathContext written by killAnt so checkQueenDeath can emit cause.
+ */
+export const SIM_VERSION_V16_COMBAT_HPDPS = 16 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V16_COMBAT_HPDPS;
 
 export interface WorldState {
   tick: number;             // 0 at creation; incremented once per tick
@@ -345,6 +362,13 @@ export interface WorldState {
   events: SimEvent[];
   droppedCombatKillCount: number;
   droppedStructuralCount: number;
+
+  /**
+   * S1 — transient per-colony queen-kill context. Written by combat.killAnt when
+   * a queen dies; read and cleared by checkQueenDeath later the same tick.
+   * Index by victim colonyId. Empty array between ticks.
+   */
+  pendingQueenDeathContexts: (QueenDeathContext | null)[];
 }
 
 /**
@@ -379,6 +403,8 @@ export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIE
     events: [],
     droppedCombatKillCount: 0,
     droppedStructuralCount: 0,
+    // S1 — transient; cleared between ticks by combat resolver.
+    pendingQueenDeathContexts: [],
   };
 }
 
@@ -411,6 +437,9 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   // droppedCombatKillCount / droppedStructuralCount are also telemetry-only.
   dst.droppedCombatKillCount = src.droppedCombatKillCount;
   dst.droppedStructuralCount = src.droppedStructuralCount;
+  // S1 — pendingQueenDeathContexts is transient (cleared each tick); copy
+  // so the render double-buffer does not observe stale mid-tick contexts.
+  dst.pendingQueenDeathContexts = src.pendingQueenDeathContexts.slice();
 
   // --- AntComponents: 19 TypedArray.set calls (zero allocation) ---
   dst.ants.posX.set(src.ants.posX);
@@ -466,6 +495,12 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   // because the v10 nurse state machine reads them every tick.
   dst.ants.carryingBroodId.set(src.ants.carryingBroodId);
   dst.ants.carriedBy.set(src.ants.carriedBy);
+  // S1 — combat HP/damage/cooldown fields. Must round-trip: the V16 resolver
+  // reads these every combat tick; the render interpolation reads them for
+  // fighter-size visual. Not copying would cause one-frame stale combat state.
+  dst.ants.hp.set(src.ants.hp);
+  dst.ants.homeGroundBonusHp.set(src.ants.homeGroundBonusHp);
+  dst.ants.attackCooldown.set(src.ants.attackCooldown);
 
   // --- colonies: delete stale dst keys; upsert each src colony ---
   // Remove dst colonies that no longer exist in src

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -437,9 +437,9 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   // droppedCombatKillCount / droppedStructuralCount are also telemetry-only.
   dst.droppedCombatKillCount = src.droppedCombatKillCount;
   dst.droppedStructuralCount = src.droppedStructuralCount;
-  // S1 — pendingQueenDeathContexts is transient (cleared each tick); copy
-  // so the render double-buffer does not observe stale mid-tick contexts.
-  dst.pendingQueenDeathContexts = src.pendingQueenDeathContexts.slice();
+  // pendingQueenDeathContexts: transient within-tick (cleared by checkQueenDeath every tick,
+  // always null at the tick boundary when copyWorldState runs). No render code reads it,
+  // so no copy is needed and the allocation is skipped to preserve zero-alloc steady state.
 
   // --- AntComponents: 19 TypedArray.set calls (zero allocation) ---
   dst.ants.posX.set(src.ants.posX);

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -501,6 +501,7 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   dst.ants.hp.set(src.ants.hp);
   dst.ants.homeGroundBonusHp.set(src.ants.homeGroundBonusHp);
   dst.ants.attackCooldown.set(src.ants.attackCooldown);
+  dst.ants.combatOpponentId.set(src.ants.combatOpponentId);
 
   // --- colonies: delete stale dst keys; upsert each src colony ---
   // Remove dst colonies that no longer exist in src


### PR DESCRIPTION
## Summary

Implements S1 (D-32): replaces the V15 coin-flip instant-kill combat model with a deterministic multi-tick HP/damage/cooldown system.

**Core combat mechanics (V16):**
- HP: 16 base, home-ground defender gets +4 buffer (depletes first)
- Damage: 4 base, +1 on own underground grid
- Cooldown: 5 ticks; windup on first contested tick (no strike), then strikes at T+5 cadence
- Simultaneous strikes — mutual kills possible
- One active pair per contested tile per tick (lowest slot indices)

**Version gating:** Pre-V16 saves replay forever on the V15 coin-flip path (byte-identical SCEN-06 replay preserved). New saves write V16.

**Bug fixes caught in internal review:**
- Phase lock prevention: when a replacement opponent joins mid-cycle, both ants wind up together (avoids indefinite cooldown phase lock)
- Home-ground bonus only granted to the newly-entering ant — veterans keep whatever bonus remains
- `queen_death` grid field now derived from `world.ants.zone` instead of hardcoded `'underground'`
- `pendingQueenDeathContexts` write gated to V16+ (no leak on V15 queen deaths)
- `combat_kill` event not emitted for `'Environment'` killerKind (reserved); TypeScript narrowing handles `'Ant' | 'Spider'`

**Render:**
- Fighter ants (AntTask.Fighting): 1.25× scale + red tint (`0xff4444`)
- Contested tiles: faint orange glow (`0xff6600`, alpha=0.25) drawn before ants

**Save migration:** Pre-S1 saves default `hp=16`, `homeGroundBonusHp` from grid occupancy check, `attackCooldown=0`.

## Test plan

- [ ] 70 test files / 2088 tests all pass (`npx vitest run`)
- [ ] UAT: start a new game and observe contested tiles glow orange; fighters appear larger and red-tinted
- [ ] UAT: invasion plays out over multiple ticks rather than instant-kill flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)