### PR TITLE
feat(s3): spider neutral predator — sim foundation (PR-A)

### DIFF
--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -356,6 +356,85 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       const w2 = deserializeWorldState(s);
       expect(w2.terrainSeed).toBe(0);
     });
+    it('V18: round-trips world.spider, spiderPriorityColonyId, and scatterReticleTile through serialize → deserialize', async () => {
+      const { SIM_VERSION_V18_SPIDER } = await import('../sim/types.js');
+      const w = createScenario(42);
+      expect(w.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V18_SPIDER);
+      const spider = w.spider!;
+      spider.state = 'Hunting';
+      spider.huntTargetTileX = 55;
+      spider.huntTargetTileY = 33;
+      spider.hungerTicks = 300;
+      spider.killsThisStrike = 2;
+      w.spiderPriorityColonyId = PLAYER_COLONY_ID;
+      w.scatterReticleTile = { x: 10, y: 20 };
+
+      const w2 = deserializeWorldState(serializeWorldState(w));
+
+      expect(w2.spider).not.toBeNull();
+      expect(w2.spider!.state).toBe('Hunting');
+      expect(w2.spider!.huntTargetTileX).toBe(55);
+      expect(w2.spider!.huntTargetTileY).toBe(33);
+      expect(w2.spider!.hungerTicks).toBe(300);
+      expect(w2.spider!.killsThisStrike).toBe(2);
+      expect(w2.spiderPriorityColonyId).toBe(PLAYER_COLONY_ID);
+      expect(w2.scatterReticleTile).toEqual({ x: 10, y: 20 });
+    });
+
+    it('V18: pre-V18 save (spider field absent) deserializes to spider: null, spiderPriorityColonyId: null', async () => {
+      const { SIM_VERSION_V17_AI_STATE } = await import('../sim/types.js');
+      const w = createScenario(42);
+      const s = serializeWorldState(w);
+      // Downgrade simVersion to pre-V18; strip the spider fields.
+      (s as { simVersion: number }).simVersion = SIM_VERSION_V17_AI_STATE;
+      delete (s as { spider?: unknown }).spider;
+      delete (s as { spiderPriorityColonyId?: unknown }).spiderPriorityColonyId;
+      delete (s as { scatterReticleTile?: unknown }).scatterReticleTile;
+      const w2 = deserializeWorldState(s);
+      expect(w2.spider).toBeNull();
+      expect(w2.spiderPriorityColonyId).toBeNull();
+      expect(w2.scatterReticleTile).toBeNull();
+    });
+
+    it('V18: null spider (spider killed mid-game) round-trips through serialize → deserialize', () => {
+      const w = createScenario(42);
+      w.spider = null; // simulate spider having been killed
+      w.spiderPriorityColonyId = null;
+      w.scatterReticleTile = null;
+      const w2 = deserializeWorldState(serializeWorldState(w));
+      expect(w2.spider).toBeNull();
+      expect(w2.spiderPriorityColonyId).toBeNull();
+      expect(w2.scatterReticleTile).toBeNull();
+    });
+
+    it('V18: spider: null in a V18 save deserializes to null with priority and reticle also null (B11 coupling)', async () => {
+      const { SIM_VERSION_V18_SPIDER } = await import('../sim/types.js');
+      const w = createScenario(42);
+      expect(w.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V18_SPIDER);
+      const s = serializeWorldState(w);
+      // Force spider null but leave priority/reticle non-null in the raw snapshot.
+      (s as { spider: null }).spider = null;
+      (s as { spiderPriorityColonyId: number }).spiderPriorityColonyId = PLAYER_COLONY_ID;
+      (s as { scatterReticleTile: { x: number; y: number } }).scatterReticleTile = { x: 5, y: 5 };
+      const w2 = deserializeWorldState(s);
+      // B11: when spider is null, priority and reticle must also be null regardless of save data.
+      expect(w2.spider).toBeNull();
+      expect(w2.spiderPriorityColonyId).toBeNull();
+      expect(w2.scatterReticleTile).toBeNull();
+    });
+
+    it('V18: spiderPriorityColonyId of Infinity, NaN, or float deserializes to null (B1 integer guard)', async () => {
+      const { SIM_VERSION_V18_SPIDER } = await import('../sim/types.js');
+      const w = createScenario(42);
+      expect(w.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V18_SPIDER);
+      const s = serializeWorldState(w);
+      for (const bad of [Infinity, -Infinity, NaN, 1.5, -0.1]) {
+        (s as { spiderPriorityColonyId: number }).spiderPriorityColonyId = bad;
+        const w2 = deserializeWorldState(s);
+        expect(w2.spiderPriorityColonyId).toBeNull();
+      }
+    });
+
     it('rejects non-integer terrainSeed (string, NaN, null, object) → falls back to 0 (issue #44 P2)', () => {
       const w = createScenario(42);
       const baseSnapshot = serializeWorldState(w);

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -356,10 +356,10 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       const w2 = deserializeWorldState(s);
       expect(w2.terrainSeed).toBe(0);
     });
-    it('V18: round-trips world.spider, spiderPriorityColonyId, and scatterReticleTile through serialize → deserialize', async () => {
-      const { SIM_VERSION_V18_SPIDER } = await import('../sim/types.js');
+    it('V20: round-trips world.spider, spiderPriorityColonyId, and scatterReticleTile through serialize → deserialize', async () => {
+      const { SIM_VERSION_V20_SPIDER } = await import('../sim/types.js');
       const w = createScenario(42);
-      expect(w.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V18_SPIDER);
+      expect(w.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V20_SPIDER);
       const spider = w.spider!;
       spider.state = 'Hunting';
       spider.huntTargetTileX = 55;
@@ -381,12 +381,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(w2.scatterReticleTile).toEqual({ x: 10, y: 20 });
     });
 
-    it('V18: pre-V18 save (spider field absent) deserializes to spider: null, spiderPriorityColonyId: null', async () => {
-      const { SIM_VERSION_V17_AI_STATE } = await import('../sim/types.js');
+    it('V20: pre-V20 save (spider field absent) deserializes to spider: null, spiderPriorityColonyId: null', async () => {
+      const { SIM_VERSION_V19_AI_STATE } = await import('../sim/types.js');
       const w = createScenario(42);
       const s = serializeWorldState(w);
-      // Downgrade simVersion to pre-V18; strip the spider fields.
-      (s as { simVersion: number }).simVersion = SIM_VERSION_V17_AI_STATE;
+      // Downgrade simVersion to pre-V20; strip the spider fields.
+      (s as { simVersion: number }).simVersion = SIM_VERSION_V19_AI_STATE;
       delete (s as { spider?: unknown }).spider;
       delete (s as { spiderPriorityColonyId?: unknown }).spiderPriorityColonyId;
       delete (s as { scatterReticleTile?: unknown }).scatterReticleTile;
@@ -396,7 +396,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(w2.scatterReticleTile).toBeNull();
     });
 
-    it('V18: null spider (spider killed mid-game) round-trips through serialize → deserialize', () => {
+    it('V20: null spider (spider killed mid-game) round-trips through serialize → deserialize', () => {
       const w = createScenario(42);
       w.spider = null; // simulate spider having been killed
       w.spiderPriorityColonyId = null;
@@ -407,10 +407,10 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(w2.scatterReticleTile).toBeNull();
     });
 
-    it('V18: spider: null in a V18 save deserializes to null with priority and reticle also null (B11 coupling)', async () => {
-      const { SIM_VERSION_V18_SPIDER } = await import('../sim/types.js');
+    it('V20: spider: null in a V20 save deserializes to null with priority and reticle also null (B11 coupling)', async () => {
+      const { SIM_VERSION_V20_SPIDER } = await import('../sim/types.js');
       const w = createScenario(42);
-      expect(w.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V18_SPIDER);
+      expect(w.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V20_SPIDER);
       const s = serializeWorldState(w);
       // Force spider null but leave priority/reticle non-null in the raw snapshot.
       (s as { spider: null }).spider = null;
@@ -423,10 +423,10 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(w2.scatterReticleTile).toBeNull();
     });
 
-    it('V18: spiderPriorityColonyId of Infinity, NaN, or float deserializes to null (B1 integer guard)', async () => {
-      const { SIM_VERSION_V18_SPIDER } = await import('../sim/types.js');
+    it('V20: spiderPriorityColonyId of Infinity, NaN, or float deserializes to null (B1 integer guard)', async () => {
+      const { SIM_VERSION_V20_SPIDER } = await import('../sim/types.js');
       const w = createScenario(42);
-      expect(w.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V18_SPIDER);
+      expect(w.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V20_SPIDER);
       const s = serializeWorldState(w);
       for (const bad of [Infinity, -Infinity, NaN, 1.5, -0.1]) {
         (s as { spiderPriorityColonyId: number }).spiderPriorityColonyId = bad;

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -447,6 +447,7 @@ interface SerializedSpiderState {
   strikeStartTick: number;
   feedingStartTick: number;
   retreatStartTick: number;
+  rampageStartTick: number;
   huntTargetTileX: number;
   huntTargetTileY: number;
   killsThisStrike: number;
@@ -1072,6 +1073,7 @@ function deserializeSpider(s: SerializedWorldState, simVersion: number): SpiderS
     strikeStartTick: typeof r.strikeStartTick === 'number' && Number.isInteger(r.strikeStartTick) ? r.strikeStartTick : 0,
     feedingStartTick: typeof r.feedingStartTick === 'number' && Number.isInteger(r.feedingStartTick) ? r.feedingStartTick : 0,
     retreatStartTick: typeof r.retreatStartTick === 'number' && Number.isInteger(r.retreatStartTick) ? r.retreatStartTick : 0,
+    rampageStartTick: typeof r.rampageStartTick === 'number' && Number.isInteger(r.rampageStartTick) ? r.rampageStartTick : 0,
     huntTargetTileX: typeof r.huntTargetTileX === 'number' && Number.isInteger(r.huntTargetTileX) ? r.huntTargetTileX : -1,
     huntTargetTileY: typeof r.huntTargetTileY === 'number' && Number.isInteger(r.huntTargetTileY) ? r.huntTargetTileY : -1,
     killsThisStrike: typeof r.killsThisStrike === 'number' && Number.isInteger(r.killsThisStrike) ? r.killsThisStrike : 0,

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -11,8 +11,8 @@
 //      Iterate via Object.entries — NEVER Array.from(world.colonies.entries()) [there is no .entries()]
 //   6. Version-gated: bumping SAVE_FORMAT_VERSION invalidates old saves (intentional for beta)
 
-import type { WorldState, EntityId, AIStateRecord } from '../sim/types.js';
-import { LEGACY_SIM_VERSION, LATEST_SIM_VERSION, SIM_VERSION_V19_AI_STATE } from '../sim/types.js';
+import type { WorldState, EntityId, AIStateRecord, SpiderState } from '../sim/types.js';
+import { LEGACY_SIM_VERSION, LATEST_SIM_VERSION, SIM_VERSION_V19_AI_STATE, SIM_VERSION_V20_SPIDER } from '../sim/types.js';
 import { AI_MAX_OPERATION_FIGHTERS } from '../sim/constants.js';
 import type { AntComponents } from '../sim/ant/ant-store.js';
 import { createAntComponents } from '../sim/ant/ant-store.js';
@@ -431,6 +431,28 @@ interface SerializedColony {
 
 interface SerializedGrid { width: number; height: number; data: number[] }
 
+/** S3 — serialized form of SpiderState. All fields are plain numbers/strings. */
+interface SerializedSpiderState {
+  state: string;
+  posX: number;
+  posY: number;
+  lairTileX: number;
+  lairTileY: number;
+  territoryRadiusTiles: number;
+  hp: number;
+  attackCooldown: number;
+  hungerTicks: number;
+  nextHuntTick: number;
+  huntStartTick: number;
+  strikeStartTick: number;
+  feedingStartTick: number;
+  retreatStartTick: number;
+  huntTargetTileX: number;
+  huntTargetTileY: number;
+  killsThisStrike: number;
+  rampageKillsThisRampage: number;
+}
+
 /** S2 — serialized form of AIStateRecord. operationFighterIds stored as number[]. */
 interface SerializedAIStateRecord {
   colonyId: number;
@@ -495,6 +517,12 @@ export interface SerializedWorldState {
   pendingChambers: Record<string, PendingChamber>;
   /** S2 — optional for backward compat with pre-V19 saves; defaults to [] on load. */
   aiState?: SerializedAIStateRecord[];
+  /** S3 — optional for backward compat with pre-V18 saves; defaults to null on load. */
+  spider?: SerializedSpiderState | null;
+  /** S3 — optional; defaults to false on load. */
+  spiderPriority?: boolean;
+  /** S3 — transient; always reset to null on load. */
+  scatterReticleTile?: { x: number; y: number } | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -648,6 +676,10 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
     // S0b: persist overflow counters; skip events (transient per design).
     droppedCombatKillCount: world.droppedCombatKillCount,
     droppedStructuralCount: world.droppedStructuralCount,
+    // S3 — spider entity.
+    spider: world.spider === null ? null : { ...world.spider },
+    spiderPriority: world.spiderPriority,
+    // scatterReticleTile is transient — not persisted; always reset to null on load.
     // S2 — AI state machine records. operationFighterIds stored as number[].
     aiState: world.aiState.map((rec) => ({
       colonyId: rec.colonyId,
@@ -1010,6 +1042,43 @@ function deserializeAIStateArray(s: SerializedWorldState, simVersion: number): A
   return result;
 }
 
+function isValidSpiderBehaviorState(v: unknown): v is import('../sim/types.js').SpiderBehaviorState {
+  return v === 'Patrolling' || v === 'Hunting' || v === 'Striking' ||
+         v === 'Feeding' || v === 'Rampaging' || v === 'Retreating';
+}
+
+/**
+ * S3 — deserialize world.spider from the save snapshot.
+ * Pre-V18 saves omit the field; return null.
+ */
+function deserializeSpider(s: SerializedWorldState, simVersion: number): SpiderState | null {
+  if (simVersion < SIM_VERSION_V20_SPIDER) return null;
+  const raw = s.spider;
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'object') return null;
+  const r = raw as Partial<SerializedSpiderState>;
+  return {
+    state: isValidSpiderBehaviorState(r.state) ? r.state : 'Patrolling',
+    posX: typeof r.posX === 'number' && Number.isInteger(r.posX) ? r.posX : 0,
+    posY: typeof r.posY === 'number' && Number.isInteger(r.posY) ? r.posY : 0,
+    lairTileX: typeof r.lairTileX === 'number' && Number.isInteger(r.lairTileX) ? r.lairTileX : 0,
+    lairTileY: typeof r.lairTileY === 'number' && Number.isInteger(r.lairTileY) ? r.lairTileY : 0,
+    territoryRadiusTiles: typeof r.territoryRadiusTiles === 'number' && Number.isInteger(r.territoryRadiusTiles) ? r.territoryRadiusTiles : 24,
+    hp: typeof r.hp === 'number' && Number.isInteger(r.hp) ? r.hp : 80,
+    attackCooldown: typeof r.attackCooldown === 'number' && Number.isInteger(r.attackCooldown) ? r.attackCooldown : 0,
+    hungerTicks: typeof r.hungerTicks === 'number' && Number.isInteger(r.hungerTicks) ? r.hungerTicks : 0,
+    nextHuntTick: typeof r.nextHuntTick === 'number' && Number.isInteger(r.nextHuntTick) ? r.nextHuntTick : 1200,
+    huntStartTick: typeof r.huntStartTick === 'number' && Number.isInteger(r.huntStartTick) ? r.huntStartTick : 0,
+    strikeStartTick: typeof r.strikeStartTick === 'number' && Number.isInteger(r.strikeStartTick) ? r.strikeStartTick : 0,
+    feedingStartTick: typeof r.feedingStartTick === 'number' && Number.isInteger(r.feedingStartTick) ? r.feedingStartTick : 0,
+    retreatStartTick: typeof r.retreatStartTick === 'number' && Number.isInteger(r.retreatStartTick) ? r.retreatStartTick : 0,
+    huntTargetTileX: typeof r.huntTargetTileX === 'number' && Number.isInteger(r.huntTargetTileX) ? r.huntTargetTileX : -1,
+    huntTargetTileY: typeof r.huntTargetTileY === 'number' && Number.isInteger(r.huntTargetTileY) ? r.huntTargetTileY : -1,
+    killsThisStrike: typeof r.killsThisStrike === 'number' && Number.isInteger(r.killsThisStrike) ? r.killsThisStrike : 0,
+    rampageKillsThisRampage: typeof r.rampageKillsThisRampage === 'number' && Number.isInteger(r.rampageKillsThisRampage) ? r.rampageKillsThisRampage : 0,
+  };
+}
+
 function isValidAIState(v: unknown): v is import('../sim/types.js').AIState {
   return v === 'Peacetime' || v === 'WarFooting' || v === 'Probing' || v === 'Invading' || v === 'Recovery';
 }
@@ -1296,6 +1365,11 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     pendingQueenDeathContexts: [],
     // S2 — AI state machine. Deserialize saved records, or provide defensive defaults for pre-V19 saves.
     aiState: deserializeAIStateArray(s, validatedSimVersion),
+    // S3 — spider entity; null for pre-V18 saves.
+    spider: deserializeSpider(s, validatedSimVersion),
+    spiderPriority: (validatedSimVersion >= SIM_VERSION_V20_SPIDER && s.spiderPriority === true),
+    // scatterReticleTile is transient — always reset on load.
+    scatterReticleTile: null,
     droppedCombatKillCount:
       typeof s.droppedCombatKillCount === 'number' &&
       Number.isInteger(s.droppedCombatKillCount) &&

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -452,6 +452,7 @@ interface SerializedSpiderState {
   huntTargetTileY: number;
   killsThisStrike: number;
   rampageKillsThisRampage: number;
+  rampageTargetColonyId: number;
 }
 
 /** S2 — serialized form of AIStateRecord. operationFighterIds stored as number[]. */
@@ -1088,6 +1089,7 @@ function deserializeSpider(s: SerializedWorldState, simVersion: number): SpiderS
     huntTargetTileY: huntTargetValid ? rawHuntY : -1,
     killsThisStrike: typeof r.killsThisStrike === 'number' && Number.isInteger(r.killsThisStrike) ? r.killsThisStrike : 0,
     rampageKillsThisRampage: typeof r.rampageKillsThisRampage === 'number' && Number.isInteger(r.rampageKillsThisRampage) ? r.rampageKillsThisRampage : 0,
+    rampageTargetColonyId: safeState === 'Rampaging' && typeof r.rampageTargetColonyId === 'number' && r.rampageTargetColonyId > 0 ? r.rampageTargetColonyId : -1,
   };
 }
 

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -13,7 +13,7 @@
 
 import type { WorldState, EntityId, AIStateRecord, SpiderState } from '../sim/types.js';
 import { LEGACY_SIM_VERSION, LATEST_SIM_VERSION, SIM_VERSION_V19_AI_STATE, SIM_VERSION_V20_SPIDER } from '../sim/types.js';
-import { AI_MAX_OPERATION_FIGHTERS } from '../sim/constants.js';
+import { AI_MAX_OPERATION_FIGHTERS, SPIDER_HUNT_INTERVAL_TICKS } from '../sim/constants.js';
 import type { AntComponents } from '../sim/ant/ant-store.js';
 import { createAntComponents } from '../sim/ant/ant-store.js';
 import type {
@@ -520,9 +520,9 @@ export interface SerializedWorldState {
   aiState?: SerializedAIStateRecord[];
   /** S3 — optional for backward compat with pre-V18 saves; defaults to null on load. */
   spider?: SerializedSpiderState | null;
-  /** S3 — optional; defaults to false on load. */
+  /** S3 — optional; defaults to null on load. */
   spiderPriorityColonyId?: number | null;
-  /** S3 — transient; always reset to null on load. */
+  /** S3 — preserved through save/reload; null for pre-V18 saves. */
   scatterReticleTile?: { x: number; y: number } | null;
 }
 
@@ -680,7 +680,7 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
     // S3 — spider entity.
     spider: world.spider === null ? null : { ...world.spider },
     spiderPriorityColonyId: world.spiderPriorityColonyId,
-    scatterReticleTile: world.scatterReticleTile,
+    scatterReticleTile: world.scatterReticleTile === null ? null : { ...world.scatterReticleTile },
     // S2 — AI state machine records. operationFighterIds stored as number[].
     aiState: world.aiState.map((rec) => ({
       colonyId: rec.colonyId,
@@ -1068,7 +1068,7 @@ function deserializeSpider(s: SerializedWorldState, simVersion: number): SpiderS
     hp: typeof r.hp === 'number' && Number.isInteger(r.hp) ? r.hp : 80,
     attackCooldown: typeof r.attackCooldown === 'number' && Number.isInteger(r.attackCooldown) ? r.attackCooldown : 0,
     hungerTicks: typeof r.hungerTicks === 'number' && Number.isInteger(r.hungerTicks) ? r.hungerTicks : 0,
-    nextHuntTick: typeof r.nextHuntTick === 'number' && Number.isInteger(r.nextHuntTick) ? r.nextHuntTick : 1200,
+    nextHuntTick: typeof r.nextHuntTick === 'number' && Number.isInteger(r.nextHuntTick) ? r.nextHuntTick : SPIDER_HUNT_INTERVAL_TICKS,
     huntStartTick: typeof r.huntStartTick === 'number' && Number.isInteger(r.huntStartTick) ? r.huntStartTick : 0,
     strikeStartTick: typeof r.strikeStartTick === 'number' && Number.isInteger(r.strikeStartTick) ? r.strikeStartTick : 0,
     feedingStartTick: typeof r.feedingStartTick === 'number' && Number.isInteger(r.feedingStartTick) ? r.feedingStartTick : 0,
@@ -1301,6 +1301,9 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     validateDepletionRecord(rawRecentlyDepleted[i], `recentlyDepletedFood[${i}]`);
   }
   const validatedRecentlyDepleted = rawRecentlyDepleted as DepletionRecord[];
+  // Hoist spider deserialization so spiderPriorityColonyId and scatterReticleTile
+  // can be forced null when spider is null (B11 fix: ghost-scatter prevention).
+  const _deserializedSpider = deserializeSpider(s, validatedSimVersion);
 
   return {
     tick: rawTick,
@@ -1368,10 +1371,10 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     // S2 — AI state machine. Deserialize saved records, or provide defensive defaults for pre-V19 saves.
     aiState: deserializeAIStateArray(s, validatedSimVersion),
     // S3 — spider entity; null for pre-V18 saves.
-    spider: deserializeSpider(s, validatedSimVersion),
-    spiderPriorityColonyId: (validatedSimVersion >= SIM_VERSION_V20_SPIDER && typeof s.spiderPriorityColonyId === 'number') ? s.spiderPriorityColonyId : null,
+    spider: _deserializedSpider,
+    spiderPriorityColonyId: (_deserializedSpider !== null && typeof s.spiderPriorityColonyId === 'number' && Number.isInteger(s.spiderPriorityColonyId) && s.spiderPriorityColonyId >= 0) ? s.spiderPriorityColonyId : null,
     scatterReticleTile: (() => {
-      if (validatedSimVersion < SIM_VERSION_V20_SPIDER) return null;
+      if (_deserializedSpider === null) return null;
       const r = s.scatterReticleTile;
       if (r === null || r === undefined) return null;
       if (typeof r !== 'object') return null;

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -680,7 +680,7 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
     // S3 — spider entity.
     spider: world.spider === null ? null : { ...world.spider },
     spiderPriorityColonyId: world.spiderPriorityColonyId,
-    // scatterReticleTile is transient — not persisted; always reset to null on load.
+    scatterReticleTile: world.scatterReticleTile,
     // S2 — AI state machine records. operationFighterIds stored as number[].
     aiState: world.aiState.map((rec) => ({
       colonyId: rec.colonyId,
@@ -1370,8 +1370,15 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     // S3 — spider entity; null for pre-V18 saves.
     spider: deserializeSpider(s, validatedSimVersion),
     spiderPriorityColonyId: (validatedSimVersion >= SIM_VERSION_V20_SPIDER && typeof s.spiderPriorityColonyId === 'number') ? s.spiderPriorityColonyId : null,
-    // scatterReticleTile is transient — always reset on load.
-    scatterReticleTile: null,
+    scatterReticleTile: (() => {
+      if (validatedSimVersion < SIM_VERSION_V20_SPIDER) return null;
+      const r = s.scatterReticleTile;
+      if (r === null || r === undefined) return null;
+      if (typeof r !== 'object') return null;
+      if (typeof r.x !== 'number' || typeof r.y !== 'number') return null;
+      if (!Number.isInteger(r.x) || !Number.isInteger(r.y)) return null;
+      return { x: r.x, y: r.y };
+    })(),
     droppedCombatKillCount:
       typeof s.droppedCombatKillCount === 'number' &&
       Number.isInteger(s.droppedCombatKillCount) &&

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -518,11 +518,11 @@ export interface SerializedWorldState {
   pendingChambers: Record<string, PendingChamber>;
   /** S2 — optional for backward compat with pre-V19 saves; defaults to [] on load. */
   aiState?: SerializedAIStateRecord[];
-  /** S3 — optional for backward compat with pre-V18 saves; defaults to null on load. */
+  /** S3 — optional for backward compat with pre-V20 saves; defaults to null on load. */
   spider?: SerializedSpiderState | null;
   /** S3 — optional; defaults to null on load. */
   spiderPriorityColonyId?: number | null;
-  /** S3 — preserved through save/reload; null for pre-V18 saves. */
+  /** S3 — preserved through save/reload; null for pre-V20 saves. */
   scatterReticleTile?: { x: number; y: number } | null;
 }
 
@@ -1050,7 +1050,7 @@ function isValidSpiderBehaviorState(v: unknown): v is import('../sim/types.js').
 
 /**
  * S3 — deserialize world.spider from the save snapshot.
- * Pre-V18 saves omit the field; return null.
+ * Pre-V20 saves omit the field; return null.
  */
 function deserializeSpider(s: SerializedWorldState, simVersion: number): SpiderState | null {
   if (simVersion < SIM_VERSION_V20_SPIDER) return null;
@@ -1058,8 +1058,18 @@ function deserializeSpider(s: SerializedWorldState, simVersion: number): SpiderS
   if (raw === null || raw === undefined) return null;
   if (typeof raw !== 'object') return null;
   const r = raw as Partial<SerializedSpiderState>;
+  const rawState = isValidSpiderBehaviorState(r.state) ? r.state : 'Patrolling';
+  const rawHuntX = typeof r.huntTargetTileX === 'number' && Number.isInteger(r.huntTargetTileX) ? r.huntTargetTileX : -1;
+  const rawHuntY = typeof r.huntTargetTileY === 'number' && Number.isInteger(r.huntTargetTileY) ? r.huntTargetTileY : -1;
+  // Guard: Hunting/Striking require a valid (non-sentinel) hunt target. A save with
+  // state=Hunting but target=-1 (corrupt or truncated) would route the spider to (0,0)
+  // for the full telegraph duration. Fall back to Patrolling in that case.
+  const huntTargetValid = rawHuntX >= 0 && rawHuntY >= 0;
+  const safeState = (rawState === 'Hunting' || rawState === 'Striking') && !huntTargetValid
+    ? 'Patrolling'
+    : rawState;
   return {
-    state: isValidSpiderBehaviorState(r.state) ? r.state : 'Patrolling',
+    state: safeState,
     posX: typeof r.posX === 'number' && Number.isInteger(r.posX) ? r.posX : 0,
     posY: typeof r.posY === 'number' && Number.isInteger(r.posY) ? r.posY : 0,
     lairTileX: typeof r.lairTileX === 'number' && Number.isInteger(r.lairTileX) ? r.lairTileX : 0,
@@ -1074,8 +1084,8 @@ function deserializeSpider(s: SerializedWorldState, simVersion: number): SpiderS
     feedingStartTick: typeof r.feedingStartTick === 'number' && Number.isInteger(r.feedingStartTick) ? r.feedingStartTick : 0,
     retreatStartTick: typeof r.retreatStartTick === 'number' && Number.isInteger(r.retreatStartTick) ? r.retreatStartTick : 0,
     rampageStartTick: typeof r.rampageStartTick === 'number' && Number.isInteger(r.rampageStartTick) ? r.rampageStartTick : 0,
-    huntTargetTileX: typeof r.huntTargetTileX === 'number' && Number.isInteger(r.huntTargetTileX) ? r.huntTargetTileX : -1,
-    huntTargetTileY: typeof r.huntTargetTileY === 'number' && Number.isInteger(r.huntTargetTileY) ? r.huntTargetTileY : -1,
+    huntTargetTileX: huntTargetValid ? rawHuntX : -1,
+    huntTargetTileY: huntTargetValid ? rawHuntY : -1,
     killsThisStrike: typeof r.killsThisStrike === 'number' && Number.isInteger(r.killsThisStrike) ? r.killsThisStrike : 0,
     rampageKillsThisRampage: typeof r.rampageKillsThisRampage === 'number' && Number.isInteger(r.rampageKillsThisRampage) ? r.rampageKillsThisRampage : 0,
   };
@@ -1370,9 +1380,9 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     pendingQueenDeathContexts: [],
     // S2 — AI state machine. Deserialize saved records, or provide defensive defaults for pre-V19 saves.
     aiState: deserializeAIStateArray(s, validatedSimVersion),
-    // S3 — spider entity; null for pre-V18 saves.
+    // S3 — spider entity; null for pre-V20 saves.
     spider: _deserializedSpider,
-    spiderPriorityColonyId: (_deserializedSpider !== null && typeof s.spiderPriorityColonyId === 'number' && Number.isInteger(s.spiderPriorityColonyId) && s.spiderPriorityColonyId >= 0) ? s.spiderPriorityColonyId : null,
+    spiderPriorityColonyId: (_deserializedSpider !== null && typeof s.spiderPriorityColonyId === 'number' && Number.isInteger(s.spiderPriorityColonyId) && s.spiderPriorityColonyId > 0) ? s.spiderPriorityColonyId : null,
     scatterReticleTile: (() => {
       if (_deserializedSpider === null) return null;
       const r = s.scatterReticleTile;

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -520,7 +520,7 @@ export interface SerializedWorldState {
   /** S3 — optional for backward compat with pre-V18 saves; defaults to null on load. */
   spider?: SerializedSpiderState | null;
   /** S3 — optional; defaults to false on load. */
-  spiderPriority?: boolean;
+  spiderPriorityColonyId?: number | null;
   /** S3 — transient; always reset to null on load. */
   scatterReticleTile?: { x: number; y: number } | null;
 }
@@ -678,7 +678,7 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
     droppedStructuralCount: world.droppedStructuralCount,
     // S3 — spider entity.
     spider: world.spider === null ? null : { ...world.spider },
-    spiderPriority: world.spiderPriority,
+    spiderPriorityColonyId: world.spiderPriorityColonyId,
     // scatterReticleTile is transient — not persisted; always reset to null on load.
     // S2 — AI state machine records. operationFighterIds stored as number[].
     aiState: world.aiState.map((rec) => ({
@@ -1367,7 +1367,7 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     aiState: deserializeAIStateArray(s, validatedSimVersion),
     // S3 — spider entity; null for pre-V18 saves.
     spider: deserializeSpider(s, validatedSimVersion),
-    spiderPriority: (validatedSimVersion >= SIM_VERSION_V20_SPIDER && s.spiderPriority === true),
+    spiderPriorityColonyId: (validatedSimVersion >= SIM_VERSION_V20_SPIDER && typeof s.spiderPriorityColonyId === 'number') ? s.spiderPriorityColonyId : null,
     // scatterReticleTile is transient — always reset on load.
     scatterReticleTile: null,
     droppedCombatKillCount:

--- a/src/sim/colony/colony-system.test.ts
+++ b/src/sim/colony/colony-system.test.ts
@@ -484,13 +484,15 @@ describe('tickDeathCleanup', () => {
     expect(colony.workerCount).toBe(2);
   });
 
-  it('14. queen death sets colony.defeated = true', () => {
+  it('14. queen death does NOT set colony.defeated (checkQueenDeath step 18 owns that)', () => {
     const { world, colony } = setupWorldWithQueen();
     world.ants.alive[colony.queenEntityId] = 0; // kill queen
 
     tickDeathCleanup(world, colony);
 
-    expect(colony.defeated).toBe(true);
+    // defeated is set by checkQueenDeath (step 18), not by tickDeathCleanup (step 5),
+    // so that the queen_death event is emitted before the flag is set.
+    expect(colony.defeated).toBe(false);
   });
 
   it('15. all-bucket cleanup — dead eggs/larvae/workers removed in one pass', () => {

--- a/src/sim/colony/colony-system.ts
+++ b/src/sim/colony/colony-system.ts
@@ -351,7 +351,6 @@ export function tickStarvationCheck(_world: WorldState, _colony: ColonyRecord): 
 // Backwards iteration ensures swap-remove does not skip indices when multiple
 // consecutive dead entities are encountered (PRD §4b line 388 pattern).
 // Updates cached eggCount, larvaeCount, workerCount after removal.
-// Sets colony.defeated = true when queen is dead (CLNY-08, CMBT-06 read-through).
 // ---------------------------------------------------------------------------
 
 /**
@@ -359,7 +358,9 @@ export function tickStarvationCheck(_world: WorldState, _colony: ColonyRecord): 
  *
  * Backwards iteration prevents index-skip on consecutive dead entities.
  * Updates cached count fields (eggCount, larvaeCount, workerCount) after each removal.
- * Sets colony.defeated = true if queen entity has alive === 0 (CLNY-08).
+ * colony.defeated is set by checkQueenDeath (step 18) — NOT here — so the queen_death
+ * event is emitted before the flag is set. (Starvation kills the queen at step 3;
+ * setting defeated at step 5 caused checkQueenDeath to skip event emission.)
  */
 export function tickDeathCleanup(world: WorldState, colony: ColonyRecord): void {
   const ants = world.ants;
@@ -389,11 +390,6 @@ export function tickDeathCleanup(world: WorldState, colony: ColonyRecord): void 
       colony.workers.pop();
       colony.workerCount -= 1;
     }
-  }
-
-  // Defeated flag — set when queen is dead (CLNY-08, CMBT-06 read-through)
-  if (ants.alive[colony.queenEntityId] === 0) {
-    colony.defeated = true;
   }
 }
 

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -460,6 +460,10 @@ export function killAnt(
 // S3 — Spider combat resolver
 // ---------------------------------------------------------------------------
 
+// Module-level scratch buffer: reused each call to resolveSpiderCombatOnTile to
+// avoid per-tick allocation in the combat hot path (AGENTS.md no-alloc rule).
+const SPIDER_TILE_SCRATCH: number[] = [];
+
 /**
  * Resolve one combat tick between the spider and ants on its tile.
  * Called from detectAndResolveCombat after the ant-vs-ant loop.
@@ -483,7 +487,8 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
   // Collect non-queen ants on the spider's surface tile.
   // Queens are excluded: they are either underground or at a colony start — spider
   // combat targets workers and fighters, not colony queens.
-  const onTile: number[] = [];
+  const onTile = SPIDER_TILE_SCRATCH;
+  onTile.length = 0;
   const count = ants.alive.length;
   for (let i = 0; i < count; i++) {
     if (ants.alive[i] !== 1) continue;

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -571,6 +571,7 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
         // First contact for this fighter: pair and set windup.
         ants.combatOpponentId[idx] = -2;
         ants.attackCooldown[idx] = COMBAT_COOLDOWN_TICKS;
+        ants.homeGroundBonusHp[idx] = 0; // spider is surface-only; underground bonus does not apply
         anyNewPairing = true;
         continue;
       }
@@ -629,6 +630,7 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
     // Fresh pair: set windup (no strike this tick).
     ants.attackCooldown[activeAntIdx] = COMBAT_COOLDOWN_TICKS;
     ants.combatOpponentId[activeAntIdx] = -2; // sentinel: paired with spider
+    ants.homeGroundBonusHp[activeAntIdx] = 0; // spider is surface-only; underground bonus does not apply
     spider.attackCooldown = COMBAT_COOLDOWN_TICKS;
     return;
   }

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -82,7 +82,9 @@ export function detectAndResolveCombat(world: WorldState, rng: Rng): void {
       }
     }
     for (let i = 0; i < count; i++) {
-      if (ants.alive[i] === 1 && !contestedSet.has(i)) {
+      // -2 is the spider-pairing sentinel; skip it here so resolveSpiderCombatOnTile
+      // can preserve windup state. The sentinel is cleared by clearSpiderPairingSentinels.
+      if (ants.alive[i] === 1 && !contestedSet.has(i) && ants.combatOpponentId[i] !== -2) {
         ants.combatOpponentId[i] = -1;
       }
     }
@@ -555,9 +557,11 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
     let swarmRetaliationTarget = -1;
     let anyVeteranPaired = false;
     for (const idx of onTile) {
+      // Veteran check is tile-wide: any -2 (including non-priority colony fighters)
+      // counts as an ongoing engagement that should not reset the spider's windup.
+      if (ants.combatOpponentId[idx] === -2) anyVeteranPaired = true;
       if (ants.task[idx] !== AntTask.Fighting || ants.colonyId[idx] !== priorityColonyId) continue;
       if (swarmRetaliationTarget === -1) swarmRetaliationTarget = idx;
-      if (ants.combatOpponentId[idx] === -2) anyVeteranPaired = true;
     }
     // swarmActive guarantees fighterCount >= SPIDER_SWARM_FIGHTER_THRESHOLD >= 1,
     // so the loop above always finds at least one priority fighter.
@@ -604,7 +608,8 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
     if (totalAntDamage > 0) {
       spider.hp -= totalAntDamage;
       if (spider.hp <= 0) {
-        // Clear all swarm fighter pairings when spider dies.
+        // Clear on-tile swarm fighter pairings immediately; off-tile sentinels
+        // are cleared by clearSpiderPairingSentinels in tickSpider the same tick.
         for (const idx of onTile) {
           if (ants.colonyId[idx] === priorityColonyId && ants.combatOpponentId[idx] === -2) {
             ants.combatOpponentId[idx] = -1;

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -31,7 +31,6 @@ import {
   COMBAT_DAMAGE_QUEEN,
   SPIDER_DAMAGE,
   SPIDER_SWARM_FIGHTER_THRESHOLD,
-  SPIDER_SWARM_MULTIPLIER,
 } from './constants.js';
 import { SIM_VERSION_V19_AI_STATE } from './types.js';
 import { getAIStateForColony, isInCohort } from './ai-state.js';
@@ -467,8 +466,8 @@ export function killAnt(
  *
  * Spider gets its own active pair with the first fighter (or any ant) on
  * its tile. Swarm bonus applies when: world.spiderPriorityColonyId !== null AND
- * >= SPIDER_SWARM_FIGHTER_THRESHOLD fighters share the tile. The bonus
- * multiplies each fighter's damage by SPIDER_SWARM_MULTIPLIER.
+ * >= SPIDER_SWARM_FIGHTER_THRESHOLD fighters share the tile. Each
+ * priority-colony fighter then acts with an independent cooldown (true N-fighter DPS).
  *
  * Per the evaluation-order rule (spec Part B): combat damage is applied
  * here; tickSpider (step 17.5) reads spider.hp and evaluates the
@@ -531,8 +530,80 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
   }
   const swarmActive = priorityColonyId !== null && fighterCount >= SPIDER_SWARM_FIGHTER_THRESHOLD;
 
-  // New-pairing detection: -2 sentinel means "fighting spider".
-  // A new pairing occurs when the ant is not already paired with the spider.
+  if (swarmActive) {
+    // --- Swarm path: each priority-colony fighter acts independently per tick. ---
+    // Spider retaliates once per tick against a priority-colony fighter.
+    // This gives true N-fighter DPS rather than 4× single-fighter approximation.
+
+    // Retaliation target must be a priority-colony fighter (not an enemy ant that
+    // happens to share the tile), so re-select within priority colony.
+    let swarmRetaliationTarget = activeAntIdx;
+    for (const idx of onTile) {
+      if (ants.task[idx] === AntTask.Fighting && ants.colonyId[idx] === priorityColonyId) {
+        swarmRetaliationTarget = idx;
+        break;
+      }
+    }
+
+    let totalAntDamage = 0;
+    let anyNewPairing = false;
+    for (const idx of onTile) {
+      if (ants.task[idx] !== AntTask.Fighting) continue;
+      if (ants.colonyId[idx] !== priorityColonyId) continue;
+      if (ants.combatOpponentId[idx] !== -2) {
+        // First contact for this fighter: pair and set windup.
+        ants.combatOpponentId[idx] = -2;
+        ants.attackCooldown[idx] = COMBAT_COOLDOWN_TICKS;
+        anyNewPairing = true;
+        continue;
+      }
+      const cd = ants.attackCooldown[idx]! - 1;
+      ants.attackCooldown[idx] = cd;
+      if (cd === 0) {
+        totalAntDamage += COMBAT_DAMAGE_BASE;
+        ants.attackCooldown[idx] = COMBAT_COOLDOWN_TICKS;
+      }
+    }
+
+    // Spider windup: reset unconditionally on any new pairing (matches non-swarm contract),
+    // and do NOT decrement on the same tick (mirrors non-swarm early-return behavior).
+    // If spider.attackCooldown was stale from a prior episode, this resets it correctly.
+    if (anyNewPairing) {
+      spider.attackCooldown = COMBAT_COOLDOWN_TICKS;
+    } else {
+      spider.attackCooldown = spider.attackCooldown > 0 ? spider.attackCooldown - 1 : 0;
+    }
+    const spiderStrikes = spider.attackCooldown === 0;
+    const spiderDamage = spiderStrikes ? SPIDER_DAMAGE : 0;
+
+    if (totalAntDamage === 0 && spiderDamage === 0) return;
+
+    // Apply simultaneously.
+    const antDies = spiderDamage > 0 && applyDamage(world, swarmRetaliationTarget, spiderDamage);
+
+    if (totalAntDamage > 0) {
+      spider.hp -= totalAntDamage;
+      if (spider.hp <= 0) {
+        // Clear all swarm fighter pairings when spider dies.
+        for (const idx of onTile) {
+          if (ants.colonyId[idx] === priorityColonyId && ants.combatOpponentId[idx] === -2) {
+            ants.combatOpponentId[idx] = -1;
+          }
+        }
+      }
+    }
+    if (spiderStrikes && spider.hp > 0) {
+      spider.attackCooldown = COMBAT_COOLDOWN_TICKS;
+    }
+    if (antDies) {
+      if (spider.state === 'Striking') spider.killsThisStrike += 1;
+      if (spider.state === 'Rampaging') spider.rampageKillsThisRampage += 1;
+      killAnt(world, swarmRetaliationTarget, null, null, 'Spider');
+    }
+    return;
+  }
+
+  // --- Non-swarm path: single activeAntIdx, unchanged S1 semantics. ---
   const antCurrentOpponent = ants.combatOpponentId[activeAntIdx]!;
   const isNewPairing = antCurrentOpponent !== -2;
 
@@ -550,49 +621,39 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
   spider.attackCooldown = spider.attackCooldown > 0 ? spider.attackCooldown - 1 : 0;
 
   const antStrikes = antCooldown === 0;
-  const spiderStrikes = spider.attackCooldown === 0;
+  const spiderStrikes2 = spider.attackCooldown === 0;
 
-  if (!antStrikes && !spiderStrikes) return;
+  if (!antStrikes && !spiderStrikes2) return;
 
-  // Ant damage (fighters only, with optional swarm multiplier).
-  // Swarm bonus only applies when the striking ant belongs to the priority colony.
+  // Ant damage: fighters only; no swarm multiplier (swarmActive is false here).
   let antDamage = 0;
   if (antStrikes && ants.task[activeAntIdx] === AntTask.Fighting) {
-    antDamage = COMBAT_DAMAGE_BASE; // spider is never "home ground" for ants
-    if (swarmActive && ants.colonyId[activeAntIdx] === priorityColonyId) {
-      antDamage *= SPIDER_SWARM_MULTIPLIER;
-    }
+    antDamage = COMBAT_DAMAGE_BASE;
   }
 
   // Spider damage.
-  const spiderDamage = spiderStrikes ? SPIDER_DAMAGE : 0;
+  const spiderDamage2 = spiderStrikes2 ? SPIDER_DAMAGE : 0;
 
-  // Apply damage simultaneously: compute both death results before acting.
-  const antDies = spiderDamage > 0 && applyDamage(world, activeAntIdx, spiderDamage);
+  // Apply damage simultaneously.
+  const antDies2 = spiderDamage2 > 0 && applyDamage(world, activeAntIdx, spiderDamage2);
 
   if (antDamage > 0) {
     spider.hp -= antDamage;
-    // Spider retreat threshold / death is evaluated by tickSpider at step 17.5.
-    // Clear ant pairing if spider just died so it can pair with ants next tick.
     if (spider.hp <= 0) {
       ants.combatOpponentId[activeAntIdx] = -1;
     }
   }
 
-  // Reset cooldowns for survivors.
-  if (antStrikes && !antDies) {
+  if (antStrikes && !antDies2) {
     ants.attackCooldown[activeAntIdx] = COMBAT_COOLDOWN_TICKS;
   }
-  if (spiderStrikes && spider.hp > 0) {
+  if (spiderStrikes2 && spider.hp > 0) {
     spider.attackCooldown = COMBAT_COOLDOWN_TICKS;
   }
 
-  if (antDies) {
-    // Track kills during Striking / Rampaging states.
+  if (antDies2) {
     if (spider.state === 'Striking') spider.killsThisStrike += 1;
     if (spider.state === 'Rampaging') spider.rampageKillsThisRampage += 1;
     killAnt(world, activeAntIdx, null, null, 'Spider');
-    // Clear opponent tracking for next pair formation.
-    // Spider's cooldown stays as-is for the next replacement pair.
   }
 }

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -466,7 +466,7 @@ export function killAnt(
  * Called from detectAndResolveCombat after the ant-vs-ant loop.
  *
  * Spider gets its own active pair with the first fighter (or any ant) on
- * its tile. Swarm bonus applies when: world.spiderPriority === true AND
+ * its tile. Swarm bonus applies when: world.spiderPriorityColonyId !== null AND
  * >= SPIDER_SWARM_FIGHTER_THRESHOLD fighters share the tile. The bonus
  * multiplies each fighter's damage by SPIDER_SWARM_MULTIPLIER.
  *
@@ -523,7 +523,7 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
   for (const idx of onTile) {
     if (ants.task[idx] === AntTask.Fighting) fighterCount += 1;
   }
-  const swarmActive = world.spiderPriority && fighterCount >= SPIDER_SWARM_FIGHTER_THRESHOLD;
+  const swarmActive = world.spiderPriorityColonyId !== null && fighterCount >= SPIDER_SWARM_FIGHTER_THRESHOLD;
 
   // New-pairing detection: -2 sentinel means "fighting spider".
   // A new pairing occurs when the ant is not already paired with the spider.

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -517,8 +517,9 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
     return;
   }
 
-  // Sort ascending by ant index for determinism.
-  onTile.sort((a, b) => a - b);
+  // onTile was built by ascending-index scan — already in order; no sort needed.
+  // INVARIANT: contents must remain ascending; downstream tiebreaks (activeAntIdx,
+  // swarmRetaliationTarget) rely on lowest-slot-index winning.
 
   // Prefer AntTask.Fighting ants for the active pair; fall back to any ant.
   let activeAntIdx = onTile[0]!;

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -487,6 +487,19 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
   // Collect non-queen ants on the spider's surface tile.
   // Queens are excluded: they are either underground or at a colony start — spider
   // combat targets workers and fighters, not colony queens.
+
+  // Pre-scan colony queen IDs to avoid O(ants × colonies) nested loop per tick.
+  // Two local vars cover the current max of 2 active colonies (player + AI).
+  let queenId0 = -1;
+  let queenId1 = -1;
+  for (const ckey in world.colonies) {
+    if (!Object.hasOwn(world.colonies, ckey)) continue;
+    const col = world.colonies[ckey as unknown as import('./colony/colony-store.js').ColonyId];
+    if (col === undefined) continue;
+    if (queenId0 < 0) queenId0 = col.queenEntityId;
+    else queenId1 = col.queenEntityId;
+  }
+
   const onTile = SPIDER_TILE_SCRATCH;
   onTile.length = 0;
   const count = ants.alive.length;
@@ -496,13 +509,7 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
     const ax = ants.posX[i]! >> FP_SHIFT;
     const ay = ants.posY[i]! >> FP_SHIFT;
     if (ax !== spiderTileX || ay !== spiderTileY) continue;
-    // Skip queens — check all colony queen entity ids.
-    let isQueen = false;
-    for (const ckey in world.colonies) {
-      const col = world.colonies[ckey as unknown as import('./colony/colony-store.js').ColonyId];
-      if (col !== undefined && col.queenEntityId === i) { isQueen = true; break; }
-    }
-    if (isQueen) continue;
+    if (i === queenId0 || i === queenId1) continue; // skip queens
     onTile.push(i);
   }
   if (onTile.length === 0) {
@@ -540,15 +547,20 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
     // Spider retaliates once per tick against a priority-colony fighter.
     // This gives true N-fighter DPS rather than 4× single-fighter approximation.
 
-    // Retaliation target must be a priority-colony fighter (not an enemy ant that
-    // happens to share the tile), so re-select within priority colony.
-    let swarmRetaliationTarget = activeAntIdx;
+    // Retaliation target = first priority-colony fighter on tile (lowest slot index).
+    // anyVeteranPaired = true if at least one fighter is already paired this episode.
+    // Used below to avoid resetting spider windup on late-joiner arrivals.
+    // Use -1 sentinel (not activeAntIdx) so the first match is unconditionally accepted.
+    let swarmRetaliationTarget = -1;
+    let anyVeteranPaired = false;
     for (const idx of onTile) {
-      if (ants.task[idx] === AntTask.Fighting && ants.colonyId[idx] === priorityColonyId) {
-        swarmRetaliationTarget = idx;
-        break;
-      }
+      if (ants.task[idx] !== AntTask.Fighting || ants.colonyId[idx] !== priorityColonyId) continue;
+      if (swarmRetaliationTarget === -1) swarmRetaliationTarget = idx;
+      if (ants.combatOpponentId[idx] === -2) anyVeteranPaired = true;
     }
+    // swarmActive guarantees fighterCount >= SPIDER_SWARM_FIGHTER_THRESHOLD >= 1,
+    // so the loop above always finds at least one priority fighter.
+    if (swarmRetaliationTarget === -1) swarmRetaliationTarget = activeAntIdx;
 
     let totalAntDamage = 0;
     let anyNewPairing = false;
@@ -570,10 +582,11 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
       }
     }
 
-    // Spider windup: reset unconditionally on any new pairing (matches non-swarm contract),
-    // and do NOT decrement on the same tick (mirrors non-swarm early-return behavior).
-    // If spider.attackCooldown was stale from a prior episode, this resets it correctly.
-    if (anyNewPairing) {
+    // Spider windup: reset only on the first tick of engagement (no veterans yet paired).
+    // A late-joining fighter should not pause the spider's attack cycle while veterans
+    // are already dealing damage — that would be exploitable stagger.
+    // Mirror non-swarm early-return: no decrement on the same tick as a first-ever engagement.
+    if (anyNewPairing && !anyVeteranPaired) {
       spider.attackCooldown = COMBAT_COOLDOWN_TICKS;
     } else {
       spider.attackCooldown = spider.attackCooldown > 0 ? spider.attackCooldown - 1 : 0;

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -17,19 +17,21 @@ import { Rng } from './rng.js';
 import { AntTask } from './enums.js';
 import { makeTileKey } from './tile-key.js';
 import type { WorldState, KillerKind, QueenDeathContext } from './types.js';
-import { SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V16_COMBAT_HPDPS, SIM_VERSION_V17_COMBAT_AGGRO } from './types.js';
+import { SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V16_COMBAT_HPDPS, SIM_VERSION_V17_COMBAT_AGGRO, SIM_VERSION_V20_SPIDER } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 import type { Zone } from './terrain.js';
 import { FP_SHIFT } from './fixed.js';
 import { emitEvent } from './telemetry.js';
 import {
-  COMBAT_HP_BASE,
   COMBAT_HP_HOMEGROUND_BONUS,
   COMBAT_DAMAGE_BASE,
   COMBAT_DAMAGE_HOMEGROUND,
   COMBAT_COOLDOWN_TICKS,
   COMBAT_DAMAGE_WORKER,
   COMBAT_DAMAGE_QUEEN,
+  SPIDER_DAMAGE,
+  SPIDER_SWARM_FIGHTER_THRESHOLD,
+  SPIDER_SWARM_MULTIPLIER,
 } from './constants.js';
 import { SIM_VERSION_V19_AI_STATE } from './types.js';
 import { getAIStateForColony, isInCohort } from './ai-state.js';
@@ -104,6 +106,15 @@ export function detectAndResolveCombat(world: WorldState, rng: Rng): void {
     } else {
       resolveCombatOnTile_v15(world, key, participants, rng);
     }
+  }
+
+  // S3 — spider combat: resolve spider vs ants on the spider's tile.
+  // Only during combat-active states (Striking, Rampaging). Spider in Patrolling,
+  // Hunting, Feeding, or Retreating does not engage in direct HP combat.
+  if (world.simVersion >= SIM_VERSION_V20_SPIDER &&
+      world.spider !== null &&
+      (world.spider.state === 'Striking' || world.spider.state === 'Rampaging')) {
+    resolveSpiderCombatOnTile(world);
   }
 
   // Clear pendingQueenDeathContexts for ants that survived (i.e., where the queen kill
@@ -443,5 +454,136 @@ export function killAnt(
     if (killerColony !== undefined) {
       killerColony.killCount += 1;
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// S3 — Spider combat resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve one combat tick between the spider and ants on its tile.
+ * Called from detectAndResolveCombat after the ant-vs-ant loop.
+ *
+ * Spider gets its own active pair with the first fighter (or any ant) on
+ * its tile. Swarm bonus applies when: world.spiderPriority === true AND
+ * >= SPIDER_SWARM_FIGHTER_THRESHOLD fighters share the tile. The bonus
+ * multiplies each fighter's damage by SPIDER_SWARM_MULTIPLIER.
+ *
+ * Per the evaluation-order rule (spec Part B): combat damage is applied
+ * here; tickSpider (step 17.5) reads spider.hp and evaluates the
+ * Retreating threshold afterward.
+ */
+export function resolveSpiderCombatOnTile(world: WorldState): void {
+  const spider = world.spider!;
+  const { ants } = world;
+
+  const spiderTileX = spider.posX >> FP_SHIFT;
+  const spiderTileY = spider.posY >> FP_SHIFT;
+
+  // Collect non-queen ants on the spider's surface tile.
+  // Queens are excluded: they are either underground or at a colony start — spider
+  // combat targets workers and fighters, not colony queens.
+  const onTile: number[] = [];
+  const count = ants.alive.length;
+  for (let i = 0; i < count; i++) {
+    if (ants.alive[i] !== 1) continue;
+    if (ants.zone[i] !== 0) continue; // surface only
+    const ax = ants.posX[i]! >> FP_SHIFT;
+    const ay = ants.posY[i]! >> FP_SHIFT;
+    if (ax !== spiderTileX || ay !== spiderTileY) continue;
+    // Skip queens — check all colony queen entity ids.
+    let isQueen = false;
+    for (const ckey in world.colonies) {
+      const col = world.colonies[ckey as unknown as import('./colony/colony-store.js').ColonyId];
+      if (col !== undefined && col.queenEntityId === i) { isQueen = true; break; }
+    }
+    if (isQueen) continue;
+    onTile.push(i);
+  }
+  if (onTile.length === 0) {
+    // No ants on tile — nothing to resolve this tick.
+    return;
+  }
+
+  // Sort ascending by ant index for determinism.
+  onTile.sort((a, b) => a - b);
+
+  // Prefer AntTask.Fighting ants for the active pair; fall back to any ant.
+  let activeAntIdx = onTile[0]!;
+  for (const idx of onTile) {
+    if (ants.task[idx] === AntTask.Fighting) {
+      activeAntIdx = idx;
+      break;
+    }
+  }
+
+  // Swarm bonus: priority set AND enough fighters on tile.
+  let fighterCount = 0;
+  for (const idx of onTile) {
+    if (ants.task[idx] === AntTask.Fighting) fighterCount += 1;
+  }
+  const swarmActive = world.spiderPriority && fighterCount >= SPIDER_SWARM_FIGHTER_THRESHOLD;
+
+  // New-pairing detection: -2 sentinel means "fighting spider".
+  // A new pairing occurs when the ant is not already paired with the spider.
+  const antCurrentOpponent = ants.combatOpponentId[activeAntIdx]!;
+  const isNewPairing = antCurrentOpponent !== -2;
+
+  if (isNewPairing) {
+    // Fresh pair: set windup (no strike this tick).
+    ants.attackCooldown[activeAntIdx] = COMBAT_COOLDOWN_TICKS;
+    ants.combatOpponentId[activeAntIdx] = -2; // sentinel: paired with spider
+    spider.attackCooldown = COMBAT_COOLDOWN_TICKS;
+    return;
+  }
+
+  // Decrement cooldowns.
+  const antCooldown = ants.attackCooldown[activeAntIdx]! - 1;
+  ants.attackCooldown[activeAntIdx] = antCooldown;
+  spider.attackCooldown = spider.attackCooldown > 0 ? spider.attackCooldown - 1 : 0;
+
+  const antStrikes = antCooldown === 0;
+  const spiderStrikes = spider.attackCooldown === 0;
+
+  if (!antStrikes && !spiderStrikes) return;
+
+  // Ant damage (fighters only, with optional swarm multiplier).
+  let antDamage = 0;
+  if (antStrikes && ants.task[activeAntIdx] === AntTask.Fighting) {
+    antDamage = COMBAT_DAMAGE_BASE; // spider is never "home ground" for ants
+    if (swarmActive) antDamage *= SPIDER_SWARM_MULTIPLIER;
+  }
+
+  // Spider damage.
+  const spiderDamage = spiderStrikes ? SPIDER_DAMAGE : 0;
+
+  // Apply damage simultaneously: compute both death results before acting.
+  const antDies = spiderDamage > 0 && applyDamage(world, activeAntIdx, spiderDamage);
+
+  if (antDamage > 0) {
+    spider.hp -= antDamage;
+    // Spider retreat threshold / death is evaluated by tickSpider at step 17.5.
+    // Clear ant pairing if spider just died so it can pair with ants next tick.
+    if (spider.hp <= 0) {
+      ants.combatOpponentId[activeAntIdx] = -1;
+    }
+  }
+
+  // Reset cooldowns for survivors.
+  if (antStrikes && !antDies) {
+    ants.attackCooldown[activeAntIdx] = COMBAT_COOLDOWN_TICKS;
+  }
+  if (spiderStrikes && spider.hp > 0) {
+    spider.attackCooldown = COMBAT_COOLDOWN_TICKS;
+  }
+
+  if (antDies) {
+    // Track kills during Striking / Rampaging states.
+    if (spider.state === 'Striking') spider.killsThisStrike += 1;
+    if (spider.state === 'Rampaging') spider.rampageKillsThisRampage += 1;
+    killAnt(world, activeAntIdx, null, null, 'Spider');
+    // Clear opponent tracking for next pair formation.
+    // Spider's cooldown stays as-is for the next replacement pair.
   }
 }

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -518,12 +518,18 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
     }
   }
 
-  // Swarm bonus: priority set AND enough fighters on tile.
+  // Swarm bonus: priority set AND enough fighters from the priority colony on tile.
+  // Count only priority-colony fighters to avoid granting the bonus to enemy ants.
+  const priorityColonyId = world.spiderPriorityColonyId;
   let fighterCount = 0;
-  for (const idx of onTile) {
-    if (ants.task[idx] === AntTask.Fighting) fighterCount += 1;
+  if (priorityColonyId !== null) {
+    for (const idx of onTile) {
+      if (ants.task[idx] === AntTask.Fighting && ants.colonyId[idx] === priorityColonyId) {
+        fighterCount += 1;
+      }
+    }
   }
-  const swarmActive = world.spiderPriorityColonyId !== null && fighterCount >= SPIDER_SWARM_FIGHTER_THRESHOLD;
+  const swarmActive = priorityColonyId !== null && fighterCount >= SPIDER_SWARM_FIGHTER_THRESHOLD;
 
   // New-pairing detection: -2 sentinel means "fighting spider".
   // A new pairing occurs when the ant is not already paired with the spider.
@@ -549,10 +555,13 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
   if (!antStrikes && !spiderStrikes) return;
 
   // Ant damage (fighters only, with optional swarm multiplier).
+  // Swarm bonus only applies when the striking ant belongs to the priority colony.
   let antDamage = 0;
   if (antStrikes && ants.task[activeAntIdx] === AntTask.Fighting) {
     antDamage = COMBAT_DAMAGE_BASE; // spider is never "home ground" for ants
-    if (swarmActive) antDamage *= SPIDER_SWARM_MULTIPLIER;
+    if (swarmActive && ants.colonyId[activeAntIdx] === priorityColonyId) {
+      antDamage *= SPIDER_SWARM_MULTIPLIER;
+    }
   }
 
   // Spider damage.

--- a/src/sim/commands.test.ts
+++ b/src/sim/commands.test.ts
@@ -226,6 +226,8 @@ describe('SimCommand', () => {
             return `syncai:${cmd.colonyId}:${cmd.state}`;
           case 'StartAIOperation':
             return `startop:${cmd.colonyId}:${cmd.kind}`;
+          case 'MarkSpiderPriority':
+            return `spiderpriority:${cmd.isPriority}`;
           default: {
             // Exhaustive check — TypeScript will error here if a variant is unhandled
             const _exhaustive: never = cmd;

--- a/src/sim/commands.test.ts
+++ b/src/sim/commands.test.ts
@@ -227,7 +227,7 @@ describe('SimCommand', () => {
           case 'StartAIOperation':
             return `startop:${cmd.colonyId}:${cmd.kind}`;
           case 'MarkSpiderPriority':
-            return `spiderpriority:${cmd.isPriority}`;
+            return `spiderpriority:${cmd.colonyId}:${cmd.isPriority}`;
           default: {
             // Exhaustive check — TypeScript will error here if a variant is unhandled
             const _exhaustive: never = cmd;
@@ -253,6 +253,7 @@ describe('SimCommand', () => {
         operationTargetTileY: -1, operationFighterIds: [], operationFighterCount: 0,
         operationStartFighterCount: 0, operationAttackerDeaths: 0, operationDefenderDeaths: 0,
       })).toBe('syncai:2:WarFooting');
+      expect(handleCommand({ type: 'MarkSpiderPriority', colonyId: 1, isPriority: true, issuedAtTick: 10 })).toBe('spiderpriority:1:true');
     });
   });
 

--- a/src/sim/commands.ts
+++ b/src/sim/commands.ts
@@ -106,6 +106,12 @@ export interface SyncAIStateCommand extends SimCommandBase {
   readonly operationDefenderDeaths: number;
 }
 
+/** S3 — player marks the spider as a priority target; fighters route toward it. */
+export interface MarkSpiderPriorityCommand extends SimCommandBase {
+  readonly type: 'MarkSpiderPriority';
+  readonly isPriority: boolean;
+}
+
 /**
  * S2 / V19 — AI controller signals a probe or invasion entry by pushing this command
  * instead of mutating world.aiState directly. tick() applies it via setAIRallyOperation,
@@ -131,6 +137,7 @@ export type SimCommand =
   | SetRallyPointCommand
   | ClearRallyPointCommand
   | SyncAIStateCommand
-  | StartAIOperationCommand;
+  | StartAIOperationCommand
+  | MarkSpiderPriorityCommand;
 
 export const MAX_COMMANDS_PER_TICK = 64; // PRD §5 line 680 — FIFO silent-drop beyond cap

--- a/src/sim/commands.ts
+++ b/src/sim/commands.ts
@@ -106,9 +106,10 @@ export interface SyncAIStateCommand extends SimCommandBase {
   readonly operationDefenderDeaths: number;
 }
 
-/** S3 — player marks the spider as a priority target; fighters route toward it. */
+/** S3 — a colony marks the spider as a priority target; fighters route toward it. */
 export interface MarkSpiderPriorityCommand extends SimCommandBase {
   readonly type: 'MarkSpiderPriority';
+  readonly colonyId: number;
   readonly isPriority: boolean;
 }
 

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -723,7 +723,7 @@ export const SPIDER_SCATTER_RADIUS_TILES = 1 as const;
 export const SPIDER_TERRITORY_RADIUS_TILES = 24 as const;
 
 /** S3 — Brood kills in a single rampage before spider exits to Feeding. */
-export const SPIDER_RAMPAGE_KILL_QUOTA = 5 as const;
+export const SPIDER_RAMPAGE_KILL_QUOTA = 2 as const;
 export const SPIDER_RAMPAGE_MAX_TICKS = 1200 as const;  // timeout if no kills after ~20s
 
 /** S3 — HP threshold below which spider retreats. */

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -715,11 +715,6 @@ export const SPIDER_SWARM_MULTIPLIER = 4 as const;
 /** S3 — Manhattan tile radius within which spider hunts for worker density. */
 export const SPIDER_HUNT_SEARCH_RADIUS_TILES = 12 as const;
 
-/**
- * S3 — Minimum ticks workers must dwell on a tile before spider locks onto it
- * as a hunt target. Prevents locking onto transient worker crossings.
- */
-export const SPIDER_HUNT_DWELL_TICKS = 40 as const;
 
 /** S3 — Minimum workers on a tile to qualify as a hunt target. */
 export const SPIDER_HUNT_MIN_TARGET_WORKERS = 2 as const;
@@ -732,6 +727,7 @@ export const SPIDER_TERRITORY_RADIUS_TILES = 24 as const;
 
 /** S3 — Brood kills in a single rampage before spider exits to Feeding. */
 export const SPIDER_RAMPAGE_KILL_QUOTA = 5 as const;
+export const SPIDER_RAMPAGE_MAX_TICKS = 1200 as const;  // timeout if no kills after ~20s
 
 /** S3 — HP threshold below which spider retreats. */
 export const SPIDER_RAMPAGE_RETREAT_HP = 20 as const;

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -709,9 +709,6 @@ export const SPIDER_HUNGER_MAX_TICKS = [2700, 1800, 1350] as const;
 /** S3 — Minimum fighters on spider's tile + priority required to activate swarm bonus. */
 export const SPIDER_SWARM_FIGHTER_THRESHOLD = 6 as const;
 
-/** S3 — Damage multiplier per strike when swarm bonus is active. */
-export const SPIDER_SWARM_MULTIPLIER = 4 as const;
-
 /** S3 — Manhattan tile radius within which spider hunts for worker density. */
 export const SPIDER_HUNT_SEARCH_RADIUS_TILES = 12 as const;
 

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -660,3 +660,99 @@ export const AI_MAX_OPERATION_FIGHTERS = 32 as const;
  * player entrance.
  */
 export const AI_PROBE_FALLBACK_RADIUS_TILES = 40 as const;
+
+
+// ---------------------------------------------------------------------------
+// S3 — Neutral entity sentinel
+// ---------------------------------------------------------------------------
+
+/** S3 — ColonyId sentinel for neutral entities (spider). Not a real colony. */
+export const NEUTRAL_COLONY_ID = 0 as const;
+
+// ---------------------------------------------------------------------------
+// S3 — Spider tuning constants (D-32 / M3 / D-33 / D-05)
+// ---------------------------------------------------------------------------
+
+/** S3 — Spider full / max HP. */
+export const SPIDER_HP_FULL = 80 as const;
+
+/** S3 — Damage per spider strike against an ant. */
+export const SPIDER_DAMAGE = 8 as const;
+
+/**
+ * S3 — Ticks for the hunt telegraph (reticle visible) before Striking begins.
+ * 120 ticks = 6 sim-seconds at 20 Hz (flat, not tier-scaled — per Q-10).
+ */
+export const SPIDER_TELEGRAPH_TICKS = 120 as const;
+
+/** S3 — Duration of the Striking state. 80 ticks = 4 sim-seconds. */
+export const SPIDER_STRIKE_TICKS = 80 as const;
+
+/** S3 — Duration of the Feeding state. 600 ticks = 30 sim-seconds. */
+export const SPIDER_FEEDING_TICKS = 600 as const;
+
+/**
+ * S3 — Ticks between hunt cycles (Patrolling → Hunting gate).
+ * 1200 ticks = 60 sim-seconds. NOT tier-scaled (RC-P0-006 — axis B scales
+ * only SPIDER_HUNGER_MAX_TICKS; hunt cadence stays constant across difficulties).
+ */
+export const SPIDER_HUNT_INTERVAL_TICKS = 1200 as const;
+
+/**
+ * S3 — Maximum hunger ticks before Patrolling → Rampaging transition.
+ * Tier triplet [Easy, Normal, Hard]: 2700 / 1800 / 1350 ticks.
+ * Only SPIDER_HUNGER_MAX_TICKS is tier-scaled (per D-33 / M6 Axis B World Pressure).
+ * Constant-ordering invariant: each element must exceed SPIDER_HUNT_INTERVAL_TICKS (1200).
+ */
+export const SPIDER_HUNGER_MAX_TICKS = [2700, 1800, 1350] as const;
+
+/** S3 — Minimum fighters on spider's tile + priority required to activate swarm bonus. */
+export const SPIDER_SWARM_FIGHTER_THRESHOLD = 6 as const;
+
+/** S3 — Damage multiplier per strike when swarm bonus is active. */
+export const SPIDER_SWARM_MULTIPLIER = 4 as const;
+
+/** S3 — Manhattan tile radius within which spider hunts for worker density. */
+export const SPIDER_HUNT_SEARCH_RADIUS_TILES = 12 as const;
+
+/**
+ * S3 — Minimum ticks workers must dwell on a tile before spider locks onto it
+ * as a hunt target. Prevents locking onto transient worker crossings.
+ */
+export const SPIDER_HUNT_DWELL_TICKS = 40 as const;
+
+/** S3 — Minimum workers on a tile to qualify as a hunt target. */
+export const SPIDER_HUNT_MIN_TARGET_WORKERS = 2 as const;
+
+/** S3 — Manhattan scatter radius around hunt target tile. Workers within this scatter. */
+export const SPIDER_SCATTER_RADIUS_TILES = 1 as const;
+
+/** S3 — Patrolling territory radius (tiles) around lair. */
+export const SPIDER_TERRITORY_RADIUS_TILES = 24 as const;
+
+/** S3 — Brood kills in a single rampage before spider exits to Feeding. */
+export const SPIDER_RAMPAGE_KILL_QUOTA = 5 as const;
+
+/** S3 — HP threshold below which spider retreats. */
+export const SPIDER_RAMPAGE_RETREAT_HP = 20 as const;
+
+/** S3 — HP regenerated per 20 ticks during Retreating or Feeding. */
+export const SPIDER_HP_REGEN_PER_20_TICKS = 1 as const;
+
+/** S3 — Minimum ticks in Retreating before spider can return to Patrolling. */
+export const SPIDER_RETREAT_MIN_TICKS = 200 as const;
+
+/**
+ * S3 — Spider movement speed (fixed-point per tick, same FP_SHIFT=8 as ants).
+ * 256 = 1.0 tiles/tick at 20 Hz.
+ */
+export const SPIDER_SPEED = 256 as const;
+
+/**
+ * S3 — Danger pheromone deposit per tick at spider's center tile.
+ * Calibrated for DANGER_DECAY_FP = 10: equilibrium = 1280 × 256/10 ≈ 32768
+ * (half of PHEROMONE_CAP=65280). Neighbor tiles get intDiv(1280,2)=640.
+ * Option B per spec: keeps existing DANGER_DECAY_FP=10, re-derives deposit.
+ */
+export const SPIDER_DANGER_DEPOSIT = 1280 as const;
+

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { tick } from './tick.js';
-import { createWorldState, allocateEntityId, SIM_VERSION_V13_INVARIANT_FIXES } from './types.js';
+import { createWorldState, allocateEntityId, SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V18_SPIDER } from './types.js';
 import { initAnt } from './ant/ant-store.js';
 import { createColonyRecord } from './colony/colony-store.js';
 import { createPheromoneGrid, phGet, pheromoneGridKey } from './pheromone/pheromone-store.js';
@@ -21,6 +21,8 @@ import {
   ENEMY_COLONY_ID,
   ENEMY_START_X,
   ENEMY_START_Y,
+  SPIDER_TELEGRAPH_TICKS,
+  SPIDER_HUNGER_MAX_TICKS,
 } from './constants.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
 import { Zone, UndergroundTileState, ugSet } from './terrain.js';
@@ -80,6 +82,17 @@ function serializeWorldState(w: WorldState): string {
       // tick output, so determinism compare must include them.
       pathErr:            Array.from(w.ants.pathErr),
       searchPauseTicks:   Array.from(w.ants.searchPauseTicks),
+      // Phase 9 / S3 combat fields — spider writes these every tick; omitting
+      // them would silently pass even if resolveSpiderCombatOnTile diverges.
+      hp:                 Array.from(w.ants.hp),
+      homeGroundBonusHp:  Array.from(w.ants.homeGroundBonusHp),
+      attackCooldown:     Array.from(w.ants.attackCooldown),
+      combatOpponentId:   Array.from(w.ants.combatOpponentId),
+      carryingBroodId:    Array.from(w.ants.carryingBroodId),
+      carriedBy:          Array.from(w.ants.carriedBy),
+      recentTilesX:       Array.from(w.ants.recentTilesX),
+      recentTilesY:       Array.from(w.ants.recentTilesY),
+      recentTilesHead:    Array.from(w.ants.recentTilesHead),
     },
     colonies: Object.keys(w.colonies).sort().reduce((acc, k) => {
       const c = w.colonies[Number(k) as ColonyId]!;
@@ -124,6 +137,10 @@ function serializeWorldState(w: WorldState): string {
       acc[k] = { ...w.pendingChambers[k]! };
       return acc;
     }, {} as Record<string, unknown>),
+    // S3 V18 — spider entity and priority/scatter shadow fields
+    spider: w.spider === null ? null : { ...w.spider },
+    spiderPriorityColonyId: w.spiderPriorityColonyId,
+    scatterReticleTile: w.scatterReticleTile === null ? null : { ...w.scatterReticleTile },
   });
 }
 
@@ -829,3 +846,83 @@ describe('SCEN-06: V13 replay determinism under V14 code', () => {
     expect(serializeWorldState(worldA)).toBe(serializeWorldState(worldB));
   });
 });
+// ---------------------------------------------------------------------------
+// S3 V18 — spider replay determinism (Hunting / Striking / Rampaging)
+//
+// The serializer now includes world.spider, spiderPriorityColonyId, and
+// scatterReticleTile, so any RNG use or non-deterministic branch in tickSpider
+// or resolveSpiderCombatOnTile surfaces as a divergence between the two
+// independent runs. The divergence guard ensures the spider actually reached
+// at least one non-Patrolling state during the 400-tick budget.
+// ---------------------------------------------------------------------------
+
+describe('S3 V18: spider replay determinism (Hunting → Striking → Rampaging)', () => {
+  // Stage the spider already in Hunting state with an expired timer so tick 1
+  // immediately transitions to Striking, and pre-saturate hunger so that after
+  // Striking exits to Patrolling the spider immediately rampages. This drives
+  // Hunting → Striking → Patrolling → Rampaging within the first ~90 ticks
+  // without requiring workers on a specific tile, covering all three states
+  // called out in the Codex P1 finding.
+  it('two V18 worlds from seed 7777 run byte-identical over 400 ticks through Hunting/Striking/Rampaging', () => {
+    const SEED = 7777;
+    const TICKS = 400;
+
+    function buildSpiderWorld(): WorldState {
+      const world = createScenario(SEED);
+      // Fast-fail: world must be V18 so world.spider is non-null. If createScenario
+      // regresses to a sub-V18 LATEST, this assert fires before the spider!-dereference
+      // below would throw a TypeError — clearer than an opaque null-deref.
+      expect(world.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V18_SPIDER);
+      const spider = world.spider!;
+      // Lock the lair coordinates for seed 7777. If _placeSpider changes behaviour
+      // (scan order, grid dimensions, etc.), this fails loudly rather than silently
+      // breaking the distance safety bound used in the comment below.
+      expect(spider.lairTileX).toBe(115);
+      expect(spider.lairTileY).toBe(27);
+      // Pin position to lair tile so moveTowardTile during Striking cannot drift the
+      // spider relative to the workers' starting distance.
+      spider.posX = spider.lairTileX << FP_SHIFT;
+      spider.posY = spider.lairTileY << FP_SHIFT;
+      // Pre-stage Hunting with an expired hunt timer so Striking fires on first tick.
+      spider.state = 'Hunting';
+      spider.huntTargetTileX = spider.lairTileX;
+      spider.huntTargetTileY = spider.lairTileY;
+      // huntStartTick = 0 so Hunting persists for SPIDER_TELEGRAPH_TICKS ticks before
+      // transitioning to Striking, allowing statesVisited to observe 'Hunting'.
+      // (On first call world.tick=0; 0-0=0<120 → stays Hunting; at call 121 world.tick=120 → Striking.)
+      spider.huntStartTick = 0;
+      // NORMAL_TIER_INDEX=1 → threshold 1800. After Striking exits to Patrolling
+      // hunger will be ≥1800, triggering an immediate Rampaging transition.
+      // Safety: createScenario places STARTING_WORKERS=3 at PLAYER_START_X/Y (24,64) and
+      // ENEMY_START_X/Y (104,64). The lair is at (115,27); nearest colony workers start
+      // at Manhattan distance ≥48 tiles. The combined Hunting+Striking window is 200 ticks
+      // (120+80); at WORKER_BASE_SPEED=0.5 tile/tick the theoretical straight-line coverage
+      // is 100 tiles — exceeding the 48-tile gap. However, Foraging ants follow pheromones
+      // and search randomly, not toward the spider lair; in practice they cannot reach
+      // (115,27) from (104,64) in 200 ticks of pheromone-guided wandering. The lair coord
+      // assertion on lines above will catch a future _placeSpider regression that places
+      // the lair near a colony start before the margin narrows.
+      spider.hungerTicks = SPIDER_HUNGER_MAX_TICKS[1];
+      return world;
+    }
+
+    const worldA = buildSpiderWorld();
+    const worldB = buildSpiderWorld();
+    const statesVisited = new Set<string>();
+    for (let t = 0; t < TICKS; t++) {
+      tick(worldA, []);
+      if (worldA.spider !== null) statesVisited.add(worldA.spider.state);
+    }
+    for (let t = 0; t < TICKS; t++) tick(worldB, []);
+
+    // Guard: all three required states must have been reached. worldB divergence surfaces
+    // via the parity assert below (any divergence in spider fields produces different JSON).
+    expect(statesVisited.has('Hunting')).toBe(true);
+    expect(statesVisited.has('Striking')).toBe(true);
+    expect(statesVisited.has('Rampaging')).toBe(true);
+
+    // Byte-identical parity including V18 fields.
+    expect(serializeWorldState(worldA)).toBe(serializeWorldState(worldB));
+  }, 30_000);
+});
+

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -877,8 +877,8 @@ describe('S3 V20: spider replay determinism (Hunting → Striking → Rampaging)
       // Lock the lair coordinates for seed 7777. If _placeSpider changes behaviour
       // (scan order, grid dimensions, etc.), this fails loudly rather than silently
       // breaking the distance safety bound used in the comment below.
-      expect(spider.lairTileX).toBe(115);
-      expect(spider.lairTileY).toBe(27);
+      expect(spider.lairTileX).toBe(57);
+      expect(spider.lairTileY).toBe(49);
       // Pin position to lair tile so moveTowardTile during Striking cannot drift the
       // spider relative to the workers' starting distance.
       spider.posX = spider.lairTileX << FP_SHIFT;
@@ -894,12 +894,12 @@ describe('S3 V20: spider replay determinism (Hunting → Striking → Rampaging)
       // NORMAL_TIER_INDEX=1 → threshold 1800. After Striking exits to Patrolling
       // hunger will be ≥1800, triggering an immediate Rampaging transition.
       // Safety: createScenario places STARTING_WORKERS=3 at PLAYER_START_X/Y (24,64) and
-      // ENEMY_START_X/Y (104,64). The lair is at (115,27); nearest colony workers start
+      // ENEMY_START_X/Y (104,64). The lair is at (57,49); nearest colony workers start
       // at Manhattan distance ≥48 tiles. The combined Hunting+Striking window is 200 ticks
       // (120+80); at WORKER_BASE_SPEED=0.5 tile/tick the theoretical straight-line coverage
       // is 100 tiles — exceeding the 48-tile gap. However, Foraging ants follow pheromones
       // and search randomly, not toward the spider lair; in practice they cannot reach
-      // (115,27) from (104,64) in 200 ticks of pheromone-guided wandering. The lair coord
+      // (57,49) from (24,64) in 200 ticks of pheromone-guided wandering. The lair coord
       // assertion on lines above will catch a future _placeSpider regression that places
       // the lair near a colony start before the margin narrows.
       spider.hungerTicks = SPIDER_HUNGER_MAX_TICKS[1];

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { tick } from './tick.js';
-import { createWorldState, allocateEntityId, SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V18_SPIDER } from './types.js';
+import { createWorldState, allocateEntityId, SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V20_SPIDER } from './types.js';
 import { initAnt } from './ant/ant-store.js';
 import { createColonyRecord } from './colony/colony-store.js';
 import { createPheromoneGrid, phGet, pheromoneGridKey } from './pheromone/pheromone-store.js';
@@ -137,7 +137,7 @@ function serializeWorldState(w: WorldState): string {
       acc[k] = { ...w.pendingChambers[k]! };
       return acc;
     }, {} as Record<string, unknown>),
-    // S3 V18 — spider entity and priority/scatter shadow fields
+    // S3 V20 — spider entity and priority/scatter shadow fields
     spider: w.spider === null ? null : { ...w.spider },
     spiderPriorityColonyId: w.spiderPriorityColonyId,
     scatterReticleTile: w.scatterReticleTile === null ? null : { ...w.scatterReticleTile },
@@ -847,7 +847,7 @@ describe('SCEN-06: V13 replay determinism under V14 code', () => {
   });
 });
 // ---------------------------------------------------------------------------
-// S3 V18 — spider replay determinism (Hunting / Striking / Rampaging)
+// S3 V20 — spider replay determinism (Hunting / Striking / Rampaging)
 //
 // The serializer now includes world.spider, spiderPriorityColonyId, and
 // scatterReticleTile, so any RNG use or non-deterministic branch in tickSpider
@@ -856,23 +856,23 @@ describe('SCEN-06: V13 replay determinism under V14 code', () => {
 // at least one non-Patrolling state during the 400-tick budget.
 // ---------------------------------------------------------------------------
 
-describe('S3 V18: spider replay determinism (Hunting → Striking → Rampaging)', () => {
+describe('S3 V20: spider replay determinism (Hunting → Striking → Rampaging)', () => {
   // Stage the spider already in Hunting state with an expired timer so tick 1
   // immediately transitions to Striking, and pre-saturate hunger so that after
   // Striking exits to Patrolling the spider immediately rampages. This drives
   // Hunting → Striking → Patrolling → Rampaging within the first ~90 ticks
   // without requiring workers on a specific tile, covering all three states
   // called out in the Codex P1 finding.
-  it('two V18 worlds from seed 7777 run byte-identical over 400 ticks through Hunting/Striking/Rampaging', () => {
+  it('two V20 worlds from seed 7777 run byte-identical over 400 ticks through Hunting/Striking/Rampaging', () => {
     const SEED = 7777;
     const TICKS = 400;
 
     function buildSpiderWorld(): WorldState {
       const world = createScenario(SEED);
-      // Fast-fail: world must be V18 so world.spider is non-null. If createScenario
-      // regresses to a sub-V18 LATEST, this assert fires before the spider!-dereference
+      // Fast-fail: world must be V20 so world.spider is non-null. 
+      // regresses to a sub-V20 LATEST, this assert fires before the spider!-dereference
       // below would throw a TypeError — clearer than an opaque null-deref.
-      expect(world.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V18_SPIDER);
+      expect(world.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V20_SPIDER);
       const spider = world.spider!;
       // Lock the lair coordinates for seed 7777. If _placeSpider changes behaviour
       // (scan order, grid dimensions, etc.), this fails loudly rather than silently
@@ -921,7 +921,7 @@ describe('S3 V18: spider replay determinism (Hunting → Striking → Rampaging)
     expect(statesVisited.has('Striking')).toBe(true);
     expect(statesVisited.has('Rampaging')).toBe(true);
 
-    // Byte-identical parity including V18 fields.
+    // Byte-identical parity including V20 fields.
     expect(serializeWorldState(worldA)).toBe(serializeWorldState(worldB));
   }, 30_000);
 });

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -237,10 +237,14 @@ function _isQueenAliveAndEmitLegacy(world: WorldState, colony: ColonyRecord): bo
         : null;
 
       let cause: 'InvasionKill' | 'SpiderRampage' | 'Starvation' | 'MutualDestruction' | null = null;
-      if (ctx !== null) {
-        if (ctx.killerColonyId !== null && ctx.killerColonyId !== ctx.currentGridColonyId) {
-          cause = 'InvasionKill';
-        }
+      if (ctx === null) {
+        cause = 'Starvation'; // no kill context = queen starved
+      } else if (ctx.killerKind === 'Spider') {
+        cause = 'SpiderRampage';
+      } else if (ctx.killerKind === 'Ant' && ctx.killerColonyId !== null) {
+        cause = 'InvasionKill';
+      } else if (ctx.killerKind === 'Environment') {
+        cause = 'Starvation';
       }
 
       const locX = ctx ? ctx.tile.x : (world.ants.posX[qid] ?? 0) >> FP_SHIFT;

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -294,6 +294,7 @@ function _placeSpider(world: WorldState): SpiderState {
     huntTargetTileY: -1,
     killsThisStrike: 0,
     rampageKillsThisRampage: 0,
+    rampageTargetColonyId: -1,
   };
 }
 

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -267,7 +267,7 @@ function _placeSpider(world: WorldState): SpiderState {
                (ty > PLAYER_START_Y ? ty - PLAYER_START_Y : PLAYER_START_Y - ty);
     const d2 = (tx > ENEMY_START_X  ? tx - ENEMY_START_X  : ENEMY_START_X  - tx) +
                (ty > ENEMY_START_Y  ? ty - ENEMY_START_Y  : ENEMY_START_Y  - ty);
-    if (d1 >= minDist && d2 >= minDist) {
+    if (d1 >= minDist && d2 >= minDist && Math.abs(d1 - d2) <= 20) {
       lairTileX = tx;
       lairTileY = ty;
       break;

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -289,6 +289,7 @@ function _placeSpider(world: WorldState): SpiderState {
     strikeStartTick: 0,
     feedingStartTick: 0,
     retreatStartTick: 0,
+    rampageStartTick: 0,
     huntTargetTileX: -1,
     huntTargetTileY: -1,
     killsThisStrike: 0,

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -365,7 +365,7 @@ export function createScenario(seed: number): WorldState {
 
   // --- S3: Initialize spider at a deterministic lair tile ---
   world.spider = _placeSpider(world);
-  world.spiderPriority = false;
+  world.spiderPriorityColonyId = null;
   world.scatterReticleTile = null;
 
   // --- Step 9: Write back rngState ---

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -9,7 +9,7 @@
 // No Math.random() — all randomness flows through the seeded Mulberry32 PRNG.
 // No floats — all positions use fixed-point (FP_SHIFT=8).
 
-import type { WorldState } from './types.js';
+import type { WorldState, SpiderState } from './types.js';
 import { createWorldState, allocateEntityId } from './types.js';
 import { createDefaultAIStateRecord } from './ai-state.js';
 import { createSurfaceGrid, createUndergroundGrid, SurfaceTileState, UndergroundTileState, ugSet } from './terrain.js';
@@ -42,6 +42,9 @@ import {
   WORKER_LIFESPAN_TICKS,
   ENTRANCE_SHAFT_DEPTH,
   COMBAT_HP_QUEEN,
+  SPIDER_HP_FULL,
+  SPIDER_TERRITORY_RADIUS_TILES,
+  SPIDER_HUNT_INTERVAL_TICKS,
 } from './constants.js';
 
 // ---------------------------------------------------------------------------
@@ -234,6 +237,66 @@ function initColony(
 }
 
 // ---------------------------------------------------------------------------
+// S3 — Spider lair placement (deterministic, no world.rngState draws)
+// ---------------------------------------------------------------------------
+
+/**
+ * S3 — Place spider at a deterministic lair tile derived from terrainSeed.
+ * Lair placement: surface tile not within SPIDER_TERRITORY_RADIUS_TILES of
+ * either colony start, using rejection sampling from a terrainSeed-derived hash.
+ * No rng draws from world.rngState — uses a separate hash from terrainSeed
+ * to preserve SCEN-06 replay determinism.
+ */
+function _placeSpider(world: WorldState): SpiderState {
+  const minDist = SPIDER_TERRITORY_RADIUS_TILES;
+  let h = Math.imul(world.terrainSeed, 2654435761) >>> 0;
+
+  let lairTileX = SURFACE_GRID_WIDTH >> 1;
+  let lairTileY = SURFACE_GRID_HEIGHT >> 1;
+
+  for (let attempt = 0; attempt < 1000; attempt++) {
+    h = Math.imul(h ^ (h >>> 16), 0x85ebca6b) >>> 0;
+    h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35) >>> 0;
+    h ^= h >>> 16;
+    const tx = (h >>> 0) % SURFACE_GRID_WIDTH;
+    const h2 = Math.imul(h, 0x9e3779b9) >>> 0;
+    const ty = (h2 >>> 0) % SURFACE_GRID_HEIGHT;
+
+    // Check Manhattan distance from both colony starts
+    const d1 = (tx > PLAYER_START_X ? tx - PLAYER_START_X : PLAYER_START_X - tx) +
+               (ty > PLAYER_START_Y ? ty - PLAYER_START_Y : PLAYER_START_Y - ty);
+    const d2 = (tx > ENEMY_START_X  ? tx - ENEMY_START_X  : ENEMY_START_X  - tx) +
+               (ty > ENEMY_START_Y  ? ty - ENEMY_START_Y  : ENEMY_START_Y  - ty);
+    if (d1 >= minDist && d2 >= minDist) {
+      lairTileX = tx;
+      lairTileY = ty;
+      break;
+    }
+  }
+
+  return {
+    state: 'Patrolling',
+    posX: lairTileX << FP_SHIFT,
+    posY: lairTileY << FP_SHIFT,
+    lairTileX,
+    lairTileY,
+    territoryRadiusTiles: SPIDER_TERRITORY_RADIUS_TILES,
+    hp: SPIDER_HP_FULL,
+    attackCooldown: 0,
+    hungerTicks: 0,
+    nextHuntTick: SPIDER_HUNT_INTERVAL_TICKS, // first hunt at tick 1200
+    huntStartTick: 0,
+    strikeStartTick: 0,
+    feedingStartTick: 0,
+    retreatStartTick: 0,
+    huntTargetTileX: -1,
+    huntTargetTileY: -1,
+    killsThisStrike: 0,
+    rampageKillsThisRampage: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // createScenario — one-shot world generation entry point (PRD §6a)
 // ---------------------------------------------------------------------------
 
@@ -299,6 +362,11 @@ export function createScenario(seed: number): WorldState {
   // --- S2: Initialize aiState for the enemy colony ---
   // One AIStateRecord per non-player colony with defensive defaults.
   world.aiState = [createDefaultAIStateRecord(ENEMY_COLONY_ID)];
+
+  // --- S3: Initialize spider at a deterministic lair tile ---
+  world.spider = _placeSpider(world);
+  world.spiderPriority = false;
+  world.scatterReticleTile = null;
 
   // --- Step 9: Write back rngState ---
   world.rngState = rng.getState();

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -308,12 +308,12 @@ describe('tickSpider', () => {
     it('clears world.spider when hp <= 0', () => {
       const world = makeWorld();
       world.spider = makeSpider({ hp: 0 });
-      world.spiderPriority = true;
+      world.spiderPriorityColonyId = PLAYER_COLONY_ID;
       world.scatterReticleTile = { x: 5, y: 5 };
 
       tickSpider(world);
       expect(world.spider).toBeNull();
-      expect(world.spiderPriority).toBe(false);
+      expect(world.spiderPriorityColonyId).toBeNull();
       expect(world.scatterReticleTile).toBeNull();
     });
 

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -7,6 +7,7 @@ import { tickSpider } from './spider.js';
 import { initAnt } from './ant/ant-store.js';
 import { AntTask, PheromoneType } from './enums.js';
 import { createPheromoneGrid, pheromoneGridKey } from './pheromone/pheromone-store.js';
+import { createColonyRecord } from './colony/colony-store.js';
 import {
   SPIDER_HP_FULL,
   SPIDER_TELEGRAPH_TICKS,
@@ -46,6 +47,7 @@ function makeSpider(overrides: Partial<SpiderState> = {}): SpiderState {
     huntTargetTileY: -1,
     killsThisStrike: 0,
     rampageKillsThisRampage: 0,
+    rampageTargetColonyId: -1,
     ...overrides,
   };
 }
@@ -298,6 +300,74 @@ describe('tickSpider', () => {
       // After increment: hungerTicks = SPIDER_HUNGER_MAX_TICKS[1]; triggers rampaging.
       expect(world.spider!.state).toBe('Rampaging');
       expect(world.spider!.rampageKillsThisRampage).toBe(0);
+    });
+  });
+
+
+  describe('rampageTargetColonyId — weighted colony selection', () => {
+    it('sets rampageTargetColonyId on Rampaging entry and clears it on exit', () => {
+      const world = makeWorld();
+      world.colonies[PLAYER_COLONY_ID as unknown as any] = createColonyRecord(PLAYER_COLONY_ID, 0);
+      world.colonies[PLAYER_COLONY_ID as unknown as any]!.entrances = [];
+      world.colonies[ENEMY_COLONY_ID as unknown as any] = createColonyRecord(ENEMY_COLONY_ID, 1);
+      world.colonies[ENEMY_COLONY_ID as unknown as any]!.entrances = [];
+      world.spider = makeSpider({
+        state: 'Patrolling',
+        hungerTicks: SPIDER_HUNGER_MAX_TICKS[1] - 1,
+      });
+      world.tick = 0;
+
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Rampaging');
+      expect(world.spider!.rampageTargetColonyId === PLAYER_COLONY_ID ||
+             world.spider!.rampageTargetColonyId === ENEMY_COLONY_ID).toBe(true);
+
+      // Transition to Feeding via kill quota — target should be cleared.
+      world.spider!.rampageKillsThisRampage = SPIDER_RAMPAGE_KILL_QUOTA;
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Feeding');
+      expect(world.spider!.rampageTargetColonyId).toBe(-1);
+    });
+
+    it('always targets a valid colony (not -1) when both colonies exist', () => {
+      // Run 20 rampages across varying seeds and ticks; none should produce -1.
+      for (let seed = 1; seed <= 20; seed++) {
+        const world = makeWorld(seed * 1000);
+        world.colonies[PLAYER_COLONY_ID as unknown as any] = createColonyRecord(PLAYER_COLONY_ID, 0);
+      world.colonies[PLAYER_COLONY_ID as unknown as any]!.entrances = [];
+        world.colonies[ENEMY_COLONY_ID as unknown as any] = createColonyRecord(ENEMY_COLONY_ID, 1);
+      world.colonies[ENEMY_COLONY_ID as unknown as any]!.entrances = [];
+        world.spider = makeSpider({
+          state: 'Patrolling',
+          hungerTicks: SPIDER_HUNGER_MAX_TICKS[1] - 1,
+        });
+        world.tick = seed * 100;
+        tickSpider(world);
+        expect(world.spider!.rampageTargetColonyId).toBeGreaterThan(0);
+      }
+    });
+
+    it('distributes targets across both colonies over many rampages (not always same colony)', () => {
+      // Over 50 rampages with varying ticks, both colonies should be chosen at least once.
+      const chosen = new Set<number>();
+      const world = makeWorld(42);
+      world.colonies[PLAYER_COLONY_ID as unknown as any] = createColonyRecord(PLAYER_COLONY_ID, 0);
+      world.colonies[PLAYER_COLONY_ID as unknown as any]!.entrances = [];
+      world.colonies[ENEMY_COLONY_ID as unknown as any] = createColonyRecord(ENEMY_COLONY_ID, 1);
+      world.colonies[ENEMY_COLONY_ID as unknown as any]!.entrances = [];
+      for (let tick = 0; tick < 50; tick++) {
+        world.spider = makeSpider({
+          state: 'Patrolling',
+          hungerTicks: SPIDER_HUNGER_MAX_TICKS[1] - 1,
+          rampageStartTick: 0,
+        });
+        world.tick = tick * 37; // vary tick to get different hash values
+        tickSpider(world);
+        chosen.add(world.spider!.rampageTargetColonyId);
+      }
+      // Both colonies should appear at least once across 50 rampages.
+      expect(chosen.has(PLAYER_COLONY_ID)).toBe(true);
+      expect(chosen.has(ENEMY_COLONY_ID)).toBe(true);
     });
   });
 

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -41,6 +41,7 @@ function makeSpider(overrides: Partial<SpiderState> = {}): SpiderState {
     strikeStartTick: 0,
     feedingStartTick: 0,
     retreatStartTick: 0,
+    rampageStartTick: 0,
     huntTargetTileX: -1,
     huntTargetTileY: -1,
     killsThisStrike: 0,

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -392,13 +392,13 @@ describe('tickSpider', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // V17 replay determinism: spider null for pre-V18 worlds
+  // V19 replay determinism: spider null for pre-V20 worlds
   // ---------------------------------------------------------------------------
 
-  describe('V17 replay determinism', () => {
-    it('world.spider is null when simVersion < V18 (createWorldState default before S3)', () => {
+  describe('V19 replay determinism', () => {
+    it('world.spider is null when simVersion < V20 (createWorldState default before S3)', () => {
       const world = createWorldState(42);
-      world.simVersion = SIM_VERSION_V19_AI_STATE; // pre-V18
+      world.simVersion = SIM_VERSION_V19_AI_STATE; // pre-V20
       // Spider starts null in createWorldState
       expect(world.spider).toBeNull();
     });

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -1,0 +1,456 @@
+// src/sim/spider.test.ts — S3 spider state machine unit tests.
+
+import { describe, it, expect } from 'vitest';
+import type { WorldState, SpiderState } from './types.js';
+import { createWorldState, SIM_VERSION_V19_AI_STATE, SIM_VERSION_V20_SPIDER } from './types.js';
+import { tickSpider } from './spider.js';
+import { initAnt } from './ant/ant-store.js';
+import { AntTask, PheromoneType } from './enums.js';
+import { createPheromoneGrid, pheromoneGridKey } from './pheromone/pheromone-store.js';
+import {
+  SPIDER_HP_FULL,
+  SPIDER_TELEGRAPH_TICKS,
+  SPIDER_STRIKE_TICKS,
+  SPIDER_FEEDING_TICKS,
+  SPIDER_HUNT_INTERVAL_TICKS,
+  SPIDER_HUNGER_MAX_TICKS,
+  SPIDER_RAMPAGE_KILL_QUOTA,
+  SURFACE_GRID_WIDTH,
+  PLAYER_COLONY_ID,
+  ENEMY_COLONY_ID,
+} from './constants.js';
+import { FP_SHIFT } from './fixed.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSpider(overrides: Partial<SpiderState> = {}): SpiderState {
+  return {
+    state: 'Patrolling',
+    posX: 64 << FP_SHIFT,
+    posY: 32 << FP_SHIFT,
+    lairTileX: 64,
+    lairTileY: 32,
+    territoryRadiusTiles: 24,
+    hp: SPIDER_HP_FULL,
+    attackCooldown: 0,
+    hungerTicks: 0,
+    nextHuntTick: SPIDER_HUNT_INTERVAL_TICKS,
+    huntStartTick: 0,
+    strikeStartTick: 0,
+    feedingStartTick: 0,
+    retreatStartTick: 0,
+    huntTargetTileX: -1,
+    huntTargetTileY: -1,
+    killsThisStrike: 0,
+    rampageKillsThisRampage: 0,
+    ...overrides,
+  };
+}
+
+function makeWorld(seed = 0): WorldState {
+  const world = createWorldState(seed);
+  world.simVersion = SIM_VERSION_V20_SPIDER;
+  // Add pheromone grids for both colonies so seedDangerPheromone doesn't crash.
+  for (const cid of [PLAYER_COLONY_ID, ENEMY_COLONY_ID]) {
+    const surfaceKey = pheromoneGridKey(cid, PheromoneType.DangerTrail, 'surface');
+    world.pheromoneGrids[surfaceKey] = createPheromoneGrid(SURFACE_GRID_WIDTH, 128);
+  }
+  return world;
+}
+
+/** Place a surface worker at tile (tx, ty) in the world. Returns ant index. */
+function placeWorker(world: WorldState, tx: number, ty: number, colonyId = PLAYER_COLONY_ID): number {
+  const id = world.nextEntityId++;
+  initAnt(world.ants, id, {
+    colonyId,
+    posX: tx << FP_SHIFT,
+    posY: ty << FP_SHIFT,
+    task: AntTask.Foraging,
+  });
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// State transition tests
+// ---------------------------------------------------------------------------
+
+describe('tickSpider', () => {
+  describe('null spider: no-op', () => {
+    it('does nothing when world.spider is null', () => {
+      const world = makeWorld();
+      world.spider = null;
+      world.scatterReticleTile = { x: 5, y: 5 }; // should be cleared
+      tickSpider(world);
+      expect(world.spider).toBeNull();
+      expect(world.scatterReticleTile).toBeNull();
+    });
+  });
+
+  describe('Patrolling → Hunting transition', () => {
+    it('transitions to Hunting when tick >= nextHuntTick and workers are present', () => {
+      const world = makeWorld();
+      const spiderTileX = 64;
+      const spiderTileY = 32;
+      world.spider = makeSpider({ posX: spiderTileX << FP_SHIFT, posY: spiderTileY << FP_SHIFT });
+      world.spider.nextHuntTick = 0; // trigger immediately
+
+      // Place 2 workers near spider
+      placeWorker(world, spiderTileX + 2, spiderTileY);
+      placeWorker(world, spiderTileX + 2, spiderTileY);
+
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Hunting');
+      expect(world.spider!.huntStartTick).toBe(0);
+      expect(world.spider!.huntTargetTileX).toBe(spiderTileX + 2);
+      expect(world.spider!.huntTargetTileY).toBe(spiderTileY);
+    });
+
+    it('stays Patrolling when no workers in range', () => {
+      const world = makeWorld();
+      world.spider = makeSpider();
+      world.spider.nextHuntTick = 0;
+      // No workers placed
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Patrolling');
+    });
+
+    it('stays Patrolling when tick < nextHuntTick even with workers present', () => {
+      const world = makeWorld();
+      const spiderTileX = 64;
+      const spiderTileY = 32;
+      world.spider = makeSpider({ posX: spiderTileX << FP_SHIFT, posY: spiderTileY << FP_SHIFT });
+      world.spider.nextHuntTick = 9999;
+      placeWorker(world, spiderTileX + 2, spiderTileY);
+      placeWorker(world, spiderTileX + 2, spiderTileY);
+
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Patrolling');
+    });
+  });
+
+  describe('Hunting → Striking transition', () => {
+    it('transitions to Striking after SPIDER_TELEGRAPH_TICKS', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Hunting',
+        huntStartTick: 0,
+        huntTargetTileX: 65,
+        huntTargetTileY: 32,
+      });
+      world.tick = SPIDER_TELEGRAPH_TICKS;
+
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Striking');
+      expect(world.spider!.strikeStartTick).toBe(SPIDER_TELEGRAPH_TICKS);
+      expect(world.spider!.killsThisStrike).toBe(0);
+    });
+
+    it('stays Hunting before SPIDER_TELEGRAPH_TICKS', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Hunting',
+        huntStartTick: 0,
+        huntTargetTileX: 65,
+        huntTargetTileY: 32,
+      });
+      world.tick = SPIDER_TELEGRAPH_TICKS - 1;
+
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Hunting');
+    });
+  });
+
+  describe('Striking → Feeding transition (kill path)', () => {
+    it('transitions to Feeding after SPIDER_STRIKE_TICKS when kills > 0', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Striking',
+        strikeStartTick: 0,
+        killsThisStrike: 3,
+        huntTargetTileX: 65,
+        huntTargetTileY: 32,
+      });
+      world.tick = SPIDER_STRIKE_TICKS;
+
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Feeding');
+      expect(world.spider!.feedingStartTick).toBe(SPIDER_STRIKE_TICKS);
+      expect(world.spider!.hungerTicks).toBe(0); // reset on Feeding entry
+    });
+  });
+
+  describe('Striking → Patrolling transition (scatter/frustrate path)', () => {
+    it('transitions to Patrolling after SPIDER_STRIKE_TICKS with zero kills', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Striking',
+        strikeStartTick: 0,
+        killsThisStrike: 0,
+        huntTargetTileX: 65,
+        huntTargetTileY: 32,
+      });
+      world.tick = SPIDER_STRIKE_TICKS;
+
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.nextHuntTick).toBe(SPIDER_STRIKE_TICKS + SPIDER_HUNT_INTERVAL_TICKS);
+      expect(world.spider!.huntTargetTileX).toBe(-1);
+    });
+
+    it('clears stale -2 combatOpponentId sentinels on Striking → Patrolling exit', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Striking',
+        strikeStartTick: 0,
+        killsThisStrike: 0,
+        huntTargetTileX: 65,
+        huntTargetTileY: 32,
+      });
+      // Simulate an ant that was paired with the spider during this Striking episode
+      const antId = placeWorker(world, 65, 32);
+      world.ants.combatOpponentId[antId] = -2;
+
+      world.tick = SPIDER_STRIKE_TICKS;
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.ants.combatOpponentId[antId]).toBe(-1);
+    });
+  });
+
+  describe('Feeding → Patrolling transition', () => {
+    it('returns to Patrolling after SPIDER_FEEDING_TICKS', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Feeding',
+        feedingStartTick: 0,
+        huntTargetTileX: -1,
+        huntTargetTileY: -1,
+      });
+      world.tick = SPIDER_FEEDING_TICKS;
+
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.nextHuntTick).toBe(SPIDER_FEEDING_TICKS + SPIDER_HUNT_INTERVAL_TICKS);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Hunger accrual and reset
+  // ---------------------------------------------------------------------------
+
+  describe('hunger accrual', () => {
+    it('accrues hungerTicks every tick while not Feeding', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({ state: 'Patrolling', hungerTicks: 10 });
+      world.tick = 0;
+      tickSpider(world);
+      expect(world.spider!.hungerTicks).toBe(11);
+    });
+
+    it('does not accrue hungerTicks while Feeding', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Feeding',
+        hungerTicks: 50,
+        feedingStartTick: 0,
+      });
+      world.tick = 1;
+      tickSpider(world);
+      expect(world.spider!.hungerTicks).toBe(50); // unchanged
+    });
+
+    it('resets hungerTicks on Feeding entry from Striking', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Striking',
+        strikeStartTick: 0,
+        killsThisStrike: 2,
+        hungerTicks: 500,
+        huntTargetTileX: 65,
+        huntTargetTileY: 32,
+      });
+      world.tick = SPIDER_STRIKE_TICKS;
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Feeding');
+      expect(world.spider!.hungerTicks).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rampage trigger
+  // ---------------------------------------------------------------------------
+
+  describe('Patrolling → Rampaging transition', () => {
+    it('triggers Rampaging when hungerTicks reaches SPIDER_HUNGER_MAX_TICKS[1]', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Patrolling',
+        // hungerTicks will be incremented before the check, so set to max - 1
+        hungerTicks: SPIDER_HUNGER_MAX_TICKS[1] - 1,
+      });
+      world.tick = 0;
+
+      tickSpider(world);
+      // After increment: hungerTicks = SPIDER_HUNGER_MAX_TICKS[1]; triggers rampaging.
+      expect(world.spider!.state).toBe('Rampaging');
+      expect(world.spider!.rampageKillsThisRampage).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Spider death
+  // ---------------------------------------------------------------------------
+
+  describe('spider death', () => {
+    it('clears world.spider when hp <= 0', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({ hp: 0 });
+      world.spiderPriority = true;
+      world.scatterReticleTile = { x: 5, y: 5 };
+
+      tickSpider(world);
+      expect(world.spider).toBeNull();
+      expect(world.spiderPriority).toBe(false);
+      expect(world.scatterReticleTile).toBeNull();
+    });
+
+    it('emits spider_hunt_end(swarm_retreat) when dying in Striking', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({ state: 'Striking', hp: 0, killsThisStrike: 2 });
+      tickSpider(world);
+      expect(world.spider).toBeNull();
+      // Event should be in world.events
+      const evt = world.events.find((e) => e.type === 'spider_hunt_end');
+      expect(evt).toBeDefined();
+      if (evt?.type === 'spider_hunt_end') {
+        expect(evt.payload.outcome).toBe('swarm_retreat');
+        expect(evt.payload.deaths).toBe(2);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // scatterReticleTile shadow field
+  // ---------------------------------------------------------------------------
+
+  describe('scatterReticleTile', () => {
+    it('is set during Hunting', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Hunting',
+        huntStartTick: 0,
+        huntTargetTileX: 70,
+        huntTargetTileY: 40,
+      });
+      world.scatterReticleTile = null;
+      world.tick = 1;
+
+      tickSpider(world);
+      expect(world.scatterReticleTile).not.toBeNull();
+      expect(world.scatterReticleTile!.x).toBe(70);
+      expect(world.scatterReticleTile!.y).toBe(40);
+    });
+
+    it('is set during Striking', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Striking',
+        strikeStartTick: 0,
+        huntTargetTileX: 70,
+        huntTargetTileY: 40,
+      });
+      world.scatterReticleTile = null;
+      world.tick = 1;
+
+      tickSpider(world);
+      expect(world.scatterReticleTile).not.toBeNull();
+      expect(world.scatterReticleTile!.x).toBe(70);
+    });
+
+    it('is null during Patrolling', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({ state: 'Patrolling' });
+      world.scatterReticleTile = { x: 5, y: 5 };
+
+      tickSpider(world);
+      expect(world.scatterReticleTile).toBeNull();
+    });
+
+    it('is null during Feeding', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({ state: 'Feeding', feedingStartTick: 0 });
+      world.scatterReticleTile = { x: 5, y: 5 };
+      world.tick = 1;
+
+      tickSpider(world);
+      expect(world.scatterReticleTile).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // V17 replay determinism: spider null for pre-V18 worlds
+  // ---------------------------------------------------------------------------
+
+  describe('V17 replay determinism', () => {
+    it('world.spider is null when simVersion < V18 (createWorldState default before S3)', () => {
+      const world = createWorldState(42);
+      world.simVersion = SIM_VERSION_V19_AI_STATE; // pre-V18
+      // Spider starts null in createWorldState
+      expect(world.spider).toBeNull();
+    });
+
+    it('tickSpider is a no-op when spider is null (gated by tick.ts but also safe to call directly)', () => {
+      const world = createWorldState(42);
+      world.simVersion = SIM_VERSION_V19_AI_STATE;
+      world.spider = null;
+      tickSpider(world);
+      expect(world.spider).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // HP regeneration
+  // ---------------------------------------------------------------------------
+
+  describe('HP regeneration', () => {
+    it('regenerates 1 HP per 20 ticks while Retreating', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({ state: 'Retreating', hp: 40, retreatStartTick: 0 });
+      world.tick = 20;
+
+      tickSpider(world);
+      expect(world.spider!.hp).toBe(41);
+    });
+
+    it('does not exceed SPIDER_HP_FULL', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({ state: 'Retreating', hp: SPIDER_HP_FULL - 1, retreatStartTick: 0 });
+      world.tick = 20;
+
+      tickSpider(world);
+      expect(world.spider!.hp).toBe(SPIDER_HP_FULL);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rampaging: kill quota triggers Feeding
+  // ---------------------------------------------------------------------------
+
+  describe('Rampaging → Feeding via kill quota', () => {
+    it('transitions to Feeding when rampageKillsThisRampage reaches SPIDER_RAMPAGE_KILL_QUOTA', () => {
+      const world = makeWorld();
+      world.spider = makeSpider({
+        state: 'Rampaging',
+        rampageKillsThisRampage: SPIDER_RAMPAGE_KILL_QUOTA,
+      });
+      world.tick = 100;
+
+      tickSpider(world);
+      expect(world.spider!.state).toBe('Feeding');
+      expect(world.spider!.hungerTicks).toBe(0);
+    });
+  });
+});

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -25,6 +25,7 @@ import {
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
   PHEROMONE_CAP,
+  UNDERGROUND_CEILING_ROW_Y,
 } from './constants.js';
 import { FP_SHIFT } from './fixed.js';
 
@@ -231,7 +232,11 @@ function seedUndergroundDangerPheromone(world: WorldState, spider: SpiderState, 
   if (grid === undefined) return;
 
   const tileX = spider.posX >> FP_SHIFT;
-  const tileY = spider.posY >> FP_SHIFT;
+  // Underground grid row 0 is the ceiling (entrance level). The spider is on
+  // the surface, so map the deposit to the underground entrance row rather
+  // than using the surface y coordinate (which would be out of bounds for the
+  // 64-row underground grid).
+  const tileY = UNDERGROUND_CEILING_ROW_Y;
   const center = SPIDER_DANGER_DEPOSIT;
   const neighbor = SPIDER_DANGER_DEPOSIT >> 1;
   const gridWidth = grid.width;

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -324,7 +324,7 @@ export function tickSpider(world: WorldState): void {
       emitSpiderRampageEnd(world, 'killed_in_nest', spider.rampageKillsThisRampage, false);
     }
     world.spider = null;
-    world.spiderPriority = false;
+    world.spiderPriorityColonyId = null;
     world.scatterReticleTile = null;
     return;
   }

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -37,6 +37,13 @@ import { FP_SHIFT } from './fixed.js';
 const HUNT_TILE_COUNTS = new Uint16Array(SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT);
 const HUNT_DIRTY: number[] = [];
 
+// Precomputed suffix for surface DangerTrail pheromone grid key lookup.
+// Avoids per-tick string allocation while remaining enum-safe.
+const SURFACE_DANGER_SUFFIX = `:${PheromoneType.DangerTrail}:surface`;
+
+// Module-level scratch for findNearestEntrance return value — avoids per-Rampaging-tick allocation.
+const NEAREST_ENTRANCE_SCRATCH: { x: number; y: number; colonyId: number } = { x: -1, y: -1, colonyId: -1 };
+
 // ---------------------------------------------------------------------------
 // Hunt target selection — deterministic (no rng draws)
 // ---------------------------------------------------------------------------
@@ -151,7 +158,10 @@ function findNearestEntrance(
     }
   }
   if (bestX === -1) return null;
-  return { x: bestX, y: bestY, colonyId: bestColonyId };
+  NEAREST_ENTRANCE_SCRATCH.x = bestX;
+  NEAREST_ENTRANCE_SCRATCH.y = bestY;
+  NEAREST_ENTRANCE_SCRATCH.colonyId = bestColonyId;
+  return NEAREST_ENTRANCE_SCRATCH;
 }
 
 // ---------------------------------------------------------------------------
@@ -230,7 +240,7 @@ function seedDangerPheromone(world: WorldState, spider: SpiderState): void {
   // Unrolled 5-cell cross to avoid per-tick array allocation (AGENTS.md hot-loop rule).
   for (const colonyKey in world.pheromoneGrids) {
     if (!Object.hasOwn(world.pheromoneGrids, colonyKey)) continue;
-    if (!colonyKey.endsWith(':1:surface')) continue;
+    if (!colonyKey.endsWith(SURFACE_DANGER_SUFFIX)) continue;
     const grid = world.pheromoneGrids[colonyKey]!;
     // center (spider is always within surface bounds)
     { const v = phGet(grid, tileX, tileY) + center; phSet(grid, tileX, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
@@ -381,6 +391,8 @@ export function tickSpider(world: WorldState): void {
     spider.retreatStartTick = world.tick;
     spider.huntTargetTileX = -1;
     spider.huntTargetTileY = -1;
+    spider.hungerTicks = 0; // prevent immediate re-rampaging on return to Patrolling
+    world.spiderPriorityColonyId = null;
     // Fall through to movement + pheromone below.
   }
 
@@ -442,6 +454,9 @@ export function tickSpider(world: WorldState): void {
           spider.state = 'Feeding';
           spider.feedingStartTick = world.tick;
           spider.hungerTicks = 0; // CF-P0-006: reset on Feeding entry
+          spider.huntTargetTileX = -1;
+          spider.huntTargetTileY = -1;
+          world.spiderPriorityColonyId = null;
         } else {
           emitSpiderHuntEnd(world, 'scatter', 0);
           clearSpiderPairingSentinels(world);
@@ -449,6 +464,7 @@ export function tickSpider(world: WorldState): void {
           spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
           spider.huntTargetTileX = -1;
           spider.huntTargetTileY = -1;
+          world.spiderPriorityColonyId = null;
         }
       }
       break;
@@ -472,6 +488,7 @@ export function tickSpider(world: WorldState): void {
         spider.state = 'Feeding';
         spider.feedingStartTick = world.tick;
         spider.hungerTicks = 0;
+        world.spiderPriorityColonyId = null;
       } else if (world.tick - spider.rampageStartTick >= SPIDER_RAMPAGE_MAX_TICKS) {
         // Timeout: no ants surfaced at entrance — treat as failed rampage and retreat.
         emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
@@ -480,6 +497,8 @@ export function tickSpider(world: WorldState): void {
         spider.retreatStartTick = world.tick;
         spider.huntTargetTileX = -1;
         spider.huntTargetTileY = -1;
+        spider.hungerTicks = 0; // prevent immediate re-rampaging on return to Patrolling
+        world.spiderPriorityColonyId = null;
       }
       break;
     }

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -1,0 +1,518 @@
+// src/sim/spider.ts — S3: Spider neutral predator state machine.
+// tickSpider runs at step 17.5 (after combat at step 17).
+// All decisions are deterministic from WorldState + tick; no world.rngState draws.
+
+import type { WorldState, SpiderState } from './types.js';
+import { emitEvent } from './telemetry.js';
+import { pheromoneGridKey, phGet, phSet } from './pheromone/pheromone-store.js';
+import { AntTask, PheromoneType } from './enums.js';
+import { NORMAL_TIER_INDEX } from './ai-state.js';
+import {
+  SPIDER_HP_FULL,
+  SPIDER_HUNT_INTERVAL_TICKS,
+  SPIDER_HUNGER_MAX_TICKS,
+  SPIDER_TELEGRAPH_TICKS,
+  SPIDER_STRIKE_TICKS,
+  SPIDER_FEEDING_TICKS,
+  SPIDER_HP_REGEN_PER_20_TICKS,
+  SPIDER_RAMPAGE_RETREAT_HP,
+  SPIDER_RETREAT_MIN_TICKS,
+  SPIDER_RAMPAGE_KILL_QUOTA,
+  SPIDER_HUNT_SEARCH_RADIUS_TILES,
+  SPIDER_HUNT_MIN_TARGET_WORKERS,
+  SPIDER_SPEED,
+  SPIDER_DANGER_DEPOSIT,
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
+  PHEROMONE_CAP,
+} from './constants.js';
+import { FP_SHIFT } from './fixed.js';
+
+// ---------------------------------------------------------------------------
+// Hunt target selection — deterministic (no rng draws)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the densest worker tile within SPIDER_HUNT_SEARCH_RADIUS_TILES of the
+ * spider's current position. Returns tile coords or null if no qualifying tile.
+ * Tie-break: ascending tileKey = tileY * SURFACE_GRID_WIDTH + tileX (Q-4).
+ */
+function findHuntTarget(
+  world: WorldState,
+  spider: SpiderState,
+): { x: number; y: number } | null {
+  const spiderTileX = spider.posX >> FP_SHIFT;
+  const spiderTileY = spider.posY >> FP_SHIFT;
+  const r = SPIDER_HUNT_SEARCH_RADIUS_TILES;
+
+  // Count workers per tile within radius
+  const counts = new Map<number, number>();
+  const { ants } = world;
+  const count = ants.alive.length;
+  for (let i = 0; i < count; i++) {
+    if (ants.alive[i] !== 1) continue;
+    // Only surface ants
+    if (ants.zone[i] !== 0) continue;
+    // Skip fighters — spider hunts workers (prey), not combatants
+    if (ants.task[i] === AntTask.Fighting) continue;
+    const ax = ants.posX[i]! >> FP_SHIFT;
+    const ay = ants.posY[i]! >> FP_SHIFT;
+    const dist = (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +
+                 (ay > spiderTileY ? ay - spiderTileY : spiderTileY - ay);
+    if (dist > r) continue;
+    const key = ay * SURFACE_GRID_WIDTH + ax;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  let bestKey = -1;
+  let bestCount = SPIDER_HUNT_MIN_TARGET_WORKERS - 1; // must exceed to qualify
+  let bestX = -1;
+  let bestY = -1;
+  for (const [k, c] of counts) {
+    if (c > bestCount || (c === bestCount && (bestKey === -1 || k < bestKey))) {
+      bestCount = c;
+      bestKey = k;
+      const kx = k % SURFACE_GRID_WIDTH;
+      bestX = kx;
+      bestY = (k - kx) >> 7; // SURFACE_GRID_WIDTH=128=2^7; integer divide via right-shift
+    }
+  }
+  if (bestKey === -1) return null;
+  return { x: bestX, y: bestY };
+}
+
+// ---------------------------------------------------------------------------
+// Rampage target: nearest entrance by squared-Euclidean, tileKey tiebreak
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the nearest open nest entrance (any colony) to the spider's current tile.
+ * Squared-Euclidean distance (integer, no sqrt per CF-P1-014); ties broken by
+ * ascending tileKey = tileY * SURFACE_GRID_WIDTH + tileX (QC Pass 4 AI8 / D-05).
+ */
+function findNearestEntrance(
+  world: WorldState,
+  spider: SpiderState,
+): { x: number; y: number } | null {
+  const spiderTileX = spider.posX >> FP_SHIFT;
+  const spiderTileY = spider.posY >> FP_SHIFT;
+
+  let bestDist = Number.MAX_SAFE_INTEGER;
+  let bestKey = -1;
+  let bestX = -1;
+  let bestY = -1;
+
+  for (const key in world.colonies) {
+    const colony = world.colonies[key as unknown as import('./colony/colony-store.js').ColonyId];
+    if (colony === undefined) continue;
+    for (let e = 0; e < colony.entrances.length; e++) {
+      const entrance = colony.entrances[e]!;
+      if (!entrance.isOpen) continue;
+      const dx = entrance.surfaceTileX - spiderTileX;
+      const dy = entrance.surfaceTileY - spiderTileY;
+      const dist = dx * dx + dy * dy;
+      const tk = entrance.surfaceTileY * SURFACE_GRID_WIDTH + entrance.surfaceTileX;
+      if (dist < bestDist || (dist === bestDist && tk < bestKey)) {
+        bestDist = dist;
+        bestKey = tk;
+        bestX = entrance.surfaceTileX;
+        bestY = entrance.surfaceTileY;
+      }
+    }
+  }
+  if (bestX === -1) return null;
+  return { x: bestX, y: bestY };
+}
+
+// ---------------------------------------------------------------------------
+// Movement helpers
+// ---------------------------------------------------------------------------
+
+/** Move spider one step toward (targetTileX, targetTileY). */
+function moveTowardTile(spider: SpiderState, targetX: number, targetY: number): void {
+  const curX = spider.posX >> FP_SHIFT;
+  const curY = spider.posY >> FP_SHIFT;
+  if (curX === targetX && curY === targetY) return;
+
+  const dx = targetX - curX;
+  const dy = targetY - curY;
+  // Move along the longer axis first (no diagonal per integer step; one tile per tick)
+  const ax = dx < 0 ? -dx : dx;
+  const ay = dy < 0 ? -dy : dy;
+
+  if (ax >= ay) {
+    spider.posX += dx > 0 ? SPIDER_SPEED : -SPIDER_SPEED;
+  } else {
+    spider.posY += dy > 0 ? SPIDER_SPEED : -SPIDER_SPEED;
+  }
+
+  // Clamp to grid bounds
+  const maxX = (SURFACE_GRID_WIDTH - 1) << FP_SHIFT;
+  const maxY = (SURFACE_GRID_HEIGHT - 1) << FP_SHIFT;
+  if (spider.posX < 0) spider.posX = 0;
+  if (spider.posX > maxX) spider.posX = maxX;
+  if (spider.posY < 0) spider.posY = 0;
+  if (spider.posY > maxY) spider.posY = maxY;
+}
+
+/** Move spider in a deterministic patrol arc within territory radius of lair. */
+function tickPatrolMovement(world: WorldState, spider: SpiderState): void {
+  // Simple deterministic patrol: move in a clockwise square orbit around lair.
+  // Uses world.tick to pick a target corner deterministically (no rng draws).
+  const r = spider.territoryRadiusTiles >> 1; // patrol at half radius
+  const phase = (world.tick >> 6) & 3; // change quadrant every 64 ticks
+  const lx = spider.lairTileX;
+  const ly = spider.lairTileY;
+  let tx: number;
+  let ty: number;
+  switch (phase) {
+    case 0: tx = lx + r; ty = ly - r; break;
+    case 1: tx = lx + r; ty = ly + r; break;
+    case 2: tx = lx - r; ty = ly + r; break;
+    default: tx = lx - r; ty = ly - r; break;
+  }
+  // Clamp target within grid
+  if (tx < 0) tx = 0;
+  if (tx >= SURFACE_GRID_WIDTH) tx = SURFACE_GRID_WIDTH - 1;
+  if (ty < 0) ty = 0;
+  if (ty >= SURFACE_GRID_HEIGHT) ty = SURFACE_GRID_HEIGHT - 1;
+  moveTowardTile(spider, tx, ty);
+}
+
+// ---------------------------------------------------------------------------
+// Danger pheromone deposit
+// ---------------------------------------------------------------------------
+
+/**
+ * Seed the 5-tile cross (center + N/S/E/W) on both colonies' DangerTrail grids.
+ * Center gets SPIDER_DANGER_DEPOSIT; neighbors get SPIDER_DANGER_DEPOSIT >> 1.
+ * Option B per spec: deposit calibrated for DANGER_DECAY_FP=10 (see constants.ts).
+ */
+function seedDangerPheromone(world: WorldState, spider: SpiderState): void {
+  const tileX = spider.posX >> FP_SHIFT;
+  const tileY = spider.posY >> FP_SHIFT;
+  const center = SPIDER_DANGER_DEPOSIT;
+  const neighbor = SPIDER_DANGER_DEPOSIT >> 1;
+
+  const offsets: [number, number, number][] = [
+    [tileX,     tileY,     center],
+    [tileX,     tileY - 1, neighbor],
+    [tileX,     tileY + 1, neighbor],
+    [tileX - 1, tileY,     neighbor],
+    [tileX + 1, tileY,     neighbor],
+  ];
+
+  // Deposit in both colonies' surface DangerTrail grids
+  for (const colonyKey in world.pheromoneGrids) {
+    // Filter to DangerTrail surface grids (format: "${colonyId}:1:surface")
+    if (!colonyKey.endsWith(':1:surface')) continue;
+    const grid = world.pheromoneGrids[colonyKey]!;
+    for (const [ox, oy, amt] of offsets) {
+      if (ox < 0 || ox >= SURFACE_GRID_WIDTH || oy < 0 || oy >= SURFACE_GRID_HEIGHT) continue;
+      const current = phGet(grid, ox, oy);
+      const sum = current + amt;
+      phSet(grid, ox, oy, sum > PHEROMONE_CAP ? PHEROMONE_CAP : sum);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rampaging underground danger deposit
+// ---------------------------------------------------------------------------
+
+/** During Rampaging, seed DangerTrail on the underground grid of the colony being invaded. */
+function seedUndergroundDangerPheromone(world: WorldState, spider: SpiderState, colonyId: number): void {
+  // Find the underground danger grid for this colony
+  const key = pheromoneGridKey(colonyId, PheromoneType.DangerTrail, 'underground');
+  const grid = world.pheromoneGrids[key];
+  if (grid === undefined) return;
+
+  const tileX = spider.posX >> FP_SHIFT;
+  const tileY = spider.posY >> FP_SHIFT;
+  const center = SPIDER_DANGER_DEPOSIT;
+  const neighbor = SPIDER_DANGER_DEPOSIT >> 1;
+  const gridWidth = grid.width;
+  const gridHeight = grid.height;
+
+  const offsets: [number, number, number][] = [
+    [tileX,     tileY,     center],
+    [tileX,     tileY - 1, neighbor],
+    [tileX,     tileY + 1, neighbor],
+    [tileX - 1, tileY,     neighbor],
+    [tileX + 1, tileY,     neighbor],
+  ];
+  for (const [ox, oy, amt] of offsets) {
+    if (ox < 0 || ox >= gridWidth || oy < 0 || oy >= gridHeight) continue;
+    const current = phGet(grid, ox, oy);
+    const sum = current + amt;
+    phSet(grid, ox, oy, sum > PHEROMONE_CAP ? PHEROMONE_CAP : sum);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry helpers
+// ---------------------------------------------------------------------------
+
+function emitSpiderHuntEnd(
+  world: WorldState,
+  outcome: 'kill' | 'swarm_retreat' | 'scatter',
+  deaths: number,
+): void {
+  emitEvent(world, {
+    tick: world.tick,
+    type: 'spider_hunt_end',
+    payload: { outcome, deaths },
+  });
+}
+
+function emitSpiderRampageEnd(
+  world: WorldState,
+  outcome: 'killed_in_nest' | 'killed_by_player' | 'killed_by_ai' | 'quota_met' | 'retreated',
+  broodKilled: number,
+  queenKilled: boolean,
+): void {
+  emitEvent(world, {
+    tick: world.tick,
+    type: 'spider_rampage_end',
+    payload: { outcome, broodKilled, queenKilled },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Utility: clear stale spider-pairing sentinels from live ants
+// ---------------------------------------------------------------------------
+
+/**
+ * Clear combatOpponentId === -2 (spider-paired sentinel) on all live ants.
+ * Must be called at every exit from Striking or Rampaging so that surviving
+ * ants don't skip the windup on the spider's next combat engagement.
+ */
+function clearSpiderPairingSentinels(world: WorldState): void {
+  const { ants } = world;
+  const len = ants.alive.length;
+  for (let i = 0; i < len; i++) {
+    if (ants.alive[i] === 1 && ants.combatOpponentId[i] === -2) {
+      ants.combatOpponentId[i] = -1;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// tickSpider — main entry point (step 17.5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Advance spider state machine by one tick. Called at step 17.5 (after combat).
+ * Deterministic: no world.rngState draws.
+ */
+export function tickSpider(world: WorldState): void {
+  const spider = world.spider;
+  if (spider === null) {
+    world.scatterReticleTile = null;
+    return;
+  }
+
+  // Evaluation-order rule: combat ran at step 17 and may have brought hp to 0.
+  if (spider.hp <= 0) {
+    // Spider died from combat this tick. Emit end events, then clear.
+    if (spider.state === 'Striking') {
+      emitSpiderHuntEnd(world, 'swarm_retreat', spider.killsThisStrike);
+    } else if (spider.state === 'Rampaging') {
+      emitSpiderRampageEnd(world, 'killed_in_nest', spider.rampageKillsThisRampage, false);
+    }
+    world.spider = null;
+    world.spiderPriority = false;
+    world.scatterReticleTile = null;
+    return;
+  }
+
+  // HP regeneration: 1 HP per 20 ticks while Retreating or Feeding.
+  if ((spider.state === 'Retreating' || spider.state === 'Feeding') &&
+      (world.tick % 20 === 0) &&
+      spider.hp < SPIDER_HP_FULL) {
+    spider.hp += SPIDER_HP_REGEN_PER_20_TICKS;
+    if (spider.hp > SPIDER_HP_FULL) spider.hp = SPIDER_HP_FULL;
+  }
+
+  // Hunger accrual: only while not Feeding.
+  if (spider.state !== 'Feeding') {
+    spider.hungerTicks += 1;
+  }
+
+  // --- Priority retreating-threshold check (applies to Striking and Rampaging) ---
+  // This runs before state-specific logic so a combat-damaged spider retreats
+  // immediately, even on the same tick its duration would have expired.
+  if ((spider.state === 'Striking' || spider.state === 'Rampaging') &&
+      spider.hp < SPIDER_RAMPAGE_RETREAT_HP) {
+    if (spider.state === 'Striking') {
+      emitSpiderHuntEnd(world, 'swarm_retreat', spider.killsThisStrike);
+    } else {
+      emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
+    }
+    clearSpiderPairingSentinels(world);
+    spider.state = 'Retreating';
+    spider.retreatStartTick = world.tick;
+    spider.huntTargetTileX = -1;
+    spider.huntTargetTileY = -1;
+    // Fall through to movement + pheromone below.
+  }
+
+  // --- State machine transitions ---
+  switch (spider.state) {
+    case 'Patrolling': {
+      // Hunger check first: rampaging wins over hunting on same tick.
+      if (spider.hungerTicks >= SPIDER_HUNGER_MAX_TICKS[NORMAL_TIER_INDEX]) {
+        spider.state = 'Rampaging';
+        spider.rampageKillsThisRampage = 0;
+        emitEvent(world, {
+          tick: world.tick,
+          type: 'spider_rampage_start',
+          payload: {
+            lairTile: { x: spider.lairTileX, y: spider.lairTileY },
+            hungerTicks: spider.hungerTicks,
+          },
+        });
+      } else if (world.tick >= spider.nextHuntTick) {
+        const target = findHuntTarget(world, spider);
+        if (target !== null) {
+          spider.state = 'Hunting';
+          spider.huntTargetTileX = target.x;
+          spider.huntTargetTileY = target.y;
+          spider.huntStartTick = world.tick;
+          emitEvent(world, {
+            tick: world.tick,
+            type: 'spider_hunt_start',
+            payload: {
+              reticleTile: { x: target.x, y: target.y, grid: 'surface' },
+              targetWorkers: 0, // approximation; actual count read above in findHuntTarget
+            },
+          });
+        } else {
+          // No qualifying workers in range — postpone hunt by one interval to preserve
+          // the 1200-tick cadence rather than re-scanning every tick.
+          spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        }
+      }
+      break;
+    }
+
+    case 'Hunting': {
+      if (world.tick - spider.huntStartTick >= SPIDER_TELEGRAPH_TICKS) {
+        spider.state = 'Striking';
+        spider.strikeStartTick = world.tick;
+        spider.killsThisStrike = 0;
+      }
+      break;
+    }
+
+    case 'Striking': {
+      // Duration check (retreat threshold was already handled above).
+      if (world.tick - spider.strikeStartTick >= SPIDER_STRIKE_TICKS) {
+        if (spider.killsThisStrike > 0) {
+          emitSpiderHuntEnd(world, 'kill', spider.killsThisStrike);
+          clearSpiderPairingSentinels(world);
+          spider.state = 'Feeding';
+          spider.feedingStartTick = world.tick;
+          spider.hungerTicks = 0; // CF-P0-006: reset on Feeding entry
+        } else {
+          emitSpiderHuntEnd(world, 'scatter', 0);
+          clearSpiderPairingSentinels(world);
+          spider.state = 'Patrolling';
+          spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+          spider.huntTargetTileX = -1;
+          spider.huntTargetTileY = -1;
+        }
+      }
+      break;
+    }
+
+    case 'Feeding': {
+      if (world.tick >= spider.feedingStartTick + SPIDER_FEEDING_TICKS) {
+        spider.state = 'Patrolling';
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        spider.huntTargetTileX = -1;
+        spider.huntTargetTileY = -1;
+      }
+      break;
+    }
+
+    case 'Rampaging': {
+      // Quota check: fed enough brood.
+      if (spider.rampageKillsThisRampage >= SPIDER_RAMPAGE_KILL_QUOTA) {
+        emitSpiderRampageEnd(world, 'quota_met', spider.rampageKillsThisRampage, false);
+        clearSpiderPairingSentinels(world);
+        spider.state = 'Feeding';
+        spider.feedingStartTick = world.tick;
+        spider.hungerTicks = 0;
+      }
+      break;
+    }
+
+    case 'Retreating': {
+      if (spider.hp >= SPIDER_HP_FULL &&
+          world.tick >= spider.retreatStartTick + SPIDER_RETREAT_MIN_TICKS) {
+        spider.state = 'Patrolling';
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+      }
+      break;
+    }
+  }
+
+  // --- Movement ---
+  switch (spider.state) {
+    case 'Patrolling': {
+      tickPatrolMovement(world, spider);
+      break;
+    }
+    case 'Hunting': {
+      moveTowardTile(spider, spider.huntTargetTileX, spider.huntTargetTileY);
+      break;
+    }
+    case 'Striking': {
+      // Stay on target tile.
+      moveTowardTile(spider, spider.huntTargetTileX, spider.huntTargetTileY);
+      break;
+    }
+    case 'Feeding':
+    case 'Retreating': {
+      moveTowardTile(spider, spider.lairTileX, spider.lairTileY);
+      break;
+    }
+    case 'Rampaging': {
+      const nearest = findNearestEntrance(world, spider);
+      if (nearest !== null) {
+        moveTowardTile(spider, nearest.x, nearest.y);
+      }
+      break;
+    }
+  }
+
+  // --- Danger pheromone seeding ---
+  // Surface states: Patrolling, Hunting, Striking, Rampaging (while on surface)
+  const isOnSurface = spider.state !== 'Feeding' && spider.state !== 'Retreating';
+  if (isOnSurface) {
+    seedDangerPheromone(world, spider);
+  }
+
+  // During Rampaging, also seed underground danger for all colony grids.
+  if (spider.state === 'Rampaging') {
+    for (const colonyKey in world.colonies) {
+      const cid = Number(colonyKey);
+      if (Number.isInteger(cid)) {
+        seedUndergroundDangerPheromone(world, spider, cid);
+      }
+    }
+  }
+
+  // --- scatterReticleTile shadow field: written at end for next tick's step 16 ---
+  if (spider.state === 'Hunting' || spider.state === 'Striking') {
+    if (world.scatterReticleTile === null) {
+      world.scatterReticleTile = { x: spider.huntTargetTileX, y: spider.huntTargetTileY };
+    } else {
+      world.scatterReticleTile.x = spider.huntTargetTileX;
+      world.scatterReticleTile.y = spider.huntTargetTileY;
+    }
+  } else {
+    world.scatterReticleTile = null;
+  }
+}

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -523,7 +523,7 @@ export function tickSpider(world: WorldState): void {
     }
   }
 
-  // --- scatterReticleTile shadow field: written at end for next tick's step 16 ---
+  // --- scatterReticleTile shadow field: written at end for next tick's step 10e ---
   if (spider.state === 'Hunting' || spider.state === 'Striking') {
     if (world.scatterReticleTile === null) {
       world.scatterReticleTile = { x: spider.huntTargetTileX, y: spider.huntTargetTileY };

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -523,7 +523,7 @@ export function tickSpider(world: WorldState): void {
     }
   }
 
-  // --- scatterReticleTile shadow field: written at end for next tick's step 10e ---
+  // --- scatterReticleTile shadow field: written at end for next tick's step 13e ---
   if (spider.state === 'Hunting' || spider.state === 'Striking') {
     if (world.scatterReticleTile === null) {
       world.scatterReticleTile = { x: spider.huntTargetTileX, y: spider.huntTargetTileY };

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -42,7 +42,7 @@ import { FP_SHIFT } from './fixed.js';
 function findHuntTarget(
   world: WorldState,
   spider: SpiderState,
-): { x: number; y: number } | null {
+): { x: number; y: number; workerCount: number } | null {
   const spiderTileX = spider.posX >> FP_SHIFT;
   const spiderTileY = spider.posY >> FP_SHIFT;
   const r = SPIDER_HUNT_SEARCH_RADIUS_TILES;
@@ -80,7 +80,7 @@ function findHuntTarget(
     }
   }
   if (bestKey === -1) return null;
-  return { x: bestX, y: bestY };
+  return { x: bestX, y: bestY, workerCount: bestCount };
 }
 
 // ---------------------------------------------------------------------------
@@ -395,7 +395,7 @@ export function tickSpider(world: WorldState): void {
             type: 'spider_hunt_start',
             payload: {
               reticleTile: { x: target.x, y: target.y, grid: 'surface' },
-              targetWorkers: 0, // approximation; actual count read above in findHuntTarget
+              targetWorkers: target.workerCount,
             },
           });
         } else {

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -328,6 +328,7 @@ export function tickSpider(world: WorldState): void {
     } else if (spider.state === 'Rampaging') {
       emitSpiderRampageEnd(world, 'killed_in_nest', spider.rampageKillsThisRampage, false);
     }
+    clearSpiderPairingSentinels(world);
     world.spider = null;
     world.spiderPriorityColonyId = null;
     world.scatterReticleTile = null;

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -26,7 +26,6 @@ import {
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
   PHEROMONE_CAP,
-  UNDERGROUND_CEILING_ROW_Y,
 } from './constants.js';
 import { FP_SHIFT } from './fixed.js';
 
@@ -290,36 +289,6 @@ function seedDangerPheromone(world: WorldState, spider: SpiderState): void {
     // east
     if (tileX < w - 1) { const v = phGet(grid, tileX + 1, tileY) + nb; phSet(grid, tileX + 1, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
   }
-}
-
-// ---------------------------------------------------------------------------
-// Rampaging underground danger deposit
-// ---------------------------------------------------------------------------
-
-/** During Rampaging, seed DangerTrail on the underground grid of the colony being invaded. */
-function seedUndergroundDangerPheromone(world: WorldState, spider: SpiderState, colonyId: number): void {
-  // Find the underground danger grid for this colony
-  const key = pheromoneGridKey(colonyId, PheromoneType.DangerTrail, 'underground');
-  const grid = world.pheromoneGrids[key];
-  if (grid === undefined) return;
-
-  const tileX = spider.posX >> FP_SHIFT;
-  // Underground grid row 0 is the ceiling (entrance level). The spider is on
-  // the surface, so map the deposit to the underground entrance row rather
-  // than using the surface y coordinate (which would be out of bounds for the
-  // 64-row underground grid).
-  const tileY = UNDERGROUND_CEILING_ROW_Y;
-  const center = SPIDER_DANGER_DEPOSIT;
-  const nb = SPIDER_DANGER_DEPOSIT >> 1;
-  const gw = grid.width;
-  const gh = grid.height;
-
-  // Unrolled 5-cell cross to avoid per-tick array allocation (AGENTS.md hot-loop rule).
-  if (tileX >= 0 && tileX < gw && tileY >= 0 && tileY < gh) { const v = phGet(grid, tileX, tileY) + center; phSet(grid, tileX, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
-  if (tileX >= 0 && tileX < gw && tileY - 1 >= 0) { const v = phGet(grid, tileX, tileY - 1) + nb; phSet(grid, tileX, tileY - 1, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
-  if (tileX >= 0 && tileX < gw && tileY + 1 < gh) { const v = phGet(grid, tileX, tileY + 1) + nb; phSet(grid, tileX, tileY + 1, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
-  if (tileX - 1 >= 0 && tileY >= 0 && tileY < gh) { const v = phGet(grid, tileX - 1, tileY) + nb; phSet(grid, tileX - 1, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
-  if (tileX + 1 < gw && tileY >= 0 && tileY < gh) { const v = phGet(grid, tileX + 1, tileY) + nb; phSet(grid, tileX + 1, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
 }
 
 // ---------------------------------------------------------------------------
@@ -596,12 +565,6 @@ export function tickSpider(world: WorldState): void {
     seedDangerPheromone(world, spider);
   }
 
-  // During Rampaging, seed underground danger only for the invaded colony
-  // (the one whose entrance is nearest to the spider). Seeding all colonies
-  // would create false threat signals in colonies the spider is not attacking.
-  if (spider.state === 'Rampaging' && rampageNearest !== null) {
-    seedUndergroundDangerPheromone(world, spider, rampageNearest.colonyId);
-  }
 
   // --- scatterReticleTile shadow field: written at end for next tick's step 13e ---
   if (spider.state === 'Hunting' || spider.state === 'Striking') {

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -18,6 +18,7 @@ import {
   SPIDER_RAMPAGE_RETREAT_HP,
   SPIDER_RETREAT_MIN_TICKS,
   SPIDER_RAMPAGE_KILL_QUOTA,
+  SPIDER_RAMPAGE_MAX_TICKS,
   SPIDER_HUNT_SEARCH_RADIUS_TILES,
   SPIDER_HUNT_MIN_TARGET_WORKERS,
   SPIDER_SPEED,
@@ -372,6 +373,7 @@ export function tickSpider(world: WorldState): void {
       // Hunger check first: rampaging wins over hunting on same tick.
       if (spider.hungerTicks >= SPIDER_HUNGER_MAX_TICKS[NORMAL_TIER_INDEX]) {
         spider.state = 'Rampaging';
+        spider.rampageStartTick = world.tick;
         spider.rampageKillsThisRampage = 0;
         emitEvent(world, {
           tick: world.tick,
@@ -453,6 +455,14 @@ export function tickSpider(world: WorldState): void {
         spider.state = 'Feeding';
         spider.feedingStartTick = world.tick;
         spider.hungerTicks = 0;
+      } else if (world.tick - spider.rampageStartTick >= SPIDER_RAMPAGE_MAX_TICKS) {
+        // Timeout: no ants surfaced at entrance — treat as failed rampage and retreat.
+        emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
+        clearSpiderPairingSentinels(world);
+        spider.state = 'Retreating';
+        spider.retreatStartTick = world.tick;
+        spider.huntTargetTileX = -1;
+        spider.huntTargetTileY = -1;
       }
       break;
     }

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -58,6 +58,19 @@ function findHuntTarget(
   for (let d = 0; d < HUNT_DIRTY.length; d++) HUNT_TILE_COUNTS[HUNT_DIRTY[d]!] = 0;
   HUNT_DIRTY.length = 0;
 
+  // Pre-scan queen IDs so they are excluded from worker density. Queens are identified
+  // by colony.queenEntityId (not by task — queen task may vary) to avoid counting them
+  // as prey and triggering hunts on depleted colonies. Assumes ≤2 active colonies (Phase 1).
+  let huntQueenId0 = -1;
+  let huntQueenId1 = -1;
+  for (const ckey in world.colonies) {
+    if (!Object.hasOwn(world.colonies, ckey)) continue;
+    const col = world.colonies[ckey as unknown as import('./colony/colony-store.js').ColonyId];
+    if (col === undefined) continue;
+    if (huntQueenId0 < 0) huntQueenId0 = col.queenEntityId;
+    else huntQueenId1 = col.queenEntityId;
+  }
+
   // Count workers per tile within radius.
   const { ants } = world;
   const antCount = ants.alive.length;
@@ -65,6 +78,7 @@ function findHuntTarget(
     if (ants.alive[i] !== 1) continue;
     if (ants.zone[i] !== 0) continue; // surface only
     if (ants.task[i] === AntTask.Fighting) continue; // spider hunts workers, not fighters
+    if (i === huntQueenId0 || i === huntQueenId1) continue; // queens are not prey
     const ax = ants.posX[i]! >> FP_SHIFT;
     const ay = ants.posY[i]! >> FP_SHIFT;
     const dist = (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -126,6 +126,7 @@ function findHuntTarget(
 function findNearestEntrance(
   world: WorldState,
   spider: SpiderState,
+  targetColonyId: number = -1,
 ): { x: number; y: number; colonyId: number } | null {
   const spiderTileX = spider.posX >> FP_SHIFT;
   const spiderTileY = spider.posY >> FP_SHIFT;
@@ -141,6 +142,7 @@ function findNearestEntrance(
     const cid = Number(key);
     const colony = world.colonies[key as unknown as import('./colony/colony-store.js').ColonyId];
     if (colony === undefined) continue;
+    if (targetColonyId >= 0 && cid !== targetColonyId) continue;
     for (let e = 0; e < colony.entrances.length; e++) {
       const entrance = colony.entrances[e]!;
       if (!entrance.isOpen) continue;
@@ -162,6 +164,41 @@ function findNearestEntrance(
   NEAREST_ENTRANCE_SCRATCH.y = bestY;
   NEAREST_ENTRANCE_SCRATCH.colonyId = bestColonyId;
   return NEAREST_ENTRANCE_SCRATCH;
+}
+
+
+// ---------------------------------------------------------------------------
+// Rampage target colony selection — 60/40 weighted toward richer colony
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick which colony the spider rampages on this cycle.
+ * Score = foodStored + workerCount * 10. The richer colony is favored 60/40
+ * using a deterministic hash of (terrainSeed ^ rampageStartTick) so the
+ * result looks organic but is fully replay-safe. No world.rngState draws.
+ */
+function pickRampageTarget(world: WorldState, spider: SpiderState): number {
+  const candidates: Array<{ colonyId: number; score: number }> = [];
+  for (const key in world.colonies) {
+    if (!Object.hasOwn(world.colonies, key)) continue;
+    const cid = Number(key);
+    if (cid <= 0) continue; // skip NEUTRAL_COLONY_ID
+    const col = world.colonies[key as unknown as import('./colony/colony-store.js').ColonyId];
+    if (col === undefined) continue;
+    candidates.push({ colonyId: cid, score: col.foodStored + col.workerCount * 10 });
+  }
+  if (candidates.length === 0) return -1;
+  if (candidates.length === 1) return candidates[0]!.colonyId;
+  // Richest first; ascending colonyId tiebreak for determinism.
+  candidates.sort((a, b) => b.score - a.score || a.colonyId - b.colonyId);
+  // Murmur3 finalizer seeded by terrainSeed ^ rampageStartTick — good avalanche,
+  // deterministic, no rngState draw.
+  let h = Math.imul(world.terrainSeed ^ spider.rampageStartTick, 2654435761) >>> 0;
+  h = Math.imul(h ^ (h >>> 16), 0x85ebca6b) >>> 0;
+  h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35) >>> 0;
+  h ^= h >>> 16;
+  // 60% → richer colony (index 0), 40% → poorer (index 1).
+  return (h % 100) < 60 ? candidates[0]!.colonyId : candidates[1]!.colonyId;
 }
 
 // ---------------------------------------------------------------------------
@@ -392,6 +429,7 @@ export function tickSpider(world: WorldState): void {
     spider.huntTargetTileX = -1;
     spider.huntTargetTileY = -1;
     spider.hungerTicks = 0; // prevent immediate re-rampaging on return to Patrolling
+    spider.rampageTargetColonyId = -1;
     world.spiderPriorityColonyId = null;
     // Fall through to movement + pheromone below.
   }
@@ -404,6 +442,7 @@ export function tickSpider(world: WorldState): void {
         spider.state = 'Rampaging';
         spider.rampageStartTick = world.tick;
         spider.rampageKillsThisRampage = 0;
+        spider.rampageTargetColonyId = pickRampageTarget(world, spider);
         emitEvent(world, {
           tick: world.tick,
           type: 'spider_rampage_start',
@@ -488,6 +527,7 @@ export function tickSpider(world: WorldState): void {
         spider.state = 'Feeding';
         spider.feedingStartTick = world.tick;
         spider.hungerTicks = 0;
+        spider.rampageTargetColonyId = -1;
         world.spiderPriorityColonyId = null;
       } else if (world.tick - spider.rampageStartTick >= SPIDER_RAMPAGE_MAX_TICKS) {
         // Timeout: no ants surfaced at entrance — treat as failed rampage and retreat.
@@ -498,6 +538,7 @@ export function tickSpider(world: WorldState): void {
         spider.huntTargetTileX = -1;
         spider.huntTargetTileY = -1;
         spider.hungerTicks = 0; // prevent immediate re-rampaging on return to Patrolling
+        spider.rampageTargetColonyId = -1;
         world.spiderPriorityColonyId = null;
       }
       break;
@@ -515,7 +556,12 @@ export function tickSpider(world: WorldState): void {
 
   // --- Movement ---
   // Cache nearest entrance for Rampaging once per tick (used by both movement and pheromone seeding).
-  const rampageNearest = spider.state === 'Rampaging' ? findNearestEntrance(world, spider) : null;
+  // Self-heal: a Rampaging spider loaded from a save predating rampageTargetColonyId derives
+  // its target here so behavior is consistent with a spider that never reloaded.
+  if (spider.state === 'Rampaging' && spider.rampageTargetColonyId < 0) {
+    spider.rampageTargetColonyId = pickRampageTarget(world, spider);
+  }
+  const rampageNearest = spider.state === 'Rampaging' ? findNearestEntrance(world, spider, spider.rampageTargetColonyId) : null;
   switch (spider.state) {
     case 'Patrolling': {
       tickPatrolMovement(world, spider);

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -31,6 +31,13 @@ import {
 import { FP_SHIFT } from './fixed.js';
 
 // ---------------------------------------------------------------------------
+// Module-level scratch for findHuntTarget — avoids per-call Map allocation.
+// SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT = 128 * 128 = 16384 tiles.
+// Cleared between calls via HUNT_DIRTY list. Same precedent as tick.ts flow-field buffers.
+const HUNT_TILE_COUNTS = new Uint16Array(SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT);
+const HUNT_DIRTY: number[] = [];
+
+// ---------------------------------------------------------------------------
 // Hunt target selection — deterministic (no rng draws)
 // ---------------------------------------------------------------------------
 
@@ -47,36 +54,39 @@ function findHuntTarget(
   const spiderTileY = spider.posY >> FP_SHIFT;
   const r = SPIDER_HUNT_SEARCH_RADIUS_TILES;
 
-  // Count workers per tile within radius
-  const counts = new Map<number, number>();
+  // Clear dirty tiles from previous call (reuse scratch buffer, avoid Map alloc).
+  for (let d = 0; d < HUNT_DIRTY.length; d++) HUNT_TILE_COUNTS[HUNT_DIRTY[d]!] = 0;
+  HUNT_DIRTY.length = 0;
+
+  // Count workers per tile within radius.
   const { ants } = world;
-  const count = ants.alive.length;
-  for (let i = 0; i < count; i++) {
+  const antCount = ants.alive.length;
+  for (let i = 0; i < antCount; i++) {
     if (ants.alive[i] !== 1) continue;
-    // Only surface ants
-    if (ants.zone[i] !== 0) continue;
-    // Skip fighters — spider hunts workers (prey), not combatants
-    if (ants.task[i] === AntTask.Fighting) continue;
+    if (ants.zone[i] !== 0) continue; // surface only
+    if (ants.task[i] === AntTask.Fighting) continue; // spider hunts workers, not fighters
     const ax = ants.posX[i]! >> FP_SHIFT;
     const ay = ants.posY[i]! >> FP_SHIFT;
     const dist = (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +
                  (ay > spiderTileY ? ay - spiderTileY : spiderTileY - ay);
     if (dist > r) continue;
-    const key = ay * SURFACE_GRID_WIDTH + ax;
-    counts.set(key, (counts.get(key) ?? 0) + 1);
+    const key = (ay << 7) + ax; // ay * SURFACE_GRID_WIDTH(128) + ax; 128 = 2^7
+    if (HUNT_TILE_COUNTS[key] === 0) HUNT_DIRTY.push(key);
+    HUNT_TILE_COUNTS[key] = HUNT_TILE_COUNTS[key]! + 1;
   }
 
   let bestKey = -1;
   let bestCount = SPIDER_HUNT_MIN_TARGET_WORKERS - 1; // must exceed to qualify
   let bestX = -1;
   let bestY = -1;
-  for (const [k, c] of counts) {
-    if (c > bestCount || (c === bestCount && (bestKey === -1 || k < bestKey))) {
+  for (let d = 0; d < HUNT_DIRTY.length; d++) {
+    const k = HUNT_DIRTY[d]!;
+    const c = HUNT_TILE_COUNTS[k]!;
+    if (c > bestCount || (c === bestCount && bestKey !== -1 && k < bestKey)) {
       bestCount = c;
       bestKey = k;
-      const kx = k % SURFACE_GRID_WIDTH;
-      bestX = kx;
-      bestY = (k - kx) >> 7; // SURFACE_GRID_WIDTH=128=2^7; integer divide via right-shift
+      bestX = k & 127; // k % SURFACE_GRID_WIDTH(128)
+      bestY = k >> 7;  // k / SURFACE_GRID_WIDTH(128)
     }
   }
   if (bestKey === -1) return null;
@@ -106,6 +116,7 @@ function findNearestEntrance(
   let bestColonyId = -1;
 
   for (const key in world.colonies) {
+    if (!Object.hasOwn(world.colonies, key)) continue;
     const cid = Number(key);
     const colony = world.colonies[key as unknown as import('./colony/colony-store.js').ColonyId];
     if (colony === undefined) continue;
@@ -197,27 +208,26 @@ function seedDangerPheromone(world: WorldState, spider: SpiderState): void {
   const tileX = spider.posX >> FP_SHIFT;
   const tileY = spider.posY >> FP_SHIFT;
   const center = SPIDER_DANGER_DEPOSIT;
-  const neighbor = SPIDER_DANGER_DEPOSIT >> 1;
+  const nb = SPIDER_DANGER_DEPOSIT >> 1;
+  const w = SURFACE_GRID_WIDTH;
+  const h = SURFACE_GRID_HEIGHT;
 
-  const offsets: [number, number, number][] = [
-    [tileX,     tileY,     center],
-    [tileX,     tileY - 1, neighbor],
-    [tileX,     tileY + 1, neighbor],
-    [tileX - 1, tileY,     neighbor],
-    [tileX + 1, tileY,     neighbor],
-  ];
-
-  // Deposit in both colonies' surface DangerTrail grids
+  // Deposit in both colonies' surface DangerTrail grids.
+  // Unrolled 5-cell cross to avoid per-tick array allocation (AGENTS.md hot-loop rule).
   for (const colonyKey in world.pheromoneGrids) {
-    // Filter to DangerTrail surface grids (format: "${colonyId}:1:surface")
+    if (!Object.hasOwn(world.pheromoneGrids, colonyKey)) continue;
     if (!colonyKey.endsWith(':1:surface')) continue;
     const grid = world.pheromoneGrids[colonyKey]!;
-    for (const [ox, oy, amt] of offsets) {
-      if (ox < 0 || ox >= SURFACE_GRID_WIDTH || oy < 0 || oy >= SURFACE_GRID_HEIGHT) continue;
-      const current = phGet(grid, ox, oy);
-      const sum = current + amt;
-      phSet(grid, ox, oy, sum > PHEROMONE_CAP ? PHEROMONE_CAP : sum);
-    }
+    // center (spider is always within surface bounds)
+    { const v = phGet(grid, tileX, tileY) + center; phSet(grid, tileX, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+    // north
+    if (tileY > 0) { const v = phGet(grid, tileX, tileY - 1) + nb; phSet(grid, tileX, tileY - 1, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+    // south
+    if (tileY < h - 1) { const v = phGet(grid, tileX, tileY + 1) + nb; phSet(grid, tileX, tileY + 1, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+    // west
+    if (tileX > 0) { const v = phGet(grid, tileX - 1, tileY) + nb; phSet(grid, tileX - 1, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+    // east
+    if (tileX < w - 1) { const v = phGet(grid, tileX + 1, tileY) + nb; phSet(grid, tileX + 1, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
   }
 }
 
@@ -239,23 +249,16 @@ function seedUndergroundDangerPheromone(world: WorldState, spider: SpiderState, 
   // 64-row underground grid).
   const tileY = UNDERGROUND_CEILING_ROW_Y;
   const center = SPIDER_DANGER_DEPOSIT;
-  const neighbor = SPIDER_DANGER_DEPOSIT >> 1;
-  const gridWidth = grid.width;
-  const gridHeight = grid.height;
+  const nb = SPIDER_DANGER_DEPOSIT >> 1;
+  const gw = grid.width;
+  const gh = grid.height;
 
-  const offsets: [number, number, number][] = [
-    [tileX,     tileY,     center],
-    [tileX,     tileY - 1, neighbor],
-    [tileX,     tileY + 1, neighbor],
-    [tileX - 1, tileY,     neighbor],
-    [tileX + 1, tileY,     neighbor],
-  ];
-  for (const [ox, oy, amt] of offsets) {
-    if (ox < 0 || ox >= gridWidth || oy < 0 || oy >= gridHeight) continue;
-    const current = phGet(grid, ox, oy);
-    const sum = current + amt;
-    phSet(grid, ox, oy, sum > PHEROMONE_CAP ? PHEROMONE_CAP : sum);
-  }
+  // Unrolled 5-cell cross to avoid per-tick array allocation (AGENTS.md hot-loop rule).
+  if (tileX >= 0 && tileX < gw && tileY >= 0 && tileY < gh) { const v = phGet(grid, tileX, tileY) + center; phSet(grid, tileX, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+  if (tileX >= 0 && tileX < gw && tileY - 1 >= 0) { const v = phGet(grid, tileX, tileY - 1) + nb; phSet(grid, tileX, tileY - 1, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+  if (tileX >= 0 && tileX < gw && tileY + 1 < gh) { const v = phGet(grid, tileX, tileY + 1) + nb; phSet(grid, tileX, tileY + 1, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+  if (tileX - 1 >= 0 && tileY >= 0 && tileY < gh) { const v = phGet(grid, tileX - 1, tileY) + nb; phSet(grid, tileX - 1, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+  if (tileX + 1 < gw && tileY >= 0 && tileY < gh) { const v = phGet(grid, tileX + 1, tileY) + nb; phSet(grid, tileX + 1, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
 }
 
 // ---------------------------------------------------------------------------
@@ -478,6 +481,8 @@ export function tickSpider(world: WorldState): void {
   }
 
   // --- Movement ---
+  // Cache nearest entrance for Rampaging once per tick (used by both movement and pheromone seeding).
+  const rampageNearest = spider.state === 'Rampaging' ? findNearestEntrance(world, spider) : null;
   switch (spider.state) {
     case 'Patrolling': {
       tickPatrolMovement(world, spider);
@@ -498,9 +503,8 @@ export function tickSpider(world: WorldState): void {
       break;
     }
     case 'Rampaging': {
-      const nearest = findNearestEntrance(world, spider);
-      if (nearest !== null) {
-        moveTowardTile(spider, nearest.x, nearest.y);
+      if (rampageNearest !== null) {
+        moveTowardTile(spider, rampageNearest.x, rampageNearest.y);
       }
       break;
     }
@@ -516,11 +520,8 @@ export function tickSpider(world: WorldState): void {
   // During Rampaging, seed underground danger only for the invaded colony
   // (the one whose entrance is nearest to the spider). Seeding all colonies
   // would create false threat signals in colonies the spider is not attacking.
-  if (spider.state === 'Rampaging') {
-    const nearestForSeed = findNearestEntrance(world, spider);
-    if (nearestForSeed !== null) {
-      seedUndergroundDangerPheromone(world, spider, nearestForSeed.colonyId);
-    }
+  if (spider.state === 'Rampaging' && rampageNearest !== null) {
+    seedUndergroundDangerPheromone(world, spider, rampageNearest.colonyId);
   }
 
   // --- scatterReticleTile shadow field: written at end for next tick's step 13e ---

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -195,7 +195,7 @@ function pickRampageTarget(world: WorldState, spider: SpiderState): number {
   let h = Math.imul(world.terrainSeed ^ spider.rampageStartTick, 2654435761) >>> 0;
   h = Math.imul(h ^ (h >>> 16), 0x85ebca6b) >>> 0;
   h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35) >>> 0;
-  h ^= h >>> 16;
+  h = (h ^ (h >>> 16)) >>> 0;
   // 60% → richer colony (index 0), 40% → poorer (index 1).
   return (h % 100) < 60 ? candidates[0]!.colonyId : candidates[1]!.colonyId;
 }
@@ -552,7 +552,10 @@ export function tickSpider(world: WorldState): void {
     }
     case 'Rampaging': {
       if (rampageNearest !== null) {
-        moveTowardTile(spider, rampageNearest.x, rampageNearest.y);
+        // Park one tile above the entrance so workers in zone=Surface are caught
+        // before the entrance-tile zone transition flips them to Underground.
+        const blockadeY = rampageNearest.y > 0 ? rampageNearest.y - 1 : rampageNearest.y;
+        moveTowardTile(spider, rampageNearest.x, blockadeY);
       }
       break;
     }

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -93,7 +93,7 @@ function findHuntTarget(
 function findNearestEntrance(
   world: WorldState,
   spider: SpiderState,
-): { x: number; y: number } | null {
+): { x: number; y: number; colonyId: number } | null {
   const spiderTileX = spider.posX >> FP_SHIFT;
   const spiderTileY = spider.posY >> FP_SHIFT;
 
@@ -101,8 +101,10 @@ function findNearestEntrance(
   let bestKey = -1;
   let bestX = -1;
   let bestY = -1;
+  let bestColonyId = -1;
 
   for (const key in world.colonies) {
+    const cid = Number(key);
     const colony = world.colonies[key as unknown as import('./colony/colony-store.js').ColonyId];
     if (colony === undefined) continue;
     for (let e = 0; e < colony.entrances.length; e++) {
@@ -117,11 +119,12 @@ function findNearestEntrance(
         bestKey = tk;
         bestX = entrance.surfaceTileX;
         bestY = entrance.surfaceTileY;
+        bestColonyId = cid;
       }
     }
   }
   if (bestX === -1) return null;
-  return { x: bestX, y: bestY };
+  return { x: bestX, y: bestY, colonyId: bestColonyId };
 }
 
 // ---------------------------------------------------------------------------
@@ -494,13 +497,13 @@ export function tickSpider(world: WorldState): void {
     seedDangerPheromone(world, spider);
   }
 
-  // During Rampaging, also seed underground danger for all colony grids.
+  // During Rampaging, seed underground danger only for the invaded colony
+  // (the one whose entrance is nearest to the spider). Seeding all colonies
+  // would create false threat signals in colonies the spider is not attacking.
   if (spider.state === 'Rampaging') {
-    for (const colonyKey in world.colonies) {
-      const cid = Number(colonyKey);
-      if (Number.isInteger(cid)) {
-        seedUndergroundDangerPheromone(world, spider, cid);
-      }
+    const nearestForSeed = findNearestEntrance(world, spider);
+    if (nearestForSeed !== null) {
+      seedUndergroundDangerPheromone(world, spider, nearestForSeed.colonyId);
     }
   }
 

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1135,36 +1135,6 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     }
   }
 
-  // Step 10e: spider scatter (S3) — redirect surface non-fighters within
-  // SPIDER_SCATTER_RADIUS_TILES of scatterReticleTile away from the reticle.
-  // Uses the shadow field written by tickSpider at step 17.5 the prior tick.
-  if (world.simVersion >= SIM_VERSION_V18_SPIDER && world.scatterReticleTile !== null) {
-    const rx = world.scatterReticleTile.x;
-    const ry = world.scatterReticleTile.y;
-    const r = SPIDER_SCATTER_RADIUS_TILES;
-    const { ants } = world;
-    for (let sid = 0; sid < ants.alive.length; sid++) {
-      if (ants.alive[sid] !== 1) continue;
-      if (ants.zone[sid] !== 0) continue; // surface only
-      if (ants.task[sid] === AntTask.Fighting) continue; // fighters hold ground
-      const ax = ants.posX[sid]! >> FP_SHIFT;
-      const ay = ants.posY[sid]! >> FP_SHIFT;
-      const manhDist = (ax > rx ? ax - rx : rx - ax) + (ay > ry ? ay - ry : ry - ay);
-      if (manhDist > r) continue;
-      // Push ant away from reticle: target = ant_tile + (ant_tile - reticle_tile).
-      // Special case: ant exactly on reticle tile → push north (deterministic).
-      let tx = ax + (ax - rx);
-      // Exact on-reticle: push north if possible, south otherwise (edge guard).
-      let ty = (ay === ry && ax === rx) ? (ay > 0 ? ay - 1 : ay + 1) : ay + (ay - ry);
-      if (tx < 0) tx = 0;
-      if (tx >= SURFACE_GRID_WIDTH) tx = SURFACE_GRID_WIDTH - 1;
-      if (ty < 0) ty = 0;
-      if (ty >= SURFACE_GRID_HEIGHT) ty = SURFACE_GRID_HEIGHT - 1;
-      ants.targetPosX[sid] = (tx << FP_SHIFT) + (FP_ONE >> 1);
-      ants.targetPosY[sid] = (ty << FP_SHIFT) + (FP_ONE >> 1);
-    }
-  }
-
   // ---------------------------------------------------------------------------
   // Step 11: checkPendingChambers (NEW in Phase 7)
   //   Promote fully-excavated PendingChambers to ChamberRecords.
@@ -1184,6 +1154,37 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   //   Route SearchingFood foragers to marked food piles (priority targeting).
   // ---------------------------------------------------------------------------
   routeForagerPriority(world);
+
+  // Step 13e: spider scatter (S3) — redirect surface non-fighters within
+  // SPIDER_SCATTER_RADIUS_TILES of scatterReticleTile away from the reticle.
+  // Runs AFTER routeForagerPriority (step 13) so scatter takes precedence over
+  // food-pile priority targeting for workers on the threatened tile.
+  // Uses the shadow field written by tickSpider at step 17.5 the prior tick.
+  if (world.simVersion >= SIM_VERSION_V18_SPIDER && world.scatterReticleTile !== null) {
+    const rx = world.scatterReticleTile.x;
+    const ry = world.scatterReticleTile.y;
+    const r = SPIDER_SCATTER_RADIUS_TILES;
+    const { ants } = world;
+    for (let sid = 0; sid < ants.alive.length; sid++) {
+      if (ants.alive[sid] !== 1) continue;
+      if (ants.zone[sid] !== 0) continue; // surface only
+      if (ants.task[sid] === AntTask.Fighting) continue; // fighters hold ground
+      const ax = ants.posX[sid]! >> FP_SHIFT;
+      const ay = ants.posY[sid]! >> FP_SHIFT;
+      const manhDist = (ax > rx ? ax - rx : rx - ax) + (ay > ry ? ay - ry : ry - ay);
+      if (manhDist > r) continue;
+      // Push ant away from reticle: target = ant_tile + (ant_tile - reticle_tile).
+      let tx = ax + (ax - rx);
+      // Exact on-reticle: push north if possible, south otherwise (edge guard).
+      let ty = (ay === ry && ax === rx) ? (ay > 0 ? ay - 1 : ay + 1) : ay + (ay - ry);
+      if (tx < 0) tx = 0;
+      if (tx >= SURFACE_GRID_WIDTH) tx = SURFACE_GRID_WIDTH - 1;
+      if (ty < 0) ty = 0;
+      if (ty >= SURFACE_GRID_HEIGHT) ty = SURFACE_GRID_HEIGHT - 1;
+      ants.targetPosX[sid] = (tx << FP_SHIFT) + (FP_ONE >> 1);
+      ants.targetPosY[sid] = (ty << FP_SHIFT) + (FP_ONE >> 1);
+    }
+  }
 
   // ---------------------------------------------------------------------------
   // Step 14: Pheromone deposit (per-ant — carry-only rule enforced inside tickPheromoneDeposit)

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -700,8 +700,13 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       case 'MarkSpiderPriority': {
         // Validate payload — save/replay objects are not schema-checked upstream.
         if (typeof cmd.isPriority !== 'boolean') break;
-        world.spiderPriorityColonyId = cmd.isPriority ? cmd.colonyId : null;
-        if (world.spider === null) world.spiderPriorityColonyId = null;
+        if (!cmd.isPriority) {
+          // Clear path never needs a valid colonyId.
+          world.spiderPriorityColonyId = null;
+          break;
+        }
+        if (!Number.isInteger(cmd.colonyId) || cmd.colonyId < 0) break;
+        world.spiderPriorityColonyId = world.spider !== null ? cmd.colonyId : null;
         break;
       }
       default: {

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -28,6 +28,7 @@ import {
   UNDERGROUND_CEILING_ROW_Y,
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
+  SPIDER_SCATTER_RADIUS_TILES,
   PLAYER_COLONY_ID,
 } from './constants.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
@@ -1131,6 +1132,36 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       if (ants.zone[sid] !== 0) continue; // surface only; underground fighters surface first
       ants.targetPosX[sid] = (spTileX << FP_SHIFT) + (FP_ONE >> 1);
       ants.targetPosY[sid] = (spTileY << FP_SHIFT) + (FP_ONE >> 1);
+    }
+  }
+
+  // Step 10e: spider scatter (S3) — redirect surface non-fighters within
+  // SPIDER_SCATTER_RADIUS_TILES of scatterReticleTile away from the reticle.
+  // Uses the shadow field written by tickSpider at step 17.5 the prior tick.
+  if (world.simVersion >= SIM_VERSION_V18_SPIDER && world.scatterReticleTile !== null) {
+    const rx = world.scatterReticleTile.x;
+    const ry = world.scatterReticleTile.y;
+    const r = SPIDER_SCATTER_RADIUS_TILES;
+    const { ants } = world;
+    for (let sid = 0; sid < ants.alive.length; sid++) {
+      if (ants.alive[sid] !== 1) continue;
+      if (ants.zone[sid] !== 0) continue; // surface only
+      if (ants.task[sid] === AntTask.Fighting) continue; // fighters hold ground
+      const ax = ants.posX[sid]! >> FP_SHIFT;
+      const ay = ants.posY[sid]! >> FP_SHIFT;
+      const manhDist = (ax > rx ? ax - rx : rx - ax) + (ay > ry ? ay - ry : ry - ay);
+      if (manhDist > r) continue;
+      // Push ant away from reticle: target = ant_tile + (ant_tile - reticle_tile).
+      // Special case: ant exactly on reticle tile → push north (deterministic).
+      let tx = ax + (ax - rx);
+      // Exact on-reticle: push north if possible, south otherwise (edge guard).
+      let ty = (ay === ry && ax === rx) ? (ay > 0 ? ay - 1 : ay + 1) : ay + (ay - ry);
+      if (tx < 0) tx = 0;
+      if (tx >= SURFACE_GRID_WIDTH) tx = SURFACE_GRID_WIDTH - 1;
+      if (ty < 0) ty = 0;
+      if (ty >= SURFACE_GRID_HEIGHT) ty = SURFACE_GRID_HEIGHT - 1;
+      ants.targetPosX[sid] = (tx << FP_SHIFT) + (FP_ONE >> 1);
+      ants.targetPosY[sid] = (ty << FP_SHIFT) + (FP_ONE >> 1);
     }
   }
 

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -28,8 +28,9 @@ import {
   UNDERGROUND_CEILING_ROW_Y,
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
+  PLAYER_COLONY_ID,
 } from './constants.js';
-import { FP_SHIFT } from './fixed.js';
+import { FP_SHIFT, FP_ONE } from './fixed.js';
 import { allocateWorkers, computeDigDemand } from './behavior/allocation-system.js';
 import {
   tickReconcile,
@@ -699,8 +700,8 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       case 'MarkSpiderPriority': {
         // Validate payload — save/replay objects are not schema-checked upstream.
         if (typeof cmd.isPriority !== 'boolean') break;
-        world.spiderPriority = cmd.isPriority;
-        if (world.spider === null) world.spiderPriority = false;
+        world.spiderPriorityColonyId = cmd.isPriority ? PLAYER_COLONY_ID : null;
+        if (world.spider === null) world.spiderPriorityColonyId = null;
         break;
       }
       default: {
@@ -1109,6 +1110,29 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   // Global pass (not inlined in 10a) because this is a per-ant task filter,
   // not a per-colony census mutation. Same split as Phase 7 tickDeadDiggerCleanup.
   updateFightAntTargets(world);
+
+  // Step 10d: spider priority fighter routing (S3).
+  // When any colony has spiderPriorityColonyId set, override that colony's
+  // surface fighters' targets to the spider's current tile. Runs after
+  // updateFightAntTargets so spider priority takes precedence over the rally point.
+  // Colony identity is carried in world.spiderPriorityColonyId (not a
+  // hard-coded player branch) — CLNY-08 compliant.
+  if (world.simVersion >= SIM_VERSION_V18_SPIDER &&
+      world.spiderPriorityColonyId !== null &&
+      world.spider !== null) {
+    const spiderPriorityCid = world.spiderPriorityColonyId;
+    const spTileX = world.spider.posX >> FP_SHIFT;
+    const spTileY = world.spider.posY >> FP_SHIFT;
+    const { ants } = world;
+    for (let sid = 0; sid < ants.alive.length; sid++) {
+      if (ants.alive[sid] !== 1) continue;
+      if (ants.task[sid] !== AntTask.Fighting) continue;
+      if (ants.colonyId[sid] !== spiderPriorityCid) continue;
+      if (ants.zone[sid] !== 0) continue; // surface only; underground fighters surface first
+      ants.targetPosX[sid] = (spTileX << FP_SHIFT) + (FP_ONE >> 1);
+      ants.targetPosY[sid] = (spTileY << FP_SHIFT) + (FP_ONE >> 1);
+    }
+  }
 
   // ---------------------------------------------------------------------------
   // Step 11: checkPendingChambers (NEW in Phase 7)

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -698,6 +698,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         break;
       }
       case 'MarkSpiderPriority': {
+        if (world.simVersion < SIM_VERSION_V20_SPIDER) break;
         // Validate payload — save/replay objects are not schema-checked upstream.
         if (typeof cmd.isPriority !== 'boolean') break;
         if (!cmd.isPriority) {
@@ -705,7 +706,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
           world.spiderPriorityColonyId = null;
           break;
         }
-        if (!Number.isInteger(cmd.colonyId) || cmd.colonyId < 0) break;
+        if (!Number.isInteger(cmd.colonyId) || cmd.colonyId <= 0) break;
         world.spiderPriorityColonyId = world.spider !== null ? cmd.colonyId : null;
         break;
       }
@@ -1122,7 +1123,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   // updateFightAntTargets so spider priority takes precedence over the rally point.
   // Colony identity is carried in world.spiderPriorityColonyId (not a
   // hard-coded player branch) — CLNY-08 compliant.
-  if (world.simVersion >= SIM_VERSION_V18_SPIDER &&
+  if (world.simVersion >= SIM_VERSION_V20_SPIDER &&
       world.spiderPriorityColonyId !== null &&
       world.spider !== null) {
     const spiderPriorityCid = world.spiderPriorityColonyId;
@@ -1164,7 +1165,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   // Runs AFTER routeForagerPriority (step 13) so scatter takes precedence over
   // food-pile priority targeting for workers on the threatened tile.
   // Uses the shadow field written by tickSpider at step 17.5 the prior tick.
-  if (world.simVersion >= SIM_VERSION_V18_SPIDER && world.scatterReticleTile !== null) {
+  if (world.simVersion >= SIM_VERSION_V20_SPIDER && world.scatterReticleTile !== null) {
     const rx = world.scatterReticleTile.x;
     const ry = world.scatterReticleTile.y;
     const r = SPIDER_SCATTER_RADIUS_TILES;
@@ -1277,7 +1278,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   }
 
   // ---------------------------------------------------------------------------
-  // Step 17.5: Spider state machine (S3 / V18+).
+  // Step 17.5: Spider state machine (S3 / V20+).
   // Runs after combat so spider.hp reflects this tick's damage before tickSpider
   // evaluates the Retreating threshold.
   // ---------------------------------------------------------------------------

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1,6 +1,7 @@
 // src/sim/tick.ts — Phase 9 19-step tick dispatcher.
 import type { WorldState } from './types.js';
-import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY, SIM_VERSION_V11_DEFENSIVE_BUNDLE, SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX, SIM_VERSION_V19_AI_STATE } from './types.js';
+import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY, SIM_VERSION_V11_DEFENSIVE_BUNDLE, SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX, SIM_VERSION_V19_AI_STATE, SIM_VERSION_V20_SPIDER } from './types.js';
+import { tickSpider } from './spider.js';
 import { MAX_COMMANDS_PER_TICK, type SimCommand } from './commands.js';
 import { GameOutcome, checkQueenDeath } from './game-over.js';
 import { advanceAIState, setAIRallyOperation } from './ai-state.js';
@@ -695,10 +696,16 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         setAIRallyOperation(world, cmd.colonyId, cmd.rallyTileX, cmd.rallyTileY, cmd.fighterIds, cmd.kind);
         break;
       }
+      case 'MarkSpiderPriority': {
+        world.spiderPriority = cmd.isPriority;
+        // Auto-clear when spider is dead: the UI should not dispatch this after
+        // spider death, but guard defensively.
+        if (world.spider === null) world.spiderPriority = false;
+        break;
+      }
       default: {
-        // Exhaustive narrowing — SimCommand is a 10-variant union; SyncAIState is
-        // filtered out by the `continue` guard above the switch, so the narrowed
-        // type here excludes it and the never-check still holds.
+        // Exhaustive narrowing — SimCommand is a 12-variant union (S3 adds MarkSpiderPriority).
+        // Silent-drop unknowns per PRD §5. Do NOT throw, do NOT log (wall-clock-adjacent).
         const _exhaustive: never = cmd;
         void _exhaustive;
         break;
@@ -1207,6 +1214,15 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     detectAndResolveCombat(world, rng);
   } else {
     detectAndResolveCombat(world, new Rng(world.rngState));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 17.5: Spider state machine (S3 / V18+).
+  // Runs after combat so spider.hp reflects this tick's damage before tickSpider
+  // evaluates the Retreating threshold.
+  // ---------------------------------------------------------------------------
+  if (world.simVersion >= SIM_VERSION_V20_SPIDER) {
+    tickSpider(world);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -29,7 +29,6 @@ import {
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
   SPIDER_SCATTER_RADIUS_TILES,
-  PLAYER_COLONY_ID,
 } from './constants.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
 import { allocateWorkers, computeDigDemand } from './behavior/allocation-system.js';
@@ -701,7 +700,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       case 'MarkSpiderPriority': {
         // Validate payload — save/replay objects are not schema-checked upstream.
         if (typeof cmd.isPriority !== 'boolean') break;
-        world.spiderPriorityColonyId = cmd.isPriority ? PLAYER_COLONY_ID : null;
+        world.spiderPriorityColonyId = cmd.isPriority ? cmd.colonyId : null;
         if (world.spider === null) world.spiderPriorityColonyId = null;
         break;
       }

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -697,9 +697,9 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         break;
       }
       case 'MarkSpiderPriority': {
+        // Validate payload — save/replay objects are not schema-checked upstream.
+        if (typeof cmd.isPriority !== 'boolean') break;
         world.spiderPriority = cmd.isPriority;
-        // Auto-clear when spider is dead: the UI should not dispatch this after
-        // spider death, but guard defensively.
         if (world.spider === null) world.spiderPriority = false;
         break;
       }

--- a/src/sim/types.test.ts
+++ b/src/sim/types.test.ts
@@ -52,7 +52,7 @@ describe('WorldState', () => {
       expect(keys).toContain('droppedStructuralCount'); // S0b
       expect(keys).toContain('aiState'); // S2
       expect(keys).toContain('spider'); // S3
-      expect(keys).toContain('spiderPriority'); // S3
+      expect(keys).toContain('spiderPriorityColonyId'); // S3
       expect(keys).toContain('scatterReticleTile'); // S3
     });
 

--- a/src/sim/types.test.ts
+++ b/src/sim/types.test.ts
@@ -29,10 +29,10 @@ describe('WorldState', () => {
       expect(world.rngState).toBe(4294967295);
     });
 
-    it('has exactly nineteen fields (4 Phase 5 + 3 Phase 6 + 4 Phase 7 + 1 issue #27 + 1 issue #44 + 1 issue #112 + 3 S0b telemetry + 1 S1 pendingQueenDeathContexts + 1 S2 aiState)', () => {
+    it('has exactly twenty-two fields (4 Phase 5 + 3 Phase 6 + 4 Phase 7 + 1 issue #27 + 1 issue #44 + 1 issue #112 + 3 S0b telemetry + 1 S1 pendingQueenDeathContexts + 1 S2 aiState + 3 S3 spider)', () => {
       const world = createWorldState(0);
       const keys = Object.keys(world);
-      expect(keys).toHaveLength(19);
+      expect(keys).toHaveLength(22);
       expect(keys).toContain('tick');
       expect(keys).toContain('rngState');
       expect(keys).toContain('nextEntityId');
@@ -51,6 +51,9 @@ describe('WorldState', () => {
       expect(keys).toContain('droppedCombatKillCount'); // S0b
       expect(keys).toContain('droppedStructuralCount'); // S0b
       expect(keys).toContain('aiState'); // S2
+      expect(keys).toContain('spider'); // S3
+      expect(keys).toContain('spiderPriority'); // S3
+      expect(keys).toContain('scatterReticleTile'); // S3
     });
 
     it('issue #44: terrainSeed is a deterministic, non-zero, non-rngState mix of the input seed', () => {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -306,6 +306,7 @@ export interface SpiderState {
   huntTargetTileY: number;
   killsThisStrike: number;
   rampageKillsThisRampage: number;
+  rampageTargetColonyId: number;  // colony targeted for current rampage; -1 when not rampaging
 }
 
 export interface AIStateRecord {
@@ -646,6 +647,7 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
     ds.huntTargetTileY = ss.huntTargetTileY;
     ds.killsThisStrike = ss.killsThisStrike;
     ds.rampageKillsThisRampage = ss.rampageKillsThisRampage;
+    ds.rampageTargetColonyId = ss.rampageTargetColonyId;
   }
   dst.spiderPriorityColonyId = src.spiderPriorityColonyId;
   // scatterReticleTile

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -254,7 +254,12 @@ export const SIM_VERSION_V18_INVADER_WALL_AWARE_STEP = 18 as const;
  * narrow sim helpers; probe/invasion mechanics; queen_death.aiStateAtTime populated.
  */
 export const SIM_VERSION_V19_AI_STATE = 19 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V19_AI_STATE;
+/**
+ * V20 (S3) — Spider: neutral predator entity with hunger state machine.
+ * Adds world.spider (SpiderState | null), world.spiderPriorityColonyId, world.scatterReticleTile.
+ */
+export const SIM_VERSION_V20_SPIDER = 20 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V20_SPIDER;
 
 
 /**
@@ -271,6 +276,37 @@ export type AIState =
  * S2 — Per-AI-colony state record. Lives in WorldState.aiState[].
  * Indexed by array position (iterate to find by colonyId — not dense by colonyId).
  */
+/** S3 — Spider behavior states. */
+export type SpiderBehaviorState =
+  | 'Patrolling'
+  | 'Hunting'
+  | 'Striking'
+  | 'Feeding'
+  | 'Rampaging'
+  | 'Retreating';
+
+/** S3 — Single neutral spider entity. Lives in WorldState.spider (null if not in scenario). */
+export interface SpiderState {
+  state: SpiderBehaviorState;
+  posX: number;                    // fixed-point (FP_SHIFT=8)
+  posY: number;
+  lairTileX: number;               // integer tile coords
+  lairTileY: number;
+  territoryRadiusTiles: number;
+  hp: number;
+  attackCooldown: number;
+  hungerTicks: number;             // accrues only while state !== 'Feeding'
+  nextHuntTick: number;
+  huntStartTick: number;
+  strikeStartTick: number;
+  feedingStartTick: number;
+  retreatStartTick: number;
+  huntTargetTileX: number;
+  huntTargetTileY: number;
+  killsThisStrike: number;
+  rampageKillsThisRampage: number;
+}
+
 export interface AIStateRecord {
   colonyId: ColonyId;
   state: AIState;
@@ -433,6 +469,25 @@ export interface WorldState {
    * Persisted in saves (V17+); pre-V17 saves get defensive defaults on load.
    */
   aiState: AIStateRecord[];
+
+  /**
+   * S3 — Single neutral spider entity; null if not present in this scenario.
+   * V18+ only; pre-V18 saves load with spider: null.
+   */
+  spider: SpiderState | null;
+
+  /**
+   * S3 — Player-set flag: fighters route toward spider when true.
+   * Cleared automatically when spider dies.
+   */
+  spiderPriority: boolean;
+
+  /**
+   * S3 — Shadow field for one-tick-lag scatter. Written at end of tickSpider
+   * (step 17.5); read by step 16 movement the following tick.
+   * null when spider is not Hunting or Striking.
+   */
+  scatterReticleTile: { x: number; y: number } | null;
 }
 
 /**
@@ -471,6 +526,10 @@ export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIE
     pendingQueenDeathContexts: [],
     // S2 — AI state machine. Populated by createScenario for non-player colonies.
     aiState: [],
+    // S3 — spider entity.
+    spider: null,
+    spiderPriority: false,
+    scatterReticleTile: null,
   };
 }
 
@@ -556,6 +615,45 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
         operationDefenderDeaths: s.operationDefenderDeaths,
       });
     }
+  }
+
+  // S3 — spider: copy or null
+  if (src.spider === null) {
+    dst.spider = null;
+  } else if (dst.spider === null) {
+    dst.spider = { ...src.spider };
+  } else {
+    // Reuse existing object — copy all fields
+    const ss = src.spider;
+    const ds = dst.spider;
+    ds.state = ss.state;
+    ds.posX = ss.posX;
+    ds.posY = ss.posY;
+    ds.lairTileX = ss.lairTileX;
+    ds.lairTileY = ss.lairTileY;
+    ds.territoryRadiusTiles = ss.territoryRadiusTiles;
+    ds.hp = ss.hp;
+    ds.attackCooldown = ss.attackCooldown;
+    ds.hungerTicks = ss.hungerTicks;
+    ds.nextHuntTick = ss.nextHuntTick;
+    ds.huntStartTick = ss.huntStartTick;
+    ds.strikeStartTick = ss.strikeStartTick;
+    ds.feedingStartTick = ss.feedingStartTick;
+    ds.retreatStartTick = ss.retreatStartTick;
+    ds.huntTargetTileX = ss.huntTargetTileX;
+    ds.huntTargetTileY = ss.huntTargetTileY;
+    ds.killsThisStrike = ss.killsThisStrike;
+    ds.rampageKillsThisRampage = ss.rampageKillsThisRampage;
+  }
+  dst.spiderPriority = src.spiderPriority;
+  // scatterReticleTile
+  if (src.scatterReticleTile === null) {
+    dst.scatterReticleTile = null;
+  } else if (dst.scatterReticleTile === null) {
+    dst.scatterReticleTile = { x: src.scatterReticleTile.x, y: src.scatterReticleTile.y };
+  } else {
+    dst.scatterReticleTile.x = src.scatterReticleTile.x;
+    dst.scatterReticleTile.y = src.scatterReticleTile.y;
   }
 
   // --- AntComponents: 19 TypedArray.set calls (zero allocation) ---

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -473,7 +473,7 @@ export interface WorldState {
 
   /**
    * S3 — Single neutral spider entity; null if not present in this scenario.
-   * V18+ only; pre-V18 saves load with spider: null.
+   * V20+ only; pre-V20 saves load with spider: null.
    */
   spider: SpiderState | null;
 
@@ -485,7 +485,7 @@ export interface WorldState {
 
   /**
    * S3 — Shadow field for one-tick-lag scatter. Written at end of tickSpider
-   * (step 17.5); read by step 16 movement the following tick.
+   * (step 17.5); read by step 13e movement the following tick.
    * null when spider is not Hunting or Striking.
    */
   scatterReticleTile: { x: number; y: number } | null;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -480,7 +480,7 @@ export interface WorldState {
    * S3 — Player-set flag: fighters route toward spider when true.
    * Cleared automatically when spider dies.
    */
-  spiderPriority: boolean;
+  spiderPriorityColonyId: number | null;
 
   /**
    * S3 — Shadow field for one-tick-lag scatter. Written at end of tickSpider
@@ -528,7 +528,7 @@ export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIE
     aiState: [],
     // S3 — spider entity.
     spider: null,
-    spiderPriority: false,
+    spiderPriorityColonyId: null,
     scatterReticleTile: null,
   };
 }
@@ -645,7 +645,7 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
     ds.killsThisStrike = ss.killsThisStrike;
     ds.rampageKillsThisRampage = ss.rampageKillsThisRampage;
   }
-  dst.spiderPriority = src.spiderPriority;
+  dst.spiderPriorityColonyId = src.spiderPriorityColonyId;
   // scatterReticleTile
   if (src.scatterReticleTile === null) {
     dst.scatterReticleTile = null;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -301,6 +301,7 @@ export interface SpiderState {
   strikeStartTick: number;
   feedingStartTick: number;
   retreatStartTick: number;
+  rampageStartTick: number;          // tick at which current Rampaging episode began
   huntTargetTileX: number;
   huntTargetTileY: number;
   killsThisStrike: number;
@@ -640,6 +641,7 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
     ds.strikeStartTick = ss.strikeStartTick;
     ds.feedingStartTick = ss.feedingStartTick;
     ds.retreatStartTick = ss.retreatStartTick;
+    ds.rampageStartTick = ss.rampageStartTick;
     ds.huntTargetTileX = ss.huntTargetTileX;
     ds.huntTargetTileY = ss.huntTargetTileY;
     ds.killsThisStrike = ss.killsThisStrike;


### PR DESCRIPTION
## Summary

Spider V20: surface blockade mechanic + lair equidistance constraint.

### Weighted colony targeting (previous commit)
- `pickRampageTarget`: 60/40 weighted selection toward the richer colony using murmur3 hash of `terrainSeed ^ rampageStartTick`. Prevents 100% targeting of the closest colony.
- `rampageTargetColonyId: number` on `SpiderState` (-1 when not rampaging). Self-heals on deserialization if missing.
- `findNearestEntrance` accepts optional `targetColonyId` to restrict target during Rampaging.

### Surface blockade (this commit)
- `SPIDER_RAMPAGE_KILL_QUOTA` 5 → 2: spider camps the entrance and kills 2 workers, then retreats to feed.
- Removed `seedUndergroundDangerPheromone`: spider is too large to enter the nest. Underground danger seeding was a design relic creating a false impression of nest entry. Surface danger pheromone at the entrance tile continues to run correctly.
- Lair equidistance: `_placeSpider` now requires `Math.abs(d1 - d2) <= 20` so the lair is placed in the band between both colonies, preventing one-sided hunts due to lair proximity.
- Determinism test lair pin updated for seed 7777 (57, 49 under new constraint; still ≥48 tiles from nearest colony).

## Test plan
- [ ] 2168/2168 tests pass
- [ ] `npx tsc --noEmit` clean
- [ ] Spider spawns between colonies, rampages to entrance, kills ≤2 workers, retreats
- [ ] Underground danger pheromone no longer appears on AI colony's underground grid during Rampaging
- [ ] Across multiple seeds, spider hunts both player and AI colonies

🤖 Generated with [Claude Code](https://claude.com/claude-code)