### PR TITLE
feat(s2): AI invasion + loss-cause ledger (V19)

### DIFF
--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -11,8 +11,9 @@
 //      Iterate via Object.entries — NEVER Array.from(world.colonies.entries()) [there is no .entries()]
 //   6. Version-gated: bumping SAVE_FORMAT_VERSION invalidates old saves (intentional for beta)
 
-import type { WorldState, EntityId } from '../sim/types.js';
-import { LEGACY_SIM_VERSION, LATEST_SIM_VERSION } from '../sim/types.js';
+import type { WorldState, EntityId, AIStateRecord } from '../sim/types.js';
+import { LEGACY_SIM_VERSION, LATEST_SIM_VERSION, SIM_VERSION_V19_AI_STATE } from '../sim/types.js';
+import { AI_MAX_OPERATION_FIGHTERS } from '../sim/constants.js';
 import type { AntComponents } from '../sim/ant/ant-store.js';
 import { createAntComponents } from '../sim/ant/ant-store.js';
 import type {
@@ -430,6 +431,28 @@ interface SerializedColony {
 
 interface SerializedGrid { width: number; height: number; data: number[] }
 
+/** S2 — serialized form of AIStateRecord. operationFighterIds stored as number[]. */
+interface SerializedAIStateRecord {
+  colonyId: number;
+  state: string;
+  enteredTick: number;
+  probeCount: number;
+  lastProbeEndTick: number;
+  invasionStartTick: number;
+  invasionRallyTileX: number;
+  invasionRallyTileY: number;
+  recoveryEndTick: number;
+  operationKind: string;
+  operationStartTick: number;
+  operationTargetTileX: number;
+  operationTargetTileY: number;
+  operationFighterIds: number[];
+  operationFighterCount: number;
+  operationStartFighterCount: number;
+  operationAttackerDeaths: number;
+  operationDefenderDeaths: number;
+}
+
 export interface SerializedWorldState {
   tick: number;
   rngState: number;
@@ -470,6 +493,8 @@ export interface SerializedWorldState {
    */
   recentlyDepletedFood?: DepletionRecord[];
   pendingChambers: Record<string, PendingChamber>;
+  /** S2 — optional for backward compat with pre-V17 saves; defaults to [] on load. */
+  aiState?: SerializedAIStateRecord[];
 }
 
 // ---------------------------------------------------------------------------
@@ -623,6 +648,27 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
     // S0b: persist overflow counters; skip events (transient per design).
     droppedCombatKillCount: world.droppedCombatKillCount,
     droppedStructuralCount: world.droppedStructuralCount,
+    // S2 — AI state machine records. operationFighterIds stored as number[].
+    aiState: world.aiState.map((rec) => ({
+      colonyId: rec.colonyId,
+      state: rec.state,
+      enteredTick: rec.enteredTick,
+      probeCount: rec.probeCount,
+      lastProbeEndTick: rec.lastProbeEndTick,
+      invasionStartTick: rec.invasionStartTick,
+      invasionRallyTileX: rec.invasionRallyTileX,
+      invasionRallyTileY: rec.invasionRallyTileY,
+      recoveryEndTick: rec.recoveryEndTick,
+      operationKind: rec.operationKind,
+      operationStartTick: rec.operationStartTick,
+      operationTargetTileX: rec.operationTargetTileX,
+      operationTargetTileY: rec.operationTargetTileY,
+      operationFighterIds: Array.from(rec.operationFighterIds),
+      operationFighterCount: rec.operationFighterCount,
+      operationStartFighterCount: rec.operationStartFighterCount,
+      operationAttackerDeaths: rec.operationAttackerDeaths,
+      operationDefenderDeaths: rec.operationDefenderDeaths,
+    })),
   };
 }
 
@@ -917,6 +963,61 @@ function deserializePheromoneGrid(s: SerializedGrid): PheromoneGrid {
   return g;
 }
 
+/**
+ * S2 — deserialize world.aiState from the save snapshot.
+ * Pre-V17 saves omit the field; return an empty array (scenario will populate
+ * defaults at next createScenario/load; the legacy stateless AI doesn't read aiState).
+ */
+function deserializeAIStateArray(s: SerializedWorldState, simVersion: number): AIStateRecord[] {
+  // Pre-V17: return empty array. Scenario initialization will set defaults.
+  if (simVersion < SIM_VERSION_V19_AI_STATE) return [];
+  const raw = s.aiState;
+  if (!Array.isArray(raw)) return [];
+  const result: AIStateRecord[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const r = raw[i]!;
+    if (r === null || typeof r !== 'object') continue;
+    const fightIds = Array.isArray(r.operationFighterIds)
+      ? r.operationFighterIds as number[]
+      : [];
+    const buf = new Int32Array(AI_MAX_OPERATION_FIGHTERS).fill(-1);
+    const copyLen = Math.min(fightIds.length, AI_MAX_OPERATION_FIGHTERS);
+    for (let j = 0; j < copyLen; j++) {
+      const val = fightIds[j];
+      buf[j] = (typeof val === 'number' && Number.isInteger(val)) ? val : -1;
+    }
+    result.push({
+      colonyId: typeof r.colonyId === 'number' ? r.colonyId : 0,
+      state: isValidAIState(r.state) ? r.state : 'Peacetime',
+      enteredTick: typeof r.enteredTick === 'number' ? r.enteredTick : 0,
+      probeCount: typeof r.probeCount === 'number' ? r.probeCount : 0,
+      lastProbeEndTick: typeof r.lastProbeEndTick === 'number' ? r.lastProbeEndTick : 0,
+      invasionStartTick: typeof r.invasionStartTick === 'number' ? r.invasionStartTick : 0,
+      invasionRallyTileX: typeof r.invasionRallyTileX === 'number' ? r.invasionRallyTileX : -1,
+      invasionRallyTileY: typeof r.invasionRallyTileY === 'number' ? r.invasionRallyTileY : -1,
+      recoveryEndTick: typeof r.recoveryEndTick === 'number' ? r.recoveryEndTick : 0,
+      operationKind: isValidOperationKind(r.operationKind) ? r.operationKind : 'None',
+      operationStartTick: typeof r.operationStartTick === 'number' ? r.operationStartTick : 0,
+      operationTargetTileX: typeof r.operationTargetTileX === 'number' ? r.operationTargetTileX : -1,
+      operationTargetTileY: typeof r.operationTargetTileY === 'number' ? r.operationTargetTileY : -1,
+      operationFighterIds: buf,
+      operationFighterCount: typeof r.operationFighterCount === 'number' ? r.operationFighterCount : 0,
+      operationStartFighterCount: typeof r.operationStartFighterCount === 'number' ? r.operationStartFighterCount : 0,
+      operationAttackerDeaths: typeof r.operationAttackerDeaths === 'number' ? r.operationAttackerDeaths : 0,
+      operationDefenderDeaths: typeof r.operationDefenderDeaths === 'number' ? r.operationDefenderDeaths : 0,
+    });
+  }
+  return result;
+}
+
+function isValidAIState(v: unknown): v is import('../sim/types.js').AIState {
+  return v === 'Peacetime' || v === 'WarFooting' || v === 'Probing' || v === 'Invading' || v === 'Recovery';
+}
+
+function isValidOperationKind(v: unknown): v is 'None' | 'Probe' | 'Invasion' {
+  return v === 'None' || v === 'Probe' || v === 'Invasion';
+}
+
 export function deserializeWorldState(s: SerializedWorldState): WorldState {
   // Top-level guard — must be a non-null object to read .simVersion.
   if (s === null || typeof s !== 'object') {
@@ -1193,6 +1294,8 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     events: [],
     // S1 — transient; always fresh on load (cleared between ticks).
     pendingQueenDeathContexts: [],
+    // S2 — AI state machine. Deserialize saved records, or provide defensive defaults for pre-V17 saves.
+    aiState: deserializeAIStateArray(s, validatedSimVersion),
     droppedCombatKillCount:
       typeof s.droppedCombatKillCount === 'number' &&
       Number.isInteger(s.droppedCombatKillCount) &&

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -1001,7 +1001,7 @@ function deserializeAIStateArray(s: SerializedWorldState, simVersion: number): A
       operationTargetTileX: typeof r.operationTargetTileX === 'number' ? r.operationTargetTileX : -1,
       operationTargetTileY: typeof r.operationTargetTileY === 'number' ? r.operationTargetTileY : -1,
       operationFighterIds: buf,
-      operationFighterCount: typeof r.operationFighterCount === 'number' ? r.operationFighterCount : 0,
+      operationFighterCount: typeof r.operationFighterCount === 'number' ? Math.min(Math.max(0, r.operationFighterCount), AI_MAX_OPERATION_FIGHTERS) : 0,
       operationStartFighterCount: typeof r.operationStartFighterCount === 'number' ? r.operationStartFighterCount : 0,
       operationAttackerDeaths: typeof r.operationAttackerDeaths === 'number' ? r.operationAttackerDeaths : 0,
       operationDefenderDeaths: typeof r.operationDefenderDeaths === 'number' ? r.operationDefenderDeaths : 0,

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -493,7 +493,7 @@ export interface SerializedWorldState {
    */
   recentlyDepletedFood?: DepletionRecord[];
   pendingChambers: Record<string, PendingChamber>;
-  /** S2 — optional for backward compat with pre-V17 saves; defaults to [] on load. */
+  /** S2 — optional for backward compat with pre-V19 saves; defaults to [] on load. */
   aiState?: SerializedAIStateRecord[];
 }
 
@@ -1294,7 +1294,7 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     events: [],
     // S1 — transient; always fresh on load (cleared between ticks).
     pendingQueenDeathContexts: [],
-    // S2 — AI state machine. Deserialize saved records, or provide defensive defaults for pre-V17 saves.
+    // S2 — AI state machine. Deserialize saved records, or provide defensive defaults for pre-V19 saves.
     aiState: deserializeAIStateArray(s, validatedSimVersion),
     droppedCombatKillCount:
       typeof s.droppedCombatKillCount === 'number' &&

--- a/src/render/ai-controller.test.ts
+++ b/src/render/ai-controller.test.ts
@@ -23,7 +23,7 @@ import {
   AI_BEHAVIOR_RATIO,
 } from './ai-controller.js';
 
-import { createWorldState } from '../sim/types.js';
+import { createWorldState, SIM_VERSION_V16_COMBAT_HPDPS } from '../sim/types.js';
 import { createColonyRecord } from '../sim/colony/colony-store.js';
 import type { ColonyRecord, ChamberRecord } from '../sim/colony/colony-store.js';
 import { createUndergroundGrid, ugSet, UndergroundTileState } from '../sim/terrain.js';
@@ -165,8 +165,10 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
   // -------------------------------------------------------------------------
   describe('aiInitialSetup (CMBT-02 tick-0 setup)', () => {
 
-    it('on tick 0, pushes SetBehaviorRatio with AI_BEHAVIOR_RATIO', () => {
+    it('on tick 0, pushes SetBehaviorRatio with AI_BEHAVIOR_RATIO (pre-V17)', () => {
+      // V17+ worlds skip ratio push in aiInitialSetup; _syncBehaviorRatioToAIState owns it.
       const world = makeWorld(0);
+      world.simVersion = SIM_VERSION_V16_COMBAT_HPDPS;
       const colony = addColony(world, 2 as ColonyId, 0);
       setQueenPos(world, 0, 10, 5);
       aiInitialSetup(world, colony);
@@ -174,6 +176,16 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       expect(ratioCmd).toBeDefined();
       expect((ratioCmd as { ratio: typeof AI_BEHAVIOR_RATIO }).ratio).toEqual(AI_BEHAVIOR_RATIO);
       expect(ratioCmd!.issuedAtTick).toBe(0);
+    });
+
+    it('in V17+, does NOT push SetBehaviorRatio (owned by _syncBehaviorRatioToAIState)', () => {
+      const world = makeWorld(0);
+      // world.simVersion is already V17 (LATEST_SIM_VERSION via createWorldState)
+      const colony = addColony(world, 2 as ColonyId, 0);
+      setQueenPos(world, 0, 10, 5);
+      aiInitialSetup(world, colony);
+      const ratioCmd = world.commandQueue.find((c) => c.type === 'SetBehaviorRatio');
+      expect(ratioCmd).toBeUndefined();
     });
 
     it('on tick 0, pushes DesignateEntrance for the AI queen\'s surface tile', () => {
@@ -204,13 +216,15 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       aiInitialSetup(world, colony);
       expect(world.commandQueue).toHaveLength(0);
     });
-    it('DOES push initial-setup commands after tick 0 when post-conditions unmet (#75)', () => {
+    it('DOES push initial-setup commands after tick 0 when post-conditions unmet (#75, pre-V17)', () => {
       // Pre-fix this scenario was broken: a save written before
       // aiInitialSetup existed (or where some future code path cleared
       // the AI's targetRatio / entrances) would never reinitialize. Post-
       // fix the function pushes whichever commands the post-condition
       // check determines are needed, regardless of `world.tick`.
+      // V17+: ratio push is handled by _syncBehaviorRatioToAIState, so only entrance pushed here.
       const world = makeWorld(1);
+      world.simVersion = SIM_VERSION_V16_COMBAT_HPDPS;
       const colony = addColony(world, 2 as ColonyId, 0);
       setQueenPos(world, 0, 10, 5);
       aiInitialSetup(world, colony);
@@ -230,8 +244,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       }
     });
 
-    it('SetBehaviorRatio uses the AI colonyId (not a hardcoded value)', () => {
+    it('SetBehaviorRatio uses the AI colonyId (not a hardcoded value, pre-V17)', () => {
       const world = makeWorld(0);
+      world.simVersion = SIM_VERSION_V16_COMBAT_HPDPS;
       const colony = addColony(world, 42 as ColonyId, 0);
       colony.colonyId = 42 as ColonyId;
       setQueenPos(world, 0, 10, 5);

--- a/src/render/ai-controller.test.ts
+++ b/src/render/ai-controller.test.ts
@@ -157,7 +157,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       // tick=1: aiInitialSetup no-ops (post-conditions met), aiDigHeuristic
       // no-ops (1%40≠0), aiChamberPlacement: no queen chamber → tries to find
       // open spot (all Solid → null), aiEntranceDesignation: has entrances → skip.
-      expect(world.commandQueue).toHaveLength(0);
+      // SyncAIState is pushed every V17 tick for replay determinism — exclude from check.
+      const nonSyncCmds = world.commandQueue.filter((c) => c.type !== 'SyncAIState');
+      expect(nonSyncCmds).toHaveLength(0);
     });
 
   });

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -4,13 +4,14 @@
 // The simulation has ONE code path for all colonies; AI differentiates at the CALLER
 // (GameScene's onBeforeTick calls runAIController only for non-player colonyIds).
 
-import type { WorldState } from '../sim/types.js';
+import type { WorldState, AIStateRecord } from '../sim/types.js';
 import type { ColonyId, ColonyRecord } from '../sim/colony/colony-store.js';
 import type {
   MarkDigTileCommand,
   PlaceChamberCommand,
   DesignateEntranceCommand,
   SetBehaviorRatioCommand,
+  SyncAIStateCommand,
 } from '../sim/commands.js';
 import { ChamberType } from '../sim/enums.js';
 import { UndergroundTileState, ugGet } from '../sim/terrain.js';
@@ -145,6 +146,10 @@ export function runAIController(world: WorldState, aiColonyId: ColonyId): void {
     }
     // Sync behavior ratio to state.
     _syncBehaviorRatioToAIState(world, aiColonyId, colony);
+
+    // Push SyncAIState so the snapshot-analyzer replay path (which calls tick() only,
+    // never runAIController) can reproduce world.aiState bit-identically.
+    _pushSyncAIState(world, aiColonyId);
   }
 
   aiDigHeuristic(world, colony);
@@ -537,6 +542,35 @@ const AI_STATE_RATIOS: Record<string, { forage: number; fight: number }> = {
   Invading:   { forage: 2, fight: 8 },
   Recovery:   { forage: 6, fight: 4 },
 };
+
+/** Push a SyncAIState command so replay-only paths reproduce world.aiState bit-identically. */
+function _pushSyncAIState(world: WorldState, aiColonyId: ColonyId): void {
+  const rec = world.aiState.find((r) => r.colonyId === aiColonyId);
+  if (rec === undefined) return;
+  const cmd: SyncAIStateCommand = {
+    type: 'SyncAIState',
+    colonyId: aiColonyId,
+    issuedAtTick: world.tick,
+    state: rec.state,
+    enteredTick: rec.enteredTick,
+    probeCount: rec.probeCount,
+    lastProbeEndTick: rec.lastProbeEndTick,
+    invasionStartTick: rec.invasionStartTick,
+    invasionRallyTileX: rec.invasionRallyTileX,
+    invasionRallyTileY: rec.invasionRallyTileY,
+    recoveryEndTick: rec.recoveryEndTick,
+    operationKind: rec.operationKind,
+    operationStartTick: rec.operationStartTick,
+    operationTargetTileX: rec.operationTargetTileX,
+    operationTargetTileY: rec.operationTargetTileY,
+    operationFighterIds: Array.from(rec.operationFighterIds),
+    operationFighterCount: rec.operationFighterCount,
+    operationStartFighterCount: rec.operationStartFighterCount,
+    operationAttackerDeaths: rec.operationAttackerDeaths,
+    operationDefenderDeaths: rec.operationDefenderDeaths,
+  };
+  world.commandQueue.push(cmd);
+}
 
 /** Sync the AI colony behavior ratio to its current state. */
 function _syncBehaviorRatioToAIState(

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -166,17 +166,21 @@ export function runAIController(world: WorldState, aiColonyId: ColonyId): void {
 export function aiInitialSetup(world: WorldState, colony: ColonyRecord): void {
   // 1. Set fixed behavior ratio for AI (CMBT-02). Skip if the colony's
   //    targetRatio already matches the AI ratio (idempotent across boots).
-  const ratioReady =
-    colony.targetRatio.forage === AI_BEHAVIOR_RATIO.forage &&
-    colony.targetRatio.fight === AI_BEHAVIOR_RATIO.fight;
-  if (!ratioReady) {
-    const setRatioCmd: SetBehaviorRatioCommand = {
-      type: 'SetBehaviorRatio',
-      colonyId: colony.colonyId,
-      ratio: { ...AI_BEHAVIOR_RATIO },
-      issuedAtTick: world.tick,
-    };
-    world.commandQueue.push(setRatioCmd);
+  //    V17+: _syncBehaviorRatioToAIState owns the ratio; skip here to avoid
+  //    alternating commands that thrash the ratio every tick in non-Peacetime states.
+  if (world.simVersion < SIM_VERSION_V17_AI_STATE) {
+    const ratioReady =
+      colony.targetRatio.forage === AI_BEHAVIOR_RATIO.forage &&
+      colony.targetRatio.fight === AI_BEHAVIOR_RATIO.fight;
+    if (!ratioReady) {
+      const setRatioCmd: SetBehaviorRatioCommand = {
+        type: 'SetBehaviorRatio',
+        colonyId: colony.colonyId,
+        ratio: { ...AI_BEHAVIOR_RATIO },
+        issuedAtTick: world.tick,
+      };
+      world.commandQueue.push(setRatioCmd);
+    }
   }
 
   // 2. Designate entrance at queen's surface tile. Skip if any entrance

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -28,7 +28,6 @@ import {
 import { colonyFoodTotal } from '../sim/colony/colony-system.js';
 import { SIM_VERSION_V19_AI_STATE } from '../sim/types.js';
 import {
-  advanceAIState,
   setAIRallyOperation,
   aiFighterCount,
 } from '../sim/ai-state.js';
@@ -105,44 +104,27 @@ export function runAIController(world: WorldState, aiColonyId: ColonyId): void {
 
   aiInitialSetup(world, colony);
 
-  // S2: state machine tick (gated on V17).
+  // S2: state machine policy (gated on V19).
+  // advanceAIState (state transitions) now runs inside tick.ts to preserve the
+  // sim/render boundary — render reads world.aiState from the previous tick and
+  // emits operational commands (probe entry, invasion tick, behavior ratio sync).
   if (world.simVersion >= SIM_VERSION_V19_AI_STATE) {
-    // Record state before advancing so we can detect operation exits below.
-    const prevAIRecord = world.aiState.find((r) => r.colonyId === aiColonyId);
-    const prevState = prevAIRecord?.state ?? 'Peacetime';
-    const hadRally = prevAIRecord !== undefined && prevAIRecord.invasionRallyTileX !== -1;
-
-    const aiState = advanceAIState(world, aiColonyId);
-
-    // Spec Part B §4 / Part C §5: on Probing or Invading exit, emit ClearRallyPoint
-    // so world.rallyPoint is cleared and Recovery-phase fighters re-route home.
-    const wasActive = prevState === 'Probing' || prevState === 'Invading';
-    const nowInactive = aiState.state !== 'Probing' && aiState.state !== 'Invading';
-    if (wasActive && nowInactive && hadRally) {
-      world.commandQueue.push({
-        type: 'ClearRallyPoint',
-        colonyId: aiColonyId,
-        issuedAtTick: world.tick,
-      });
-    }
-
-    // After advanceAIState, check if we should transition WarFooting→Probing
-    // (target selection is a guard — render side picks the target).
-    if (aiState.state === 'WarFooting') {
-      const ticksSinceLast = world.tick - aiState.lastProbeEndTick;
-      if (ticksSinceLast >= AI_PROBE_INTERVAL_TICKS
-          && aiFighterCount(world, aiColonyId) >= AI_PROBE_FIGHTER_COUNT) {
-        aiStateMachineTick_probeEntry(world, aiColonyId, colony);
+    const aiStateRecord = world.aiState.find((r) => r.colonyId === aiColonyId);
+    if (aiStateRecord !== undefined) {
+      const curState = aiStateRecord.state;
+      if (curState === 'WarFooting') {
+        const ticksSinceLast = world.tick - aiStateRecord.lastProbeEndTick;
+        if (ticksSinceLast >= AI_PROBE_INTERVAL_TICKS
+            && aiFighterCount(world, aiColonyId) >= AI_PROBE_FIGHTER_COUNT) {
+          aiStateMachineTick_probeEntry(world, aiColonyId, colony);
+        }
       }
-    }
-    if (aiState.state === 'Invading') {
-      aiInvasionTick(world, aiColonyId);
-    }
-    // Guard: skip aiProbeTick on the entry tick — aiStateMachineTick_probeEntry
-    // already emitted SetRallyPoint; running aiProbeTick on the same tick would
-    // emit a duplicate before colony.rallyPoint is populated by queue drain.
-    if (aiState.state === 'Probing' && prevState === 'Probing') {
-      aiProbeTick(world, aiColonyId);
+      if (curState === 'Invading') {
+        aiInvasionTick(world, aiColonyId);
+      }
+      if (curState === 'Probing') {
+        aiProbeTick(world, aiColonyId);
+      }
     }
     // Sync behavior ratio to state.
     _syncBehaviorRatioToAIState(world, aiColonyId, colony);

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -570,7 +570,7 @@ function aiStateMachineTick_probeEntry(
   aiColonyId: ColonyId,
   _colony: ColonyRecord,
 ): void {
-  const target = _selectProbeTarget(world);
+  const target = _selectProbeTarget(world, aiColonyId);
   if (target === null) return; // no target → don't transition
 
   // Commit the closest 3 alive AI fighters by ascending ant index.
@@ -645,16 +645,16 @@ function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
 }
 
 /** Select probe target (Q3 spec). */
-function _selectProbeTarget(world: WorldState): { tileX: number; tileY: number } | null {
+function _selectProbeTarget(world: WorldState, aiColonyId: ColonyId): { tileX: number; tileY: number } | null {
   // Priority 1: closest player-marked food pile by ascending pile ID for ties.
   const playerColony = world.colonies[PLAYER_COLONY_ID];
   if (playerColony === undefined) return null;
 
   let bestPile: { tileX: number; tileY: number; id: number; dist: number } | null = null;
-  const enemyCol = world.colonies[2]; // ENEMY_COLONY_ID = 2
+  const aiCol = world.colonies[aiColonyId];
   // We need a reference point: AI's entrance or colony start.
-  const aiEntranceX = enemyCol !== undefined && enemyCol.entrances.length > 0
-    ? enemyCol.entrances[0]!.surfaceTileX
+  const aiEntranceX = aiCol !== undefined && aiCol.entrances.length > 0
+    ? aiCol.entrances[0]!.surfaceTileX
     : 104; // ENEMY_START_X fallback
 
   for (const pile of world.foodPiles) {

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -137,7 +137,10 @@ export function runAIController(world: WorldState, aiColonyId: ColonyId): void {
     if (aiState.state === 'Invading') {
       aiInvasionTick(world, aiColonyId);
     }
-    if (aiState.state === 'Probing') {
+    // Guard: skip aiProbeTick on the entry tick — aiStateMachineTick_probeEntry
+    // already emitted SetRallyPoint; running aiProbeTick on the same tick would
+    // emit a duplicate before colony.rallyPoint is populated by queue drain.
+    if (aiState.state === 'Probing' && prevState === 'Probing') {
       aiProbeTick(world, aiColonyId);
     }
     // Sync behavior ratio to state.

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -656,6 +656,7 @@ function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
 
     // Commit ALL alive AI fighters up to AI_MAX_OPERATION_FIGHTERS (lowest indices first).
     const fighters = _selectAllFighters(world, aiColonyId);
+    if (fighters.length === 0) return; // no fighters — retry next tick when fighters are available
 
     // Push StartAIOperation so tick.ts applies setAIRallyOperation sim-side (ADR-0007).
     world.commandQueue.push({

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -21,22 +21,15 @@ import {
   UNDERGROUND_CEILING_ROW_Y,
   PLAYER_COLONY_ID,
   ENEMY_START_X,
-  ENEMY_START_Y,
   AI_PROBE_INTERVAL_TICKS,
   AI_PROBE_FIGHTER_COUNT,
   AI_PROBE_FALLBACK_RADIUS_TILES,
   AI_MAX_OPERATION_FIGHTERS,
-  AI_INVADING_FIGHTER_THRESHOLD,
-  AI_INVADING_FOOD_FRAC_PCT,
-  AI_INVADING_MIN_TICK,
 } from '../sim/constants.js';
 import { colonyFoodTotal } from '../sim/colony/colony-system.js';
 import { SIM_VERSION_V19_AI_STATE } from '../sim/types.js';
 import {
   aiFighterCount,
-  aiFoodStored,
-  aiFoodCapacity,
-  NORMAL_TIER_INDEX,
 } from '../sim/ai-state.js';
 
 import { AntTask } from '../sim/enums.js';
@@ -120,16 +113,10 @@ export function runAIController(world: WorldState, aiColonyId: ColonyId): void {
     if (aiStateRecord !== undefined) {
       const curState = aiStateRecord.state;
       if (curState === 'WarFooting') {
-        const invasionReady =
-          world.tick >= AI_INVADING_MIN_TICK &&
-          aiFighterCount(world, aiColonyId) >= AI_INVADING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX] &&
-          aiFoodStored(world, aiColonyId) * 100 >= aiFoodCapacity(world, aiColonyId) * AI_INVADING_FOOD_FRAC_PCT;
-        if (!invasionReady) {
-          const ticksSinceLast = world.tick - aiStateRecord.lastProbeEndTick;
-          if (ticksSinceLast >= AI_PROBE_INTERVAL_TICKS
-              && aiFighterCount(world, aiColonyId) >= AI_PROBE_FIGHTER_COUNT) {
-            aiStateMachineTick_probeEntry(world, aiColonyId, colony);
-          }
+        const ticksSinceLast = world.tick - aiStateRecord.lastProbeEndTick;
+        if (ticksSinceLast >= AI_PROBE_INTERVAL_TICKS
+            && aiFighterCount(world, aiColonyId) >= AI_PROBE_FIGHTER_COUNT) {
+          aiStateMachineTick_probeEntry(world, aiColonyId, colony);
         }
       }
       if (curState === 'Invading') {
@@ -718,7 +705,9 @@ function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
 
     // Commit ALL alive AI fighters up to AI_MAX_OPERATION_FIGHTERS (lowest indices first).
     const fighters = _selectAllFighters(world, aiColonyId);
-    if (fighters.length === 0) return; // no fighters — retry next tick when fighters are available
+    // tick.ts rejects Invasion StartAIOperation with fighterIds.length < 3; skip early and
+    // avoid pushing a SetRallyPoint that routes uncohorted fighters toward the enemy entrance.
+    if (fighters.length < 3) return;
 
     // Push StartAIOperation so tick.ts applies setAIRallyOperation sim-side (ADR-0007).
     world.commandQueue.push({
@@ -743,8 +732,8 @@ function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
     }
   }
 
-  // When invasion ends (advanceAIState → _endInvasion resets invasionRallyTileX/Y to -1),
-  // runAIController emits ClearRallyPoint in the wasActive && nowInactive block above.
+  // When invasion ends, advanceAIState → _endInvasion emits ClearRallyPoint and resets
+  // invasionRallyTileX/Y to -1. The re-emit block above is harmless (invasionRallyTileX === -1).
 }
 
 /** Select probe target (Q3 spec). */
@@ -759,11 +748,14 @@ function _selectProbeTarget(world: WorldState, aiColonyId: ColonyId): { tileX: n
   const aiEntranceX = aiCol !== undefined && aiCol.entrances.length > 0
     ? aiCol.entrances[0]!.surfaceTileX
     : ENEMY_START_X;
+  const aiEntranceY = aiCol !== undefined && aiCol.entrances.length > 0
+    ? aiCol.entrances[0]!.surfaceTileY
+    : 0; // surface row — all current entrances have surfaceTileY=0
 
   for (const pile of world.foodPiles) {
     const isMarked = playerColony.priorityFoodPileId === pile.foodPileId;
     if (!isMarked) continue;
-    const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - ENEMY_START_Y);
+    const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - aiEntranceY);
     if (bestPile === null || dist < bestPile.dist || (dist === bestPile.dist && pile.foodPileId < bestPile.id)) {
       bestPile = { tileX: pile.tileX, tileY: pile.tileY, id: pile.foodPileId, dist };
     }
@@ -782,7 +774,7 @@ function _selectProbeTarget(world: WorldState, aiColonyId: ColonyId): { tileX: n
     }
     if (!withinRadius) continue;
     // Pick closest to AI entrance by ascending pile ID for ties.
-    const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - ENEMY_START_Y);
+    const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - aiEntranceY);
     if (bestPile === null || dist < bestPile.dist || (dist === bestPile.dist && pile.foodPileId < bestPile.id)) {
       bestPile = { tileX: pile.tileX, tileY: pile.tileY, id: pile.foodPileId, dist };
     }

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -16,8 +16,23 @@ import { ChamberType } from '../sim/enums.js';
 import { UndergroundTileState, ugGet } from '../sim/terrain.js';
 import { FP_SHIFT } from '../sim/fixed.js';
 import { CHAMBER_DIMENSIONS } from '../sim/colony/chamber.js';
-import { UNDERGROUND_CEILING_ROW_Y } from '../sim/constants.js';
+import {
+  UNDERGROUND_CEILING_ROW_Y,
+  PLAYER_COLONY_ID,
+  AI_PROBE_INTERVAL_TICKS,
+  AI_PROBE_FIGHTER_COUNT,
+  AI_PROBE_FALLBACK_RADIUS_TILES,
+  AI_MAX_OPERATION_FIGHTERS,
+} from '../sim/constants.js';
 import { colonyFoodTotal } from '../sim/colony/colony-system.js';
+import { SIM_VERSION_V19_AI_STATE } from '../sim/types.js';
+import {
+  advanceAIState,
+  setAIRallyOperation,
+  aiFighterCount,
+} from '../sim/ai-state.js';
+
+import { AntTask } from '../sim/enums.js';
 
 export const AI_DIG_INTERVAL = 40 as const;       // every 2 seconds @ 20Hz
 /**
@@ -88,6 +103,47 @@ export function runAIController(world: WorldState, aiColonyId: ColonyId): void {
   if (colony === undefined || colony.defeated) return;
 
   aiInitialSetup(world, colony);
+
+  // S2: state machine tick (gated on V17).
+  if (world.simVersion >= SIM_VERSION_V19_AI_STATE) {
+    // Record state before advancing so we can detect operation exits below.
+    const prevAIRecord = world.aiState.find((r) => r.colonyId === aiColonyId);
+    const prevState = prevAIRecord?.state ?? 'Peacetime';
+    const hadRally = prevAIRecord !== undefined && prevAIRecord.invasionRallyTileX !== -1;
+
+    const aiState = advanceAIState(world, aiColonyId);
+
+    // Spec Part B §4 / Part C §5: on Probing or Invading exit, emit ClearRallyPoint
+    // so world.rallyPoint is cleared and Recovery-phase fighters re-route home.
+    const wasActive = prevState === 'Probing' || prevState === 'Invading';
+    const nowInactive = aiState.state !== 'Probing' && aiState.state !== 'Invading';
+    if (wasActive && nowInactive && hadRally) {
+      world.commandQueue.push({
+        type: 'ClearRallyPoint',
+        colonyId: aiColonyId,
+        issuedAtTick: world.tick,
+      });
+    }
+
+    // After advanceAIState, check if we should transition WarFooting→Probing
+    // (target selection is a guard — render side picks the target).
+    if (aiState.state === 'WarFooting') {
+      const ticksSinceLast = world.tick - aiState.lastProbeEndTick;
+      if (ticksSinceLast >= AI_PROBE_INTERVAL_TICKS
+          && aiFighterCount(world, aiColonyId) >= AI_PROBE_FIGHTER_COUNT) {
+        aiStateMachineTick_probeEntry(world, aiColonyId, colony);
+      }
+    }
+    if (aiState.state === 'Invading') {
+      aiInvasionTick(world, aiColonyId);
+    }
+    if (aiState.state === 'Probing') {
+      aiProbeTick(world, aiColonyId);
+    }
+    // Sync behavior ratio to state.
+    _syncBehaviorRatioToAIState(world, aiColonyId, colony);
+  }
+
   aiDigHeuristic(world, colony);
   aiChamberPlacement(world, colony);
   aiEntranceDesignation(world, colony);
@@ -459,6 +515,241 @@ export function aiEntranceDesignation(world: WorldState, colony: ColonyRecord): 
       return;
     }
   }
+}
+
+
+// ---------------------------------------------------------------------------
+// S2: AI state machine subroutines
+// ---------------------------------------------------------------------------
+
+/** Behavior ratios per AI state (forage:fight on 0-10 scale). */
+const AI_STATE_RATIOS: Record<string, { forage: number; fight: number }> = {
+  Peacetime:  { forage: 7, fight: 3 },
+  WarFooting: { forage: 3, fight: 7 },
+  Probing:    { forage: 3, fight: 7 },
+  Invading:   { forage: 2, fight: 8 },
+  Recovery:   { forage: 6, fight: 4 },
+};
+
+/** Sync the AI colony behavior ratio to its current state. */
+function _syncBehaviorRatioToAIState(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  colony: ColonyRecord,
+): void {
+  // Get current aiState
+  let currentState = 'Peacetime';
+  for (let i = 0; i < world.aiState.length; i++) {
+    if (world.aiState[i]!.colonyId === aiColonyId) {
+      currentState = world.aiState[i]!.state;
+      break;
+    }
+  }
+  const targetRatio = AI_STATE_RATIOS[currentState] ?? AI_BEHAVIOR_RATIO;
+  if (colony.targetRatio.forage !== targetRatio.forage
+      || colony.targetRatio.fight !== targetRatio.fight) {
+    const setRatioCmd: SetBehaviorRatioCommand = {
+      type: 'SetBehaviorRatio',
+      colonyId: aiColonyId,
+      ratio: { ...targetRatio },
+      issuedAtTick: world.tick,
+    };
+    world.commandQueue.push(setRatioCmd);
+  }
+}
+
+/**
+ * Attempt WarFooting→Probing transition with target selection.
+ * Target selection is the guard: if no target, transition does NOT fire.
+ * Q3 spec: pick closest player-marked food pile by ascending pile ID.
+ * Fallback: closest unmarked surface pile within AI_PROBE_FALLBACK_RADIUS_TILES
+ * of any open player entrance.
+ */
+function aiStateMachineTick_probeEntry(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  _colony: ColonyRecord,
+): void {
+  const target = _selectProbeTarget(world);
+  if (target === null) return; // no target → don't transition
+
+  // Commit the closest 3 alive AI fighters by ascending ant index.
+  const fighters = _selectProbeFighters(world, aiColonyId);
+  if (fighters.length < AI_PROBE_FIGHTER_COUNT) return; // not enough fighters
+
+  setAIRallyOperation(world, aiColonyId, target.tileX, target.tileY, fighters, 'Probe');
+
+  // Emit SetRallyPoint SimCommand so world.rallyPoint is set for fighters.
+  _emitSetRallyPoint(world, aiColonyId, target.tileX, target.tileY);
+}
+
+/**
+ * aiProbeTick — runs while state === Probing.
+ * Re-emit SetRallyPoint only when colony.rallyPoint is null (e.g. first post-load tick
+ * if the saved rallyPoint was somehow cleared). Per spec NTH-5: colony.rallyPoint is
+ * the derived consequence; aiState.invasionRallyTileX/Y is the sim-state-of-record.
+ * The probe end conditions are handled by advanceAIState → _checkProbingToWarFooting.
+ */
+function aiProbeTick(world: WorldState, aiColonyId: ColonyId): void {
+  let aiState: import('../sim/types.js').AIStateRecord | null = null;
+  for (let i = 0; i < world.aiState.length; i++) {
+    if (world.aiState[i]!.colonyId === aiColonyId) { aiState = world.aiState[i]!; break; }
+  }
+  if (aiState === null) return;
+  // Re-emit rally only if rally is active in sim-state but colony.rallyPoint is null.
+  if (aiState.invasionRallyTileX !== -1) {
+    const colony = world.colonies[aiColonyId];
+    if (colony !== undefined && colony.rallyPoint === null) {
+      _emitSetRallyPoint(world, aiColonyId, aiState.invasionRallyTileX, aiState.invasionRallyTileY);
+    }
+  }
+}
+
+/**
+ * aiInvasionTick — runs while state === Invading.
+ * Q4: if entering Invading (invasionStartTick === world.tick), pick entrance and commit fighters.
+ * Re-emit rally if needed.
+ */
+function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
+  let aiState: import('../sim/types.js').AIStateRecord | null = null;
+  for (let i = 0; i < world.aiState.length; i++) {
+    if (world.aiState[i]!.colonyId === aiColonyId) { aiState = world.aiState[i]!; break; }
+  }
+  if (aiState === null) return;
+
+  // On invasion entry tick: commit fighters and select target entrance.
+  if (aiState.invasionStartTick === world.tick && aiState.operationKind === 'None') {
+    // Select target entrance (Q4): player entrance closest to last probe target.
+    const targetEntrance = _selectInvasionEntrance(world, aiState);
+    if (targetEntrance === null) return;
+
+    // Commit ALL alive AI fighters up to AI_MAX_OPERATION_FIGHTERS (lowest indices first).
+    const fighters = _selectAllFighters(world, aiColonyId);
+
+    setAIRallyOperation(world, aiColonyId, targetEntrance.surfaceTileX, targetEntrance.surfaceTileY, fighters, 'Invasion');
+    _emitSetRallyPoint(world, aiColonyId, targetEntrance.surfaceTileX, targetEntrance.surfaceTileY);
+    return;
+  }
+
+  // Re-emit rally only if rally is active in sim-state but colony.rallyPoint is null
+  // (handles first post-load tick when world.rallyPoint was somehow cleared).
+  if (aiState.invasionRallyTileX !== -1) {
+    const colony = world.colonies[aiColonyId];
+    if (colony !== undefined && colony.rallyPoint === null) {
+      _emitSetRallyPoint(world, aiColonyId, aiState.invasionRallyTileX, aiState.invasionRallyTileY);
+    }
+  }
+
+  // When invasion ends (advanceAIState → _endInvasion resets invasionRallyTileX/Y to -1),
+  // runAIController emits ClearRallyPoint in the wasActive && nowInactive block above.
+}
+
+/** Select probe target (Q3 spec). */
+function _selectProbeTarget(world: WorldState): { tileX: number; tileY: number } | null {
+  // Priority 1: closest player-marked food pile by ascending pile ID for ties.
+  const playerColony = world.colonies[PLAYER_COLONY_ID];
+  if (playerColony === undefined) return null;
+
+  let bestPile: { tileX: number; tileY: number; id: number; dist: number } | null = null;
+  const enemyCol = world.colonies[2]; // ENEMY_COLONY_ID = 2
+  // We need a reference point: AI's entrance or colony start.
+  const aiEntranceX = enemyCol !== undefined && enemyCol.entrances.length > 0
+    ? enemyCol.entrances[0]!.surfaceTileX
+    : 104; // ENEMY_START_X fallback
+
+  for (const pile of world.foodPiles) {
+    const isMarked = playerColony.priorityFoodPileId === pile.foodPileId;
+    if (!isMarked) continue;
+    const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - 64);
+    if (bestPile === null || dist < bestPile.dist || (dist === bestPile.dist && pile.foodPileId < bestPile.id)) {
+      bestPile = { tileX: pile.tileX, tileY: pile.tileY, id: pile.foodPileId, dist };
+    }
+  }
+  if (bestPile !== null) return { tileX: bestPile.tileX, tileY: bestPile.tileY };
+
+  // Priority 2: closest unmarked surface pile within AI_PROBE_FALLBACK_RADIUS_TILES
+  // of any open player entrance.
+  for (const pile of world.foodPiles) {
+    // Check if within radius of any open player entrance.
+    let withinRadius = false;
+    for (const entrance of playerColony.entrances) {
+      if (!entrance.isOpen) continue;
+      const dist = Math.abs(pile.tileX - entrance.surfaceTileX) + Math.abs(pile.tileY - entrance.surfaceTileY);
+      if (dist <= AI_PROBE_FALLBACK_RADIUS_TILES) { withinRadius = true; break; }
+    }
+    if (!withinRadius) continue;
+    // Pick closest to AI entrance by ascending pile ID for ties.
+    const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - 64);
+    if (bestPile === null || dist < bestPile.dist || (dist === bestPile.dist && pile.foodPileId < bestPile.id)) {
+      bestPile = { tileX: pile.tileX, tileY: pile.tileY, id: pile.foodPileId, dist };
+    }
+  }
+  return bestPile !== null ? { tileX: bestPile.tileX, tileY: bestPile.tileY } : null;
+}
+
+/** Select the 3 alive AI fighters with the lowest ant index (ascending). */
+function _selectProbeFighters(world: WorldState, aiColonyId: ColonyId): number[] {
+  const { ants } = world;
+  const fighters: number[] = [];
+  for (let i = 0; i < ants.alive.length && fighters.length < AI_PROBE_FIGHTER_COUNT; i++) {
+    if (ants.alive[i] !== 1) continue;
+    if (ants.colonyId[i] !== aiColonyId) continue;
+    if (ants.task[i] !== AntTask.Fighting) continue;
+    fighters.push(i);
+  }
+  return fighters;
+}
+
+/** Select ALL alive AI fighters (lowest indices first, up to AI_MAX_OPERATION_FIGHTERS). */
+function _selectAllFighters(world: WorldState, aiColonyId: ColonyId): number[] {
+  const { ants } = world;
+  const fighters: number[] = [];
+  const maxFighters = AI_MAX_OPERATION_FIGHTERS;
+  for (let i = 0; i < ants.alive.length && fighters.length < maxFighters; i++) {
+    if (ants.alive[i] !== 1) continue;
+    if (ants.colonyId[i] !== aiColonyId) continue;
+    if (ants.task[i] !== AntTask.Fighting) continue;
+    fighters.push(i);
+  }
+  return fighters;
+}
+
+/** Select invasion entrance (Q4): player entrance closest to AI's last probe target. Falls back to first open. */
+function _selectInvasionEntrance(
+  world: WorldState,
+  aiState: import('../sim/types.js').AIStateRecord,
+): import('../sim/colony/entrance.js').NestEntrance | null {
+  const playerColony = world.colonies[PLAYER_COLONY_ID];
+  if (playerColony === undefined) return null;
+  const openEntrances = playerColony.entrances.filter((e) => e.isOpen);
+  if (openEntrances.length === 0) return null;
+  if (openEntrances.length === 1) return openEntrances[0]!;
+
+  // Use last probe target as reference (invasionRallyTileX/Y from a prior probe).
+  const refX = aiState.invasionRallyTileX !== -1 ? aiState.invasionRallyTileX : aiState.operationTargetTileX;
+  const refY = aiState.invasionRallyTileY !== -1 ? aiState.invasionRallyTileY : aiState.operationTargetTileY;
+  if (refX === -1) return openEntrances[0]!;
+
+  let best = openEntrances[0]!;
+  let bestDist = Math.abs(best.surfaceTileX - refX) + Math.abs(best.surfaceTileY - refY);
+  for (let i = 1; i < openEntrances.length; i++) {
+    const e = openEntrances[i]!;
+    const dist = Math.abs(e.surfaceTileX - refX) + Math.abs(e.surfaceTileY - refY);
+    if (dist < bestDist) { best = e; bestDist = dist; }
+  }
+  return best;
+}
+
+/** Emit SetRallyPoint command for the AI colony. */
+function _emitSetRallyPoint(world: WorldState, aiColonyId: ColonyId, tileX: number, tileY: number): void {
+  const cmd = {
+    type: 'SetRallyPoint' as const,
+    colonyId: aiColonyId,
+    tileX,
+    tileY,
+    issuedAtTick: world.tick,
+  };
+  world.commandQueue.push(cmd);
 }
 
 // --- Helpers ---

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -28,7 +28,6 @@ import {
 import { colonyFoodTotal } from '../sim/colony/colony-system.js';
 import { SIM_VERSION_V19_AI_STATE } from '../sim/types.js';
 import {
-  setAIRallyOperation,
   aiFighterCount,
 } from '../sim/ai-state.js';
 
@@ -600,7 +599,16 @@ function aiStateMachineTick_probeEntry(
   const fighters = _selectProbeFighters(world, aiColonyId);
   if (fighters.length < AI_PROBE_FIGHTER_COUNT) return; // not enough fighters
 
-  setAIRallyOperation(world, aiColonyId, target.tileX, target.tileY, fighters, 'Probe');
+  // Push StartAIOperation so tick.ts applies setAIRallyOperation sim-side (ADR-0007).
+  world.commandQueue.push({
+    type: 'StartAIOperation',
+    colonyId: aiColonyId,
+    kind: 'Probe',
+    rallyTileX: target.tileX,
+    rallyTileY: target.tileY,
+    fighterIds: fighters,
+    issuedAtTick: world.tick,
+  });
 
   // Emit SetRallyPoint SimCommand so world.rallyPoint is set for fighters.
   _emitSetRallyPoint(world, aiColonyId, target.tileX, target.tileY);
@@ -649,7 +657,16 @@ function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
     // Commit ALL alive AI fighters up to AI_MAX_OPERATION_FIGHTERS (lowest indices first).
     const fighters = _selectAllFighters(world, aiColonyId);
 
-    setAIRallyOperation(world, aiColonyId, targetEntrance.surfaceTileX, targetEntrance.surfaceTileY, fighters, 'Invasion');
+    // Push StartAIOperation so tick.ts applies setAIRallyOperation sim-side (ADR-0007).
+    world.commandQueue.push({
+      type: 'StartAIOperation',
+      colonyId: aiColonyId,
+      kind: 'Invasion',
+      rallyTileX: targetEntrance.surfaceTileX,
+      rallyTileY: targetEntrance.surfaceTileY,
+      fighterIds: fighters,
+      issuedAtTick: world.tick,
+    });
     _emitSetRallyPoint(world, aiColonyId, targetEntrance.surfaceTileX, targetEntrance.surfaceTileY);
     return;
   }

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -176,7 +176,7 @@ export function aiInitialSetup(world: WorldState, colony: ColonyRecord): void {
   //    targetRatio already matches the AI ratio (idempotent across boots).
   //    V17+: _syncBehaviorRatioToAIState owns the ratio; skip here to avoid
   //    alternating commands that thrash the ratio every tick in non-Peacetime states.
-  if (world.simVersion < SIM_VERSION_V17_AI_STATE) {
+  if (world.simVersion < SIM_VERSION_V19_AI_STATE) {
     const ratioReady =
       colony.targetRatio.forage === AI_BEHAVIOR_RATIO.forage &&
       colony.targetRatio.fight === AI_BEHAVIOR_RATIO.fight;

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -607,7 +607,7 @@ function aiProbeTick(world: WorldState, aiColonyId: ColonyId): void {
 
 /**
  * aiInvasionTick — runs while state === Invading.
- * Q4: if entering Invading (invasionStartTick === world.tick), pick entrance and commit fighters.
+ * Q4: pick entrance and commit fighters on entry (or retry if entrance was unavailable).
  * Re-emit rally if needed.
  */
 function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
@@ -617,9 +617,9 @@ function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
   }
   if (aiState === null) return;
 
-  // On invasion entry tick: commit fighters and select target entrance.
-  if (aiState.invasionStartTick === world.tick && aiState.operationKind === 'None') {
-    // Select target entrance (Q4): player entrance closest to last probe target.
+  // Commit fighters and select target entrance.
+  // Retry every tick while operationKind is None — entrance may be unavailable on entry tick.
+  if (aiState.operationKind === 'None') {
     const targetEntrance = _selectInvasionEntrance(world, aiState);
     if (targetEntrance === null) return;
 

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -20,15 +20,23 @@ import { CHAMBER_DIMENSIONS } from '../sim/colony/chamber.js';
 import {
   UNDERGROUND_CEILING_ROW_Y,
   PLAYER_COLONY_ID,
+  ENEMY_START_X,
+  ENEMY_START_Y,
   AI_PROBE_INTERVAL_TICKS,
   AI_PROBE_FIGHTER_COUNT,
   AI_PROBE_FALLBACK_RADIUS_TILES,
   AI_MAX_OPERATION_FIGHTERS,
+  AI_INVADING_FIGHTER_THRESHOLD,
+  AI_INVADING_FOOD_FRAC_PCT,
+  AI_INVADING_MIN_TICK,
 } from '../sim/constants.js';
 import { colonyFoodTotal } from '../sim/colony/colony-system.js';
 import { SIM_VERSION_V19_AI_STATE } from '../sim/types.js';
 import {
   aiFighterCount,
+  aiFoodStored,
+  aiFoodCapacity,
+  NORMAL_TIER_INDEX,
 } from '../sim/ai-state.js';
 
 import { AntTask } from '../sim/enums.js';
@@ -112,10 +120,16 @@ export function runAIController(world: WorldState, aiColonyId: ColonyId): void {
     if (aiStateRecord !== undefined) {
       const curState = aiStateRecord.state;
       if (curState === 'WarFooting') {
-        const ticksSinceLast = world.tick - aiStateRecord.lastProbeEndTick;
-        if (ticksSinceLast >= AI_PROBE_INTERVAL_TICKS
-            && aiFighterCount(world, aiColonyId) >= AI_PROBE_FIGHTER_COUNT) {
-          aiStateMachineTick_probeEntry(world, aiColonyId, colony);
+        const invasionReady =
+          world.tick >= AI_INVADING_MIN_TICK &&
+          aiFighterCount(world, aiColonyId) >= AI_INVADING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX] &&
+          aiFoodStored(world, aiColonyId) * 100 >= aiFoodCapacity(world, aiColonyId) * AI_INVADING_FOOD_FRAC_PCT;
+        if (!invasionReady) {
+          const ticksSinceLast = world.tick - aiStateRecord.lastProbeEndTick;
+          if (ticksSinceLast >= AI_PROBE_INTERVAL_TICKS
+              && aiFighterCount(world, aiColonyId) >= AI_PROBE_FIGHTER_COUNT) {
+            aiStateMachineTick_probeEntry(world, aiColonyId, colony);
+          }
         }
       }
       if (curState === 'Invading') {
@@ -524,10 +538,58 @@ const AI_STATE_RATIOS: Record<string, { forage: number; fight: number }> = {
   Recovery:   { forage: 6, fight: 4 },
 };
 
-/** Push a SyncAIState command so replay-only paths reproduce world.aiState bit-identically. */
+interface _SyncSnapshot {
+  state: string; enteredTick: number; probeCount: number; lastProbeEndTick: number;
+  invasionStartTick: number; invasionRallyTileX: number; invasionRallyTileY: number;
+  recoveryEndTick: number; operationKind: string; operationStartTick: number;
+  operationTargetTileX: number; operationTargetTileY: number;
+  operationFighterCount: number; operationStartFighterCount: number;
+  operationAttackerDeaths: number; operationDefenderDeaths: number;
+}
+const _syncCache = new Map<ColonyId, _SyncSnapshot>();
+
+export function resetAIControllerCache(): void {
+  _syncCache.clear();
+}
+
+/** Push a SyncAIState command so replay-only paths reproduce world.aiState bit-identically.
+ *  Only emits when at least one scalar field changed since the last emission. */
 function _pushSyncAIState(world: WorldState, aiColonyId: ColonyId): void {
   const rec = world.aiState.find((r) => r.colonyId === aiColonyId);
   if (rec === undefined) return;
+
+  const cached = _syncCache.get(aiColonyId);
+  const changed = cached === undefined
+    || cached.state !== rec.state
+    || cached.enteredTick !== rec.enteredTick
+    || cached.probeCount !== rec.probeCount
+    || cached.lastProbeEndTick !== rec.lastProbeEndTick
+    || cached.invasionStartTick !== rec.invasionStartTick
+    || cached.invasionRallyTileX !== rec.invasionRallyTileX
+    || cached.invasionRallyTileY !== rec.invasionRallyTileY
+    || cached.recoveryEndTick !== rec.recoveryEndTick
+    || cached.operationKind !== rec.operationKind
+    || cached.operationStartTick !== rec.operationStartTick
+    || cached.operationTargetTileX !== rec.operationTargetTileX
+    || cached.operationTargetTileY !== rec.operationTargetTileY
+    || cached.operationFighterCount !== rec.operationFighterCount
+    || cached.operationStartFighterCount !== rec.operationStartFighterCount
+    || cached.operationAttackerDeaths !== rec.operationAttackerDeaths
+    || cached.operationDefenderDeaths !== rec.operationDefenderDeaths;
+
+  if (!changed) return;
+
+  _syncCache.set(aiColonyId, {
+    state: rec.state, enteredTick: rec.enteredTick, probeCount: rec.probeCount,
+    lastProbeEndTick: rec.lastProbeEndTick, invasionStartTick: rec.invasionStartTick,
+    invasionRallyTileX: rec.invasionRallyTileX, invasionRallyTileY: rec.invasionRallyTileY,
+    recoveryEndTick: rec.recoveryEndTick, operationKind: rec.operationKind,
+    operationStartTick: rec.operationStartTick, operationTargetTileX: rec.operationTargetTileX,
+    operationTargetTileY: rec.operationTargetTileY, operationFighterCount: rec.operationFighterCount,
+    operationStartFighterCount: rec.operationStartFighterCount,
+    operationAttackerDeaths: rec.operationAttackerDeaths, operationDefenderDeaths: rec.operationDefenderDeaths,
+  });
+
   const cmd: SyncAIStateCommand = {
     type: 'SyncAIState',
     colonyId: aiColonyId,
@@ -696,12 +758,12 @@ function _selectProbeTarget(world: WorldState, aiColonyId: ColonyId): { tileX: n
   // We need a reference point: AI's entrance or colony start.
   const aiEntranceX = aiCol !== undefined && aiCol.entrances.length > 0
     ? aiCol.entrances[0]!.surfaceTileX
-    : 104; // ENEMY_START_X fallback
+    : ENEMY_START_X;
 
   for (const pile of world.foodPiles) {
     const isMarked = playerColony.priorityFoodPileId === pile.foodPileId;
     if (!isMarked) continue;
-    const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - 64);
+    const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - ENEMY_START_Y);
     if (bestPile === null || dist < bestPile.dist || (dist === bestPile.dist && pile.foodPileId < bestPile.id)) {
       bestPile = { tileX: pile.tileX, tileY: pile.tileY, id: pile.foodPileId, dist };
     }
@@ -720,7 +782,7 @@ function _selectProbeTarget(world: WorldState, aiColonyId: ColonyId): { tileX: n
     }
     if (!withinRadius) continue;
     // Pick closest to AI entrance by ascending pile ID for ties.
-    const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - 64);
+    const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - ENEMY_START_Y);
     if (bestPile === null || dist < bestPile.dist || (dist === bestPile.dist && pile.foodPileId < bestPile.id)) {
       bestPile = { tileX: pile.tileX, tileY: pile.tileY, id: pile.foodPileId, dist };
     }

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -33,7 +33,7 @@ import { createGameLoop, type GameLoop, MS_PER_TICK } from '../platform/game-loo
 import { hasSave, loadSave, deleteSave, tickAutosave, FutureSimVersionError, manualSave } from '../platform/save.js';
 import { deserializeWorldState } from '../platform/save.js';
 import { loadSettings, saveSettings } from '../platform/settings.js';
-import { runAIController } from './ai-controller.js';
+import { runAIController, resetAIControllerCache } from './ai-controller.js';
 import { buildDebugSnapshot } from '../platform/debug-snapshot.js';
 import { downloadDebugSnapshot } from './debug-snapshot-download.js';
 import {
@@ -453,6 +453,11 @@ export class GameScene extends Phaser.Scene {
     // ants against the previous world's topology. Clear them here, before the
     // new world first ticks.
     resetFlowFieldCaches();
+    // SyncAIState change-detection cache: must be cleared alongside flow-field caches so an
+    // in-session bootFromSave whose loaded aiState matches the stale prior-session cache
+    // doesn't suppress the first-tick SyncAIState, which would cause inputLog to diverge
+    // from a fresh-page replay of the same save.
+    resetAIControllerCache();
     // Render-only ant-facing smoothing: same rationale as the flow-field
     // caches. The AntFacingCache is keyed by ant id, and the new session
     // reuses ids 0..N from scratch — a stale heading from the prior session

--- a/src/sim/ai-state.test.ts
+++ b/src/sim/ai-state.test.ts
@@ -1,0 +1,421 @@
+// src/sim/ai-state.test.ts
+// S2 — unit tests for ai-state.ts narrow sim helpers.
+// Covers CF-P1-010 boundary cases, getAIStateForColony, operation death counters.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createWorldState } from './types.js';
+import type { WorldState, AIStateRecord } from './types.js';
+import { SIM_VERSION_V19_AI_STATE } from './types.js';
+import { createScenario } from './scenario.js';
+import { tick } from './tick.js';
+import {
+  advanceAIState,
+  setAIRallyOperation,
+  endAIRallyOperation,
+  getAIStateForColony,
+  isInCohort,
+  aiFighterCount,
+  aiFoodStored,
+  aiFoodCapacity,
+  playerWorkerCount,
+  createDefaultAIStateRecord,
+  NORMAL_TIER_INDEX,
+} from './ai-state.js';
+import { killAnt } from './combat.js';
+import { initAnt } from './ant/ant-store.js';
+import { createColonyRecord } from './colony/colony-store.js';
+import type { ColonyId } from './colony/colony-store.js';
+import { AntTask } from './enums.js';
+import { FP_SHIFT } from './fixed.js';
+import {
+  PLAYER_COLONY_ID,
+  ENEMY_COLONY_ID,
+  AI_WARFOOTING_FIGHTER_THRESHOLD,
+  AI_WARFOOTING_FOOD_FRAC_PCT,
+  AI_FRONTAGE_PLAYER_WORKERS_ABS,
+  AI_FRONTAGE_PLAYER_WORKERS_RATIO_X100,
+  AI_WARFOOTING_MIN_TICK,
+  AI_MAX_OPERATION_FIGHTERS,
+} from './constants.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeMinimalWorld(): WorldState {
+  const world = createWorldState(42);
+  world.simVersion = SIM_VERSION_V19_AI_STATE;
+  // Initialize two colonies
+  const playerColony = createColonyRecord(PLAYER_COLONY_ID as ColonyId, 0);
+  playerColony.entrances = [];
+  playerColony.rallyPoint = null;
+  playerColony.digFlowFieldDirty = false;
+  playerColony.foodFlowFieldDirty = false;
+  playerColony.foodStored = 1000;
+  playerColony.workerCount = 5;
+  world.colonies[PLAYER_COLONY_ID as ColonyId] = playerColony;
+
+  const enemyColony = createColonyRecord(ENEMY_COLONY_ID as ColonyId, 1);
+  enemyColony.entrances = [];
+  enemyColony.rallyPoint = null;
+  enemyColony.digFlowFieldDirty = false;
+  enemyColony.foodFlowFieldDirty = false;
+  enemyColony.foodStored = 2000;
+  enemyColony.workerCount = 10;
+  world.colonies[ENEMY_COLONY_ID as ColonyId] = enemyColony;
+
+  // Initialize ants for queen slots
+  initAnt(world.ants, 0, { colonyId: PLAYER_COLONY_ID, posX: 0, posY: 0, task: AntTask.Idle });
+  initAnt(world.ants, 1, { colonyId: ENEMY_COLONY_ID, posX: 0, posY: 0, task: AntTask.Idle });
+
+  // Initialize aiState
+  world.aiState = [createDefaultAIStateRecord(ENEMY_COLONY_ID as ColonyId)];
+  return world;
+}
+
+/** Spawn N alive fighters for a colony, starting at entity slot `startId`. */
+function spawnFighters(world: WorldState, colonyId: number, count: number, startId: number): number[] {
+  const ids: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const id = startId + i;
+    initAnt(world.ants, id, {
+      colonyId,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting,
+    });
+    ids.push(id);
+  }
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// getAIStateForColony
+// ---------------------------------------------------------------------------
+
+describe('getAIStateForColony', () => {
+  it('finds the record by colonyId even when array index != colonyId', () => {
+    const world = makeMinimalWorld();
+    // aiState has one entry for ENEMY_COLONY_ID=2, at index 0
+    expect(world.aiState.length).toBe(1);
+    expect(world.aiState[0]!.colonyId).toBe(ENEMY_COLONY_ID);
+
+    const rec = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId);
+    expect(rec).not.toBeNull();
+    expect(rec!.colonyId).toBe(ENEMY_COLONY_ID);
+  });
+
+  it('returns null for an unknown colonyId', () => {
+    const world = makeMinimalWorld();
+    const rec = getAIStateForColony(world, 999 as ColonyId);
+    expect(rec).toBeNull();
+  });
+
+  it('works with multiple aiState entries', () => {
+    const world = makeMinimalWorld();
+    // Add a second colony with id=3
+    world.aiState.push(createDefaultAIStateRecord(3 as ColonyId));
+    const rec2 = getAIStateForColony(world, 3 as ColonyId);
+    expect(rec2).not.toBeNull();
+    expect(rec2!.colonyId).toBe(3);
+    // Original still accessible
+    const rec1 = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId);
+    expect(rec1!.colonyId).toBe(ENEMY_COLONY_ID);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isInCohort
+// ---------------------------------------------------------------------------
+
+describe('isInCohort', () => {
+  it('returns true for id in cohort', () => {
+    const cohort = new Int32Array([5, 10, 15, -1, -1]);
+    expect(isInCohort(10, cohort, 3)).toBe(true);
+  });
+
+  it('returns false for id not in cohort', () => {
+    const cohort = new Int32Array([5, 10, 15, -1, -1]);
+    expect(isInCohort(7, cohort, 3)).toBe(false);
+  });
+
+  it('respects count parameter (ignores slots beyond count)', () => {
+    const cohort = new Int32Array([5, 10, 15, 20, -1]);
+    // count=3: only checks slots 0,1,2 → 20 at slot 3 should NOT be found
+    expect(isInCohort(20, cohort, 3)).toBe(false);
+    expect(isInCohort(20, cohort, 4)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CF-P1-010 boundary tests: Peacetime → WarFooting transitions
+// ---------------------------------------------------------------------------
+
+describe('advanceAIState — Peacetime → WarFooting (CF-P1-010)', () => {
+  it('(a) aiReady && ageReady but !frontageReady → fires', () => {
+    const world = makeMinimalWorld();
+    world.tick = AI_WARFOOTING_MIN_TICK; // age ready
+
+    // AI: enough fighters + enough food
+    const minFighters = AI_WARFOOTING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX];
+    spawnFighters(world, ENEMY_COLONY_ID, minFighters, 10);
+    // Set food: enough for 50% threshold
+    const cap = aiFoodCapacity(world, ENEMY_COLONY_ID as ColonyId);
+    world.colonies[ENEMY_COLONY_ID as ColonyId]!.foodStored = Math.ceil(cap * AI_WARFOOTING_FOOD_FRAC_PCT / 100);
+
+    // Player: low workers — NOT frontage ready
+    world.colonies[PLAYER_COLONY_ID as ColonyId]!.workerCount = 2;
+
+    const aiState = advanceAIState(world, ENEMY_COLONY_ID as ColonyId);
+    expect(aiState.state).toBe('WarFooting');
+  });
+
+  it('(b) aiReady && frontageReady but !ageReady → fires (early entry)', () => {
+    const world = makeMinimalWorld();
+    world.tick = AI_WARFOOTING_MIN_TICK - 1; // NOT age ready
+
+    // AI: enough fighters + enough food
+    const minFighters = AI_WARFOOTING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX];
+    spawnFighters(world, ENEMY_COLONY_ID, minFighters, 10);
+    const cap = aiFoodCapacity(world, ENEMY_COLONY_ID as ColonyId);
+    world.colonies[ENEMY_COLONY_ID as ColonyId]!.foodStored = Math.ceil(cap * AI_WARFOOTING_FOOD_FRAC_PCT / 100);
+
+    // Player: many workers, satisfying frontage hook
+    const aiWorkers = world.colonies[ENEMY_COLONY_ID as ColonyId]!.workerCount;
+    const playerNeeded = Math.max(
+      AI_FRONTAGE_PLAYER_WORKERS_ABS,
+      Math.ceil(AI_FRONTAGE_PLAYER_WORKERS_RATIO_X100 * aiWorkers / 100),
+    );
+    world.colonies[PLAYER_COLONY_ID as ColonyId]!.workerCount = playerNeeded;
+
+    const aiState = advanceAIState(world, ENEMY_COLONY_ID as ColonyId);
+    expect(aiState.state).toBe('WarFooting');
+  });
+
+  it('(c) !aiReady (not enough fighters) → does NOT fire', () => {
+    const world = makeMinimalWorld();
+    world.tick = AI_WARFOOTING_MIN_TICK + 1000; // age ready, frontage would be ready
+
+    // AI: NOT enough fighters
+    const minFighters = AI_WARFOOTING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX];
+    spawnFighters(world, ENEMY_COLONY_ID, minFighters - 1, 10); // one short
+    const cap = aiFoodCapacity(world, ENEMY_COLONY_ID as ColonyId);
+    world.colonies[ENEMY_COLONY_ID as ColonyId]!.foodStored = Math.ceil(cap * AI_WARFOOTING_FOOD_FRAC_PCT / 100);
+
+    // Player: large enough to trigger frontage
+    world.colonies[PLAYER_COLONY_ID as ColonyId]!.workerCount = 100;
+
+    const aiState = advanceAIState(world, ENEMY_COLONY_ID as ColonyId);
+    expect(aiState.state).toBe('Peacetime');
+  });
+
+  it('(d) !aiReady (not enough food) → does NOT fire even with age ready', () => {
+    const world = makeMinimalWorld();
+    world.tick = AI_WARFOOTING_MIN_TICK + 500;
+
+    // AI: enough fighters but NOT enough food
+    const minFighters = AI_WARFOOTING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX];
+    spawnFighters(world, ENEMY_COLONY_ID, minFighters + 2, 10);
+    world.colonies[ENEMY_COLONY_ID as ColonyId]!.foodStored = 0; // no food
+
+    const aiState = advanceAIState(world, ENEMY_COLONY_ID as ColonyId);
+    expect(aiState.state).toBe('Peacetime');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Operation death counter tests (QC Pass 4 AR-P1-001)
+// ---------------------------------------------------------------------------
+
+describe('operation death counters (AR-P1-001)', () => {
+  function setupInvasionWorld() {
+    const world = makeMinimalWorld();
+    world.simVersion = SIM_VERSION_V19_AI_STATE;
+
+    // Spawn AI fighters (cohort) at slots 10..14
+    const cohortIds = spawnFighters(world, ENEMY_COLONY_ID, 5, 10);
+    // Spawn a late-arrival AI fighter NOT in cohort at slot 20
+    spawnFighters(world, ENEMY_COLONY_ID, 1, 20);
+    // Spawn player ant at slot 30
+    spawnFighters(world, PLAYER_COLONY_ID, 1, 30);
+
+    // Set up active invasion operation with cohort = slots 10..14
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    aiState.state = 'Invading';
+    aiState.enteredTick = 0;
+    aiState.invasionStartTick = 0;
+    aiState.operationKind = 'Invasion';
+    aiState.operationStartTick = 0;
+    aiState.operationFighterCount = cohortIds.length;
+    for (let i = 0; i < cohortIds.length; i++) {
+      aiState.operationFighterIds[i] = cohortIds[i]!;
+    }
+    aiState.operationAttackerDeaths = 0;
+    aiState.operationDefenderDeaths = 0;
+
+    return { world, cohortIds };
+  }
+
+  it('player ant killed by spider → does NOT increment operationDefenderDeaths', () => {
+    const { world } = setupInvasionWorld();
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    // Kill player ant (slot 30) by spider (killerColonyId=null, killerKind='Spider')
+    killAnt(world, 30, null, null, 'Spider');
+    expect(aiState.operationDefenderDeaths).toBe(0);
+  });
+
+  it('player ant killed by late-arrival AI fighter (not in cohort) → does NOT increment', () => {
+    const { world } = setupInvasionWorld();
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    // Kill player ant (slot 30) by late-arrival (slot 20, not in cohort 10..14)
+    killAnt(world, 30, ENEMY_COLONY_ID as ColonyId, 20, 'Ant');
+    expect(aiState.operationDefenderDeaths).toBe(0);
+  });
+
+  it('player ant killed by committed-cohort AI fighter → increments operationDefenderDeaths by 1', () => {
+    const { world } = setupInvasionWorld();
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    // Kill player ant (slot 30) by committed cohort fighter (slot 10)
+    killAnt(world, 30, ENEMY_COLONY_ID as ColonyId, 10, 'Ant');
+    expect(aiState.operationDefenderDeaths).toBe(1);
+  });
+
+  it('committed-cohort AI fighter killed by player → increments operationAttackerDeaths by 1', () => {
+    const { world } = setupInvasionWorld();
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    // Kill committed cohort fighter (slot 10) by player ant (slot 30)
+    killAnt(world, 10, PLAYER_COLONY_ID as ColonyId, 30, 'Ant');
+    expect(aiState.operationAttackerDeaths).toBe(1);
+  });
+
+  it('late-arrival AI fighter killed by player → does NOT increment operationAttackerDeaths', () => {
+    const { world } = setupInvasionWorld();
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    // Kill late-arrival (slot 20, not in cohort) by player
+    killAnt(world, 20, PLAYER_COLONY_ID as ColonyId, 30, 'Ant');
+    expect(aiState.operationAttackerDeaths).toBe(0);
+  });
+
+  it('multiple kills accumulate correctly', () => {
+    const { world } = setupInvasionWorld();
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    // Kill two cohort fighters by player
+    killAnt(world, 10, PLAYER_COLONY_ID as ColonyId, 30, 'Ant');
+    killAnt(world, 11, PLAYER_COLONY_ID as ColonyId, 30, 'Ant');
+    expect(aiState.operationAttackerDeaths).toBe(2);
+    // Kill player by cohort fighter
+    spawnFighters(world, PLAYER_COLONY_ID, 1, 31);
+    killAnt(world, 31, ENEMY_COLONY_ID as ColonyId, 12, 'Ant');
+    expect(aiState.operationDefenderDeaths).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setAIRallyOperation — probe cohort selection (correct fighters committed)
+// ---------------------------------------------------------------------------
+
+describe('setAIRallyOperation — probe cohort', () => {
+  it('commits exactly the provided fighter IDs to the cohort', () => {
+    const world = makeMinimalWorld();
+    // Spawn 5 AI fighters; provide 3 as probe cohort
+    spawnFighters(world, ENEMY_COLONY_ID, 5, 10);
+    const cohort = [10, 11, 12]; // closest 3 by ascending index
+
+    // Set state to WarFooting first
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    aiState.state = 'WarFooting';
+
+    setAIRallyOperation(world, ENEMY_COLONY_ID as ColonyId, 50, 50, cohort, 'Probe');
+
+    const updatedAI = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    expect(updatedAI.state).toBe('Probing');
+    expect(updatedAI.operationKind).toBe('Probe');
+    expect(updatedAI.operationFighterCount).toBe(3);
+    expect(updatedAI.operationFighterIds[0]).toBe(10);
+    expect(updatedAI.operationFighterIds[1]).toBe(11);
+    expect(updatedAI.operationFighterIds[2]).toBe(12);
+    // Unused slots remain -1
+    expect(updatedAI.operationFighterIds[3]).toBe(-1);
+  });
+
+  it('emits ai_state_transition WarFooting→Probing event', () => {
+    const world = makeMinimalWorld();
+    spawnFighters(world, ENEMY_COLONY_ID, 3, 10);
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    aiState.state = 'WarFooting';
+
+    const eventsBefore = world.events.length;
+    setAIRallyOperation(world, ENEMY_COLONY_ID as ColonyId, 50, 50, [10, 11, 12], 'Probe');
+    const newEvents = world.events.slice(eventsBefore);
+    const transitionEvent = newEvents.find((e) => e.type === 'ai_state_transition');
+    expect(transitionEvent).toBeDefined();
+    expect(transitionEvent!.payload).toMatchObject({ from: 'WarFooting', to: 'Probing' });
+  });
+
+  it('emits invasion_start event for Invasion operation', () => {
+    const world = makeMinimalWorld();
+    spawnFighters(world, ENEMY_COLONY_ID, 5, 10);
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    aiState.state = 'WarFooting';
+
+    const eventsBefore = world.events.length;
+    setAIRallyOperation(world, ENEMY_COLONY_ID as ColonyId, 40, 64, [10, 11, 12, 13, 14], 'Invasion');
+    const newEvents = world.events.slice(eventsBefore);
+    const invasionEvent = newEvents.find((e) => e.type === 'invasion_start');
+    expect(invasionEvent).toBeDefined();
+    expect(invasionEvent!.payload).toMatchObject({ fighterCount: 5 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// endAIRallyOperation — emits invasion_end
+// ---------------------------------------------------------------------------
+
+describe('endAIRallyOperation', () => {
+  it('emits invasion_end event for Invasion operation', () => {
+    const world = makeMinimalWorld();
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    aiState.state = 'Invading';
+    aiState.operationKind = 'Invasion';
+    aiState.operationAttackerDeaths = 3;
+    aiState.operationDefenderDeaths = 2;
+
+    const eventsBefore = world.events.length;
+    endAIRallyOperation(world, ENEMY_COLONY_ID as ColonyId, 'fighter_rout');
+    const newEvents = world.events.slice(eventsBefore);
+    const endEvent = newEvents.find((e) => e.type === 'invasion_end');
+    expect(endEvent).toBeDefined();
+    expect(endEvent!.payload).toMatchObject({
+      outcome: 'fighter_rout',
+      attackerLosses: 3,
+      defenderLosses: 2,
+    });
+  });
+
+  it('transitions Invading → Recovery after invasion_end', () => {
+    const world = makeMinimalWorld();
+    const aiState = getAIStateForColony(world, ENEMY_COLONY_ID as ColonyId)!;
+    aiState.state = 'Invading';
+    aiState.operationKind = 'Invasion';
+
+    endAIRallyOperation(world, ENEMY_COLONY_ID as ColonyId, 'timeout');
+    expect(aiState.state).toBe('Recovery');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createDefaultAIStateRecord — defensive defaults shape check
+// ---------------------------------------------------------------------------
+
+describe('createDefaultAIStateRecord', () => {
+  it('creates a record with correct defensive defaults', () => {
+    const rec = createDefaultAIStateRecord(ENEMY_COLONY_ID as ColonyId);
+    expect(rec.colonyId).toBe(ENEMY_COLONY_ID);
+    expect(rec.state).toBe('Peacetime');
+    expect(rec.operationKind).toBe('None');
+    expect(rec.operationFighterIds.length).toBe(AI_MAX_OPERATION_FIGHTERS);
+    expect(rec.operationFighterIds[0]).toBe(-1);
+    expect(rec.invasionRallyTileX).toBe(-1);
+    expect(rec.invasionRallyTileY).toBe(-1);
+  });
+});

--- a/src/sim/ai-state.ts
+++ b/src/sim/ai-state.ts
@@ -349,8 +349,9 @@ function _checkInvadingToRecovery(
 ): void {
   // Exit conditions (CF-P0-005 — cohort-based):
   // 1. Queen kill → game ends; AI stays Invading (Q-6: aiStateAtTime = "Invading")
-  // 2. Cohort alive < 3
-  // 3. Timeout
+  // 2. Cohort alive < 3 (only once a cohort has been committed)
+  // 3. Timeout (only once a cohort has been committed, so entrance-retry ticks don't burn the budget)
+  if (aiState.operationFighterCount === 0) return;
   const aliveCount = cohortAliveCount(world, aiState);
   const timeout = world.tick - aiState.operationStartTick >= AI_INVADING_TIMEOUT_TICKS;
   const rout = aliveCount < 3;

--- a/src/sim/ai-state.ts
+++ b/src/sim/ai-state.ts
@@ -326,7 +326,7 @@ function _checkProbingToWarFooting(
   aiState: AIStateRecord,
 ): void {
   // Exit conditions (evaluated against committed cohort per CF-P0-005):
-  // 1. All committed fighters dead
+  // 1. All committed fighters dead (zero-cohort case → allDead=true, recovers immediately)
   // 2. All committed fighters "done" (returned home non-fighting)
   // 3. Timeout
   const allDead = cohortAliveCount(world, aiState) === 0;
@@ -360,10 +360,21 @@ function _checkInvadingToRecovery(
   // 1. Queen kill → game ends; AI stays Invading (Q-6: aiStateAtTime = "Invading")
   // 2. Cohort alive < 3 (only once a cohort has been committed)
   // 3. Timeout (only once a cohort has been committed, so entrance-retry ticks don't burn the budget)
-  if (aiState.operationFighterCount === 0) return;
+  if (aiState.operationFighterCount === 0) {
+    // No cohort committed yet (entrance-retry window). Use invasionStartTick so
+    // entrance unavailability can't lock the AI in Invading indefinitely.
+    if (world.tick - aiState.invasionStartTick >= AI_INVADING_TIMEOUT_TICKS) {
+      _endInvasion(world, aiColonyId, aiState, 'timeout');
+    }
+    return;
+  }
   const aliveCount = cohortAliveCount(world, aiState);
-  const timeout = world.tick - aiState.operationStartTick >= AI_INVADING_TIMEOUT_TICKS;
-  const rout = aliveCount < 3;
+  // Use invasionStartTick (invasion entry) not operationStartTick (cohort commit) so the
+  // entrance-retry window and the cohort fight share one budget, not two.
+  const timeout = world.tick - aiState.invasionStartTick >= AI_INVADING_TIMEOUT_TICKS;
+  // P0-2: clamp rout threshold to cohort size so a 1-2 fighter cohort doesn't
+  // immediately rout (shouldn't happen in practice; tick.ts rejects < 3 for Invasion).
+  const rout = aliveCount < Math.min(3, aiState.operationStartFighterCount);
 
   if (rout || timeout) {
     const outcome: 'fighter_rout' | 'timeout' = rout ? 'fighter_rout' : 'timeout';
@@ -376,6 +387,7 @@ function _checkRecoveryToPeacetime(
   aiColonyId: ColonyId,
   aiState: AIStateRecord,
 ): void {
+  if (aiState.recoveryEndTick === 0) return;
   if (world.tick >= aiState.recoveryEndTick) {
     aiState.state = 'Peacetime';
     aiState.enteredTick = world.tick;
@@ -492,7 +504,10 @@ export function setAIRallyOperation(
     aiState.invasionRallyTileY = rallyTileY;
     aiState.state = 'Invading';
     aiState.enteredTick = world.tick;
-    aiState.invasionStartTick = world.tick;
+    // Preserve invasionStartTick set by _checkWarFootingToInvading (tick T) so that both
+    // the pre-cohort and cohort timeout paths share a single budget from invasion entry.
+    // Only overwrite if it was somehow not set (e.g., SyncAIState-restored state).
+    if (aiState.invasionStartTick === 0) aiState.invasionStartTick = world.tick;
 
     emitEvent(world, {
       tick: world.tick,

--- a/src/sim/ai-state.ts
+++ b/src/sim/ai-state.ts
@@ -224,7 +224,6 @@ export function advanceAIState(world: WorldState, aiColonyId: ColonyId): AIState
     const fighters = aiFighterCount(world, aiColonyId);
     const foodStored = aiFoodStored(world, aiColonyId);
     const foodCap = aiFoodCapacity(world, aiColonyId);
-    const foodFrac100 = foodCap > 0 ? ((foodStored * 100) / foodCap) | 0 : 0;
     emitEvent(world, {
       tick: world.tick,
       type: 'ai_state_transition',
@@ -234,7 +233,8 @@ export function advanceAIState(world: WorldState, aiColonyId: ColonyId): AIState
         to: aiState.state,
         triggerValues: {
           aiFighterCount: fighters,
-          aiFoodStorageFrac100: foodFrac100,
+          aiFoodStored: foodStored,
+          aiFoodCap: foodCap,
           playerWorkerCount: playerWorkerCount(world),
         },
       },
@@ -458,7 +458,6 @@ export function setAIRallyOperation(
     const fighters = aiFighterCount(world, aiColonyId);
     const foodStored = aiFoodStored(world, aiColonyId);
     const foodCap = aiFoodCapacity(world, aiColonyId);
-    const foodFrac100 = foodCap > 0 ? ((foodStored * 100) / foodCap) | 0 : 0;
     emitEvent(world, {
       tick: world.tick,
       type: 'ai_state_transition',
@@ -468,7 +467,8 @@ export function setAIRallyOperation(
         to: 'Probing',
         triggerValues: {
           aiFighterCount: fighters,
-          aiFoodStorageFrac100: foodFrac100,
+          aiFoodStored: foodStored,
+          aiFoodCap: foodCap,
           playerWorkerCount: playerWorkerCount(world),
         },
       },

--- a/src/sim/ai-state.ts
+++ b/src/sim/ai-state.ts
@@ -1,0 +1,524 @@
+// src/sim/ai-state.ts
+// S2 — narrow sim helpers for AI state machine mutation + event emission.
+//
+// Render-side ai-controller.ts calls these helpers; it never writes world.aiState.* directly.
+// Per CF-P0-004 / ADR-0007: sim owns mutation and event emission; render owns policy.
+//
+// QC Pass 4 AR-P0-001: S2 V17 ships Normal-only tier reads. S5 V20 refactors to
+// tierIndex(world.difficulty) at every NORMAL_TIER_INDEX lookup site.
+
+import type { WorldState, AIState, AIStateRecord } from './types.js';
+import type { ColonyId } from './colony/colony-store.js';
+import { emitEvent } from './telemetry.js';
+import { AntTask, ChamberType } from './enums.js';
+import { Zone } from './terrain.js';
+import { FP_SHIFT } from './fixed.js';
+import {
+  PLAYER_COLONY_ID,
+  ENEMY_COLONY_ID,
+  AI_WARFOOTING_MIN_TICK,
+  AI_WARFOOTING_FIGHTER_THRESHOLD,
+  AI_WARFOOTING_FOOD_FRAC_PCT,
+  AI_INVADING_FOOD_FRAC_PCT,
+  AI_FRONTAGE_PLAYER_WORKERS_ABS,
+  AI_FRONTAGE_PLAYER_WORKERS_RATIO_X100,
+  AI_PROBE_INTERVAL_TICKS,
+  AI_PROBE_FIGHTER_COUNT,
+  AI_PROBE_TIMEOUT_TICKS,
+  AI_INVADING_MIN_TICK,
+  AI_INVADING_FIGHTER_THRESHOLD,
+  AI_INVADING_TIMEOUT_TICKS,
+  AI_RECOVERY_DURATION_TICKS,
+  AI_MAX_OPERATION_FIGHTERS,
+  BASE_FOOD_STORAGE_CAPACITY,
+  FOOD_CHAMBER_CAPACITY,
+} from './constants.js';
+
+
+// QC Pass 4 AR-P0-001: Normal-only tier index. S5 V20 replaces this with tierIndex(world.difficulty).
+export const NORMAL_TIER_INDEX = 1 as const;
+
+// ---------------------------------------------------------------------------
+// Helper: create a fresh AIStateRecord at defensive defaults (pre-V17 migration)
+// ---------------------------------------------------------------------------
+
+export function createDefaultAIStateRecord(colonyId: ColonyId): AIStateRecord {
+  return {
+    colonyId,
+    state: 'Peacetime',
+    enteredTick: 0,
+    probeCount: 0,
+    lastProbeEndTick: 0,
+    invasionStartTick: 0,
+    invasionRallyTileX: -1,
+    invasionRallyTileY: -1,
+    recoveryEndTick: 0,
+    operationKind: 'None',
+    operationStartTick: 0,
+    operationTargetTileX: -1,
+    operationTargetTileY: -1,
+    operationFighterIds: new Int32Array(AI_MAX_OPERATION_FIGHTERS).fill(-1),
+    operationFighterCount: 0,
+    operationStartFighterCount: 0,
+    operationAttackerDeaths: 0,
+    operationDefenderDeaths: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sim-safe lookup: iterate world.aiState to find the record by colonyId.
+ * QC Pass 4 AR-P1-001: do NOT assume array is dense-indexed by raw ColonyId.
+ */
+export function getAIStateForColony(world: WorldState, colonyId: ColonyId): AIStateRecord | null {
+  for (let i = 0; i < world.aiState.length; i++) {
+    if (world.aiState[i]!.colonyId === colonyId) return world.aiState[i]!;
+  }
+  return null;
+}
+
+/**
+ * O(n) cohort membership check. n ≤ AI_MAX_OPERATION_FIGHTERS (32) — negligible.
+ */
+export function isInCohort(id: number, cohort: Int32Array, count: number): boolean {
+  for (let i = 0; i < count; i++) {
+    if (cohort[i] === id) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// World-state query helpers used by the state machine
+// ---------------------------------------------------------------------------
+
+/** Count alive AI fighters (colonyId === aiColonyId AND task === Fighting). */
+export function aiFighterCount(world: WorldState, aiColonyId: ColonyId): number {
+  const { ants } = world;
+  let count = 0;
+  for (let i = 0; i < ants.alive.length; i++) {
+    if (ants.alive[i] !== 1) continue;
+    if (ants.colonyId[i] !== aiColonyId) continue;
+    if (ants.task[i] === AntTask.Fighting) count += 1;
+  }
+  return count;
+}
+
+/** Count alive AI workers of any task (excludes dead ants). */
+export function aiWorkerCount(world: WorldState, aiColonyId: ColonyId): number {
+  const colony = world.colonies[aiColonyId];
+  if (colony === undefined) return 0;
+  return colony.workerCount;
+}
+
+/** Total food stored by the AI colony (entrance pool + food chambers). */
+export function aiFoodStored(world: WorldState, aiColonyId: ColonyId): number {
+  const colony = world.colonies[aiColonyId];
+  if (colony === undefined) return 0;
+  let total = colony.foodStored;
+  for (let i = 0; i < colony.chambers.length; i++) {
+    const ch = colony.chambers[i]!;
+    if (ch.chamberType === ChamberType.FoodStorage) total += ch.foodStored;
+  }
+  return total;
+}
+
+/** Total food storage capacity of the AI colony (base + food chambers). */
+export function aiFoodCapacity(world: WorldState, aiColonyId: ColonyId): number {
+  const colony = world.colonies[aiColonyId];
+  if (colony === undefined) return BASE_FOOD_STORAGE_CAPACITY;
+  let capacity = BASE_FOOD_STORAGE_CAPACITY;
+  for (let i = 0; i < colony.chambers.length; i++) {
+    const ch = colony.chambers[i]!;
+    if (ch.chamberType === ChamberType.FoodStorage) capacity += FOOD_CHAMBER_CAPACITY;
+  }
+  return capacity;
+}
+
+/** Player colony worker count. */
+export function playerWorkerCount(world: WorldState): number {
+  const colony = world.colonies[PLAYER_COLONY_ID];
+  if (colony === undefined) return 0;
+  return colony.workerCount;
+}
+
+// ---------------------------------------------------------------------------
+// Cohort-alive-count helper (for operation exit conditions)
+// ---------------------------------------------------------------------------
+
+/** Count how many fighters in the committed cohort are still alive. */
+function cohortAliveCount(world: WorldState, aiState: AIStateRecord): number {
+  let count = 0;
+  for (let i = 0; i < aiState.operationFighterCount; i++) {
+    const id = aiState.operationFighterIds[i]!;
+    if (id >= 0 && world.ants.alive[id] === 1) count += 1;
+  }
+  return count;
+}
+
+/** Check if all committed probe cohort fighters are "done" (dead or returned home non-fighting). */
+function allProbeFightersDone(world: WorldState, aiState: AIStateRecord): boolean {
+  const { ants } = world;
+  for (let i = 0; i < aiState.operationFighterCount; i++) {
+    const id = aiState.operationFighterIds[i]!;
+    if (id < 0) continue;
+    if (ants.alive[id] !== 1) continue; // dead = done
+    // "Done" = alive AND back in AI's underground grid AND task !== Fighting.
+    // In-transit (alive but on surface or not yet returned) is NOT done.
+    const onAIGrid = ants.zone[id] === Zone.Underground &&
+      ants.currentGridColonyId[id] === aiState.colonyId;
+    const notFighting = ants.task[id] !== AntTask.Fighting;
+    if (!(onAIGrid && notFighting)) return false; // still out
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// advanceAIState — evaluate transitions, write new state, emit events
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate AI state machine transitions for one tick and mutate world.aiState.
+ * Called from render-side aiStateMachineTick; never called with a player colony.
+ * Returns the (potentially updated) AIStateRecord for the colony.
+ */
+export function advanceAIState(world: WorldState, aiColonyId: ColonyId): AIStateRecord {
+  let aiState = getAIStateForColony(world, aiColonyId);
+  if (aiState === null) {
+    // Should not happen if scenario initializes correctly; defensive fallback.
+    const rec = createDefaultAIStateRecord(aiColonyId);
+    world.aiState.push(rec);
+    aiState = rec;
+  }
+
+  const prevState = aiState.state;
+
+  switch (aiState.state) {
+    case 'Peacetime':
+      _tryTransitionPeacetimeToWarFooting(world, aiColonyId, aiState);
+      break;
+    case 'WarFooting':
+      // QC Pass 4 AD3: check Invading BEFORE probe-interval to ensure Invading fires
+      // at tick 6600 if conditions are met, not slipping a probe-cycle further out.
+      if (_checkWarFootingToInvading(world, aiColonyId, aiState)) break;
+      _tryTransitionWarFootingToProbing(world, aiColonyId, aiState);
+      break;
+    case 'Probing':
+      _checkProbingToWarFooting(world, aiColonyId, aiState);
+      break;
+    case 'Invading':
+      _checkInvadingToRecovery(world, aiColonyId, aiState);
+      break;
+    case 'Recovery':
+      _checkRecoveryToPeacetime(world, aiColonyId, aiState);
+      break;
+  }
+
+  // Increment ticksInState alias (not a separate field; use enteredTick for this)
+  // Note: ticksInState = world.tick - aiState.enteredTick (derived, not stored separately)
+
+  if (aiState.state !== prevState) {
+    // Emit ai_state_transition structural event.
+    const fighters = aiFighterCount(world, aiColonyId);
+    const foodStored = aiFoodStored(world, aiColonyId);
+    const foodCap = aiFoodCapacity(world, aiColonyId);
+    const foodFrac100 = foodCap > 0 ? ((foodStored * 100) / foodCap) | 0 : 0;
+    emitEvent(world, {
+      tick: world.tick,
+      type: 'ai_state_transition',
+      payload: {
+        colonyId: aiColonyId,
+        from: prevState,
+        to: aiState.state,
+        triggerValues: {
+          aiFighterCount: fighters,
+          aiFoodStorageFrac100: foodFrac100,
+          playerWorkerCount: playerWorkerCount(world),
+        },
+      },
+    });
+  }
+
+  return aiState;
+}
+
+// ---------------------------------------------------------------------------
+// State transition helpers (internal)
+// ---------------------------------------------------------------------------
+
+function _tryTransitionPeacetimeToWarFooting(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  aiState: AIStateRecord,
+): void {
+  const fighters = aiFighterCount(world, aiColonyId);
+  const foodStored = aiFoodStored(world, aiColonyId);
+  const foodCap = aiFoodCapacity(world, aiColonyId);
+
+  // CF-P1-010: aiReady AND (ageReady OR frontageReady)
+  const aiReady =
+    fighters >= AI_WARFOOTING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX] &&
+    foodStored * 100 >= foodCap * AI_WARFOOTING_FOOD_FRAC_PCT;
+
+  const ageReady = world.tick >= AI_WARFOOTING_MIN_TICK;
+
+  const aiWorkers = aiWorkerCount(world, aiColonyId);
+  const playerWorkers = playerWorkerCount(world);
+  const frontageReady =
+    playerWorkers >= AI_FRONTAGE_PLAYER_WORKERS_ABS &&
+    playerWorkers * 100 >= AI_FRONTAGE_PLAYER_WORKERS_RATIO_X100 * aiWorkers;
+
+  if (aiReady && (ageReady || frontageReady)) {
+    aiState.state = 'WarFooting';
+    aiState.enteredTick = world.tick;
+  }
+}
+
+/** Returns true if transition fired (to prevent probe check on same tick). */
+function _checkWarFootingToInvading(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  aiState: AIStateRecord,
+): boolean {
+  const fighters = aiFighterCount(world, aiColonyId);
+  const foodStored = aiFoodStored(world, aiColonyId);
+  const foodCap = aiFoodCapacity(world, aiColonyId);
+
+  if (
+    fighters >= AI_INVADING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX] &&
+    foodStored * 100 >= foodCap * AI_INVADING_FOOD_FRAC_PCT &&
+    world.tick >= AI_INVADING_MIN_TICK
+  ) {
+    aiState.state = 'Invading';
+    aiState.enteredTick = world.tick;
+    aiState.invasionStartTick = world.tick;
+    return true;
+  }
+  return false;
+}
+
+function _tryTransitionWarFootingToProbing(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  aiState: AIStateRecord,
+): void {
+  // Probe-interval check: every AI_PROBE_INTERVAL_TICKS while in WarFooting.
+  // Guard: aiFighterCount >= 3 AND probe target must exist (checked by caller via setAIRallyOperation).
+  // The actual transition is completed by the render-side controller calling setAIRallyOperation.
+  // Here we just check the time gate and fighter count gate.
+  const ticksSinceLastProbe = world.tick - aiState.lastProbeEndTick;
+  if (ticksSinceLastProbe < AI_PROBE_INTERVAL_TICKS) return;
+  if (aiFighterCount(world, aiColonyId) < AI_PROBE_FIGHTER_COUNT) return;
+  // Signal to caller that probe conditions are met (state left as WarFooting until
+  // setAIRallyOperation is called with operationKind='Probe' which transitions to Probing).
+  // The render controller reads aiState.state and calls setAIRallyOperation to proceed.
+  // To communicate probe-readiness, we set a sentinel: operationKind remains 'None'
+  // but the render checks probe-interval conditions itself. This is policy-side.
+  // (no state mutation here — render side does the target check and calls setAIRallyOperation)
+}
+
+function _checkProbingToWarFooting(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  aiState: AIStateRecord,
+): void {
+  // Exit conditions (evaluated against committed cohort per CF-P0-005):
+  // 1. All committed fighters dead
+  // 2. All committed fighters "done" (returned home non-fighting)
+  // 3. Timeout
+  const allDead = cohortAliveCount(world, aiState) === 0;
+  const timeout = world.tick - aiState.operationStartTick >= AI_PROBE_TIMEOUT_TICKS;
+  const allDone = !allDead && allProbeFightersDone(world, aiState);
+
+  if (allDead || allDone || timeout) {
+    aiState.state = 'WarFooting';
+    aiState.enteredTick = world.tick;
+    aiState.lastProbeEndTick = world.tick;
+    aiState.probeCount += 1;
+    // Reset operation fields
+    _clearOperationFields(aiState);
+  }
+}
+
+function _checkInvadingToRecovery(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  aiState: AIStateRecord,
+): void {
+  // Exit conditions (CF-P0-005 — cohort-based):
+  // 1. Queen kill → game ends; AI stays Invading (Q-6: aiStateAtTime = "Invading")
+  // 2. Cohort alive < 3
+  // 3. Timeout
+  const aliveCount = cohortAliveCount(world, aiState);
+  const timeout = world.tick - aiState.operationStartTick >= AI_INVADING_TIMEOUT_TICKS;
+  const rout = aliveCount < 3;
+
+  if (rout || timeout) {
+    const outcome: 'fighter_rout' | 'timeout' = rout ? 'fighter_rout' : 'timeout';
+    _endInvasion(world, aiColonyId, aiState, outcome);
+  }
+}
+
+function _checkRecoveryToPeacetime(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  aiState: AIStateRecord,
+): void {
+  if (world.tick >= aiState.recoveryEndTick) {
+    aiState.state = 'Peacetime';
+    aiState.enteredTick = world.tick;
+  }
+}
+
+function _endInvasion(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  aiState: AIStateRecord,
+  outcome: 'queen_kill' | 'fighter_rout' | 'timeout',
+): void {
+  const attackerLosses = aiState.operationAttackerDeaths;
+  const defenderLosses = aiState.operationDefenderDeaths;
+
+  emitEvent(world, {
+    tick: world.tick,
+    type: 'invasion_end',
+    payload: {
+      colonyId: aiColonyId,
+      outcome,
+      attackerLosses,
+      defenderLosses,
+    },
+  });
+
+  aiState.state = 'Recovery';
+  aiState.enteredTick = world.tick;
+  aiState.recoveryEndTick = world.tick + AI_RECOVERY_DURATION_TICKS[NORMAL_TIER_INDEX];
+  aiState.invasionStartTick = 0;
+  aiState.invasionRallyTileX = -1;
+  aiState.invasionRallyTileY = -1;
+  _clearOperationFields(aiState);
+}
+
+function _clearOperationFields(aiState: AIStateRecord): void {
+  aiState.operationKind = 'None';
+  aiState.operationStartTick = 0;
+  aiState.operationTargetTileX = -1;
+  aiState.operationTargetTileY = -1;
+  aiState.operationFighterIds.fill(-1);
+  aiState.operationFighterCount = 0;
+  aiState.operationStartFighterCount = 0;
+  aiState.operationAttackerDeaths = 0;
+  aiState.operationDefenderDeaths = 0;
+}
+
+// ---------------------------------------------------------------------------
+// setAIRallyOperation — atomically write operation fields; emit invasion_start
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomically writes rally/operation state and transitions to Probing or Invading.
+ * Emits invasion_start for Invasion operations.
+ * Called by render-side ai-controller.ts after target selection.
+ */
+export function setAIRallyOperation(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  rallyTileX: number,
+  rallyTileY: number,
+  committedFighterIds: readonly number[],
+  operationKind: 'Probe' | 'Invasion',
+): void {
+  let aiState = getAIStateForColony(world, aiColonyId);
+  if (aiState === null) return;
+
+  const count = Math.min(committedFighterIds.length, AI_MAX_OPERATION_FIGHTERS);
+  aiState.operationKind = operationKind;
+  aiState.operationStartTick = world.tick;
+  aiState.operationTargetTileX = rallyTileX;
+  aiState.operationTargetTileY = rallyTileY;
+  aiState.operationFighterIds.fill(-1);
+  for (let i = 0; i < count; i++) {
+    aiState.operationFighterIds[i] = committedFighterIds[i]!;
+  }
+  aiState.operationFighterCount = count;
+  aiState.operationStartFighterCount = count;
+  aiState.operationAttackerDeaths = 0;
+  aiState.operationDefenderDeaths = 0;
+
+  if (operationKind === 'Probe') {
+    aiState.invasionRallyTileX = rallyTileX;
+    aiState.invasionRallyTileY = rallyTileY;
+    aiState.state = 'Probing';
+    aiState.enteredTick = world.tick;
+    // ai_state_transition event emitted by advanceAIState caller check
+    // (but since setAIRallyOperation is called from the render controller AFTER
+    // advanceAIState, we emit it here directly)
+    const fighters = aiFighterCount(world, aiColonyId);
+    const foodStored = aiFoodStored(world, aiColonyId);
+    const foodCap = aiFoodCapacity(world, aiColonyId);
+    const foodFrac100 = foodCap > 0 ? ((foodStored * 100) / foodCap) | 0 : 0;
+    emitEvent(world, {
+      tick: world.tick,
+      type: 'ai_state_transition',
+      payload: {
+        colonyId: aiColonyId,
+        from: 'WarFooting',
+        to: 'Probing',
+        triggerValues: {
+          aiFighterCount: fighters,
+          aiFoodStorageFrac100: foodFrac100,
+          playerWorkerCount: playerWorkerCount(world),
+        },
+      },
+    });
+  } else {
+    // Invasion
+    aiState.invasionRallyTileX = rallyTileX;
+    aiState.invasionRallyTileY = rallyTileY;
+    aiState.state = 'Invading';
+    aiState.enteredTick = world.tick;
+    aiState.invasionStartTick = world.tick;
+
+    emitEvent(world, {
+      tick: world.tick,
+      type: 'invasion_start',
+      payload: {
+        colonyId: aiColonyId,
+        rallyTile: { x: rallyTileX, y: rallyTileY, grid: 'surface' },
+        fighterCount: count,
+        targetGrid: PLAYER_COLONY_ID,
+      },
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// endAIRallyOperation — reset operation state; emit invasion_end for Invasion
+// ---------------------------------------------------------------------------
+
+/**
+ * Called by render-side ai-controller.ts when an operation (Probe or Invasion) ends
+ * due to external cause (e.g., queen kill detected by checkQueenDeath).
+ * For natural operation termination (cohort attrition / timeout), advanceAIState
+ * handles the transition; this is for callers that need to force-end an operation.
+ */
+export function endAIRallyOperation(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  outcome: 'queen_kill' | 'fighter_rout' | 'timeout',
+): void {
+  const aiState = getAIStateForColony(world, aiColonyId);
+  if (aiState === null) return;
+
+  if (aiState.operationKind === 'Invasion') {
+    _endInvasion(world, aiColonyId, aiState, outcome);
+  } else if (aiState.operationKind === 'Probe') {
+    aiState.state = 'WarFooting';
+    aiState.enteredTick = world.tick;
+    aiState.lastProbeEndTick = world.tick;
+    aiState.probeCount += 1;
+    _clearOperationFields(aiState);
+  }
+}

--- a/src/sim/ai-state.ts
+++ b/src/sim/ai-state.ts
@@ -9,6 +9,7 @@
 
 import type { WorldState, AIState, AIStateRecord } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
+import type { ClearRallyPointCommand } from './commands.js';
 import { emitEvent } from './telemetry.js';
 import { AntTask, ChamberType } from './enums.js';
 import { Zone } from './terrain.js';
@@ -333,10 +334,17 @@ function _checkProbingToWarFooting(
   const allDone = !allDead && allProbeFightersDone(world, aiState);
 
   if (allDead || allDone || timeout) {
+    // Emit ClearRallyPoint before clearing rally tile so fighters re-route home.
+    if (aiState.invasionRallyTileX !== -1) {
+      const clearCmd: ClearRallyPointCommand = { type: 'ClearRallyPoint', colonyId: aiColonyId, issuedAtTick: world.tick };
+      world.commandQueue.push(clearCmd);
+    }
     aiState.state = 'WarFooting';
     aiState.enteredTick = world.tick;
     aiState.lastProbeEndTick = world.tick;
     aiState.probeCount += 1;
+    aiState.invasionRallyTileX = -1;
+    aiState.invasionRallyTileY = -1;
     // Reset operation fields
     _clearOperationFields(aiState);
   }
@@ -393,6 +401,9 @@ function _endInvasion(
     },
   });
 
+  // Emit ClearRallyPoint so fighters stop routing to the invasion target and go home.
+  const clearCmd: ClearRallyPointCommand = { type: 'ClearRallyPoint', colonyId: aiColonyId, issuedAtTick: world.tick };
+  world.commandQueue.push(clearCmd);
   aiState.state = 'Recovery';
   aiState.enteredTick = world.tick;
   aiState.recoveryEndTick = world.tick + AI_RECOVERY_DURATION_TICKS[NORMAL_TIER_INDEX];

--- a/src/sim/ai-state.ts
+++ b/src/sim/ai-state.ts
@@ -343,9 +343,10 @@ function _checkProbingToWarFooting(
     aiState.enteredTick = world.tick;
     aiState.lastProbeEndTick = world.tick;
     aiState.probeCount += 1;
-    aiState.invasionRallyTileX = -1;
-    aiState.invasionRallyTileY = -1;
-    // Reset operation fields
+    // Intentionally preserve invasionRallyTileX/Y as the "last probe target" so that
+    // _selectInvasionEntrance can use it for proximity-based entrance selection when
+    // Invading starts later. The live colony.rallyPoint is cleared above via ClearRallyPoint.
+    // These fields will be overwritten when the next probe or invasion begins.
     _clearOperationFields(aiState);
   }
 }

--- a/src/sim/ai-state.ts
+++ b/src/sim/ai-state.ts
@@ -363,8 +363,21 @@ function _checkInvadingToRecovery(
   if (aiState.operationFighterCount === 0) {
     // No cohort committed yet (entrance-retry window). Use invasionStartTick so
     // entrance unavailability can't lock the AI in Invading indefinitely.
+    // Guard against save-restored state with invasionStartTick=0 (mirrors the guard in
+    // setAIRallyOperation at the cohort-committed path).
+    if (aiState.invasionStartTick === 0) aiState.invasionStartTick = world.tick;
     if (world.tick - aiState.invasionStartTick >= AI_INVADING_TIMEOUT_TICKS) {
-      _endInvasion(world, aiColonyId, aiState, 'timeout');
+      // setAIRallyOperation was never called (no entrance found), so no invasion_start
+      // was emitted and no rally point is set. Transition directly to Recovery without
+      // _endInvasion to avoid emitting an orphaned invasion_end event or a spurious
+      // ClearRallyPoint. advanceAIState still emits ai_state_transition after this returns.
+      aiState.state = 'Recovery';
+      aiState.enteredTick = world.tick;
+      aiState.recoveryEndTick = world.tick + AI_RECOVERY_DURATION_TICKS[NORMAL_TIER_INDEX];
+      aiState.invasionStartTick = 0;
+      aiState.invasionRallyTileX = -1;
+      aiState.invasionRallyTileY = -1;
+      _clearOperationFields(aiState);
     }
     return;
   }

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -31,6 +31,8 @@ import {
   COMBAT_DAMAGE_WORKER,
   COMBAT_DAMAGE_QUEEN,
 } from './constants.js';
+import { SIM_VERSION_V19_AI_STATE } from './types.js';
+import { getAIStateForColony, isInCohort } from './ai-state.js';
 
 /**
  * Sweep all live ants, bucket by tile, and resolve combat on tiles shared by 2+ colonies.
@@ -408,6 +410,33 @@ export function killAnt(
   // Reset combat state so replacement ants wind up fresh.
   ants.attackCooldown[antIndex] = 0;
   ants.combatOpponentId[antIndex] = -1;
+
+  // S2 — increment operation death counters if an active operation is running.
+  // QC Pass 4 AR-P1-001: precise predicates using committed-cohort lookup.
+  // Gate on V17 so pre-V17 saves skip this (world.aiState may be empty).
+  // CLNY-08: no direct PLAYER_COLONY_ID / ENEMY_COLONY_ID equality branching.
+  // Instead, iterate world.aiState to find any active operation that involves this kill.
+  if (world.simVersion >= SIM_VERSION_V19_AI_STATE) {
+    for (let _ai = 0; _ai < world.aiState.length; _ai++) {
+      const enemyAI = world.aiState[_ai]!;
+      if (enemyAI.operationKind === 'None') continue;
+      const aiColId = enemyAI.colonyId;
+      const victimColId = ants.colonyId[antIndex]! as ColonyId;
+      // operationAttackerDeaths: victim is a committed-cohort AI fighter.
+      if (victimColId === aiColId
+          && isInCohort(antIndex, enemyAI.operationFighterIds, enemyAI.operationFighterCount)) {
+        enemyAI.operationAttackerDeaths += 1;
+      }
+      // operationDefenderDeaths: victim is a non-AI ant (defender) killed by a committed-cohort AI fighter.
+      if (victimColId !== aiColId
+          && killerKind === 'Ant'
+          && killerColonyId === aiColId
+          && killerId !== null
+          && isInCohort(killerId, enemyAI.operationFighterIds, enemyAI.operationFighterCount)) {
+        enemyAI.operationDefenderDeaths += 1;
+      }
+    }
+  }
 
   if (killerColonyId !== null && killerColonyId !== 0) {
     const killerColony = world.colonies[killerColonyId];

--- a/src/sim/commands.test.ts
+++ b/src/sim/commands.test.ts
@@ -224,6 +224,8 @@ describe('SimCommand', () => {
             return `clearrally:${cmd.colonyId}`;
           case 'SyncAIState':
             return `syncai:${cmd.colonyId}:${cmd.state}`;
+          case 'StartAIOperation':
+            return `startop:${cmd.colonyId}:${cmd.kind}`;
           default: {
             // Exhaustive check — TypeScript will error here if a variant is unhandled
             const _exhaustive: never = cmd;

--- a/src/sim/commands.test.ts
+++ b/src/sim/commands.test.ts
@@ -199,9 +199,9 @@ describe('SimCommand', () => {
   });
 
   describe('discriminated union type narrowing', () => {
-    it('9-variant exhaustive switch: all variants handled, default never arm compiles', () => {
+    it('10-variant exhaustive switch: all variants handled, default never arm compiles', () => {
       // This function's type correctness is validated by TypeScript at compile time.
-      // The runtime test verifies the discriminant values are correct for all 9 variants.
+      // The runtime test verifies the discriminant values are correct for all 10 variants.
       function handleCommand(cmd: SimCommand): string {
         switch (cmd.type) {
           case 'NoOp':
@@ -222,6 +222,8 @@ describe('SimCommand', () => {
             return `rally:${cmd.colonyId}:${cmd.tileX},${cmd.tileY}`;
           case 'ClearRallyPoint':
             return `clearrally:${cmd.colonyId}`;
+          case 'SyncAIState':
+            return `syncai:${cmd.colonyId}:${cmd.state}`;
           default: {
             // Exhaustive check — TypeScript will error here if a variant is unhandled
             const _exhaustive: never = cmd;
@@ -239,6 +241,14 @@ describe('SimCommand', () => {
       expect(handleCommand({ type: 'DesignateEntrance', colonyId: 1, surfaceTileX: 20, surfaceTileY: 64, issuedAtTick: 6 })).toBe('entrance:20,64');
       expect(handleCommand({ type: 'SetRallyPoint', colonyId: 1, tileX: 10, tileY: 20, issuedAtTick: 7 })).toBe('rally:1:10,20');
       expect(handleCommand({ type: 'ClearRallyPoint', colonyId: 1, issuedAtTick: 8 })).toBe('clearrally:1');
+      expect(handleCommand({
+        type: 'SyncAIState', colonyId: 2, issuedAtTick: 9, state: 'WarFooting',
+        enteredTick: 2400, probeCount: 0, lastProbeEndTick: 0, invasionStartTick: 0,
+        invasionRallyTileX: -1, invasionRallyTileY: -1, recoveryEndTick: 0,
+        operationKind: 'None', operationStartTick: 0, operationTargetTileX: -1,
+        operationTargetTileY: -1, operationFighterIds: [], operationFighterCount: 0,
+        operationStartFighterCount: 0, operationAttackerDeaths: 0, operationDefenderDeaths: 0,
+      })).toBe('syncai:2:WarFooting');
     });
   });
 

--- a/src/sim/commands.ts
+++ b/src/sim/commands.ts
@@ -106,6 +106,20 @@ export interface SyncAIStateCommand extends SimCommandBase {
   readonly operationDefenderDeaths: number;
 }
 
+/**
+ * S2 / V19 — AI controller signals a probe or invasion entry by pushing this command
+ * instead of mutating world.aiState directly. tick() applies it via setAIRallyOperation,
+ * keeping all world.aiState writes inside the sim layer (ADR-0007).
+ */
+export interface StartAIOperationCommand extends SimCommandBase {
+  readonly type: 'StartAIOperation';
+  readonly colonyId: ColonyId;
+  readonly kind: 'Probe' | 'Invasion';
+  readonly rallyTileX: number;
+  readonly rallyTileY: number;
+  readonly fighterIds: readonly number[];
+}
+
 export type SimCommand =
   | NoOpCommand
   | SetBehaviorRatioCommand
@@ -116,6 +130,7 @@ export type SimCommand =
   | DesignateEntranceCommand
   | SetRallyPointCommand
   | ClearRallyPointCommand
-  | SyncAIStateCommand;
+  | SyncAIStateCommand
+  | StartAIOperationCommand;
 
 export const MAX_COMMANDS_PER_TICK = 64; // PRD §5 line 680 — FIFO silent-drop beyond cap

--- a/src/sim/commands.ts
+++ b/src/sim/commands.ts
@@ -4,6 +4,7 @@
 // Phase 7 adds 3 variants: CancelDigMark, PlaceChamber, DesignateEntrance.
 
 import type { ColonyId, BehaviorRatio } from './colony/colony-store.js';
+import type { AIState } from './types.js';
 import type { ChamberType } from './enums.js';
 
 export interface SimCommandBase {
@@ -76,6 +77,35 @@ export interface ClearRallyPointCommand extends SimCommandBase {
   readonly colonyId: ColonyId;
 }
 
+/**
+ * S2 / V17 — snapshot of one AIStateRecord pushed to commandQueue by runAIController
+ * every tick in the V17 path. tick() applies it so the snapshot analyzer's replay-only
+ * path (which never calls runAIController) produces bit-identical world.aiState.
+ * operationFighterIds is serialized as number[] (JSON-safe; reconstructed as Int32Array
+ * in the handler).
+ */
+export interface SyncAIStateCommand extends SimCommandBase {
+  readonly type: 'SyncAIState';
+  readonly colonyId: ColonyId;
+  readonly state: AIState;
+  readonly enteredTick: number;
+  readonly probeCount: number;
+  readonly lastProbeEndTick: number;
+  readonly invasionStartTick: number;
+  readonly invasionRallyTileX: number;
+  readonly invasionRallyTileY: number;
+  readonly recoveryEndTick: number;
+  readonly operationKind: 'None' | 'Probe' | 'Invasion';
+  readonly operationStartTick: number;
+  readonly operationTargetTileX: number;
+  readonly operationTargetTileY: number;
+  readonly operationFighterIds: readonly number[];
+  readonly operationFighterCount: number;
+  readonly operationStartFighterCount: number;
+  readonly operationAttackerDeaths: number;
+  readonly operationDefenderDeaths: number;
+}
+
 export type SimCommand =
   | NoOpCommand
   | SetBehaviorRatioCommand
@@ -85,6 +115,7 @@ export type SimCommand =
   | PlaceChamberCommand
   | DesignateEntranceCommand
   | SetRallyPointCommand
-  | ClearRallyPointCommand;
+  | ClearRallyPointCommand
+  | SyncAIStateCommand;
 
 export const MAX_COMMANDS_PER_TICK = 64; // PRD §5 line 680 — FIFO silent-drop beyond cap

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -521,6 +521,7 @@ export const EXCURSION_WOBBLE_PERCENT = 20;
  */
 export const ENTRANCE_DEPOSIT_SUPPRESS_RADIUS = 3;
 
+
 // ---------------------------------------------------------------------------
 // S1 — Combat math (HP / damage / cooldown)
 // ---------------------------------------------------------------------------
@@ -561,3 +562,101 @@ export const COMBAT_DAMAGE_QUEEN = 6 as const;
 /** Base HP for the queen. Higher than workers so it takes a coordinated group of fighters
  *  to kill her. Flagged TBD for S6-Tune. */
 export const COMBAT_HP_QUEEN = 30 as const;
+
+// ---------------------------------------------------------------------------
+// S2 — AI State Machine (D-20 / D-27 / D-29 / D-34)
+// ---------------------------------------------------------------------------
+
+/**
+ * S2 / D-34 — Minimum round age (ticks) before AI can enter WarFooting on age alone.
+ * 2400 ticks = 120s at 20Hz. The AI also has a frontage trigger (see
+ * AI_FRONTAGE_PLAYER_WORKERS_ABS) that can fire before this tick.
+ */
+export const AI_WARFOOTING_MIN_TICK = 2400 as const;
+
+/**
+ * S2 / D-27 — Ticks between probe attempts while in WarFooting state.
+ * 1800 ticks = 90s at 20Hz. Second probe ~4:30 given first at ~3:30.
+ */
+export const AI_PROBE_INTERVAL_TICKS = 1800 as const;
+
+/**
+ * S2 / D-27 — Number of fighters committed to a probe cohort.
+ * Closest 3 alive AI fighters by ascending ant index.
+ */
+export const AI_PROBE_FIGHTER_COUNT = 3 as const;
+
+/**
+ * S2 / D-27 — Timeout after which a probe automatically ends if the cohort
+ * hasn't completed normally. 600 ticks = 30s at 20Hz.
+ */
+export const AI_PROBE_TIMEOUT_TICKS = 600 as const;
+
+/**
+ * S2 / D-34 / QC Pass 4 AI1 — Minimum round age for full invasion.
+ * 6600 ticks = 330s = 5:30 at 20Hz. Locks first Invading to the 5:30–6:30 arc.
+ */
+export const AI_INVADING_MIN_TICK = 6600 as const;
+
+/**
+ * S2 — Invasion timeout: max ticks an invasion can run before auto-ending.
+ * 1800 ticks = 90s at 20Hz.
+ */
+export const AI_INVADING_TIMEOUT_TICKS = 1800 as const;
+
+/**
+ * S2 — Recovery duration after an invasion ends, indexed [Easy, Normal, Hard].
+ * S2 reads only index NORMAL_TIER_INDEX=1. S5 wires the tier selector at V20.
+ * 1200 ticks = 60s at 20Hz.
+ */
+export const AI_RECOVERY_DURATION_TICKS = [1200, 1200, 1200] as const;
+
+/**
+ * S2 / D-29 / CF-P1-010 — Fighter count threshold for WarFooting entry,
+ * indexed [Easy, Normal, Hard]. S2 reads only NORMAL_TIER_INDEX=1.
+ */
+export const AI_WARFOOTING_FIGHTER_THRESHOLD = [10, 8, 6] as const;
+
+/**
+ * S2 — Fighter count threshold for Invading entry, indexed [Easy, Normal, Hard].
+ * S2 reads only NORMAL_TIER_INDEX=1.
+ */
+export const AI_INVADING_FIGHTER_THRESHOLD = [18, 15, 12] as const;
+
+/**
+ * S2 / CF-P1-010 — Food storage minimum for WarFooting entry (integer percent, ×100 safe).
+ * Usage: `aiFoodStored * 100 >= aiFoodCapacity * AI_WARFOOTING_FOOD_FRAC_PCT`
+ */
+export const AI_WARFOOTING_FOOD_FRAC_PCT = 50 as const;
+
+/**
+ * S2 — Food storage minimum for Invading entry (integer percent, ×100 safe).
+ * Usage: `aiFoodStored * 100 >= aiFoodCapacity * AI_INVADING_FOOD_FRAC_PCT`
+ */
+export const AI_INVADING_FOOD_FRAC_PCT = 70 as const;
+
+/**
+ * S2 / D-29 — Absolute floor for the hybrid frontage trigger: player workers >= 24
+ * AND player workers >= 1.3× AI workers triggers WarFooting regardless of age.
+ */
+export const AI_FRONTAGE_PLAYER_WORKERS_ABS = 24 as const;
+
+/**
+ * S2 / D-29 — Ratio multiplier (×100) for the hybrid frontage trigger.
+ * Usage: `playerWorkers * 100 >= AI_FRONTAGE_PLAYER_WORKERS_RATIO_X100 * aiWorkers`
+ * Integer-safe; avoids float division. 130 → 1.3× threshold.
+ */
+export const AI_FRONTAGE_PLAYER_WORKERS_RATIO_X100 = 130 as const;
+
+/**
+ * S2 / CF-P0-005 — Fixed-length buffer size for committed fighter cohort.
+ * `AIStateRecord.operationFighterIds` is always this length; unused slots are -1.
+ */
+export const AI_MAX_OPERATION_FIGHTERS = 32 as const;
+
+/**
+ * S2 — Fallback radius (tiles) for probe target selection when no marked food pile
+ * exists. Picks closest unmarked surface pile within this distance of any open
+ * player entrance.
+ */
+export const AI_PROBE_FALLBACK_RADIUS_TILES = 40 as const;

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -1,6 +1,7 @@
 // Phase 5 scope: outcome enum only. checkQueenDeath is Phase 9 scope — see Phase 4 PRD §5a.
 // S0b: emits queen_death SimEvent on first detection (cause: null for pre-V16 saves).
 // S1: reads pendingQueenDeathContexts (written by killAnt) to fill in cause=InvasionKill.
+// S2: two-pass loop for MutualDestruction; reads aiState for aiStateAtTime; full inferCause.
 
 export const GameOutcome = {
   None: 0,
@@ -10,68 +11,44 @@ export const GameOutcome = {
 } as const;
 export type GameOutcome = typeof GameOutcome[keyof typeof GameOutcome];
 
-import type { WorldState } from './types.js';
+import type { WorldState, AIState } from './types.js';
 import type { ColonyId, ColonyRecord } from './colony/colony-store.js';
 import { emitEvent } from './telemetry.js';
-import { SIM_VERSION_V16_COMBAT_HPDPS } from './types.js';
+import { SIM_VERSION_V16_COMBAT_HPDPS, SIM_VERSION_V19_AI_STATE } from './types.js';
+import { FP_SHIFT } from './fixed.js';
+
+/**
+ * S2 — infer queen_death cause from the kill context and game outcome.
+ * Branch order per spec Part E (MutualDestruction → SpiderRampage → InvasionKill → Starvation).
+ */
+function inferCause(
+  ctx: WorldState['pendingQueenDeathContexts'][number],
+  gameOutcome: GameOutcome,
+): 'InvasionKill' | 'SpiderRampage' | 'Starvation' | 'MutualDestruction' | null {
+  if (gameOutcome === GameOutcome.MutualDestruction) return 'MutualDestruction';
+  if (ctx === null || ctx === undefined) return 'Starvation'; // no killing strike
+  if (ctx.killerKind === 'Spider') return 'SpiderRampage';
+  if (ctx.killerKind === 'Ant' && ctx.killerColonyId !== null) {
+    // Cross-grid: killer from outside the grid where the queen died
+    if (ctx.killerColonyId !== ctx.currentGridColonyId) return 'InvasionKill';
+    // Same-grid combat (rare but possible)
+    return 'InvasionKill';
+  }
+  return null;
+}
 
 /**
  * Returns true if the colony's queen is alive per world.ants.
  * Side effect (idempotent): sets colony.defeated = true when queen is dead.
- * S1: reads world.pendingQueenDeathContexts to fill in queen_death cause.
  */
 function isQueenAlive(world: WorldState, colony: ColonyRecord): boolean {
   const qid = colony.queenEntityId;
-  const alive = world.ants.alive[qid] === 1;
-  if (!alive) {
-    if (!colony.defeated) {
-      // Set before emitting (defensive guard against hypothetical re-entrancy).
-      colony.defeated = true;
-
-      // S1: read kill-site context written by combat.killAnt this same tick.
-      const ctx = world.simVersion >= SIM_VERSION_V16_COMBAT_HPDPS
-        ? (world.pendingQueenDeathContexts[colony.colonyId] ?? null)
-        : null;
-
-      // Determine cause: InvasionKill when the killer is from outside the grid where
-      // the queen died — i.e. the killer was the invader in that grid (RC-P1-003).
-      let cause: 'InvasionKill' | 'SpiderRampage' | 'Starvation' | 'MutualDestruction' | null = null;
-      if (ctx !== null) {
-        if (ctx.killerColonyId !== null && ctx.killerColonyId !== ctx.currentGridColonyId) {
-          cause = 'InvasionKill';
-        }
-        // SpiderRampage, Starvation, MutualDestruction: S2/S5/S6 will extend this.
-      }
-
-      // Location from kill-site context when available; fall back to queen's current tile.
-      const locX = ctx ? ctx.tile.x : (world.ants.posX[qid] ?? 0) >> 8;
-      const locY = ctx ? ctx.tile.y : (world.ants.posY[qid] ?? 0) >> 8;
-      const grid: 'surface' | 'underground' = (world.ants.zone[qid] ?? 1) === 0 ? 'surface' : 'underground';
-
-      emitEvent(world, {
-        tick: world.tick,
-        type: 'queen_death',
-        payload: {
-          cause,
-          location: { x: locX, y: locY, grid },
-          aiStateAtTime: null, // S2 fills this
-        },
-      });
-
-      // Clear the context so it's not re-read if isQueenAlive is called again.
-      if (ctx !== null) {
-        world.pendingQueenDeathContexts[colony.colonyId] = null;
-      }
-    } else {
-      colony.defeated = true;
-    }
-    return false;
-  }
-  return true;
+  return world.ants.alive[qid] === 1;
 }
 
 /**
  * Phase 9 / CMBT-06, CMBT-07 — determine phase-end outcome from queen liveness.
+ * S2: two-pass loop for correct MutualDestruction attribution.
  *
  * CLNY-08: this module does NOT import the platform-layer player colony constant — player colony
  * is either the caller-supplied playerColonyId or (fallback) the smallest numeric colonyId present in world.colonies.
@@ -99,7 +76,127 @@ export function checkQueenDeath(world: WorldState, playerColonyId?: ColonyId): G
   const playerColony = world.colonies[playerCid];
   if (playerColony === undefined) return GameOutcome.None;
 
-  const playerAlive = isQueenAlive(world, playerColony);
+  // For pre-V17 saves: use legacy single-pass path (S1 behavior).
+  if (world.simVersion < SIM_VERSION_V19_AI_STATE) {
+    return _checkQueenDeathLegacy(world, playerCid, playerColony);
+  }
+
+  // --- S2 two-pass loop ---
+
+  // Pass 1 (detection): find which queens died this tick; set colony.defeated.
+  // Compute GameOutcome knowing all results.
+  const diedThisTick: ColonyId[] = [];
+
+  if (!isQueenAlive(world, playerColony) && !playerColony.defeated) {
+    diedThisTick.push(playerCid);
+  }
+
+  let otherColonyCount = 0;
+  for (const key in world.colonies) {
+    if (!Object.hasOwn(world.colonies, key)) continue;
+    const cid = Number(key) as ColonyId;
+    if (cid === playerCid) continue;
+    otherColonyCount += 1;
+    const colony = world.colonies[cid]!;
+    if (!isQueenAlive(world, colony) && !colony.defeated) {
+      diedThisTick.push(cid);
+    }
+  }
+
+  // Compute GameOutcome from the set of newly-dead queens.
+  const playerDied = diedThisTick.includes(playerCid);
+  const otherDied = diedThisTick.some((cid) => cid !== playerCid);
+  const playerCurrentlyAlive = isQueenAlive(world, playerColony);
+  const anyOtherAlive = (() => {
+    for (const key in world.colonies) {
+      if (!Object.hasOwn(world.colonies, key)) continue;
+      const cid = Number(key) as ColonyId;
+      if (cid === playerCid) continue;
+      const colony = world.colonies[cid]!;
+      if (isQueenAlive(world, colony)) return true;
+    }
+    return false;
+  })();
+
+  // For GameOutcome: detect based on who JUST died.
+  let gameOutcome: GameOutcome = GameOutcome.None;
+  if (playerDied && otherDied) {
+    gameOutcome = GameOutcome.MutualDestruction;
+  } else if (playerDied) {
+    gameOutcome = GameOutcome.Defeat;
+  } else if (otherDied && !anyOtherAlive && !playerDied) {
+    // All enemy colonies dead
+    gameOutcome = GameOutcome.Victory;
+  }
+
+  // Pass 2 (event emission): for each newly-dead queen, emit queen_death.
+  for (const cid of diedThisTick) {
+    const colony = world.colonies[cid]!;
+    if (!colony.defeated) {
+      colony.defeated = true;
+    }
+
+    const ctx = world.simVersion >= SIM_VERSION_V16_COMBAT_HPDPS
+      ? (world.pendingQueenDeathContexts[cid] ?? null)
+      : null;
+
+    // S2: look up aiStateAtTime from world.aiState for the killer colony.
+    let aiStateAtTime: AIState | null = null;
+    if (ctx !== null && world.simVersion >= SIM_VERSION_V19_AI_STATE) {
+      for (let i = 0; i < world.aiState.length; i++) {
+        // Check if the AI colony was the killer
+        if (world.aiState[i]!.colonyId === ctx.killerColonyId) {
+          aiStateAtTime = world.aiState[i]!.state;
+          break;
+        }
+      }
+    }
+
+    const cause = world.simVersion >= SIM_VERSION_V16_COMBAT_HPDPS
+      ? inferCause(ctx, gameOutcome)
+      : null;
+
+    // Location from kill-site context when available; fall back to queen's current tile.
+    const qid = colony.queenEntityId;
+    const locX = ctx ? ctx.tile.x : (world.ants.posX[qid] ?? 0) >> FP_SHIFT;
+    const locY = ctx ? ctx.tile.y : (world.ants.posY[qid] ?? 0) >> FP_SHIFT;
+    const grid: 'surface' | 'underground' = (world.ants.zone[qid] ?? 1) === 0 ? 'surface' : 'underground';
+
+    emitEvent(world, {
+      tick: world.tick,
+      type: 'queen_death',
+      payload: {
+        cause,
+        location: { x: locX, y: locY, grid },
+        aiStateAtTime,
+      },
+    });
+
+    // Clear context.
+    if (ctx !== null) {
+      world.pendingQueenDeathContexts[cid] = null;
+    }
+  }
+
+  // Return the outcome.
+  if (otherColonyCount === 0) {
+    return playerCurrentlyAlive ? GameOutcome.None : GameOutcome.Defeat;
+  }
+  if (playerCurrentlyAlive && !anyOtherAlive) return GameOutcome.Victory;
+  if (!playerCurrentlyAlive && anyOtherAlive) return GameOutcome.Defeat;
+  if (!playerCurrentlyAlive && !anyOtherAlive) return GameOutcome.MutualDestruction;
+  return GameOutcome.None;
+}
+
+/**
+ * Legacy single-pass path for pre-V17 saves (S1 behavior, byte-identical replay).
+ */
+function _checkQueenDeathLegacy(
+  world: WorldState,
+  playerCid: ColonyId,
+  playerColony: ColonyRecord,
+): GameOutcome {
+  const playerAlive = _isQueenAliveAndEmitLegacy(world, playerColony);
 
   let anyOtherAlive = false;
   let otherColonyCount = 0;
@@ -109,12 +206,10 @@ export function checkQueenDeath(world: WorldState, playerColonyId?: ColonyId): G
     if (cid === playerCid) continue;
     otherColonyCount += 1;
     const colony = world.colonies[cid]!;
-    if (isQueenAlive(world, colony)) anyOtherAlive = true;
+    if (_isQueenAliveAndEmitLegacy(world, colony)) anyOtherAlive = true;
   }
 
-  // Single-colony sandboxes: no enemies → no win condition.
   if (otherColonyCount === 0) {
-    // Defeat only if the lone colony's queen is dead.
     return playerAlive ? GameOutcome.None : GameOutcome.Defeat;
   }
 
@@ -122,4 +217,51 @@ export function checkQueenDeath(world: WorldState, playerColonyId?: ColonyId): G
   if (!playerAlive && anyOtherAlive) return GameOutcome.Defeat;
   if (!playerAlive && !anyOtherAlive) return GameOutcome.MutualDestruction;
   return GameOutcome.None;
+}
+
+/**
+ * S1-compatible single-queen death detection and event emission (pre-V17 path).
+ * Returns true if the colony's queen is alive.
+ */
+function _isQueenAliveAndEmitLegacy(world: WorldState, colony: ColonyRecord): boolean {
+  const qid = colony.queenEntityId;
+  const alive = world.ants.alive[qid] === 1;
+  if (!alive) {
+    if (!colony.defeated) {
+      colony.defeated = true;
+
+      const ctx = world.simVersion >= SIM_VERSION_V16_COMBAT_HPDPS
+        ? (world.pendingQueenDeathContexts[colony.colonyId] ?? null)
+        : null;
+
+      let cause: 'InvasionKill' | 'SpiderRampage' | 'Starvation' | 'MutualDestruction' | null = null;
+      if (ctx !== null) {
+        if (ctx.killerColonyId !== null && ctx.killerColonyId !== ctx.currentGridColonyId) {
+          cause = 'InvasionKill';
+        }
+      }
+
+      const locX = ctx ? ctx.tile.x : (world.ants.posX[qid] ?? 0) >> FP_SHIFT;
+      const locY = ctx ? ctx.tile.y : (world.ants.posY[qid] ?? 0) >> FP_SHIFT;
+      const grid: 'surface' | 'underground' = (world.ants.zone[qid] ?? 1) === 0 ? 'surface' : 'underground';
+
+      emitEvent(world, {
+        tick: world.tick,
+        type: 'queen_death',
+        payload: {
+          cause,
+          location: { x: locX, y: locY, grid },
+          aiStateAtTime: null,
+        },
+      });
+
+      if (ctx !== null) {
+        world.pendingQueenDeathContexts[colony.colonyId] = null;
+      }
+    } else {
+      colony.defeated = true;
+    }
+    return false;
+  }
+  return true;
 }

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -120,12 +120,13 @@ export function checkQueenDeath(world: WorldState, playerColonyId?: ColonyId): G
 
   // For GameOutcome: detect based on who JUST died.
   let gameOutcome: GameOutcome = GameOutcome.None;
-  if (playerDied && otherDied) {
+  if (playerDied && otherDied && !anyOtherAlive) {
+    // Player and last enemy queen died in same tick.
     gameOutcome = GameOutcome.MutualDestruction;
   } else if (playerDied) {
     gameOutcome = GameOutcome.Defeat;
-  } else if (otherDied && !anyOtherAlive && !playerDied) {
-    // All enemy colonies dead
+  } else if (otherDied && !anyOtherAlive) {
+    // All enemy colonies dead.
     gameOutcome = GameOutcome.Victory;
   }
 

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -11,6 +11,7 @@
 
 import type { WorldState } from './types.js';
 import { createWorldState, allocateEntityId } from './types.js';
+import { createDefaultAIStateRecord } from './ai-state.js';
 import { createSurfaceGrid, createUndergroundGrid, SurfaceTileState, UndergroundTileState, ugSet } from './terrain.js';
 import { initAnt } from './ant/ant-store.js';
 import { createColonyRecord } from './colony/colony-store.js';
@@ -294,6 +295,10 @@ export function createScenario(seed: number): WorldState {
       world.pheromoneGrids[undergroundKey] = createPheromoneGrid(UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
     }
   }
+
+  // --- S2: Initialize aiState for the enemy colony ---
+  // One AIStateRecord per non-player colony with defensive defaults.
+  world.aiState = [createDefaultAIStateRecord(ENEMY_COLONY_ID)];
 
   // --- Step 9: Write back rngState ---
   world.rngState = rng.getState();

--- a/src/sim/telemetry.ts
+++ b/src/sim/telemetry.ts
@@ -43,7 +43,8 @@ export type SimEvent =
         to: AIState;
         triggerValues: {
           aiFighterCount: number;
-          aiFoodStorageFrac100: number;
+          aiFoodStored: number;
+          aiFoodCap: number;
           playerWorkerCount: number;
         };
       };

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1,8 +1,9 @@
 // src/sim/tick.ts — Phase 9 19-step tick dispatcher.
 import type { WorldState } from './types.js';
-import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY, SIM_VERSION_V11_DEFENSIVE_BUNDLE, SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX } from './types.js';
+import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY, SIM_VERSION_V11_DEFENSIVE_BUNDLE, SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX, SIM_VERSION_V19_AI_STATE } from './types.js';
 import { MAX_COMMANDS_PER_TICK, type SimCommand } from './commands.js';
 import { GameOutcome, checkQueenDeath } from './game-over.js';
+import { advanceAIState } from './ai-state.js';
 import { detectAndResolveCombat } from './combat.js';
 import { Rng } from './rng.js';
 import {
@@ -239,7 +240,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         srec.operationTargetTileY = sc.operationTargetTileY;
         srec.operationFighterIds.set(sc.operationFighterIds);
         srec.operationFighterIds.fill(-1, sc.operationFighterIds.length);
-        srec.operationFighterCount = sc.operationFighterCount;
+        srec.operationFighterCount = Math.min(sc.operationFighterCount, sc.operationFighterIds.length);
         srec.operationStartFighterCount = sc.operationStartFighterCount;
         srec.operationAttackerDeaths = sc.operationAttackerDeaths;
         srec.operationDefenderDeaths = sc.operationDefenderDeaths;
@@ -688,6 +689,17 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         void _exhaustive;
         break;
       }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 1b: Advance AI state machines (timeout/death transitions).
+  // Gated on V19; moved from render-side to preserve the sim/render boundary
+  // (ADR-0007: only tick.ts mutates WorldState).
+  // ---------------------------------------------------------------------------
+  if (world.simVersion >= SIM_VERSION_V19_AI_STATE) {
+    for (let i = 0; i < world.aiState.length; i++) {
+      advanceAIState(world, world.aiState[i]!.colonyId);
     }
   }
 

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -645,8 +645,32 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         colony.rallyPoint = null;
         break;
       }
+      case 'SyncAIState': {
+        // S2 / V17 — apply AI state snapshot so replay paths (snapshot analyzer)
+        // that skip runAIController produce bit-identical world.aiState.
+        let rec = world.aiState.find((r) => r.colonyId === cmd.colonyId);
+        if (rec === undefined) break;
+        rec.state = cmd.state;
+        rec.enteredTick = cmd.enteredTick;
+        rec.probeCount = cmd.probeCount;
+        rec.lastProbeEndTick = cmd.lastProbeEndTick;
+        rec.invasionStartTick = cmd.invasionStartTick;
+        rec.invasionRallyTileX = cmd.invasionRallyTileX;
+        rec.invasionRallyTileY = cmd.invasionRallyTileY;
+        rec.recoveryEndTick = cmd.recoveryEndTick;
+        rec.operationKind = cmd.operationKind;
+        rec.operationStartTick = cmd.operationStartTick;
+        rec.operationTargetTileX = cmd.operationTargetTileX;
+        rec.operationTargetTileY = cmd.operationTargetTileY;
+        rec.operationFighterIds.set(cmd.operationFighterIds);
+        rec.operationFighterCount = cmd.operationFighterCount;
+        rec.operationStartFighterCount = cmd.operationStartFighterCount;
+        rec.operationAttackerDeaths = cmd.operationAttackerDeaths;
+        rec.operationDefenderDeaths = cmd.operationDefenderDeaths;
+        break;
+      }
       default: {
-        // Exhaustive narrowing — SimCommand is a 9-variant union (Phase 9 adds SetRallyPoint + ClearRallyPoint).
+        // Exhaustive narrowing — SimCommand is a 10-variant union (S2 adds SyncAIState).
         // Silent-drop unknowns per PRD §5. Do NOT throw, do NOT log (wall-clock-adjacent).
         const _exhaustive: never = cmd;
         void _exhaustive;

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -685,6 +685,9 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         if (world.simVersion < SIM_VERSION_V19_AI_STATE) break;
         if (!isTileCoord(cmd.rallyTileX, SURFACE_GRID_WIDTH)) break;
         if (!isTileCoord(cmd.rallyTileY, SURFACE_GRID_HEIGHT)) break;
+        // Validate fighterIds: a non-array (from a malformed save/replay entry) would cause
+        // setAIRallyOperation to throw TypeError on .length access. Drop the command silently.
+        if (!Array.isArray(cmd.fighterIds)) break;
         setAIRallyOperation(world, cmd.colonyId, cmd.rallyTileX, cmd.rallyTileY, cmd.fighterIds, cmd.kind);
         break;
       }

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -223,7 +223,8 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     if (commands[i]!.type === 'SyncAIState') {
       const sc = commands[i] as import('./commands.js').SyncAIStateCommand;
       const srec = world.aiState.find((r) => r.colonyId === sc.colonyId);
-      if (srec !== undefined) {
+      // P1: validate buffer length before set() to prevent RangeError on malformed payloads.
+      if (srec !== undefined && sc.operationFighterIds.length <= srec.operationFighterIds.length) {
         srec.state = sc.state;
         srec.enteredTick = sc.enteredTick;
         srec.probeCount = sc.probeCount;
@@ -237,6 +238,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         srec.operationTargetTileX = sc.operationTargetTileX;
         srec.operationTargetTileY = sc.operationTargetTileY;
         srec.operationFighterIds.set(sc.operationFighterIds);
+        srec.operationFighterIds.fill(-1, sc.operationFighterIds.length);
         srec.operationFighterCount = sc.operationFighterCount;
         srec.operationStartFighterCount = sc.operationStartFighterCount;
         srec.operationAttackerDeaths = sc.operationAttackerDeaths;
@@ -245,10 +247,15 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     }
   }
 
-  const limit = commands.length < MAX_COMMANDS_PER_TICK ? commands.length : MAX_COMMANDS_PER_TICK;
-
-  for (let i = 0; i < limit; i++) {
+  // SyncAIState is excluded from the cap: it was already applied in the uncapped
+  // pre-pass above, so counting it against MAX_COMMANDS_PER_TICK would silently
+  // drop one real gameplay command per AI tick under high-command-count loads.
+  let nonSyncCmdCount = 0;
+  for (let i = 0; i < commands.length; i++) {
     const cmd = commands[i]!;
+    if (cmd.type === 'SyncAIState') continue;
+    if (nonSyncCmdCount >= MAX_COMMANDS_PER_TICK) break;
+    nonSyncCmdCount++;
     switch (cmd.type) {
       case 'NoOp':
         // No state change — by definition a no-op.
@@ -673,33 +680,10 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         colony.rallyPoint = null;
         break;
       }
-      case 'SyncAIState': {
-        // S2 / V17 — apply AI state snapshot so replay paths (snapshot analyzer)
-        // that skip runAIController produce bit-identical world.aiState.
-        let rec = world.aiState.find((r) => r.colonyId === cmd.colonyId);
-        if (rec === undefined) break;
-        rec.state = cmd.state;
-        rec.enteredTick = cmd.enteredTick;
-        rec.probeCount = cmd.probeCount;
-        rec.lastProbeEndTick = cmd.lastProbeEndTick;
-        rec.invasionStartTick = cmd.invasionStartTick;
-        rec.invasionRallyTileX = cmd.invasionRallyTileX;
-        rec.invasionRallyTileY = cmd.invasionRallyTileY;
-        rec.recoveryEndTick = cmd.recoveryEndTick;
-        rec.operationKind = cmd.operationKind;
-        rec.operationStartTick = cmd.operationStartTick;
-        rec.operationTargetTileX = cmd.operationTargetTileX;
-        rec.operationTargetTileY = cmd.operationTargetTileY;
-        rec.operationFighterIds.set(cmd.operationFighterIds);
-        rec.operationFighterCount = cmd.operationFighterCount;
-        rec.operationStartFighterCount = cmd.operationStartFighterCount;
-        rec.operationAttackerDeaths = cmd.operationAttackerDeaths;
-        rec.operationDefenderDeaths = cmd.operationDefenderDeaths;
-        break;
-      }
       default: {
-        // Exhaustive narrowing — SimCommand is a 10-variant union (S2 adds SyncAIState).
-        // Silent-drop unknowns per PRD §5. Do NOT throw, do NOT log (wall-clock-adjacent).
+        // Exhaustive narrowing — SimCommand is a 10-variant union; SyncAIState is
+        // filtered out by the `continue` guard above the switch, so the narrowed
+        // type here excludes it and the never-check still holds.
         const _exhaustive: never = cmd;
         void _exhaustive;
         break;

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -686,9 +686,10 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         if (world.simVersion < SIM_VERSION_V19_AI_STATE) break;
         if (!isTileCoord(cmd.rallyTileX, SURFACE_GRID_WIDTH)) break;
         if (!isTileCoord(cmd.rallyTileY, SURFACE_GRID_HEIGHT)) break;
-        // Validate fighterIds: a non-array (from a malformed save/replay entry) would cause
-        // setAIRallyOperation to throw TypeError on .length access. Drop the command silently.
-        if (!Array.isArray(cmd.fighterIds)) break;
+        // Validate fighterIds: non-array or empty array from a malformed save/replay entry
+        // would cause setAIRallyOperation to set operationFighterCount=0, leaving the AI
+        // stuck in Invading indefinitely (aiInvasionTick won't retry once operationKind !== 'None').
+        if (!Array.isArray(cmd.fighterIds) || cmd.fighterIds.length === 0) break;
         setAIRallyOperation(world, cmd.colonyId, cmd.rallyTileX, cmd.rallyTileY, cmd.fighterIds, cmd.kind);
         break;
       }

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -221,7 +221,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   // SyncAIState pre-pass: applied before the cap so replay determinism is
   // preserved even on high-command-count ticks (>64 commands in queue).
   // ---------------------------------------------------------------------------
-  for (let i = 0; i < commands.length; i++) {
+  if (world.simVersion >= SIM_VERSION_V19_AI_STATE) for (let i = 0; i < commands.length; i++) {
     if (commands[i]!.type === 'SyncAIState') {
       const sc = commands[i] as import('./commands.js').SyncAIStateCommand;
       const srec = world.aiState.find((r) => r.colonyId === sc.colonyId);
@@ -690,6 +690,8 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         // would cause setAIRallyOperation to set operationFighterCount=0, leaving the AI
         // stuck in Invading indefinitely (aiInvasionTick won't retry once operationKind !== 'None').
         if (!Array.isArray(cmd.fighterIds) || cmd.fighterIds.length === 0) break;
+        // Invasion cohorts < 3 fighters trigger immediate rout on first tick; reject them.
+        if (cmd.kind === 'Invasion' && cmd.fighterIds.length < 3) break;
         setAIRallyOperation(world, cmd.colonyId, cmd.rallyTileX, cmd.rallyTileY, cmd.fighterIds, cmd.kind);
         break;
       }

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -216,7 +216,35 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   // ---------------------------------------------------------------------------
   // Step 1: Process commands (FIFO cap — PRD §5; indexed loop, no allocation)
   //         Extended in Phase 7 with real handlers for all 7 SimCommand variants.
+  // SyncAIState pre-pass: applied before the cap so replay determinism is
+  // preserved even on high-command-count ticks (>64 commands in queue).
   // ---------------------------------------------------------------------------
+  for (let i = 0; i < commands.length; i++) {
+    if (commands[i]!.type === 'SyncAIState') {
+      const sc = commands[i] as import('./commands.js').SyncAIStateCommand;
+      const srec = world.aiState.find((r) => r.colonyId === sc.colonyId);
+      if (srec !== undefined) {
+        srec.state = sc.state;
+        srec.enteredTick = sc.enteredTick;
+        srec.probeCount = sc.probeCount;
+        srec.lastProbeEndTick = sc.lastProbeEndTick;
+        srec.invasionStartTick = sc.invasionStartTick;
+        srec.invasionRallyTileX = sc.invasionRallyTileX;
+        srec.invasionRallyTileY = sc.invasionRallyTileY;
+        srec.recoveryEndTick = sc.recoveryEndTick;
+        srec.operationKind = sc.operationKind;
+        srec.operationStartTick = sc.operationStartTick;
+        srec.operationTargetTileX = sc.operationTargetTileX;
+        srec.operationTargetTileY = sc.operationTargetTileY;
+        srec.operationFighterIds.set(sc.operationFighterIds);
+        srec.operationFighterCount = sc.operationFighterCount;
+        srec.operationStartFighterCount = sc.operationStartFighterCount;
+        srec.operationAttackerDeaths = sc.operationAttackerDeaths;
+        srec.operationDefenderDeaths = sc.operationDefenderDeaths;
+      }
+    }
+  }
+
   const limit = commands.length < MAX_COMMANDS_PER_TICK ? commands.length : MAX_COMMANDS_PER_TICK;
 
   for (let i = 0; i < limit; i++) {

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -146,6 +146,7 @@ void (undefined as unknown as PendingChamber);
  *       Extended in Phase 7: real MarkDigTile, MarkFoodPile handlers;
  *       new CancelDigMark, PlaceChamber, DesignateEntrance handlers.
  *       Extended in Phase 9: SetRallyPoint, ClearRallyPoint handlers (9-variant exhaustive switch).
+ * 1b.  (removed — advanceAIState moved to step 18b, after checkQueenDeath)
  *  2.  Reconcile colony stats
  *  3.  Food consumption
  *  4.  Starvation check
@@ -703,17 +704,6 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   }
 
   // ---------------------------------------------------------------------------
-  // Step 1b: Advance AI state machines (timeout/death transitions).
-  // Gated on V19; moved from render-side to preserve the sim/render boundary
-  // (ADR-0007: only tick.ts mutates WorldState).
-  // ---------------------------------------------------------------------------
-  if (world.simVersion >= SIM_VERSION_V19_AI_STATE) {
-    for (let i = 0; i < world.aiState.length; i++) {
-      advanceAIState(world, world.aiState[i]!.colonyId);
-    }
-  }
-
-  // ---------------------------------------------------------------------------
   // Steps 2-8: Per-colony loop
   // ---------------------------------------------------------------------------
   for (const colonyId in world.colonies) {
@@ -1220,6 +1210,19 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   // Step 18: game-over detection (Phase 9 / CMBT-06/07).
   // ---------------------------------------------------------------------------
   const outcome = checkQueenDeath(world);
+
+  // ---------------------------------------------------------------------------
+  // Step 18b: Advance AI state machines (timeout/death transitions).
+  // Placed AFTER checkQueenDeath so aiStateAtTime in queen_death events reflects
+  // the AI state at kill time, not a same-tick post-transition state (e.g. the
+  // invading AI routing to Recovery on the same tick it kills the queen).
+  // Gated on V19; moved from render-side to preserve ADR-0007 sim/render boundary.
+  // ---------------------------------------------------------------------------
+  if (world.simVersion >= SIM_VERSION_V19_AI_STATE) {
+    for (let i = 0; i < world.aiState.length; i++) {
+      advanceAIState(world, world.aiState[i]!.colonyId);
+    }
+  }
 
   // ---------------------------------------------------------------------------
   // Step 19: rngState writeback (BEFORE tick increment per PRD §4 serialization contract)

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -3,7 +3,7 @@ import type { WorldState } from './types.js';
 import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY, SIM_VERSION_V11_DEFENSIVE_BUNDLE, SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX, SIM_VERSION_V19_AI_STATE } from './types.js';
 import { MAX_COMMANDS_PER_TICK, type SimCommand } from './commands.js';
 import { GameOutcome, checkQueenDeath } from './game-over.js';
-import { advanceAIState } from './ai-state.js';
+import { advanceAIState, setAIRallyOperation } from './ai-state.js';
 import { detectAndResolveCombat } from './combat.js';
 import { Rng } from './rng.js';
 import {
@@ -679,6 +679,13 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         const colony = world.colonies[cmd.colonyId];
         if (colony === undefined) break;
         colony.rallyPoint = null;
+        break;
+      }
+      case 'StartAIOperation': {
+        if (world.simVersion < SIM_VERSION_V19_AI_STATE) break;
+        if (!isTileCoord(cmd.rallyTileX, SURFACE_GRID_WIDTH)) break;
+        if (!isTileCoord(cmd.rallyTileY, SURFACE_GRID_HEIGHT)) break;
+        setAIRallyOperation(world, cmd.colonyId, cmd.rallyTileX, cmd.rallyTileY, cmd.fighterIds, cmd.kind);
         break;
       }
       default: {

--- a/src/sim/types.test.ts
+++ b/src/sim/types.test.ts
@@ -29,10 +29,10 @@ describe('WorldState', () => {
       expect(world.rngState).toBe(4294967295);
     });
 
-    it('has exactly eighteen fields (4 Phase 5 + 3 Phase 6 + 4 Phase 7 + 1 issue #27 + 1 issue #44 + 1 issue #112 + 3 S0b telemetry + 1 S1 pendingQueenDeathContexts)', () => {
+    it('has exactly nineteen fields (4 Phase 5 + 3 Phase 6 + 4 Phase 7 + 1 issue #27 + 1 issue #44 + 1 issue #112 + 3 S0b telemetry + 1 S1 pendingQueenDeathContexts + 1 S2 aiState)', () => {
       const world = createWorldState(0);
       const keys = Object.keys(world);
-      expect(keys).toHaveLength(18);
+      expect(keys).toHaveLength(19);
       expect(keys).toContain('tick');
       expect(keys).toContain('rngState');
       expect(keys).toContain('nextEntityId');
@@ -50,6 +50,7 @@ describe('WorldState', () => {
       expect(keys).toContain('events'); // S0b
       expect(keys).toContain('droppedCombatKillCount'); // S0b
       expect(keys).toContain('droppedStructuralCount'); // S0b
+      expect(keys).toContain('aiState'); // S2
     });
 
     it('issue #44: terrainSeed is a deterministic, non-zero, non-rngState mix of the input seed', () => {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -248,7 +248,51 @@ export const SIM_VERSION_V17_COMBAT_AGGRO = 17 as const;
  * the old direct-hostile-position rawDx/rawDy path (byte-stable).
  */
 export const SIM_VERSION_V18_INVADER_WALL_AWARE_STEP = 18 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V18_INVADER_WALL_AWARE_STEP;
+/**
+ * V19 (S2) — AI state machine: adds WorldState.aiState (AIStateRecord[]) with
+ * full operation-cohort tracking; advanceAIState/setAIRallyOperation/endAIRallyOperation
+ * narrow sim helpers; probe/invasion mechanics; queen_death.aiStateAtTime populated.
+ */
+export const SIM_VERSION_V19_AI_STATE = 19 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V19_AI_STATE;
+
+
+/**
+ * S2 — AI colony state machine states.
+ */
+export type AIState =
+  | 'Peacetime'
+  | 'WarFooting'
+  | 'Probing'
+  | 'Invading'
+  | 'Recovery';
+
+/**
+ * S2 — Per-AI-colony state record. Lives in WorldState.aiState[].
+ * Indexed by array position (iterate to find by colonyId — not dense by colonyId).
+ */
+export interface AIStateRecord {
+  colonyId: ColonyId;
+  state: AIState;
+  enteredTick: number;             // tick at which the current state was entered
+  probeCount: number;              // probes fired since last Peacetime
+  lastProbeEndTick: number;        // for spacing between probes
+  invasionStartTick: number;       // 0 if not Invading
+  invasionRallyTileX: number;      // -1 if no active rally; integer tile coords
+  invasionRallyTileY: number;
+  recoveryEndTick: number;         // 0 if not in Recovery
+
+  // Committed-force operation tracking (CF-P0-005)
+  operationKind: 'None' | 'Probe' | 'Invasion';
+  operationStartTick: number;
+  operationTargetTileX: number;
+  operationTargetTileY: number;
+  operationFighterIds: Int32Array; // committed cohort, fixed-length buffer (AI_MAX_OPERATION_FIGHTERS=32), padded with -1
+  operationFighterCount: number;   // active length of operationFighterIds
+  operationStartFighterCount: number;
+  operationAttackerDeaths: number;
+  operationDefenderDeaths: number;
+}
 
 export interface WorldState {
   tick: number;             // 0 at creation; incremented once per tick
@@ -381,6 +425,14 @@ export interface WorldState {
    * Index by victim colonyId. Empty array between ticks.
    */
   pendingQueenDeathContexts: (QueenDeathContext | null)[];
+
+  /**
+   * S2 — per-AI-colony state machine record. One entry per non-player colony.
+   * Indexed by array position (iterate to find by colonyId — NOT dense by colonyId
+   * since colonyId values may not be contiguous starting from 0).
+   * Persisted in saves (V17+); pre-V17 saves get defensive defaults on load.
+   */
+  aiState: AIStateRecord[];
 }
 
 /**
@@ -417,6 +469,8 @@ export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIE
     droppedStructuralCount: 0,
     // S1 — transient; cleared between ticks by combat resolver.
     pendingQueenDeathContexts: [],
+    // S2 — AI state machine. Populated by createScenario for non-player colonies.
+    aiState: [],
   };
 }
 
@@ -452,6 +506,57 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   // pendingQueenDeathContexts: transient within-tick (cleared by checkQueenDeath every tick,
   // always null at the tick boundary when copyWorldState runs). No render code reads it,
   // so no copy is needed and the allocation is skipped to preserve zero-alloc steady state.
+
+  // S2 — aiState: deep-copy the array and each record's Int32Array buffer.
+  // Length-adjust: grow or shrink dst.aiState to match src.aiState.
+  while (dst.aiState.length > src.aiState.length) dst.aiState.pop();
+  for (let i = 0; i < src.aiState.length; i++) {
+    const s = src.aiState[i]!;
+    if (i < dst.aiState.length) {
+      // Reuse existing record — copy scalars, then copy Int32Array buffer.
+      const d = dst.aiState[i]!;
+      d.colonyId = s.colonyId;
+      d.state = s.state;
+      d.enteredTick = s.enteredTick;
+      d.probeCount = s.probeCount;
+      d.lastProbeEndTick = s.lastProbeEndTick;
+      d.invasionStartTick = s.invasionStartTick;
+      d.invasionRallyTileX = s.invasionRallyTileX;
+      d.invasionRallyTileY = s.invasionRallyTileY;
+      d.recoveryEndTick = s.recoveryEndTick;
+      d.operationKind = s.operationKind;
+      d.operationStartTick = s.operationStartTick;
+      d.operationTargetTileX = s.operationTargetTileX;
+      d.operationTargetTileY = s.operationTargetTileY;
+      d.operationFighterIds.set(s.operationFighterIds);
+      d.operationFighterCount = s.operationFighterCount;
+      d.operationStartFighterCount = s.operationStartFighterCount;
+      d.operationAttackerDeaths = s.operationAttackerDeaths;
+      d.operationDefenderDeaths = s.operationDefenderDeaths;
+    } else {
+      // Grow: push a new deep copy.
+      dst.aiState.push({
+        colonyId: s.colonyId,
+        state: s.state,
+        enteredTick: s.enteredTick,
+        probeCount: s.probeCount,
+        lastProbeEndTick: s.lastProbeEndTick,
+        invasionStartTick: s.invasionStartTick,
+        invasionRallyTileX: s.invasionRallyTileX,
+        invasionRallyTileY: s.invasionRallyTileY,
+        recoveryEndTick: s.recoveryEndTick,
+        operationKind: s.operationKind,
+        operationStartTick: s.operationStartTick,
+        operationTargetTileX: s.operationTargetTileX,
+        operationTargetTileY: s.operationTargetTileY,
+        operationFighterIds: Int32Array.from(s.operationFighterIds),
+        operationFighterCount: s.operationFighterCount,
+        operationStartFighterCount: s.operationStartFighterCount,
+        operationAttackerDeaths: s.operationAttackerDeaths,
+        operationDefenderDeaths: s.operationDefenderDeaths,
+      });
+    }
+  }
 
   // --- AntComponents: 19 TypedArray.set calls (zero allocation) ---
   dst.ants.posX.set(src.ants.posX);


### PR DESCRIPTION
## Summary

- Rebased `feat/s2-ai-invasion` onto `main` (replacing closed PR #136)
- Resolved conflict with V17 (combat aggro, merged in PR #141): renamed `SIM_VERSION_V17_AI_STATE` → `SIM_VERSION_V19_AI_STATE = 19` to reserve V18 for the wall-aware invader step (PR #139)
- All S1 follow-up constants (FIGHT_AGGRO_RADIUS, COMBAT_DAMAGE_WORKER, COMBAT_DAMAGE_QUEEN, COMBAT_HP_QUEEN) from main are preserved alongside S2 AI state machine constants

## Changes

- `types.ts`: `SIM_VERSION_V19_AI_STATE = 19`, `LATEST_SIM_VERSION` updated, `AIState` + `AIStateRecord` types added
- `constants.ts`: Both S1 follow-up block and S2 AI state machine block included
- All 6 consumer files renamed from V17 → V19
- All 2119 tests pass

## Replaces

Closes #136 (was auto-closed when the S1 base branch was deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)