### PR TITLE
feat(combat): fighter sight aggression + non-fighter damage + queen stats

### DIFF
--- a/src/sim/ant/ant-store.ts
+++ b/src/sim/ant/ant-store.ts
@@ -40,6 +40,7 @@ import {
   WORKER_BASE_SPEED,
   WORKER_LIFESPAN_TICKS,
   COMBAT_HP_BASE,
+  COMBAT_HP_QUEEN,
 } from '../constants.js';
 
 // ---------------------------------------------------------------------------
@@ -382,6 +383,8 @@ export interface InitAntSpec {
    * Corresponds to Zone.Surface and Zone.Underground in terrain.ts.
    */
   zone?: number;
+  /** Override initial HP. Defaults to COMBAT_HP_BASE. Use COMBAT_HP_QUEEN for the queen. */
+  hp?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -443,7 +446,7 @@ export function initAnt(ants: AntComponents, id: EntityId, spec: InitAntSpec): v
   ants.carriedBy[id]         = -1;
   // S1 — fresh ant starts at full base HP; home-ground bonus is set by
   // the combat resolver on first engagement on home ground.
-  ants.hp[id]               = COMBAT_HP_BASE;
+  ants.hp[id]               = spec.hp ?? COMBAT_HP_BASE;
   ants.homeGroundBonusHp[id]= 0;
   ants.attackCooldown[id]   = 0;
   ants.combatOpponentId[id] = -1;

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -43,6 +43,7 @@ import {
   SIM_VERSION_V10_VISIBLE_BROOD_CARRY,
   SIM_VERSION_V13_INVARIANT_FIXES,
   SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX,
+  SIM_VERSION_V17_COMBAT_AGGRO,
 } from '../types.js';
 import { createColonyRecord } from '../colony/colony-store.js';
 import { initAnt, createAntComponents, RECENT_TILES_LEN, isRecentTile } from './ant-store.js';
@@ -67,6 +68,7 @@ import {
   ENTRANCE_DEPOSIT_SUPPRESS_RADIUS,
   WORKER_BASE_SPEED,
   QUEEN_EGG_INTERVAL_TICKS,
+  FIGHT_AGGRO_RADIUS,
   SEARCH_PAUSE_BASE_TICKS,
   SEARCH_PAUSE_JITTER_TICKS,
 } from '../constants.js';
@@ -2106,6 +2108,88 @@ describe('updateFightAntTargets', () => {
     // Unknown colony ant: target unchanged
     expect(world.ants.targetPosX[unknownColonyAntId]).toBe(-1);
     expect(world.ants.targetPosY[unknownColonyAntId]).toBe(-1);
+  });
+
+  it('V16: proximity aggro scan is suppressed (enemy nearby does NOT override rally)', () => {
+    // Gate test: pre-V17 worlds must NOT apply the aggro scan.
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = SIM_VERSION_V17_COMBAT_AGGRO - 1; // V16
+
+    const COLONY_A = 1 as const;
+    const COLONY_B = 2 as const;
+    const colA = createColonyRecord(COLONY_A, 0);
+    colA.entrances = [{ entranceId: 1, surfaceTileX: 50, surfaceTileY: 5, isOpen: true }];
+    colA.rallyPoint = { tileX: 50, tileY: 5 };
+    colA.digFlowFieldDirty = false;
+    world.colonies[COLONY_A] = colA;
+
+    const fighter = allocateEntityId(world);
+    initAnt(world.ants, fighter, {
+      colonyId: COLONY_A,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting,
+      subTask: 0,
+    });
+    world.ants.zone[fighter] = 0; // Zone.Surface
+
+    // Enemy ant placed 1 tile away (within FIGHT_AGGRO_RADIUS)
+    const enemy = allocateEntityId(world);
+    initAnt(world.ants, enemy, {
+      colonyId: COLONY_B,
+      posX: (10 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Idle,
+      subTask: 0,
+    });
+    world.ants.zone[enemy] = 0; // same zone
+
+    updateFightAntTargets(world);
+
+    // In V16, enemy is present but aggro scan is off → target follows rally, NOT the enemy.
+    const rallyFP = (50 << FP_SHIFT) + (FP_ONE >> 1);
+    expect(world.ants.targetPosX[fighter]).toBe(rallyFP);
+  });
+
+  it('V17: proximity aggro scan routes fighter toward nearby enemy (overrides rally)', () => {
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = SIM_VERSION_V17_COMBAT_AGGRO; // V17
+
+    const COLONY_A = 1 as const;
+    const COLONY_B = 2 as const;
+    const colA = createColonyRecord(COLONY_A, 0);
+    colA.entrances = [{ entranceId: 1, surfaceTileX: 50, surfaceTileY: 5, isOpen: true }];
+    colA.rallyPoint = { tileX: 50, tileY: 5 };
+    colA.digFlowFieldDirty = false;
+    world.colonies[COLONY_A] = colA;
+
+    const fighter = allocateEntityId(world);
+    initAnt(world.ants, fighter, {
+      colonyId: COLONY_A,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting,
+      subTask: 0,
+    });
+    world.ants.zone[fighter] = 0; // Zone.Surface
+
+    // Enemy ant placed within FIGHT_AGGRO_RADIUS
+    const enemyTileX = 10 + Math.floor(FIGHT_AGGRO_RADIUS / 2);
+    const enemy = allocateEntityId(world);
+    initAnt(world.ants, enemy, {
+      colonyId: COLONY_B,
+      posX: (enemyTileX << FP_SHIFT) + (FP_ONE >> 1),
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Idle,
+      subTask: 0,
+    });
+    world.ants.zone[enemy] = 0; // same zone
+
+    updateFightAntTargets(world);
+
+    // In V17, enemy within radius → target is the enemy's position (not the rally).
+    expect(world.ants.targetPosX[fighter]).toBe((enemyTileX << FP_SHIFT) + (FP_ONE >> 1));
+    expect(world.ants.targetPosX[fighter]).not.toBe((50 << FP_SHIFT) + (FP_ONE >> 1));
   });
 });
 

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -2135,6 +2135,7 @@ describe('updateFightAntTargets', () => {
 
     // Enemy ant placed 1 tile away (within FIGHT_AGGRO_RADIUS)
     const colB_v16 = createColonyRecord(COLONY_B, 0);
+    colB_v16.queenEntityId = -1; // no queen in this test colony
     colB_v16.entrances = [];
     colB_v16.digFlowFieldDirty = false;
     world.colonies[COLONY_B] = colB_v16;
@@ -2182,6 +2183,7 @@ describe('updateFightAntTargets', () => {
 
     // Enemy ant placed within FIGHT_AGGRO_RADIUS
     const colB_v17 = createColonyRecord(COLONY_B, 0);
+    colB_v17.queenEntityId = -1; // no queen in this test colony
     colB_v17.entrances = [];
     colB_v17.digFlowFieldDirty = false;
     world.colonies[COLONY_B] = colB_v17;

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -2134,6 +2134,10 @@ describe('updateFightAntTargets', () => {
     world.ants.zone[fighter] = 0; // Zone.Surface
 
     // Enemy ant placed 1 tile away (within FIGHT_AGGRO_RADIUS)
+    const colB_v16 = createColonyRecord(COLONY_B, 0);
+    colB_v16.entrances = [];
+    colB_v16.digFlowFieldDirty = false;
+    world.colonies[COLONY_B] = colB_v16;
     const enemy = allocateEntityId(world);
     initAnt(world.ants, enemy, {
       colonyId: COLONY_B,
@@ -2143,6 +2147,8 @@ describe('updateFightAntTargets', () => {
       subTask: 0,
     });
     world.ants.zone[enemy] = 0; // same zone
+    colB_v16.workers.push(enemy);
+    colB_v16.workerCount += 1;
 
     updateFightAntTargets(world);
 
@@ -2158,8 +2164,9 @@ describe('updateFightAntTargets', () => {
     const COLONY_A = 1 as const;
     const COLONY_B = 2 as const;
     const colA = createColonyRecord(COLONY_A, 0);
+    // Rally NOT on any entrance — ensures aggro scan is not suppressed.
     colA.entrances = [{ entranceId: 1, surfaceTileX: 50, surfaceTileY: 5, isOpen: true }];
-    colA.rallyPoint = { tileX: 50, tileY: 5 };
+    colA.rallyPoint = { tileX: 10, tileY: 10 }; // rally on fighter's own tile, not entrance
     colA.digFlowFieldDirty = false;
     world.colonies[COLONY_A] = colA;
 
@@ -2174,6 +2181,10 @@ describe('updateFightAntTargets', () => {
     world.ants.zone[fighter] = 0; // Zone.Surface
 
     // Enemy ant placed within FIGHT_AGGRO_RADIUS
+    const colB_v17 = createColonyRecord(COLONY_B, 0);
+    colB_v17.entrances = [];
+    colB_v17.digFlowFieldDirty = false;
+    world.colonies[COLONY_B] = colB_v17;
     const enemyTileX = 10 + Math.floor(FIGHT_AGGRO_RADIUS / 2);
     const enemy = allocateEntityId(world);
     initAnt(world.ants, enemy, {
@@ -2184,6 +2195,8 @@ describe('updateFightAntTargets', () => {
       subTask: 0,
     });
     world.ants.zone[enemy] = 0; // same zone
+    colB_v17.workers.push(enemy);
+    colB_v17.workerCount += 1;
 
     updateFightAntTargets(world);
 

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -43,6 +43,7 @@ import {
   SIM_VERSION_V12_SIM_CORRECTNESS_BUNDLE,
   SIM_VERSION_V13_INVARIANT_FIXES,
   SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX,
+  SIM_VERSION_V17_COMBAT_AGGRO,
   type WorldState,
 } from '../types.js';
 import {
@@ -2040,27 +2041,30 @@ export function updateFightAntTargets(world: WorldState): void {
     // Proximity aggression: scan for nearest enemy ant within FIGHT_AGGRO_RADIUS tiles
     // in the same zone. Any alive enemy (any task) is a valid target. If found, route
     // directly toward it — overrides rally and hold-radius. Phase 4 PRD §3d.
-    const aggroZone = ants.zone[id];
-    const aggroTileX = ants.posX[id]! >> FP_SHIFT;
-    const aggroTileY = ants.posY[id]! >> FP_SHIFT;
-    let nearestEnemy = -1;
-    let nearestEnemyDist = FIGHT_AGGRO_RADIUS + 1;
-    for (let eid = 0; eid < ants.alive.length; eid++) {
-      if (ants.alive[eid] !== 1) continue;
-      if (ants.colonyId[eid] === colonyId) continue;
-      if (ants.zone[eid] !== aggroZone) continue;
-      const eTileX = ants.posX[eid]! >> FP_SHIFT;
-      const eTileY = ants.posY[eid]! >> FP_SHIFT;
-      const dist = Math.abs(eTileX - aggroTileX) + Math.abs(eTileY - aggroTileY);
-      if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) {
-        nearestEnemyDist = dist;
-        nearestEnemy = eid;
+    // V17+ only — pre-V17 saves replay without this pass.
+    if (world.simVersion >= SIM_VERSION_V17_COMBAT_AGGRO) {
+      const aggroZone = ants.zone[id];
+      const aggroTileX = ants.posX[id]! >> FP_SHIFT;
+      const aggroTileY = ants.posY[id]! >> FP_SHIFT;
+      let nearestEnemy = -1;
+      let nearestEnemyDist = FIGHT_AGGRO_RADIUS + 1;
+      for (let eid = 0; eid < ants.alive.length; eid++) {
+        if (ants.alive[eid] !== 1) continue;
+        if (ants.colonyId[eid] === colonyId) continue;
+        if (ants.zone[eid] !== aggroZone) continue;
+        const eTileX = ants.posX[eid]! >> FP_SHIFT;
+        const eTileY = ants.posY[eid]! >> FP_SHIFT;
+        const dist = Math.abs(eTileX - aggroTileX) + Math.abs(eTileY - aggroTileY);
+        if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) {
+          nearestEnemyDist = dist;
+          nearestEnemy = eid;
+        }
       }
-    }
-    if (nearestEnemy >= 0) {
-      ants.targetPosX[id] = ants.posX[nearestEnemy]!;
-      ants.targetPosY[id] = ants.posY[nearestEnemy]!;
-      continue;
+      if (nearestEnemy >= 0) {
+        ants.targetPosX[id] = ants.posX[nearestEnemy]!;
+        ants.targetPosY[id] = ants.posY[nearestEnemy]!;
+        continue;
+      }
     }
 
     // No enemy in range: fall back to rally routing.

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -1963,17 +1963,15 @@ export function updateFightAntTargets(world: WorldState): void {
     rallyOnEntrance[colony.colonyId] = hit;
   }
 
-  // Precompute per-colony target lists (workers + queen) for the V17 aggro scan.
-  // Done once per tick so the inner scan is O(active ants) with no per-fighter allocs.
-  const aggroTargetsByColony = new Map<number, readonly number[]>();
+  // Precompute enemy colony refs for V17 aggro scan — iterate workers+queen directly
+  // (no array copies; queen checked separately to avoid spreading the workers list).
+  type AggroColony = { cid: number; workers: readonly number[]; queenEntityId: number };
+  const aggroEnemyColonies: AggroColony[] = [];
   if (world.simVersion >= SIM_VERSION_V17_COMBAT_AGGRO) {
     for (const cidKey in world.colonies) {
       if (!Object.hasOwn(world.colonies, cidKey)) continue;
       const col = world.colonies[cidKey as unknown as keyof typeof world.colonies];
-      if (!col) continue;
-      const qid = col.queenEntityId;
-      const targets: number[] = qid >= 0 ? [...col.workers, qid] : [...col.workers];
-      aggroTargetsByColony.set(Number(cidKey), targets);
+      if (col) aggroEnemyColonies.push({ cid: Number(cidKey), workers: col.workers, queenEntityId: col.queenEntityId });
     }
   }
 
@@ -2064,19 +2062,23 @@ export function updateFightAntTargets(world: WorldState): void {
       const aggroTileY = ants.posY[id]! >> FP_SHIFT;
       let nearestEnemy = -1;
       let nearestEnemyDist = FIGHT_AGGRO_RADIUS + 1;
-      // Scan precomputed targets per enemy colony (no per-fighter allocs).
-      for (const [enemyCid, targets] of aggroTargetsByColony) {
-        if (enemyCid === colonyId) continue;
-        for (const eid of targets) {
+      // Scan enemy colony workers + queen directly (no array copies, no per-fighter allocs).
+      for (const ec of aggroEnemyColonies) {
+        if (ec.cid === colonyId) continue;
+        for (const eid of ec.workers) {
           if (ants.alive[eid] !== 1) continue;
           if (ants.zone[eid] !== aggroZone) continue;
           const eTileX = ants.posX[eid]! >> FP_SHIFT;
           const eTileY = ants.posY[eid]! >> FP_SHIFT;
           const dist = Math.abs(eTileX - aggroTileX) + Math.abs(eTileY - aggroTileY);
-          if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) {
-            nearestEnemyDist = dist;
-            nearestEnemy = eid;
-          }
+          if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) { nearestEnemyDist = dist; nearestEnemy = eid; }
+        }
+        const qid = ec.queenEntityId;
+        if (qid >= 0 && ants.alive[qid] === 1 && ants.zone[qid] === aggroZone) {
+          const qTileX = ants.posX[qid]! >> FP_SHIFT;
+          const qTileY = ants.posY[qid]! >> FP_SHIFT;
+          const dist = Math.abs(qTileX - aggroTileX) + Math.abs(qTileY - aggroTileY);
+          if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) { nearestEnemyDist = dist; nearestEnemy = qid; }
         }
       }
       if (nearestEnemy >= 0) {

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -2041,23 +2041,28 @@ export function updateFightAntTargets(world: WorldState): void {
     // Proximity aggression: scan for nearest enemy ant within FIGHT_AGGRO_RADIUS tiles
     // in the same zone. Any alive enemy (any task) is a valid target. If found, route
     // directly toward it — overrides rally and hold-radius. Phase 4 PRD §3d.
-    // V17+ only — pre-V17 saves replay without this pass.
-    if (world.simVersion >= SIM_VERSION_V17_COMBAT_AGGRO) {
+    // V17+ only; also suppressed when the rally is an open enemy entrance — invasion
+    // fighters must march to the entrance tile uninterrupted; surface aggro would
+    // deflect them before they reach the descent point.
+    if (world.simVersion >= SIM_VERSION_V17_COMBAT_AGGRO && !rallyOnEntrance[colony.colonyId]) {
       const aggroZone = ants.zone[id];
       const aggroTileX = ants.posX[id]! >> FP_SHIFT;
       const aggroTileY = ants.posY[id]! >> FP_SHIFT;
       let nearestEnemy = -1;
       let nearestEnemyDist = FIGHT_AGGRO_RADIUS + 1;
-      for (let eid = 0; eid < ants.alive.length; eid++) {
-        if (ants.alive[eid] !== 1) continue;
-        if (ants.colonyId[eid] === colonyId) continue;
-        if (ants.zone[eid] !== aggroZone) continue;
-        const eTileX = ants.posX[eid]! >> FP_SHIFT;
-        const eTileY = ants.posY[eid]! >> FP_SHIFT;
-        const dist = Math.abs(eTileX - aggroTileX) + Math.abs(eTileY - aggroTileY);
-        if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) {
-          nearestEnemyDist = dist;
-          nearestEnemy = eid;
+      // Iterate enemy-colony workers lists instead of full entity array (O(active ants)).
+      for (const [cid, enemyColony] of Object.entries(world.colonies)) {
+        if (Number(cid) === colonyId) continue;
+        for (const eid of enemyColony.workers) {
+          if (ants.alive[eid] !== 1) continue;
+          if (ants.zone[eid] !== aggroZone) continue;
+          const eTileX = ants.posX[eid]! >> FP_SHIFT;
+          const eTileY = ants.posY[eid]! >> FP_SHIFT;
+          const dist = Math.abs(eTileX - aggroTileX) + Math.abs(eTileY - aggroTileY);
+          if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) {
+            nearestEnemyDist = dist;
+            nearestEnemy = eid;
+          }
         }
       }
       if (nearestEnemy >= 0) {

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -2068,13 +2068,16 @@ export function updateFightAntTargets(world: WorldState): void {
         for (const eid of ec.workers) {
           if (ants.alive[eid] !== 1) continue;
           if (ants.zone[eid] !== aggroZone) continue;
+          // Underground grids are disjoint spaces — reject candidates in a different grid.
+          if (aggroZone === Zone.Underground && ants.currentGridColonyId[eid] !== currentGridColonyId) continue;
           const eTileX = ants.posX[eid]! >> FP_SHIFT;
           const eTileY = ants.posY[eid]! >> FP_SHIFT;
           const dist = Math.abs(eTileX - aggroTileX) + Math.abs(eTileY - aggroTileY);
           if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) { nearestEnemyDist = dist; nearestEnemy = eid; }
         }
         const qid = ec.queenEntityId;
-        if (qid >= 0 && ants.alive[qid] === 1 && ants.zone[qid] === aggroZone) {
+        if (qid >= 0 && ants.alive[qid] === 1 && ants.zone[qid] === aggroZone
+            && (aggroZone !== Zone.Underground || ants.currentGridColonyId[qid] === currentGridColonyId)) {
           const qTileX = ants.posX[qid]! >> FP_SHIFT;
           const qTileY = ants.posY[qid]! >> FP_SHIFT;
           const dist = Math.abs(qTileX - aggroTileX) + Math.abs(qTileY - aggroTileY);

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -2051,7 +2051,8 @@ export function updateFightAntTargets(world: WorldState): void {
     }
 
     // Proximity aggression: scan for nearest enemy ant within FIGHT_AGGRO_RADIUS tiles
-    // in the same zone. Any alive enemy (any task) is a valid target. If found, route
+    // in the same zone. Workers and queen are scanned; brood is underground-only so
+    // it is never reachable from a surface scan. If an enemy is found, route
     // directly toward it — overrides rally and hold-radius. Phase 4 PRD §3d.
     // V17+ only; surface only (underground fighters use pickNearestHostileUnderground
     // for combat routing); suppressed when the rally is on any open entrance (own OR

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -2053,11 +2053,14 @@ export function updateFightAntTargets(world: WorldState): void {
     // Proximity aggression: scan for nearest enemy ant within FIGHT_AGGRO_RADIUS tiles
     // in the same zone. Any alive enemy (any task) is a valid target. If found, route
     // directly toward it — overrides rally and hold-radius. Phase 4 PRD §3d.
-    // V17+ only; also suppressed when the rally is on any open entrance (own OR
+    // V17+ only; surface only (underground fighters use pickNearestHostileUnderground
+    // for combat routing); suppressed when the rally is on any open entrance (own OR
     // enemy) — rallyOnEntrance is colony-agnostic (see precompute above): fighters
     // must walk to the exact tile so the descent trigger fires, whether it's an
     // invasion into an enemy grid or a defensive descent into their own grid.
-    if (world.simVersion >= SIM_VERSION_V17_COMBAT_AGGRO && !rallyOnEntrance[colony.colonyId]) {
+    if (world.simVersion >= SIM_VERSION_V17_COMBAT_AGGRO
+        && ants.zone[id] === Zone.Surface
+        && !rallyOnEntrance[colony.colonyId]) {
       const aggroZone = ants.zone[id];
       const aggroTileX = ants.posX[id]! >> FP_SHIFT;
       const aggroTileY = ants.posY[id]! >> FP_SHIFT;

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -2053,9 +2053,10 @@ export function updateFightAntTargets(world: WorldState): void {
     // Proximity aggression: scan for nearest enemy ant within FIGHT_AGGRO_RADIUS tiles
     // in the same zone. Any alive enemy (any task) is a valid target. If found, route
     // directly toward it — overrides rally and hold-radius. Phase 4 PRD §3d.
-    // V17+ only; also suppressed when the rally is an open enemy entrance — invasion
-    // fighters must march to the entrance tile uninterrupted; surface aggro would
-    // deflect them before they reach the descent point.
+    // V17+ only; also suppressed when the rally is on any open entrance (own OR
+    // enemy) — rallyOnEntrance is colony-agnostic (see precompute above): fighters
+    // must walk to the exact tile so the descent trigger fires, whether it's an
+    // invasion into an enemy grid or a defensive descent into their own grid.
     if (world.simVersion >= SIM_VERSION_V17_COMBAT_AGGRO && !rallyOnEntrance[colony.colonyId]) {
       const aggroZone = ants.zone[id];
       const aggroTileX = ants.posX[id]! >> FP_SHIFT;

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -1963,6 +1963,20 @@ export function updateFightAntTargets(world: WorldState): void {
     rallyOnEntrance[colony.colonyId] = hit;
   }
 
+  // Precompute per-colony target lists (workers + queen) for the V17 aggro scan.
+  // Done once per tick so the inner scan is O(active ants) with no per-fighter allocs.
+  const aggroTargetsByColony = new Map<number, readonly number[]>();
+  if (world.simVersion >= SIM_VERSION_V17_COMBAT_AGGRO) {
+    for (const cidKey in world.colonies) {
+      if (!Object.hasOwn(world.colonies, cidKey)) continue;
+      const col = world.colonies[cidKey as unknown as keyof typeof world.colonies];
+      if (!col) continue;
+      const qid = col.queenEntityId;
+      const targets: number[] = qid >= 0 ? [...col.workers, qid] : [...col.workers];
+      aggroTargetsByColony.set(Number(cidKey), targets);
+    }
+  }
+
   for (let id = 0; id < ants.alive.length; id++) {
     if (ants.alive[id] !== 1) continue;
     if (ants.task[id] !== AntTask.Fighting) continue;
@@ -2050,10 +2064,10 @@ export function updateFightAntTargets(world: WorldState): void {
       const aggroTileY = ants.posY[id]! >> FP_SHIFT;
       let nearestEnemy = -1;
       let nearestEnemyDist = FIGHT_AGGRO_RADIUS + 1;
-      // Iterate enemy-colony workers lists instead of full entity array (O(active ants)).
-      for (const [cid, enemyColony] of Object.entries(world.colonies)) {
-        if (Number(cid) === colonyId) continue;
-        for (const eid of enemyColony.workers) {
+      // Scan precomputed targets per enemy colony (no per-fighter allocs).
+      for (const [enemyCid, targets] of aggroTargetsByColony) {
+        if (enemyCid === colonyId) continue;
+        for (const eid of targets) {
           if (ants.alive[eid] !== 1) continue;
           if (ants.zone[eid] !== aggroZone) continue;
           const eTileX = ants.posX[eid]! >> FP_SHIFT;

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -83,6 +83,7 @@ import {
   SEARCH_PAUSE_JITTER_TICKS,
   FOOD_TRAIL_DEPOSIT,
   FOOD_TRAIL_DEPOSIT_V14,
+  FIGHT_AGGRO_RADIUS,
 } from '../constants.js';
 import { FP_SHIFT, FP_ONE } from '../fixed.js';
 import { Rng } from '../rng.js';
@@ -2036,7 +2037,33 @@ export function updateFightAntTargets(world: WorldState): void {
       continue;
     }
 
-    // Surface fighter (or underground with no entrances yet): target rally tile center.
+    // Proximity aggression: scan for nearest enemy ant within FIGHT_AGGRO_RADIUS tiles
+    // in the same zone. Any alive enemy (any task) is a valid target. If found, route
+    // directly toward it — overrides rally and hold-radius. Phase 4 PRD §3d.
+    const aggroZone = ants.zone[id];
+    const aggroTileX = ants.posX[id]! >> FP_SHIFT;
+    const aggroTileY = ants.posY[id]! >> FP_SHIFT;
+    let nearestEnemy = -1;
+    let nearestEnemyDist = FIGHT_AGGRO_RADIUS + 1;
+    for (let eid = 0; eid < ants.alive.length; eid++) {
+      if (ants.alive[eid] !== 1) continue;
+      if (ants.colonyId[eid] === colonyId) continue;
+      if (ants.zone[eid] !== aggroZone) continue;
+      const eTileX = ants.posX[eid]! >> FP_SHIFT;
+      const eTileY = ants.posY[eid]! >> FP_SHIFT;
+      const dist = Math.abs(eTileX - aggroTileX) + Math.abs(eTileY - aggroTileY);
+      if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) {
+        nearestEnemyDist = dist;
+        nearestEnemy = eid;
+      }
+    }
+    if (nearestEnemy >= 0) {
+      ants.targetPosX[id] = ants.posX[nearestEnemy]!;
+      ants.targetPosY[id] = ants.posY[nearestEnemy]!;
+      continue;
+    }
+
+    // No enemy in range: fall back to rally routing.
     //
     // Anti-oscillation: if the ant is already within RALLY_HOLD_RADIUS_TILES
     // Manhattan of the rally tile, clear the target to -1 so the Fighting

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -288,6 +288,12 @@ function makeV16World(seed = 42): { world: WorldState; cid1: ColonyId; cid2: Col
   return r;
 }
 
+function makeV17World(seed = 42): { world: WorldState; cid1: ColonyId; cid2: ColonyId } {
+  const r = makeWorldWith2Colonies(seed);
+  r.world.simVersion = 17;
+  return r;
+}
+
 /** Run N ticks of combat on a world where ants are already on a contested tile. */
 function runCombatTicks(world: WorldState, n: number): void {
   const rng = new Rng(world.rngState);
@@ -420,12 +426,12 @@ describe('V16 combat resolver', () => {
     world.ants.currentGridColonyId[defender] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
     const attacker = spawnFighter(world, cid2, 5, 7, Zone.Underground);
     world.ants.currentGridColonyId[attacker] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
-    // Fighters skip windup: first strike fires on tick 1.
+    // V16: fighters wind up on tick 1, first strike fires at tick 6.
     // Attacker deals COMBAT_DAMAGE_BASE=4; defender bonus=4 absorbs all → bonus=0, base HP intact.
-    runCombatTicks(world, 1);
+    runCombatTicks(world, 6); // windup T=1, first strike T=6
     expect(world.ants.homeGroundBonusHp[defender]).toBe(0);   // bonus fully depleted by first strike
     expect(world.ants.hp[defender]).toBe(COMBAT_HP_BASE);     // base HP untouched
-    // Second strike fires at tick 1 + COMBAT_COOLDOWN_TICKS = 6. Bonus=0 → base HP takes damage.
+    // Second strike fires at tick 6 + COMBAT_COOLDOWN_TICKS = 11. Bonus=0 → base HP takes damage.
     runCombatTicks(world, COMBAT_COOLDOWN_TICKS);
     expect(world.ants.homeGroundBonusHp[defender]).toBe(0);
     expect(world.ants.hp[defender]).toBe(COMBAT_HP_BASE - COMBAT_DAMAGE_BASE);
@@ -480,9 +486,9 @@ describe('V16 2v2 two-tile chamber frontage', () => {
 // Non-fighter and queen combat stats (S1 follow-up)
 // =============================================================================
 
-describe('non-fighter and queen combat stats (V16)', () => {
+describe('non-fighter and queen combat stats (V17)', () => {
   it('fighter strikes on tick 1 against non-fighter; non-fighter winds up 5 ticks', () => {
-    const { world, cid1, cid2 } = makeV16World();
+    const { world, cid1, cid2 } = makeV17World();
     const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
     const worker  = spawnAnt(world, cid2, 5, 7, Zone.Surface);   // AntTask.Idle = non-fighter
     // Tick 1: fighter strikes immediately (no windup); worker starts winding up.
@@ -497,17 +503,17 @@ describe('non-fighter and queen combat stats (V16)', () => {
   });
 
   it('non-fighter deals COMBAT_DAMAGE_WORKER damage per strike (not 0)', () => {
-    const { world, cid1, cid2 } = makeV16World();
+    const { world, cid1, cid2 } = makeV17World();
     const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
     const worker  = spawnAnt(world, cid2, 5, 7, Zone.Surface);
-    // Run 1+5 = 6 ticks: worker winds up on tick 1, strikes on tick 6.
+    // V17: fighter skips windup (strikes tick 1); worker winds up 5 ticks, strikes tick 6.
     runCombatTicks(world, 6);
     // Worker should have dealt COMBAT_DAMAGE_WORKER=1 damage (not 0).
     expect(world.ants.hp[fighter]).toBe(COMBAT_HP_BASE - COMBAT_DAMAGE_WORKER);
   });
 
   it('queen deals COMBAT_DAMAGE_QUEEN damage per strike', () => {
-    const { world, cid1, cid2 } = makeV16World();
+    const { world, cid1, cid2 } = makeV17World();
     // Spawn a queen ant with full queen HP; designate it as cid2 queen.
     const queenAnt = allocateEntityId(world);
     initAnt(world.ants, queenAnt, {

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -280,7 +280,7 @@ describe('coin flip distribution (CMBT-05, V15 path)', () => {
 // S1 — V16 HP/damage/cooldown combat tests
 // =============================================================================
 
-import { COMBAT_HP_BASE, COMBAT_HP_HOMEGROUND_BONUS, COMBAT_COOLDOWN_TICKS } from './constants.js';
+import { COMBAT_HP_BASE, COMBAT_HP_HOMEGROUND_BONUS, COMBAT_COOLDOWN_TICKS, COMBAT_DAMAGE_BASE, COMBAT_DAMAGE_WORKER, COMBAT_DAMAGE_QUEEN, COMBAT_HP_QUEEN } from './constants.js';
 
 function makeV16World(seed = 42): { world: WorldState; cid1: ColonyId; cid2: ColonyId } {
   const r = makeWorldWith2Colonies(seed);
@@ -420,15 +420,15 @@ describe('V16 combat resolver', () => {
     world.ants.currentGridColonyId[defender] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
     const attacker = spawnFighter(world, cid2, 5, 7, Zone.Underground);
     world.ants.currentGridColonyId[attacker] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
-    // After windup, set defender's hp/bonus to known state
-    runCombatTicks(world, 1); // windup
-    expect(world.ants.homeGroundBonusHp[defender]).toBe(COMBAT_HP_HOMEGROUND_BONUS);
-    expect(world.ants.hp[defender]).toBe(COMBAT_HP_BASE);
-    // Run one more round (5 ticks) to trigger first strike
-    runCombatTicks(world, 5);
-    // Attacker deals COMBAT_DAMAGE_BASE=4; defender bonus=4 → bonus absorbs all 4 → bonus=0, hp=16
+    // Fighters skip windup: first strike fires on tick 1.
+    // Attacker deals COMBAT_DAMAGE_BASE=4; defender bonus=4 absorbs all → bonus=0, base HP intact.
+    runCombatTicks(world, 1);
+    expect(world.ants.homeGroundBonusHp[defender]).toBe(0);   // bonus fully depleted by first strike
+    expect(world.ants.hp[defender]).toBe(COMBAT_HP_BASE);     // base HP untouched
+    // Second strike fires at tick 1 + COMBAT_COOLDOWN_TICKS = 6. Bonus=0 → base HP takes damage.
+    runCombatTicks(world, COMBAT_COOLDOWN_TICKS);
     expect(world.ants.homeGroundBonusHp[defender]).toBe(0);
-    expect(world.ants.hp[defender]).toBe(COMBAT_HP_BASE);
+    expect(world.ants.hp[defender]).toBe(COMBAT_HP_BASE - COMBAT_DAMAGE_BASE);
   });
 });
 
@@ -472,5 +472,74 @@ describe('V16 2v2 two-tile chamber frontage', () => {
     // Pairs are independent — each tile resolved its own fight.
     expect(world.colonies[cid1]!.killCount).toBe(2);
     expect(world.colonies[cid2]!.killCount).toBe(0);
+  });
+});
+
+
+// =============================================================================
+// Non-fighter and queen combat stats (S1 follow-up)
+// =============================================================================
+
+describe('non-fighter and queen combat stats (V16)', () => {
+  it('fighter strikes on tick 1 against non-fighter; non-fighter winds up 5 ticks', () => {
+    const { world, cid1, cid2 } = makeV16World();
+    const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const worker  = spawnAnt(world, cid2, 5, 7, Zone.Surface);   // AntTask.Idle = non-fighter
+    // Tick 1: fighter strikes immediately (no windup); worker starts winding up.
+    runCombatTicks(world, 1);
+    expect(world.ants.hp[worker]).toBe(COMBAT_HP_BASE - COMBAT_DAMAGE_BASE); // fighter dealt 4
+    expect(world.ants.hp[fighter]).toBe(COMBAT_HP_BASE);                      // worker hasn't struck yet
+    expect(world.ants.attackCooldown[worker]).toBe(COMBAT_COOLDOWN_TICKS - 1); // 5→4
+    // Worker strikes at tick 1 + COMBAT_COOLDOWN_TICKS = 6.
+    runCombatTicks(world, COMBAT_COOLDOWN_TICKS - 1); // ticks 2-5: worker cooldown → 0
+    runCombatTicks(world, 1);                          // tick 6: worker strikes for COMBAT_DAMAGE_WORKER=1
+    expect(world.ants.hp[fighter]).toBe(COMBAT_HP_BASE - COMBAT_DAMAGE_WORKER);
+  });
+
+  it('non-fighter deals COMBAT_DAMAGE_WORKER damage per strike (not 0)', () => {
+    const { world, cid1, cid2 } = makeV16World();
+    const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const worker  = spawnAnt(world, cid2, 5, 7, Zone.Surface);
+    // Run 1+5 = 6 ticks: worker winds up on tick 1, strikes on tick 6.
+    runCombatTicks(world, 6);
+    // Worker should have dealt COMBAT_DAMAGE_WORKER=1 damage (not 0).
+    expect(world.ants.hp[fighter]).toBe(COMBAT_HP_BASE - COMBAT_DAMAGE_WORKER);
+  });
+
+  it('queen deals COMBAT_DAMAGE_QUEEN damage per strike', () => {
+    const { world, cid1, cid2 } = makeV16World();
+    // Spawn a queen ant with full queen HP; designate it as cid2 queen.
+    const queenAnt = allocateEntityId(world);
+    initAnt(world.ants, queenAnt, {
+      colonyId: Number(cid2),
+      posX: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (7 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      hp: COMBAT_HP_QUEEN,
+    });
+    world.colonies[cid2]!.workers.push(queenAnt);
+    world.colonies[cid2]!.workerCount += 1;
+    world.colonies[cid2]!.queenEntityId = queenAnt;
+    const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    // T=1: fighter strikes queen for COMBAT_DAMAGE_BASE=4 (no windup). Queen starts winding up.
+    runCombatTicks(world, 1);
+    expect(world.ants.hp[queenAnt]).toBe(COMBAT_HP_QUEEN - COMBAT_DAMAGE_BASE);
+    expect(world.ants.hp[fighter]).toBe(COMBAT_HP_BASE); // queen hasn't struck yet
+    // T=6: queen strikes for COMBAT_DAMAGE_QUEEN=6. Fighter also strikes (second hit).
+    runCombatTicks(world, COMBAT_COOLDOWN_TICKS);
+    expect(world.ants.hp[fighter]).toBe(COMBAT_HP_BASE - COMBAT_DAMAGE_QUEEN);
+  });
+
+  it('queen starts with COMBAT_HP_QUEEN HP when spawned via scenario', () => {
+    // Verify that initAnt with hp:COMBAT_HP_QUEEN correctly initialises the queen's HP.
+    // (Tested here via direct initAnt call to keep test fast and scenario-independent.)
+    const { world, cid1 } = makeV16World();
+    const queenSlot = allocateEntityId(world);
+    const { FP_SHIFT: _shift } = { FP_SHIFT: 8 };
+    initAnt(world.ants, queenSlot, {
+      colonyId: Number(cid1), posX: 10 << 8, posY: 10 << 8,
+      task: AntTask.Idle, hp: COMBAT_HP_QUEEN,
+    });
+    expect(world.ants.hp[queenSlot]).toBe(COMBAT_HP_QUEEN);
   });
 });

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -495,10 +495,10 @@ describe('non-fighter and queen combat stats (V17)', () => {
     runCombatTicks(world, 1);
     expect(world.ants.hp[worker]).toBe(COMBAT_HP_BASE - COMBAT_DAMAGE_BASE); // fighter dealt 4
     expect(world.ants.hp[fighter]).toBe(COMBAT_HP_BASE);                      // worker hasn't struck yet
-    expect(world.ants.attackCooldown[worker]).toBe(COMBAT_COOLDOWN_TICKS - 1); // 5→4
+    expect(world.ants.attackCooldown[worker]).toBe(COMBAT_COOLDOWN_TICKS); // 6→5
     // Worker strikes at tick 1 + COMBAT_COOLDOWN_TICKS = 6.
-    runCombatTicks(world, COMBAT_COOLDOWN_TICKS - 1); // ticks 2-5: worker cooldown → 0
-    runCombatTicks(world, 1);                          // tick 6: worker strikes for COMBAT_DAMAGE_WORKER=1
+    runCombatTicks(world, COMBAT_COOLDOWN_TICKS - 1); // ticks 2-5: worker cooldown → 1
+    runCombatTicks(world, 1);                          // tick 6: worker cooldown → 0, strikes
     expect(world.ants.hp[fighter]).toBe(COMBAT_HP_BASE - COMBAT_DAMAGE_WORKER);
   });
 

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -193,7 +193,11 @@ function strikeDamage(world: WorldState, antId: number, strikes: boolean): numbe
   if (world.simVersion < SIM_VERSION_V17_COMBAT_AGGRO) return 0;
   const cid = ants.colonyId[antId]! as ColonyId;
   const colony = world.colonies[cid];
-  return colony != null && colony.queenEntityId === antId ? COMBAT_DAMAGE_QUEEN : COMBAT_DAMAGE_WORKER;
+  if (colony == null) return 0;
+  if (colony.queenEntityId === antId) return COMBAT_DAMAGE_QUEEN;
+  // Brood (eggs/larvae share AntTask.Idle with adult workers) cannot retaliate.
+  if (colony.eggs.includes(antId) || colony.larvae.includes(antId)) return 0;
+  return COMBAT_DAMAGE_WORKER;
 }
 
 /**

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -266,12 +266,16 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
     // V17+: fighters skip windup on first pair (cooldown=1 → strike this tick).
     // Pre-V17: all new pairings return early (full windup), replay-safe.
     const skipWindup = world.simVersion >= SIM_VERSION_V17_COMBAT_AGGRO;
-    if (aNew) ants.attackCooldown[antA] = (aIsFighter && skipWindup) ? 1 : COMBAT_COOLDOWN_TICKS;
-    if (bNew) ants.attackCooldown[antB] = (bIsFighter && skipWindup) ? 1 : COMBAT_COOLDOWN_TICKS;
+    // Compute first so cooldown assignments can compensate (see below).
+    const fighterStrikesNow = skipWindup && ((aNew && aIsFighter) || (bNew && bIsFighter));
+    // When a fighter strikes on the pairing tick the decrement below runs immediately.
+    // Newly-paired non-fighters start at COMBAT_COOLDOWN_TICKS+1 so they land at
+    // COMBAT_COOLDOWN_TICKS after that decrement — full windup window preserved.
+    if (aNew) ants.attackCooldown[antA] = (aIsFighter && skipWindup) ? 1 : COMBAT_COOLDOWN_TICKS + (fighterStrikesNow && !aIsFighter ? 1 : 0);
+    if (bNew) ants.attackCooldown[antB] = (bIsFighter && skipWindup) ? 1 : COMBAT_COOLDOWN_TICKS + (fighterStrikesNow && !bIsFighter ? 1 : 0);
     // Return early unless a newly-paired V17 fighter is about to strike (cooldown=1).
     // Preserves the original V16 invariant: no strike fires on a pairing tick, even
     // if the non-new side has cooldown=1 (that strike is deferred to the next tick).
-    const fighterStrikesNow = skipWindup && ((aNew && aIsFighter) || (bNew && bIsFighter));
     if (!fighterStrikesNow) return;
   }
 

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -189,6 +189,8 @@ function strikeDamage(world: WorldState, antId: number, strikes: boolean): numbe
       ? COMBAT_DAMAGE_HOMEGROUND
       : COMBAT_DAMAGE_BASE;
   }
+  // V17+: non-fighters retaliate with reduced damage. Pre-V17: 0 (replay-safe for V16 saves).
+  if (world.simVersion < SIM_VERSION_V17_COMBAT_AGGRO) return 0;
   const cid = ants.colonyId[antId]! as ColonyId;
   const colony = world.colonies[cid];
   return colony != null && colony.queenEntityId === antId ? COMBAT_DAMAGE_QUEEN : COMBAT_DAMAGE_WORKER;

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -17,7 +17,7 @@ import { Rng } from './rng.js';
 import { AntTask } from './enums.js';
 import { makeTileKey } from './tile-key.js';
 import type { WorldState, KillerKind, QueenDeathContext } from './types.js';
-import { SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V16_COMBAT_HPDPS } from './types.js';
+import { SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V16_COMBAT_HPDPS, SIM_VERSION_V17_COMBAT_AGGRO } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 import type { Zone } from './terrain.js';
 import { FP_SHIFT } from './fixed.js';
@@ -261,14 +261,16 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
     // accumulated progress to avoid penalizing an ongoing combatant on a re-entry.
     const aIsFighter = ants.task[antA] === AntTask.Fighting;
     const bIsFighter = ants.task[antB] === AntTask.Fighting;
-    if (aNew) ants.attackCooldown[antA] = aIsFighter ? 1 : COMBAT_COOLDOWN_TICKS;
-    if (bNew) ants.attackCooldown[antB] = bIsFighter ? 1 : COMBAT_COOLDOWN_TICKS;
-    // Return early only if no strike will fire this tick:
-    //   newly-paired fighters (cooldown just set to 1 → will decrement to 0), OR
-    //   non-new sides already at cooldown=1 (their pending strike must not be skipped).
-    if (!(aNew && aIsFighter) && !(bNew && bIsFighter) &&
-        ants.attackCooldown[antA] !== 1 && ants.attackCooldown[antB] !== 1) return;
-    // At least one ant will strike this tick: fall through to decrement + strike resolution
+    // V17+: fighters skip windup on first pair (cooldown=1 → strike this tick).
+    // Pre-V17: all new pairings return early (full windup), replay-safe.
+    const skipWindup = world.simVersion >= SIM_VERSION_V17_COMBAT_AGGRO;
+    if (aNew) ants.attackCooldown[antA] = (aIsFighter && skipWindup) ? 1 : COMBAT_COOLDOWN_TICKS;
+    if (bNew) ants.attackCooldown[antB] = (bIsFighter && skipWindup) ? 1 : COMBAT_COOLDOWN_TICKS;
+    // Return early unless a newly-paired V17 fighter is about to strike (cooldown=1).
+    // Preserves the original V16 invariant: no strike fires on a pairing tick, even
+    // if the non-new side has cooldown=1 (that strike is deferred to the next tick).
+    const fighterStrikesNow = skipWindup && ((aNew && aIsFighter) || (bNew && bIsFighter));
+    if (!fighterStrikesNow) return;
   }
 
   // Decrement cooldowns. Strike when either reaches 0.

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -263,19 +263,21 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
     // accumulated progress to avoid penalizing an ongoing combatant on a re-entry.
     const aIsFighter = ants.task[antA] === AntTask.Fighting;
     const bIsFighter = ants.task[antB] === AntTask.Fighting;
-    // V17+: fighters skip windup on first pair (cooldown=1 → strike this tick).
-    // Pre-V17: all new pairings return early (full windup), replay-safe.
     const skipWindup = world.simVersion >= SIM_VERSION_V17_COMBAT_AGGRO;
-    // Compute first so cooldown assignments can compensate (see below).
     const fighterStrikesNow = skipWindup && ((aNew && aIsFighter) || (bNew && bIsFighter));
-    // When a fighter strikes on the pairing tick the decrement below runs immediately.
-    // Newly-paired non-fighters start at COMBAT_COOLDOWN_TICKS+1 so they land at
-    // COMBAT_COOLDOWN_TICKS after that decrement — full windup window preserved.
-    if (aNew) ants.attackCooldown[antA] = (aIsFighter && skipWindup) ? 1 : COMBAT_COOLDOWN_TICKS + (fighterStrikesNow && !aIsFighter ? 1 : 0);
-    if (bNew) ants.attackCooldown[antB] = (bIsFighter && skipWindup) ? 1 : COMBAT_COOLDOWN_TICKS + (fighterStrikesNow && !bIsFighter ? 1 : 0);
+    if (skipWindup) {
+      // V17+: only reset the newly-paired side — veterans keep accumulated progress.
+      // Non-fighters start at COMBAT_COOLDOWN_TICKS+1 when fighterStrikesNow so the
+      // immediate decrement below leaves them at exactly COMBAT_COOLDOWN_TICKS.
+      if (aNew) ants.attackCooldown[antA] = aIsFighter ? 1 : COMBAT_COOLDOWN_TICKS + (fighterStrikesNow ? 1 : 0);
+      if (bNew) ants.attackCooldown[antB] = bIsFighter ? 1 : COMBAT_COOLDOWN_TICKS + (fighterStrikesNow ? 1 : 0);
+    } else {
+      // Pre-V17: reset both sides unconditionally — preserves V16 replay semantics.
+      ants.attackCooldown[antA] = COMBAT_COOLDOWN_TICKS;
+      ants.attackCooldown[antB] = COMBAT_COOLDOWN_TICKS;
+    }
     // Return early unless a newly-paired V17 fighter is about to strike (cooldown=1).
-    // Preserves the original V16 invariant: no strike fires on a pairing tick, even
-    // if the non-new side has cooldown=1 (that strike is deferred to the next tick).
+    // In pre-V17, fighterStrikesNow is always false, so this always returns.
     if (!fighterStrikesNow) return;
   }
 

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -28,6 +28,8 @@ import {
   COMBAT_DAMAGE_BASE,
   COMBAT_DAMAGE_HOMEGROUND,
   COMBAT_COOLDOWN_TICKS,
+  COMBAT_DAMAGE_WORKER,
+  COMBAT_DAMAGE_QUEEN,
 } from './constants.js';
 
 /**
@@ -175,6 +177,24 @@ function applyDamage(world: WorldState, antIdx: number, damage: number): boolean
 }
 
 /**
+ * Damage dealt by `antId` when it strikes. Fighters use home-ground damage or base;
+ * queen uses COMBAT_DAMAGE_QUEEN; all other non-fighters use COMBAT_DAMAGE_WORKER.
+ * Returns 0 if the ant does not strike (strikes=false).
+ */
+function strikeDamage(world: WorldState, antId: number, strikes: boolean): number {
+  if (!strikes) return 0;
+  const { ants } = world;
+  if (ants.task[antId] === AntTask.Fighting) {
+    return (ants.zone[antId] === 1 && ants.currentGridColonyId[antId] === ants.colonyId[antId]!)
+      ? COMBAT_DAMAGE_HOMEGROUND
+      : COMBAT_DAMAGE_BASE;
+  }
+  const cid = ants.colonyId[antId]! as ColonyId;
+  const colony = world.colonies[cid];
+  return colony != null && colony.queenEntityId === antId ? COMBAT_DAMAGE_QUEEN : COMBAT_DAMAGE_WORKER;
+}
+
+/**
  * Resolve combat on a single tile using the V16 HP/damage/cooldown model.
  * One active pair per tick (lowest slot from each colony). Strikes are simultaneous.
  */
@@ -217,8 +237,6 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
   const bFresh = ants.attackCooldown[antB] === 0;
 
   if (aNew || bNew) {
-    ants.attackCooldown[antA] = COMBAT_COOLDOWN_TICKS;
-    ants.attackCooldown[antB] = COMBAT_COOLDOWN_TICKS;
     ants.combatOpponentId[antA] = antB;
     ants.combatOpponentId[antB] = antA;
     // Fresh ants get a full bonus based on current location.
@@ -238,7 +256,19 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
     } else if (!bOnHome) {
       ants.homeGroundBonusHp[antB] = 0;
     }
-    return;
+    // Fighters skip windup (always ready to strike); non-fighters wind up.
+    // Only reset cooldown for the newly-paired side — the other side keeps its
+    // accumulated progress to avoid penalizing an ongoing combatant on a re-entry.
+    const aIsFighter = ants.task[antA] === AntTask.Fighting;
+    const bIsFighter = ants.task[antB] === AntTask.Fighting;
+    if (aNew) ants.attackCooldown[antA] = aIsFighter ? 1 : COMBAT_COOLDOWN_TICKS;
+    if (bNew) ants.attackCooldown[antB] = bIsFighter ? 1 : COMBAT_COOLDOWN_TICKS;
+    // Return early only if no strike will fire this tick:
+    //   newly-paired fighters (cooldown just set to 1 → will decrement to 0), OR
+    //   non-new sides already at cooldown=1 (their pending strike must not be skipped).
+    if (!(aNew && aIsFighter) && !(bNew && bIsFighter) &&
+        ants.attackCooldown[antA] !== 1 && ants.attackCooldown[antB] !== 1) return;
+    // At least one ant will strike this tick: fall through to decrement + strike resolution
   }
 
   // Decrement cooldowns. Strike when either reaches 0.
@@ -250,18 +280,11 @@ function resolveCombatOnTile_v16(world: WorldState, _tileKey: number, participan
 
   if (!aStrikes && !bStrikes) return;
 
-  // Compute damage dealt by each striker. Only AntTask.Fighting ants deal damage;
-  // workers, nurses, and queens caught in combat do not strike back (spec Part A §3).
-  const aDamage = aStrikes && ants.task[antA] === AntTask.Fighting
-    ? ((ants.zone[antA] === 1 && ants.currentGridColonyId[antA] === ants.colonyId[antA]!)
-        ? COMBAT_DAMAGE_HOMEGROUND
-        : COMBAT_DAMAGE_BASE)
-    : 0;
-  const bDamage = bStrikes && ants.task[antB] === AntTask.Fighting
-    ? ((ants.zone[antB] === 1 && ants.currentGridColonyId[antB] === ants.colonyId[antB]!)
-        ? COMBAT_DAMAGE_HOMEGROUND
-        : COMBAT_DAMAGE_BASE)
-    : 0;
+  // Damage by task: fighters deal full damage (with home-ground bonus); non-fighters
+  // fight back weakly. Queen uses COMBAT_DAMAGE_QUEEN (identified via colony.queenEntityId);
+  // all other non-fighters use COMBAT_DAMAGE_WORKER. Queen damage flagged TBD for S6-Tune.
+  const aDamage = strikeDamage(world, antA, aStrikes);
+  const bDamage = strikeDamage(world, antB, bStrikes);
 
   // Simultaneous damage: compute both death results before killing either.
   const aDies = bDamage > 0 && applyDamage(world, antA, bDamage);

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -540,3 +540,24 @@ export const COMBAT_DAMAGE_HOMEGROUND = 5 as const;
 
 /** S1 / D-32 — Ticks between strikes; also the windup length (first contested tick). */
 export const COMBAT_COOLDOWN_TICKS = 5 as const;
+
+// ---------------------------------------------------------------------------
+// S1 follow-up — Fighter aggression radius + non-fighter combat stats
+// ---------------------------------------------------------------------------
+
+/** Manhattan tile radius within which a surface fighter scans for enemy ants before
+ *  falling back to rally-point routing. Phase 4 PRD §3d. */
+export const FIGHT_AGGRO_RADIUS = 4 as const;
+
+/** Damage dealt per strike by a non-fighter ant (worker / forager / nurse) defending itself.
+ *  25% of COMBAT_DAMAGE_BASE — non-fighters can fight back but weakly. */
+export const COMBAT_DAMAGE_WORKER = 1 as const;
+
+/** Damage dealt per strike by the queen ant. High value makes the queen dangerous to
+ *  engage directly — it takes multiple fighters to bring her down.
+ *  Flagged TBD: queen damage/HP may be tuned in S6-Tune once playtrace data exists. */
+export const COMBAT_DAMAGE_QUEEN = 6 as const;
+
+/** Base HP for the queen. Higher than workers so it takes a coordinated group of fighters
+ *  to kill her. Flagged TBD for S6-Tune. */
+export const COMBAT_HP_QUEEN = 30 as const;

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -40,6 +40,7 @@ import {
   UNDERGROUND_GRID_HEIGHT,
   WORKER_LIFESPAN_TICKS,
   ENTRANCE_SHAFT_DEPTH,
+  COMBAT_HP_QUEEN,
 } from './constants.js';
 
 // ---------------------------------------------------------------------------
@@ -175,6 +176,7 @@ function initColony(
     posY:     startY << FP_SHIFT,
     task:     AntTask.Idle,
     lifespan: WORKER_LIFESPAN_TICKS,
+    hp:       COMBAT_HP_QUEEN,
   });
 
   const colony = createColonyRecord(colonyId, queenId);

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -236,7 +236,12 @@ export const SIM_VERSION_V15_TELEMETRY = 15 as const;
  * QueenDeathContext written by killAnt so checkQueenDeath can emit cause.
  */
 export const SIM_VERSION_V16_COMBAT_HPDPS = 16 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V16_COMBAT_HPDPS;
+/**
+ * V17 — Combat aggro: fighter sight-aggression (proximity scan) + immediate
+ * fighter strikes on new pair (attackCooldown=1 vs COMBAT_COOLDOWN_TICKS).
+ */
+export const SIM_VERSION_V17_COMBAT_AGGRO = 17 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V17_COMBAT_AGGRO;
 
 export interface WorldState {
   tick: number;             // 0 at creation; incremented once per tick


### PR DESCRIPTION
## Summary

- **Fighter sight aggression**: Fighting ants now detect and charge nearby enemies within `FIGHT_AGGRO_RADIUS` tiles on the surface, instead of only engaging when directly adjacent.
- **Non-fighter strike damage**: Non-fighting ants (workers, foragers) take a reduced `strikeDamage` hit when caught in combat, making fights more consequential.
- **Queen stats**: Queen ants now have distinct HP and combat stats seeded by `scenario.ts`.

## Rebased from #138

PR #138 was stacked on `feat/s1-combat-math` which was squashed into main as PR #135. This PR replays only the single aggro commit onto `main`.

## Test plan
- [ ] `env -u NODE_OPTIONS npx vitest run src/sim/combat.test.ts` — all combat tests pass
- [ ] `env -u NODE_OPTIONS npx vitest run` — only pre-existing determinism flake fails (present on `main` before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)