### PR TITLE
feat(s3): spider render layer — sprite, hunt reticle, hunger tint + ring (PR-B)

### DIFF
--- a/public/assets/sprites/spider.svg
+++ b/public/assets/sprites/spider.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" shape-rendering="crispEdges">
+  <g fill="#ffffff">
+    <!-- Legs drawn first; body ellipses overlap the inner joints naturally -->
+    <!-- Top-side legs L1-L4, front to back -->
+    <rect x="10" y="13" width="2" height="5"/>
+    <rect x="3"  y="11" width="9" height="2"/>
+    <rect x="16" y="10" width="2" height="7"/>
+    <rect x="5"  y="8"  width="11" height="2"/>
+    <rect x="27" y="10" width="2" height="7"/>
+    <rect x="29" y="8"  width="11" height="2"/>
+    <rect x="35" y="13" width="2" height="5"/>
+    <rect x="36" y="11" width="9" height="2"/>
+    <!-- Bottom-side legs L5-L8, front to back (mirror of top) -->
+    <rect x="10" y="30" width="2" height="5"/>
+    <rect x="3"  y="35" width="9" height="2"/>
+    <rect x="16" y="31" width="2" height="7"/>
+    <rect x="5"  y="38" width="11" height="2"/>
+    <rect x="27" y="31" width="2" height="7"/>
+    <rect x="29" y="38" width="11" height="2"/>
+    <rect x="35" y="30" width="2" height="5"/>
+    <rect x="36" y="35" width="9" height="2"/>
+    <!-- Chelicerae (forward fangs) -->
+    <rect x="5" y="20" width="4" height="2"/>
+    <rect x="5" y="26" width="4" height="2"/>
+    <!-- Body segments -->
+    <ellipse cx="17" cy="24" rx="9"  ry="8"/>
+    <ellipse cx="35" cy="24" rx="11" ry="10"/>
+  </g>
+  <!-- Eyes (black - stay dark regardless of hunger tint) -->
+  <circle cx="11" cy="20" r="1.5" fill="#000000"/>
+  <circle cx="11" cy="28" r="1.5" fill="#000000"/>
+</svg>

--- a/src/render/ant-sprite-layer.ts
+++ b/src/render/ant-sprite-layer.ts
@@ -81,7 +81,7 @@ export const FOOD_CACHE_TEXTURE = 'food-cache';
 export const SPIDER_TEXTURE       = 'spider';
 export const SPIDER_SPRITE_WIDTH  = 48;
 export const SPIDER_SPRITE_HEIGHT = 48;
-export const SPIDER_SPRITE_DEPTH  = 52; // above ants (depth 50)
+export const SPIDER_SPRITE_DEPTH  = 52; // above ants (depth 50); exported unlike ant/static depths which are pool-internal
 
 // Rasterization sizes — keep in sync with the SVG viewBox values in
 // code/public/assets/sprites/{worker,queen}-ant.svg. Phaser's load.svg

--- a/src/render/ant-sprite-layer.ts
+++ b/src/render/ant-sprite-layer.ts
@@ -48,12 +48,24 @@ export interface StaticSpriteDrawOptions {
   tint?: number;
 }
 
+/** S3 — Spider entity draw options. */
+export interface SpiderSpriteDrawOptions {
+  /** Screen-space pixel X of the sprite center. */
+  x: number;
+  /** Screen-space pixel Y of the sprite center. */
+  y: number;
+  /** Hunger-derived multiplicative tint: 0xCCCCCC (idle) → 0xFF3300 (rampage). */
+  tint: number;
+}
+
 export interface AntSpriteLayer {
   /** Reset the per-frame draw cursor. Hidden sprites are reused in draw order. */
   beginFrame(): void;
   drawAnt(opts: AntSpriteDrawOptions): void;
   /** Draw a static (non-rotating) entity — egg, larva, or food cache. */
   drawStatic(opts: StaticSpriteDrawOptions): void;
+  /** S3 — Draw the spider entity. */
+  drawSpider(opts: SpiderSpriteDrawOptions): void;
   /** Hide any pooled sprites not touched this frame. */
   endFrame(): void;
 }
@@ -64,6 +76,12 @@ export const ANT_TEXTURE_QUEEN  = 'ant-queen';
 export const EGG_TEXTURE        = 'egg';
 export const LARVA_TEXTURE      = 'larva';
 export const FOOD_CACHE_TEXTURE = 'food-cache';
+
+// S3 spider
+export const SPIDER_TEXTURE       = 'spider';
+export const SPIDER_SPRITE_WIDTH  = 48;
+export const SPIDER_SPRITE_HEIGHT = 48;
+export const SPIDER_SPRITE_DEPTH  = 52; // above ants (depth 50)
 
 // Rasterization sizes — keep in sync with the SVG viewBox values in
 // code/public/assets/sprites/{worker,queen}-ant.svg. Phaser's load.svg

--- a/src/render/ant-sprite-pool.ts
+++ b/src/render/ant-sprite-pool.ts
@@ -20,8 +20,11 @@ import {
   EGG_TEXTURE,
   FOOD_CACHE_TEXTURE,
   LARVA_TEXTURE,
+  SPIDER_SPRITE_DEPTH,
+  SPIDER_TEXTURE,
   type AntSpriteDrawOptions,
   type AntSpriteLayer,
+  type SpiderSpriteDrawOptions,
   type StaticSpriteDrawOptions,
   type StaticSpriteKind,
 } from './ant-sprite-layer.js';
@@ -85,6 +88,17 @@ export class AntSpritePool implements AntSpriteLayer {
     for (let i = this.nextIdx; i < this.pool.length; i++) {
       this.pool[i]!.setVisible(false);
     }
+  }
+
+  drawSpider(opts: SpiderSpriteDrawOptions): void {
+    const sprite = this.acquire();
+    sprite.setTexture(SPIDER_TEXTURE);
+    sprite.setPosition(opts.x, opts.y);
+    sprite.setTint(opts.tint);
+    sprite.setRotation(0);
+    sprite.setScale(1);
+    sprite.setDepth(SPIDER_SPRITE_DEPTH);
+    sprite.setVisible(true);
   }
 
   /** Test hook: current pool size (live + hidden). */

--- a/src/render/draw-surface.test.ts
+++ b/src/render/draw-surface.test.ts
@@ -17,6 +17,7 @@ import type { GfxLike } from './draw-surface.js';
 import type {
   AntSpriteDrawOptions,
   AntSpriteLayer,
+  SpiderSpriteDrawOptions,
   StaticSpriteDrawOptions,
 } from './ant-sprite-layer.js';
 import type { WorldState } from '../sim/types.js';
@@ -95,6 +96,7 @@ class MockAntSprites implements AntSpriteLayer {
   beginFrame(): void { this.beginFrames++; }
   drawAnt(opts: AntSpriteDrawOptions): void { this.calls.push({ ...opts }); }
   drawStatic(opts: StaticSpriteDrawOptions): void { this.staticCalls.push({ ...opts }); }
+  drawSpider(_opts: SpiderSpriteDrawOptions): void { /* no-op in tests */ }
   endFrame(): void { this.endFrames++; }
   reset(): void {
     this.calls = []; this.staticCalls = [];

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -360,16 +360,20 @@ export function drawSurfaceEntities(
     const currPxY = (curr.spider.posY * TILE_SIZE_PX) / FP_ONE;
     const prevPxX = spiderPrev !== null ? (spiderPrev.posX * TILE_SIZE_PX) / FP_ONE : currPxX;
     const prevPxY = spiderPrev !== null ? (spiderPrev.posY * TILE_SIZE_PX) / FP_ONE : currPxY;
+    // Spider has no zone field (surface-only) and never teleports between ticks,
+    // so a null-check on prev.spider suffices — no zone-match guard needed.
+    // Spider has no zone field (surface-only) and never teleports between ticks,
+    // so a null-check on prev.spider suffices as the interp guard.
     const useSpiderInterp = spiderPrev !== null;
     const baseSX = useSpiderInterp ? prevPxX + (currPxX - prevPxX) * alpha : currPxX;
     const baseSY = useSpiderInterp ? prevPxY + (currPxY - prevPxY) * alpha : currPxY;
     const spiderScreenX = baseSX - left * TILE_SIZE_PX;
     const spiderScreenY = baseSY - top  * TILE_SIZE_PX;
 
-    const spiderCullMargin = SPIDER_SPRITE_WIDTH;
-    if (spiderScreenX > -spiderCullMargin && spiderScreenX < canvasW + spiderCullMargin
-      && spiderScreenY > -spiderCullMargin && spiderScreenY < canvasH + spiderCullMargin) {
+    if (spiderScreenX > -SPIDER_SPRITE_WIDTH  && spiderScreenX < canvasW + SPIDER_SPRITE_WIDTH
+      && spiderScreenY > -SPIDER_SPRITE_HEIGHT && spiderScreenY < canvasH + SPIDER_SPRITE_HEIGHT) {
 
+      // S5 will replace NORMAL_TIER_INDEX with tierIndex(world.difficulty).
       const hungerFraction = Math.min(
         curr.spider.hungerTicks / SPIDER_HUNGER_MAX_TICKS[NORMAL_TIER_INDEX],
         1,

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -361,8 +361,6 @@ export function drawSurfaceEntities(
     const prevPxX = spiderPrev !== null ? (spiderPrev.posX * TILE_SIZE_PX) / FP_ONE : currPxX;
     const prevPxY = spiderPrev !== null ? (spiderPrev.posY * TILE_SIZE_PX) / FP_ONE : currPxY;
     // Spider has no zone field (surface-only) and never teleports between ticks,
-    // so a null-check on prev.spider suffices — no zone-match guard needed.
-    // Spider has no zone field (surface-only) and never teleports between ticks,
     // so a null-check on prev.spider suffices as the interp guard.
     const useSpiderInterp = spiderPrev !== null;
     const baseSX = useSpiderInterp ? prevPxX + (currPxX - prevPxX) * alpha : currPxX;

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -41,6 +41,12 @@ import {
 } from './terrain-atlas.js';
 export type { AntSpriteLayer } from './ant-sprite-layer.js';
 import type { CameraState } from './camera.js';
+import {
+  SPIDER_SPRITE_HEIGHT,
+  SPIDER_SPRITE_WIDTH,
+} from './ant-sprite-layer.js';
+import { SPIDER_HUNGER_MAX_TICKS } from '../sim/constants.js';
+import { NORMAL_TIER_INDEX } from '../sim/ai-state.js';
 
 // ---------------------------------------------------------------------------
 // GfxLike — minimal Graphics interface (Phaser.GameObjects.Graphics satisfies this)
@@ -267,6 +273,20 @@ export function drawSurfaceEntities(
     }
   }
 
+  // --- Hunt reticle (S3) ---
+  // Draw a red tile overlay at the spider's locked target during Hunting/Striking.
+  // Drawn before ants so workers on the target tile are visible over the reticle.
+  // world.scatterReticleTile is the one-tick-lag shadow field written by tickSpider.
+  if (curr.scatterReticleTile !== null) {
+    const { x: rtx, y: rty } = curr.scatterReticleTile;
+    const rsx = (rtx - left) * TILE_SIZE_PX;
+    const rsy = (rty - top)  * TILE_SIZE_PX;
+    if (rsx > -TILE_SIZE_PX && rsx < canvasW && rsy > -TILE_SIZE_PX && rsy < canvasH) {
+      gfx.fillStyle(0xFF2200, 0.45);
+      gfx.fillRect(rsx, rsy, TILE_SIZE_PX, TILE_SIZE_PX);
+    }
+  }
+
   // --- Ants on surface (zone === 0) ---
   // Wrong-plane flicker guard (09 render polish): when an ant's zone flipped
   // between prev and curr (e.g. queen descending through an entrance), OR when
@@ -329,6 +349,49 @@ export function drawSurfaceEntities(
       // S1: fighters render slightly larger (+1px equivalent at TILE_SIZE_PX=16).
       scale: isFighter && !isQueen ? 1.25 : 1.0,
     });
+  }
+
+  // --- Spider sprite + hunger ring (S3) ---
+  // Drawn above ants (SPIDER_SPRITE_DEPTH = 52 > ANT_SPRITE_DEPTH = 50).
+  // Spider is always on the surface regardless of behavior state.
+  if (curr.spider !== null) {
+    const spiderPrev = prev.spider;
+    const currPxX = (curr.spider.posX * TILE_SIZE_PX) / FP_ONE;
+    const currPxY = (curr.spider.posY * TILE_SIZE_PX) / FP_ONE;
+    const prevPxX = spiderPrev !== null ? (spiderPrev.posX * TILE_SIZE_PX) / FP_ONE : currPxX;
+    const prevPxY = spiderPrev !== null ? (spiderPrev.posY * TILE_SIZE_PX) / FP_ONE : currPxY;
+    const useSpiderInterp = spiderPrev !== null;
+    const baseSX = useSpiderInterp ? prevPxX + (currPxX - prevPxX) * alpha : currPxX;
+    const baseSY = useSpiderInterp ? prevPxY + (currPxY - prevPxY) * alpha : currPxY;
+    const spiderScreenX = baseSX - left * TILE_SIZE_PX;
+    const spiderScreenY = baseSY - top  * TILE_SIZE_PX;
+
+    const spiderCullMargin = SPIDER_SPRITE_WIDTH;
+    if (spiderScreenX > -spiderCullMargin && spiderScreenX < canvasW + spiderCullMargin
+      && spiderScreenY > -spiderCullMargin && spiderScreenY < canvasH + spiderCullMargin) {
+
+      const hungerFraction = Math.min(
+        curr.spider.hungerTicks / SPIDER_HUNGER_MAX_TICKS[NORMAL_TIER_INDEX],
+        1,
+      );
+      const tint = lerpColor(0xCCCCCC, 0xFF3300, hungerFraction);
+
+      sprites.drawSpider({ x: spiderScreenX, y: spiderScreenY, tint });
+
+      // Hunger ring: appears at 70% hunger, fades in to full alpha at 100%.
+      if (hungerFraction > 0.7) {
+        const ringAlpha = ((hungerFraction - 0.7) / 0.3) * 0.85;
+        const rl = Math.round(spiderScreenX - SPIDER_SPRITE_WIDTH  / 2);
+        const rt = Math.round(spiderScreenY - SPIDER_SPRITE_HEIGHT / 2);
+        const rw = SPIDER_SPRITE_WIDTH;
+        const rh = SPIDER_SPRITE_HEIGHT;
+        gfx.fillStyle(0xFF4400, ringAlpha);
+        gfx.fillRect(rl,          rt,          rw, 2);
+        gfx.fillRect(rl,          rt + rh - 2, rw, 2);
+        gfx.fillRect(rl,          rt + 2,      2,  rh - 4);
+        gfx.fillRect(rl + rw - 2, rt + 2,      2,  rh - 4);
+      }
+    }
   }
 
   // --- Rally-point marker (Phase 9 usability fix) ---

--- a/src/render/draw-underground.test.ts
+++ b/src/render/draw-underground.test.ts
@@ -18,6 +18,7 @@ import type { GfxLike } from './draw-surface.js';
 import type {
   AntSpriteDrawOptions,
   AntSpriteLayer,
+  SpiderSpriteDrawOptions,
   StaticSpriteDrawOptions,
 } from './ant-sprite-layer.js';
 import type { WorldState } from '../sim/types.js';
@@ -101,6 +102,7 @@ class MockAntSprites implements AntSpriteLayer {
   beginFrame(): void { this.beginFrames++; }
   drawAnt(opts: AntSpriteDrawOptions): void { this.calls.push({ ...opts }); }
   drawStatic(opts: StaticSpriteDrawOptions): void { this.staticCalls.push({ ...opts }); }
+  drawSpider(_opts: SpiderSpriteDrawOptions): void { /* no-op in tests */ }
   endFrame(): void { this.endFrames++; }
   staticOfKind(kind: StaticSpriteDrawOptions['kind']): StaticSpriteDrawOptions[] {
     return this.staticCalls.filter(c => c.kind === kind);

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -81,6 +81,9 @@ import {
   LARVA_TEXTURE,
   QUEEN_SPRITE_HEIGHT,
   QUEEN_SPRITE_WIDTH,
+  SPIDER_SPRITE_HEIGHT,
+  SPIDER_SPRITE_WIDTH,
+  SPIDER_TEXTURE,
   WORKER_SPRITE_HEIGHT,
   WORKER_SPRITE_WIDTH,
 } from './ant-sprite-layer.js';
@@ -251,6 +254,9 @@ export class GameScene extends Phaser.Scene {
     });
     this.load.svg(FOOD_CACHE_TEXTURE, `${spriteBase}food-cache.svg`, {
       width: FOOD_CACHE_SPRITE_WIDTH, height: FOOD_CACHE_SPRITE_HEIGHT,
+    });
+    this.load.svg(SPIDER_TEXTURE, `${spriteBase}spider.svg`, {
+      width: SPIDER_SPRITE_WIDTH, height: SPIDER_SPRITE_HEIGHT,
     });
   }
 

--- a/tests/spider-render.spec.ts
+++ b/tests/spider-render.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect, type ConsoleMessage } from '@playwright/test';
+
+test('spider renders on surface — visual verification', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('console', (msg: ConsoleMessage) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', (err: Error) => consoleErrors.push(err.message));
+
+  await page.goto('/');
+  const canvas = page.locator('canvas').first();
+  await canvas.waitFor({ state: 'attached', timeout: 10_000 });
+
+  // Let the round run: ants settle, spider initializes, first patrol ticks
+  await page.waitForTimeout(6000);
+
+  await page.screenshot({ path: 'test-results/spider-render-6s.png', fullPage: false });
+
+  // No JS errors at any point during boot + 6s of sim
+  expect(consoleErrors, `console errors: ${consoleErrors.join('; ')}`).toHaveLength(0);
+
+  // Canvas still live
+  await expect(canvas).toBeAttached();
+});

--- a/tests/spider-render.spec.ts
+++ b/tests/spider-render.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type ConsoleMessage } from '@playwright/test';
 
-test('spider renders on surface — visual verification', async ({ page }) => {
+test('spider boot smoke — no JS errors, canvas live after 6s of sim', async ({ page }) => {
   const consoleErrors: string[] = [];
   page.on('console', (msg: ConsoleMessage) => {
     if (msg.type() === 'error') consoleErrors.push(msg.text());


### PR DESCRIPTION
## Summary

PR-B of Stage 3 (The Spider). All sim logic shipped in PR-A (#137); this PR adds the three D-21 visualizations required for the mechanic to ship:

- **Spider SVG sprite** (`public/assets/sprites/spider.svg`): 48×48 white-fill programmer-art spider — two body ovals (cephalothorax + abdomen), chelicerae, 8 L-shaped legs (4/side), black eyes. White fill enables Phaser multiplicative tinting.
- **Hunt reticle**: red semi-transparent tile overlay drawn at `world.scatterReticleTile` during Hunting/Striking states, behind ants so workers on the target are still visible.
- **Hunger visualization**: body tint lerps from 0xCCCCCC (idle) → 0xFF3300 (full hunger), and an orange border ring fades in above 70% hunger threshold. Both read `SPIDER_HUNGER_MAX_TICKS[NORMAL_TIER_INDEX]`; S5 will wire real difficulty tier.

`MarkSpiderPriority` input wiring (right-click → command dispatch) is explicitly deferred to a follow-up PR. Fighters already engage the spider organically when they share its tile via rally-point flow.

## Implementation notes

- `AntSpriteLayer` interface extended with `drawSpider()`; `AntSpritePool` implements it using the existing pool pattern (depth 52, above ants at 50).
- Both draw-surface and draw-underground test mocks updated (`drawSpider` no-op).
- Spider is surface-only; it never descends underground (PR-A revised the stage-doc design — 3×3 tiles too large for colony tunnels).
- Viewport cull uses `SPIDER_SPRITE_WIDTH` for X axis, `SPIDER_SPRITE_HEIGHT` for Y axis.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 2168/2168 pass
- [x] `bash scripts/check-asset-paths.sh` — clean
- [x] `npx playwright test tests/spider-render.spec.ts` — boot smoke passes (no JS errors, canvas live after 6s)
- [ ] Visual UAT: spider visible on surface, grey → red tint as hunger grows, ring appears near rampage threshold, red reticle flashes on target tile during Hunting/Striking

🤖 Generated with [Claude Code](https://claude.com/claude-code)