### PR TITLE
S4: Reproduction lever — surplus-scaled egg interval + nurse maturation acceleration (V21)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,15 @@ Branch names: `feat/<short-description>`, `fix/<short-description>`, `chore/<sho
 
 This applies to AI agents working in this repo as well as human contributors. The size of the change is not the criterion.
 
+**AI agents must use the `/ship` workflow before pushing any branch.** The workflow is:
+1. Implement the work.
+2. Run an internal code review loop: spawn a fresh review subagent (no prior session context) with only the current `git diff`, have it identify bugs and edge cases, address any findings, and repeat until the agent reports zero new issues.
+3. Commit and push, then open a PR.
+4. Post `@codex review` on the PR.
+5. Wait for the external review loop: poll for a `THUMBS_UP` reaction from `chatgpt-codex-connector[bot]`; if findings are posted, address them, re-run the internal review loop, push, and re-trigger `@codex review`.
+
+**Never push without completing step 2 (internal review agent pass).** The agent must be spawned fresh with no prior session context and must see the actual diff — reviewing from memory does not count.
+
 ## PR Review Process
 
 Every PR is reviewed by at least two independent AI code reviewers:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,14 +62,14 @@ Branch names: `feat/<short-description>`, `fix/<short-description>`, `chore/<sho
 
 This applies to AI agents working in this repo as well as human contributors. The size of the change is not the criterion.
 
-**AI agents must use the `/ship` workflow before pushing any branch.** The workflow is:
-1. Implement the work.
-2. Run an internal code review loop: spawn a fresh review subagent (no prior session context) with only the current `git diff`, have it identify bugs and edge cases, address any findings, and repeat until the agent reports zero new issues.
-3. Commit and push, then open a PR.
-4. Post `@codex review` on the PR.
-5. Wait for the external review loop: poll for a `THUMBS_UP` reaction from `chatgpt-codex-connector[bot]`; if findings are posted, address them, re-run the internal review loop, push, and re-trigger `@codex review`.
+**AI agents must invoke the `/ship` skill before pushing any branch.** `/ship` is a Claude Code project skill (invoked via the Skill tool with `skill: "ship"`) that enforces the full PR cycle:
 
-**Never push without completing step 2 (internal review agent pass).** The agent must be spawned fresh with no prior session context and must see the actual diff — reviewing from memory does not count.
+1. **Internal review loop** — spawn a fresh Agent (no prior session context) passing only the current `git diff` and ask it to identify bugs, logic errors, and edge cases. Address each finding, then repeat until a pass returns no new issues. Cap at five iterations; if issues remain, flag for human review rather than pushing.
+2. **Commit, push, and open a PR** — stage, commit with a Conventional Commits message, push the branch, and open a PR with summary and test plan.
+3. **Trigger Codex review** — post the PR comment `@codex review`. This invokes an automated bot reviewer on the PR; the comment is required because the bot does not auto-trigger on owner-authored pushes.
+4. **External review loop** — poll the PR's GitHub reactions API for a `THUMBS_UP` from `chatgpt-codex-connector[bot]` (the bot's explicit "clean" signal). If the bot posts findings instead, address them, re-run the internal loop, push, and re-trigger `@codex review`. If no signal arrives after ~30 minutes, report "reviewer did not respond" and stop.
+
+**The internal review pass (step 1) is mandatory before every push.** "Fresh Agent" means a new subagent invocation with no conversation history — reviewing from memory or using an agent that has seen the implementation session does not satisfy this requirement.
 
 ## PR Review Process
 

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -412,6 +412,8 @@ interface SerializedColony {
   foodStored: number; workerCount: number; eggCount: number; larvaeCount: number; nurseCount: number;
   eggs: EntityId[]; larvae: EntityId[]; workers: EntityId[];
   chambers: ChamberRecord[];
+  /** S4 V21+ — tick at which queen last laid. Optional for backward compat; defaults to -QUEEN_EGG_INTERVAL_BASE_TICKS on old saves. */
+  queenLastEggTick?: number;
   // Phase 10 / D-04 silent-migration: serialized shape is the runtime BehaviorRatio
   // (post-migration `{ forage, fight }`), but the legacy `dig` field is allowed for
   // backward compatibility with pre-Phase-10 saves. Migration via migrateBehaviorRatio
@@ -622,6 +624,7 @@ function serializeColony(c: ColonyRecord): SerializedColony {
     taskCensus:           { ...c.taskCensus },
     defeated:             c.defeated,
     reconcileCountdown:   c.reconcileCountdown,
+    queenLastEggTick:     c.queenLastEggTick,
     entrances:            c.entrances.map((e) => ({ ...e })),
     rallyPoint:           c.rallyPoint === null ? null : { ...c.rallyPoint },
     digFlowFieldDirty:    c.digFlowFieldDirty,
@@ -972,6 +975,7 @@ function deserializeColony(s: SerializedColony): ColonyRecord {
   c.foodFlowFieldDirty   = s.foodFlowFieldDirty ?? false;
   c.killCount            = s.killCount;
   c.priorityFoodPileId   = s.priorityFoodPileId ?? null;
+  c.queenLastEggTick     = s.queenLastEggTick ?? -300; // old saves: default to -QUEEN_EGG_INTERVAL_BASE_TICKS so queen can lay on first eligible tick
   // Issue #101 — validate chamber records before they reach the runtime.
   // Done after the spread so the validator inspects the persisted shape;
   // throw aborts deserializeWorldState's map() and propagates to bootFromSave.

--- a/src/render/ai-controller.integration.test.ts
+++ b/src/render/ai-controller.integration.test.ts
@@ -43,8 +43,13 @@ const SEED = 42;
 // whole point of issue #33 (chambers spread vertically, max chamber Y > 15
 // per the acceptance criteria), so the slower bootstrap is the intended
 // trade-off.
-const TOTAL_TICKS = 6000;
-const TRAJECTORY_WINDOW_START = 5500;   // track workerCount from tick 5500..6000
+const TOTAL_TICKS = 8000;
+const TRAJECTORY_WINDOW_START = 7000;   // track workerCount from tick 7000..8000
+// S4 change: queen now lays on first eligible tick (elapsed-since-last-lay gate), not at modulo
+// boundaries. In the AI scenario, chambers complete ~tick 4000; first egg lays immediately,
+// creating ~6 larvae by tick 6000. First new worker matures at ~tick 7600 (4000+3600).
+// Window extended from 5500..6000 → 7000..8000 so the monitoring window contains the
+// stable post-first-worker-maturation state.
 const DIAGNOSTIC_INTERVAL = 500;         // log snapshot every 500 ticks (pre-audit)
 
 // -----------------------------------------------------------------------------
@@ -202,7 +207,7 @@ describe('AI-only scenario 6000 ticks', () => {
       `workerCount declined across ticks ${TRAJECTORY_WINDOW_START}..${TOTAL_TICKS}: ` +
       `started=${startWC} ended=${endWC}. ${ctx}`,
     ).toBeGreaterThanOrEqual(startWC);
-  }, 60_000); // 6000 ticks + assertions may take >5s default; allow 60s budget.
+  }, 120_000); // 8000 ticks at ~8ms/tick; allow 120s budget (S4 extended window).
 });
 
 // -----------------------------------------------------------------------------

--- a/src/render/minimap.test.ts
+++ b/src/render/minimap.test.ts
@@ -197,6 +197,7 @@ const stubColonies: WorldState['colonies'] = {
     rallyPoint: null, digFlowFieldDirty: false, foodFlowFieldDirty: false,
     killCount: 0,
     priorityFoodPileId: null,
+    queenLastEggTick: -300,
   } as WorldState['colonies'][number],
 };
 

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -59,7 +59,7 @@ import {
 import type { AntComponents } from './ant-store.js';
 import { isRecentTile, pushRecentTile, clearRecentTiles, isBroodReclaimable } from './ant-store.js';
 import type { ColonyRecord, ChamberRecord } from '../colony/colony-store.js';
-import { hasCompletedChamber, isFoodChamberDepositable } from '../colony/colony-system.js';
+import { hasCompletedChamber, isFoodChamberDepositable, colonyFoodTotal } from '../colony/colony-system.js';
 import { AntTask, ForagingSubState, DiggingSubState, NursingSubState, ChamberType, PheromoneType } from '../enums.js';
 import {
   WORKER_CARRY_CAPACITY,
@@ -950,9 +950,18 @@ export function tickNurseActions(world: WorldState): void {
       // deposit. searchPauseTicks is repurposed as the dwell counter — it is
       // not used by nursing-task ants (search-pause logic only runs for
       // Foraging ants). When the dwell expires, nurse returns to Idle.
+      //
+      // Emergency exit: colony food zero → nurse must forage to prevent
+      // starvation lock. Pairs with the step-8 allocation override in
+      // tick.ts. Brood-transport priority is enforced at deposit time
+      // (depositCarriedBrood skips Attending when claimable brood remains),
+      // so no per-tick brood check is needed here.
       if (world.simVersion >= SIM_VERSION_V21_REPRODUCTION && subTask === NursingSubState.Attending) {
+        const colonyId = ants.colonyId[id]!;
+        const colony   = world.colonies[colonyId];
+        const starving = colony !== undefined && colonyFoodTotal(colony) === 0;
         ants.searchPauseTicks[id] = ants.searchPauseTicks[id]! + 1;
-        if (ants.searchPauseTicks[id]! >= NURSE_ATTEND_DWELL_TICKS) {
+        if (starving || ants.searchPauseTicks[id]! >= NURSE_ATTEND_DWELL_TICKS) {
           ants.task[id]             = AntTask.Idle;
           ants.subTask[id]          = 0;
           ants.searchPauseTicks[id] = 0;
@@ -1281,10 +1290,24 @@ function depositCarriedBrood(
   // S4 V21+: nurse enters Attending substate and dwells at the Nursery tile
   // for NURSE_ATTEND_DWELL_TICKS, accelerating adjacent larvae. Pre-V21:
   // carrier returns to Idle immediately; step 10a re-allocates next tick.
+  //
+  // Brood-transport priority (UAT fix): if uncarried brood still exists
+  // outside the Nursery (e.g., the queen laid new eggs while this nurse was
+  // carrying the previous batch), skip Attending and return to Idle immediately
+  // so step 10a re-assigns this nurse to pick up the next brood. Attending
+  // only starts when the pickup pool is empty — brood in the Queen chamber
+  // receives zero maturation benefit, so transport must come first.
+  // This check runs once per deposit (not per tick), keeping it cheap.
   if (world.simVersion >= SIM_VERSION_V21_REPRODUCTION) {
-    ants.subTask[nurseId]          = NursingSubState.Attending;
-    ants.searchPauseTicks[nurseId] = 0;
-    // task remains AntTask.Nursing — Attending is a Nursing substate
+    if (colonyHasClaimableBrood(world, colony)) {
+      ants.task[nurseId]             = AntTask.Idle;
+      ants.subTask[nurseId]          = 0;
+      ants.searchPauseTicks[nurseId] = 0;
+    } else {
+      ants.subTask[nurseId]          = NursingSubState.Attending;
+      ants.searchPauseTicks[nurseId] = 0;
+      // task remains AntTask.Nursing — Attending is a Nursing substate
+    }
   } else {
     ants.task[nurseId]    = AntTask.Idle;
     ants.subTask[nurseId] = 0;

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -1302,13 +1302,14 @@ function computeNurseryDepositPosition(
 /**
  * Issue #17 Phase 1 — v10 deposit. The carrier (`nurseId`) has just arrived
  * at a tile inside a Nursery footprint while carrying brood `broodId`.
- * Place the brood inside the specific Nursery chamber the nurse is standing
- * in (spread by `broodId % openCount` within that chamber's Open tiles).
- * Falls back to the all-chambers pool only if the nurse's chamber cannot be
- * identified (pathological state — should never occur in production).
  *
- * Restricting to the nurse's current chamber prevents brood from teleporting
- * to a distant Nursery chamber that the nurse has not physically reached.
+ * V21+: places brood inside the specific Nursery chamber the nurse is standing
+ * in (spread by `broodId % openCount` within that chamber's Open tiles),
+ * preventing teleportation to a distant chamber. Falls back to the all-chambers
+ * pool only if the nurse's chamber cannot be identified (pathological).
+ *
+ * Pre-V21: uses the original all-chambers spread via `computeNurseryDepositPosition`
+ * to preserve byte-identical replay of pre-V21 saves.
  *
  * No allocations, no RNG.
  */
@@ -1319,26 +1320,32 @@ function depositCarriedBrood(
   broodId: number,
 ): void {
   const ants = world.ants;
-  // Identify which Nursery chamber the nurse is standing in so the deposit
-  // stays within that chamber. Using the nurse's tile position (which the
-  // v10 flow guarantees is inside a Nursery footprint at this call site).
-  const nurseTileX = ants.posX[nurseId]! >> FP_SHIFT;
-  const nurseTileY = ants.posY[nurseId]! >> FP_SHIFT;
-  let nurseChamber: ChamberRecord | null = null;
-  for (let c = 0; c < colony.chambers.length; c++) {
-    const ch = colony.chambers[c]!;
-    if (ch.chamberType !== ChamberType.Nursery) continue;
-    const bx = ch.posX >> FP_SHIFT;
-    const by = ch.posY >> FP_SHIFT;
-    if (nurseTileX >= bx && nurseTileX < bx + ch.width &&
-        nurseTileY >= by && nurseTileY < by + ch.height) {
-      nurseChamber = ch;
-      break;
+  // S4 V21+: restrict deposit to the nurse's current Nursery chamber so brood
+  // never teleports to a distant chamber the nurse hasn't physically reached.
+  // Pre-V21 worlds use the original all-chambers distribution to preserve
+  // byte-identical replay of pre-V21 saves.
+  let pos: { x: number; y: number } | null = null;
+  if (world.simVersion >= SIM_VERSION_V21_REPRODUCTION) {
+    const nurseTileX = ants.posX[nurseId]! >> FP_SHIFT;
+    const nurseTileY = ants.posY[nurseId]! >> FP_SHIFT;
+    let nurseChamber: ChamberRecord | null = null;
+    for (let c = 0; c < colony.chambers.length; c++) {
+      const ch = colony.chambers[c]!;
+      if (ch.chamberType !== ChamberType.Nursery) continue;
+      const bx = ch.posX >> FP_SHIFT;
+      const by = ch.posY >> FP_SHIFT;
+      if (nurseTileX >= bx && nurseTileX < bx + ch.width &&
+          nurseTileY >= by && nurseTileY < by + ch.height) {
+        nurseChamber = ch;
+        break;
+      }
     }
+    pos = nurseChamber !== null
+      ? computeDepositPositionInChamber(world, colony, broodId, nurseChamber)
+      : computeNurseryDepositPosition(world, colony, broodId); // fallback (pathological)
+  } else {
+    pos = computeNurseryDepositPosition(world, colony, broodId);
   }
-  const pos = nurseChamber !== null
-    ? computeDepositPositionInChamber(world, colony, broodId, nurseChamber)
-    : computeNurseryDepositPosition(world, colony, broodId); // fallback (pathological)
   // Fallback: if the helper returns null (no grid, no Open Nursery tile —
   // test-harness or pathological state), keep the brood at the carrier's
   // current tile. Never reachable in production because the v10 path only

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -45,6 +45,7 @@ import {
   SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX,
   SIM_VERSION_V17_COMBAT_AGGRO,
   SIM_VERSION_V18_INVADER_WALL_AWARE_STEP,
+  SIM_VERSION_V21_REPRODUCTION,
   type WorldState,
 } from '../types.js';
 import {
@@ -86,6 +87,7 @@ import {
   FOOD_TRAIL_DEPOSIT,
   FOOD_TRAIL_DEPOSIT_V14,
   FIGHT_AGGRO_RADIUS,
+  NURSE_ATTEND_DWELL_TICKS,
 } from '../constants.js';
 import { FP_SHIFT, FP_ONE } from '../fixed.js';
 import { Rng } from '../rng.js';
@@ -944,6 +946,20 @@ export function tickNurseActions(world: WorldState): void {
         }
         continue;
       }
+      // S4 V21+ Attending handler: nurse dwells at the Nursery tile after
+      // deposit. searchPauseTicks is repurposed as the dwell counter — it is
+      // not used by nursing-task ants (search-pause logic only runs for
+      // Foraging ants). When the dwell expires, nurse returns to Idle.
+      if (world.simVersion >= SIM_VERSION_V21_REPRODUCTION && subTask === NursingSubState.Attending) {
+        ants.searchPauseTicks[id] = ants.searchPauseTicks[id]! + 1;
+        if (ants.searchPauseTicks[id]! >= NURSE_ATTEND_DWELL_TICKS) {
+          ants.task[id]             = AntTask.Idle;
+          ants.subTask[id]          = 0;
+          ants.searchPauseTicks[id] = 0;
+        }
+        continue;
+      }
+
       if (subTask !== NursingSubState.MovingToBrood) continue;
 
       const colonyId = ants.colonyId[id]!;
@@ -1262,9 +1278,17 @@ function depositCarriedBrood(
   // Clear both ends of the carry pointer.
   ants.carryingBroodId[nurseId] = -1;
   ants.carriedBy[broodId]       = -1;
-  // Carrier returns to Idle; step 10a next tick re-allocates per ratio.
-  ants.task[nurseId]    = AntTask.Idle;
-  ants.subTask[nurseId] = 0;
+  // S4 V21+: nurse enters Attending substate and dwells at the Nursery tile
+  // for NURSE_ATTEND_DWELL_TICKS, accelerating adjacent larvae. Pre-V21:
+  // carrier returns to Idle immediately; step 10a re-allocates next tick.
+  if (world.simVersion >= SIM_VERSION_V21_REPRODUCTION) {
+    ants.subTask[nurseId]          = NursingSubState.Attending;
+    ants.searchPauseTicks[nurseId] = 0;
+    // task remains AntTask.Nursing — Attending is a Nursing substate
+  } else {
+    ants.task[nurseId]    = AntTask.Idle;
+    ants.subTask[nurseId] = 0;
+  }
 }
 
 /**
@@ -1426,6 +1450,8 @@ export function getTaskDirection(
   }
 
   if (task === AntTask.Nursing) {
+    // S4 V21+ Attending nurses are stationary at their Nursery tile.
+    if (ants.subTask[antId] === NursingSubState.Attending) return { dx: 0, dy: 0 };
     // colonyId keys the nursing chamber flow-field (indexed by the nurse's
     // OWN colony — nurses never cross grids); gridColonyId keys the
     // underground grid the ant currently occupies (Phase 09.1 Chunk 0).

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -1202,13 +1202,53 @@ function findUncarriedBroodOnTile(
 }
 
 /**
+ * Compute a deposit position within a single Nursery `chamber`, spread
+ * across its Open tiles by `broodId % openCount` in row-major order.
+ * Returns `null` if no underground grid or no Open tile exists in that chamber.
+ *
+ * Used by `depositCarriedBrood` (v10+) to keep brood in the specific chamber
+ * the nurse physically arrived at, preventing cross-chamber teleportation.
+ */
+function computeDepositPositionInChamber(
+  world: WorldState,
+  colony: ColonyRecord,
+  broodId: number,
+  chamber: ChamberRecord,
+): { x: number; y: number } | null {
+  const underground = world.undergroundGrids[colony.colonyId];
+  if (!underground) return null;
+  const bx = chamber.posX >> FP_SHIFT;
+  const by = chamber.posY >> FP_SHIFT;
+  let openCount = 0;
+  for (let ty = 0; ty < chamber.height; ty++) {
+    for (let tx = 0; tx < chamber.width; tx++) {
+      if (ugGet(underground, bx + tx, by + ty) === UndergroundTileState.Open) openCount++;
+    }
+  }
+  if (openCount === 0) return null;
+  const targetIndex = broodId % openCount;
+  let cursor = 0;
+  for (let ty = 0; ty < chamber.height; ty++) {
+    for (let tx = 0; tx < chamber.width; tx++) {
+      const cx = bx + tx;
+      const cy = by + ty;
+      if (ugGet(underground, cx, cy) !== UndergroundTileState.Open) continue;
+      if (cursor === targetIndex) {
+        return { x: (cx << FP_SHIFT) + (FP_ONE >> 1), y: (cy << FP_SHIFT) + (FP_ONE >> 1) };
+      }
+      cursor++;
+    }
+  }
+  return null;
+}
+
+/**
  * Issue #17 Phase 1 — compute the fixed-point Nursery deposit position for
  * brood `broodId`, spread across all Open tiles in the colony's Nursery
  * chambers via `broodId % openCount` in row-major order. Returns `null` if
- * no underground grid OR no Open Nursery tile exists. Shared by the v10
- * `depositCarriedBrood` (visible-carry deposit) and the pre-v10
- * `transportBroodToNursery` (legacy teleport) so both produce byte-
- * identical deposit positions for the same inputs.
+ * no underground grid OR no Open Nursery tile exists. Used by the pre-v10
+ * `transportBroodToNursery` (legacy teleport) and as a fallback from
+ * `depositCarriedBrood` when the nurse's chamber cannot be identified.
  */
 function computeNurseryDepositPosition(
   world: WorldState,
@@ -1262,9 +1302,13 @@ function computeNurseryDepositPosition(
 /**
  * Issue #17 Phase 1 — v10 deposit. The carrier (`nurseId`) has just arrived
  * at a tile inside a Nursery footprint while carrying brood `broodId`.
- * Place the brood at a Nursery Open tile (spread by `broodId % openCount`,
- * matching the pre-v10 `transportBroodToNursery` distribution), then clear
- * the carry slot on both ends and return the carrier to Idle.
+ * Place the brood inside the specific Nursery chamber the nurse is standing
+ * in (spread by `broodId % openCount` within that chamber's Open tiles).
+ * Falls back to the all-chambers pool only if the nurse's chamber cannot be
+ * identified (pathological state — should never occur in production).
+ *
+ * Restricting to the nurse's current chamber prevents brood from teleporting
+ * to a distant Nursery chamber that the nurse has not physically reached.
  *
  * No allocations, no RNG.
  */
@@ -1275,7 +1319,26 @@ function depositCarriedBrood(
   broodId: number,
 ): void {
   const ants = world.ants;
-  const pos = computeNurseryDepositPosition(world, colony, broodId);
+  // Identify which Nursery chamber the nurse is standing in so the deposit
+  // stays within that chamber. Using the nurse's tile position (which the
+  // v10 flow guarantees is inside a Nursery footprint at this call site).
+  const nurseTileX = ants.posX[nurseId]! >> FP_SHIFT;
+  const nurseTileY = ants.posY[nurseId]! >> FP_SHIFT;
+  let nurseChamber: ChamberRecord | null = null;
+  for (let c = 0; c < colony.chambers.length; c++) {
+    const ch = colony.chambers[c]!;
+    if (ch.chamberType !== ChamberType.Nursery) continue;
+    const bx = ch.posX >> FP_SHIFT;
+    const by = ch.posY >> FP_SHIFT;
+    if (nurseTileX >= bx && nurseTileX < bx + ch.width &&
+        nurseTileY >= by && nurseTileY < by + ch.height) {
+      nurseChamber = ch;
+      break;
+    }
+  }
+  const pos = nurseChamber !== null
+    ? computeDepositPositionInChamber(world, colony, broodId, nurseChamber)
+    : computeNurseryDepositPosition(world, colony, broodId); // fallback (pathological)
   // Fallback: if the helper returns null (no grid, no Open Nursery tile —
   // test-harness or pathological state), keep the brood at the carrier's
   // current tile. Never reachable in production because the v10 path only

--- a/src/sim/colony/colony-store.test.ts
+++ b/src/sim/colony/colony-store.test.ts
@@ -96,10 +96,10 @@ describe('createColonyRecord', () => {
     expect('idleCount' in r).toBe(false);
   });
 
-  it('(11) ColonyRecord Phase 2 factory returns 19 fields (17 Phase 2 + killCount + priorityFoodPileId; Phase 3 extensions are undefined until caller assigns)', () => {
+  it('(11) ColonyRecord Phase 2 factory returns 20 fields (17 Phase 2 + killCount + priorityFoodPileId + queenLastEggTick; Phase 3 extensions are undefined until caller assigns)', () => {
     const r = createColonyRecord(1, 0);
-    // Factory returns exactly 19 fields (17 Phase 2 + Phase 9 killCount + Phase 9 priorityFoodPileId)
-    expect(Object.keys(r).length).toBe(19);
+    // Factory returns exactly 20 fields (17 Phase 2 + Phase 9 killCount + Phase 9 priorityFoodPileId + S4 queenLastEggTick)
+    expect(Object.keys(r).length).toBe(20);
   });
 
   it('createColonyRecord initializes killCount to 0', () => {

--- a/src/sim/colony/colony-store.ts
+++ b/src/sim/colony/colony-store.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_BEHAVIOR_RATIO,
   STARVATION_GRACE_TICKS,
   RECONCILE_INTERVAL_TICKS,
+  QUEEN_EGG_INTERVAL_BASE_TICKS,
 } from '../constants.js';
 
 // ---------------------------------------------------------------------------
@@ -149,6 +150,14 @@ export interface ColonyRecord {
    *  Read by routeForagerPriority; mutated by the MarkFoodPile command handler.
    *  Initialized to null in createColonyRecord. Round-trips through copyWorldState + save. */
   priorityFoodPileId: FoodPileId | null;
+
+  /** S4 V21+ — world tick at which the queen most recently laid an egg.
+   *  Used by tickQueenEggProduction to enforce the selected interval as elapsed
+   *  ticks since the last lay, not a global modulo (which misfires when the
+   *  surplus tier changes mid-cycle). Initialized to -QUEEN_EGG_INTERVAL_BASE_TICKS
+   *  so the queen can lay on tick 0 (0 - (-300) = 300 ≥ 300). Round-trips
+   *  through copyWorldState + save. */
+  queenLastEggTick: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -207,6 +216,7 @@ export function createColonyRecord(colonyId: ColonyId, queenEntityId: EntityId):
     reconcileCountdown:    RECONCILE_INTERVAL_TICKS,
     killCount:             0,
     priorityFoodPileId:    null,
+    queenLastEggTick:      -QUEEN_EGG_INTERVAL_BASE_TICKS,
   }) as unknown as ColonyRecord;
 }
 

--- a/src/sim/colony/colony-system.ts
+++ b/src/sim/colony/colony-system.ts
@@ -255,6 +255,25 @@ export function hasCompletedChamber(
   return false;
 }
 
+/**
+ * S4 — Returns the tile count of the largest completed Nursery chamber in the
+ * colony. This is the throughput cap for nurse-acceleration per tick: at most
+ * N larvae can receive nurse acceleration per tick, where N = this value.
+ *
+ * Returns 0 if no completed Nursery chamber exists (broodFrozen should gate
+ * the caller before this case is reached in normal play).
+ */
+export function largestNurseryTileCount(colony: ColonyRecord): number {
+  let max = 0;
+  for (let c = 0; c < colony.chambers.length; c++) {
+    const ch = colony.chambers[c]!;
+    if (ch.chamberType !== ChamberType.Nursery) continue;
+    const tiles = ch.width * ch.height;
+    if (tiles > max) max = tiles;
+  }
+  return max;
+}
+
 // ---------------------------------------------------------------------------
 // tickFoodConsumption — PRD §8a steps 3 AND 4 combined (CLNY-04, CLNY-05)
 //

--- a/src/sim/colony/larva-maturation.ts
+++ b/src/sim/colony/larva-maturation.ts
@@ -1,0 +1,189 @@
+// larva-maturation.ts — S4 V21+ nurse-acceleration pass for larva maturation.
+//
+// Runs as a second sub-step inside tick step 7, AFTER tickLifecycleTransitions
+// has applied the baseline +1 age increment to every larva.
+//
+// Per-tick contract:
+//   1. Gate on world.simVersion >= SIM_VERSION_V21_REPRODUCTION; no-op otherwise.
+//   2. Compute nursery throughput cap = tile count of the largest completed
+//      Nursery chamber (from largestNurseryTileCount in colony-system.ts).
+//   3. Iterate colony.larvae (existing larvae after baseline tick).
+//   4. For each larva, find the lowest-index nurse in Attending OR Feeding
+//      substate within Manhattan-1, not yet used this tick.
+//   5. Assign the nurse (stamp-mark it), consume one throughput slot, and
+//      apply LARVA_MATURE_NURSE_ACCELERATION (+1) to the larva's age.
+//   6. If the extra tick matures the larva, promote it (swap-remove + push to
+//      workers) — mirrors the promotion logic in tickLifecycleTransitions Loop 2.
+//
+// Hot-path discipline (QC Pass 4 AR-P1-002):
+//   - No per-tick allocations. nurseScratch is allocated once at module load
+//     (Uint32Array, not serialized, not persisted).
+//   - Mark-stamp pattern: currentStamp increments once per tick. Claiming a
+//     nurse writes the current stamp into usedStamp[nurseId]. Checking is
+//     `usedStamp[nurseId] === currentStamp`. Wraps at Uint32 max (~4 billion
+//     ticks = ~6 years of sim time at 20 Hz) — safe for v3.0 timescales.
+//   - No sorted temporary list. colony.larvae is iterated in its current order
+//     (deterministic for a given sim state; not strictly ascending entity ID
+//     post swap-remove, but still fully deterministic).
+//
+// Nurse adjacency definition: Manhattan distance ≤ 1 between tile positions
+// (same tile or N/S/E/W neighbor). Matches Q3 DEFAULT_ACCEPTED in S4 stage doc.
+//
+// Throughput cap semantics: "largest contiguous Nursery chamber tile count"
+// per stage doc. Two separate 12-tile Nursery chambers yield cap = 12 (one
+// chamber's tiles, not 24). Building one larger Nursery is the intended
+// growth lever.
+
+import type { WorldState } from '../types.js';
+import { SIM_VERSION_V21_REPRODUCTION } from '../types.js';
+import type { ColonyRecord } from './colony-store.js';
+import { hasCompletedChamber, largestNurseryTileCount } from './colony-system.js';
+import { AntTask, ChamberType, NursingSubState } from '../enums.js';
+import { FP_SHIFT } from '../fixed.js';
+import {
+  LARVA_MATURE_TICKS,
+  LARVA_MATURE_NURSE_ACCELERATION,
+  STARVATION_GRACE_TICKS,
+  WORKER_BASE_SPEED,
+} from '../constants.js';
+import type { AntComponents } from '../ant/ant-store.js';
+import { MAX_ENTITIES } from '../constants.js';
+
+// ---------------------------------------------------------------------------
+// Module-level scratch — allocated once, not serialized, not per-tick.
+// ---------------------------------------------------------------------------
+
+const nurseScratch = {
+  /** Per-nurse stamp: nurseScratch.usedStamp[nurseId] === currentStamp means used this tick. */
+  usedStamp:    new Uint32Array(MAX_ENTITIES),
+  /** Incremented once per tick before the acceleration pass. Uint32 wrap is safe. */
+  currentStamp: 0,
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * S4 V21+ — Nurse acceleration pass for larva maturation.
+ *
+ * Call from tick step 7, after tickLifecycleTransitions(world, colony).
+ * No-op under pre-V21 sim versions.
+ */
+export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): void {
+  if (world.simVersion < SIM_VERSION_V21_REPRODUCTION) return;
+
+  // Brood frozen = no completed Nursery. Nurses can't exist without a Nursery
+  // (behavior allocator gates on hasNursery), so there's nothing to accelerate.
+  if (!hasCompletedChamber(colony, ChamberType.Nursery)) return;
+
+  const cap = largestNurseryTileCount(colony);
+  if (cap <= 0) return;
+
+  // Advance the stamp (Uint32 wraps naturally).
+  nurseScratch.currentStamp = (nurseScratch.currentStamp + 1) >>> 0;
+  const stamp = nurseScratch.currentStamp;
+
+  let slotsRemaining = cap;
+  const ants = world.ants;
+
+  // Snapshot length: only accelerate larvae that existed before this sub-step.
+  // Larvae that were just promoted from eggs in Loop 1 of tickLifecycleTransitions
+  // this tick are at indices >= snapLen; we skip them to avoid double-processing.
+  // (They already have age=0 and can't promote anyway, but the snap is hygienic.)
+  const snapLen = colony.larvae.length;
+
+  for (let i = snapLen - 1; i >= 0; i--) {
+    if (slotsRemaining <= 0) break;
+
+    const larvaId = colony.larvae[i]!;
+    if (ants.alive[larvaId] !== 1) continue; // dead larvae cleaned up at step 5
+
+    const larvaTileX = ants.posX[larvaId]! >> FP_SHIFT;
+    const larvaTileY = ants.posY[larvaId]! >> FP_SHIFT;
+
+    const nurseId = findAdjacentAttendingOrFeedingNurse(
+      ants,
+      world.nextEntityId,
+      colony.colonyId,
+      larvaTileX,
+      larvaTileY,
+      nurseScratch.usedStamp,
+      stamp,
+    );
+    if (nurseId < 0) continue; // no eligible nurse adjacent
+
+    // Claim the nurse and consume a throughput slot.
+    nurseScratch.usedStamp[nurseId] = stamp;
+    slotsRemaining -= 1;
+
+    // Apply the extra maturation tick (larva-side cap: +1 per tick max).
+    const newAge = ants.age[larvaId]! + LARVA_MATURE_NURSE_ACCELERATION;
+    ants.age[larvaId] = newAge;
+
+    if (newAge >= LARVA_MATURE_TICKS) {
+      // Promote larva → worker: same pattern as tickLifecycleTransitions Loop 2.
+      colony.larvae[i] = colony.larvae[colony.larvae.length - 1]!;
+      colony.larvae.pop();
+      colony.larvaeCount -= 1;
+      ants.age[larvaId]             = 0;
+      ants.starvationTimer[larvaId] = STARVATION_GRACE_TICKS;
+      ants.task[larvaId]            = AntTask.Idle;
+      ants.speed[larvaId]           = WORKER_BASE_SPEED;
+      colony.workers.push(larvaId);
+      colony.workerCount += 1;
+      // If a nurse was carrying this larva (Feeding state), drop the carry.
+      // The new worker keeps the carrier's last position (posX/posY were synced).
+      const carrierId = ants.carriedBy[larvaId]!;
+      if (carrierId !== -1) {
+        if (ants.alive[carrierId] === 1 && ants.carryingBroodId[carrierId] === larvaId) {
+          ants.carryingBroodId[carrierId]  = -1;
+          ants.task[carrierId]             = AntTask.Idle;
+          ants.subTask[carrierId]          = 0;
+          // Clear the Attending dwell counter so the future Forager search-pause
+          // logic (which decrements searchPauseTicks > 0) doesn't see a stale
+          // non-zero value from the mid-dwell abort.
+          ants.searchPauseTicks[carrierId] = 0;
+        }
+        ants.carriedBy[larvaId] = -1;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the lowest-entity-ID nurse in NursingSubState.Attending or Feeding that
+ * is within Manhattan distance 1 of (larvaTileX, larvaTileY) and has not yet
+ * been used this tick (stamp check).
+ *
+ * Returns -1 if no eligible nurse is found.
+ */
+function findAdjacentAttendingOrFeedingNurse(
+  ants:         AntComponents,
+  entityCount:  number,
+  colonyId:     number,
+  larvaTileX:   number,
+  larvaTileY:   number,
+  usedStamp:    Uint32Array,
+  stamp:        number,
+): number {
+  let bestId = -1;
+  for (let j = 0; j < entityCount; j++) {
+    if (ants.alive[j] !== 1) continue;
+    if (ants.colonyId[j] !== colonyId) continue;
+    if (ants.task[j] !== AntTask.Nursing) continue;
+    const st = ants.subTask[j]!;
+    if (st !== NursingSubState.Attending && st !== NursingSubState.Feeding) continue;
+    if (usedStamp[j] === stamp) continue;
+    const nx = ants.posX[j]! >> FP_SHIFT;
+    const ny = ants.posY[j]! >> FP_SHIFT;
+    if (Math.abs(nx - larvaTileX) + Math.abs(ny - larvaTileY) > 1) continue;
+    // Lowest entity ID wins (deterministic; older nurses get priority).
+    if (bestId < 0 || j < bestId) bestId = j;
+  }
+  return bestId;
+}

--- a/src/sim/colony/larva-maturation.ts
+++ b/src/sim/colony/larva-maturation.ts
@@ -51,6 +51,18 @@ import { MAX_ENTITIES } from '../constants.js';
 
 // ---------------------------------------------------------------------------
 // Module-level scratch — allocated once, not serialized, not per-tick.
+//
+// Save/load safety: this scratch holds NO inter-tick state. Its only role is
+// to track which nurses have already been claimed as accelerators within the
+// current tick's backward loop. Once tickLarvaMaturation returns, all nurse
+// claims are already reflected in WorldState (ants.age, ants.task, etc.) and
+// the stamp values are stale. On reload from a snapshot, currentStamp resets
+// to 0 and usedStamp is all-zeros; the first post-load tick increments stamp
+// to 1 and correctly sees no nurses pre-claimed — identical to a fresh start.
+//
+// This is the same pattern used throughout ant-system.ts (Issues #67, #69) for
+// hot-path scratch objects: one allocation at module load, stamp-or-fill per tick,
+// never serialized, deterministic within any contiguous run or replay.
 // ---------------------------------------------------------------------------
 
 const nurseScratch = {

--- a/src/sim/colony/larva-maturation.ts
+++ b/src/sim/colony/larva-maturation.ts
@@ -98,6 +98,10 @@ export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): vo
 
     const larvaId = colony.larvae[i]!;
     if (ants.alive[larvaId] !== 1) continue; // dead larvae cleaned up at step 5
+    // Newly hatched larvae (from this tick's tickLifecycleTransitions Loop 1) have
+    // age=0 — Loop 2 did not process them (snapLen excluded them). Skip them to
+    // preserve the "one lifecycle phase per tick" invariant.
+    if (ants.age[larvaId] === 0) continue;
 
     const larvaTileX = ants.posX[larvaId]! >> FP_SHIFT;
     const larvaTileY = ants.posY[larvaId]! >> FP_SHIFT;

--- a/src/sim/colony/larva-maturation.ts
+++ b/src/sim/colony/larva-maturation.ts
@@ -92,8 +92,10 @@ export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): vo
   const cap = largestNurseryTileCount(colony);
   if (cap <= 0) return;
 
-  // Advance the stamp (Uint32 wraps naturally).
-  nurseScratch.currentStamp = (nurseScratch.currentStamp + 1) >>> 0;
+  // Advance the stamp. Skip 0: usedStamp[] is zero-initialized, so stamp===0
+  // would falsely treat every nurse as "used this tick" after a full Uint32
+  // wrap (~4 billion ticks). `|| 1` bumps the one collision tick to 1.
+  nurseScratch.currentStamp = ((nurseScratch.currentStamp + 1) >>> 0) || 1;
   const stamp = nurseScratch.currentStamp;
 
   let slotsRemaining = cap;

--- a/src/sim/colony/larva-maturation.ts
+++ b/src/sim/colony/larva-maturation.ts
@@ -118,7 +118,7 @@ export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): vo
     const larvaTileX = ants.posX[larvaId]! >> FP_SHIFT;
     const larvaTileY = ants.posY[larvaId]! >> FP_SHIFT;
 
-    const nurseId = findAdjacentAttendingOrFeedingNurse(
+    const nurseId = findAdjacentAttendingNurse(
       ants,
       world.nextEntityId,
       colony.colonyId,
@@ -172,13 +172,20 @@ export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): vo
 // ---------------------------------------------------------------------------
 
 /**
- * Find the lowest-entity-ID nurse in NursingSubState.Attending or Feeding that
- * is within Manhattan distance 1 of (larvaTileX, larvaTileY) and has not yet
- * been used this tick (stamp check).
+ * Find the lowest-entity-ID nurse in NursingSubState.Attending that is within
+ * Manhattan distance 1 of (larvaTileX, larvaTileY) and has not yet been used
+ * this tick (stamp check).
+ *
+ * Only Attending nurses qualify — they have already deposited their brood in
+ * the Nursery and are dwelling there to accelerate development. Feeding nurses
+ * (carrying brood in transit) are excluded: they may be anywhere along the
+ * Queen-chamber → Nursery route, so counting them would grant acceleration
+ * credit before brood is in the Nursery, and potentially to larvae that are
+ * not yet in the Nursery environment.
  *
  * Returns -1 if no eligible nurse is found.
  */
-function findAdjacentAttendingOrFeedingNurse(
+function findAdjacentAttendingNurse(
   ants:         AntComponents,
   entityCount:  number,
   colonyId:     number,
@@ -192,8 +199,7 @@ function findAdjacentAttendingOrFeedingNurse(
     if (ants.alive[j] !== 1) continue;
     if (ants.colonyId[j] !== colonyId) continue;
     if (ants.task[j] !== AntTask.Nursing) continue;
-    const st = ants.subTask[j]!;
-    if (st !== NursingSubState.Attending && st !== NursingSubState.Feeding) continue;
+    if (ants.subTask[j] !== NursingSubState.Attending) continue;
     if (usedStamp[j] === stamp) continue;
     const nx = ants.posX[j]! >> FP_SHIFT;
     const ny = ants.posY[j]! >> FP_SHIFT;

--- a/src/sim/colony/lifecycle-system.test.ts
+++ b/src/sim/colony/lifecycle-system.test.ts
@@ -131,9 +131,12 @@ describe('tickQueenEggProduction — CLNY-01', () => {
     expect(colony.eggCount).toBe(0);
   });
 
-  it('4. does NOT produce an egg when tick is off-cycle (tick=1)', () => {
+  it('4. does NOT produce an egg when fewer ticks have elapsed than the interval', () => {
+    // S4 V21+: gate is elapsed-since-last-lay, not global modulo.
+    // Simulate a queen who laid 1 tick ago — interval hasn't elapsed yet.
     const { world, colony } = setupWorldWithQueen();
-    world.tick = 1; // 1 % 300 !== 0
+    world.tick = 1;
+    colony.queenLastEggTick = 0; // laid 1 tick ago; 1 < 300 → no lay
 
     tickQueenEggProduction(world, colony);
 

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -112,7 +112,15 @@ export function tickQueenEggProduction(world: WorldState, colony: ColonyRecord):
   const eggInterval = world.simVersion >= SIM_VERSION_V21_REPRODUCTION
     ? eggIntervalForColony(colony) : QUEEN_EGG_INTERVAL_TICKS;
   if (eggInterval < 0) return; // QUEEN_EGG_INTERVAL_DISABLED sentinel
-  if ((world.tick % eggInterval) !== 0) return;
+  // V21+: elapsed-since-last-lay prevents spurious double-lays when the surplus
+  // tier changes mid-cycle (e.g., interval drops from 300→200 at tick 301 after
+  // a lay at tick 300; modulo would fire again at tick 400, only 100 ticks later).
+  // Pre-V21: static interval — modulo is safe and backward-compatible.
+  if (world.simVersion >= SIM_VERSION_V21_REPRODUCTION) {
+    if (world.tick - colony.queenLastEggTick < eggInterval) return;
+  } else {
+    if ((world.tick % eggInterval) !== 0) return;
+  }
 
   // Gate 2: food threshold — issue #15: read TOTAL stockpile (entrance pool +
   // every FoodStorage chamber.foodStored). Pre-#15 this read colony.foodStored
@@ -240,6 +248,7 @@ export function tickQueenEggProduction(world: WorldState, colony: ColonyRecord):
 
   colony.eggs.push(eggId);
   colony.eggCount += 1;
+  colony.queenLastEggTick = world.tick; // update after lay so next interval is measured from here
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -87,9 +87,11 @@ import { SIM_VERSION_V21_REPRODUCTION } from '../types.js';
 //
 // Returns QUEEN_EGG_INTERVAL_DISABLED (-1) when food is below the gate
 // threshold (Gate 2 absorbs this; returning -1 keeps Gate 1 clean).
-// Returns one of four interval constants based on surplus ratio (×10
-// integer arithmetic — no floats, no intDiv, positive operands safe for
-// Math.trunc).
+// Returns one of four interval constants based on surplus ratio. Uses pure
+// integer multiplication comparisons to avoid division and bitwise truncation:
+//   food10 >= K * denom  ↔  surplus ratio ≥ K/10
+// JS numbers are 64-bit floats; integers up to 2^53 are exact, so even
+// extreme stockpiles cannot overflow or round incorrectly.
 // ---------------------------------------------------------------------------
 
 function eggIntervalForColony(colony: ColonyRecord): number {
@@ -98,11 +100,10 @@ function eggIntervalForColony(colony: ColonyRecord): number {
   const mouthsRaw = colony.workerCount + colony.larvaeCount + colony.eggCount + 1; // +1 queen
   const mouths    = Math.max(mouthsRaw, COLONY_SIZE_FLOOR);
   const denom     = mouths * FOOD_PER_ANT_BASELINE;
-  // eslint-disable-next-line no-restricted-syntax -- PRD §7b integer ratio; | 0 truncates to 32-bit int
-  const sX10      = (foodTotal * 10 / denom) | 0;
-  if (sX10 >= 100) return QUEEN_EGG_INTERVAL_FLOOR_TICKS;
-  if (sX10 >= 50)  return QUEEN_EGG_INTERVAL_FAST_TICKS;
-  if (sX10 >= 30)  return QUEEN_EGG_INTERVAL_MEDIUM_TICKS;
+  const food10    = foodTotal * 10; // multiply once; no division, no | 0 truncation
+  if (food10 >= 100 * denom) return QUEEN_EGG_INTERVAL_FLOOR_TICKS;
+  if (food10 >=  50 * denom) return QUEEN_EGG_INTERVAL_FAST_TICKS;
+  if (food10 >=  30 * denom) return QUEEN_EGG_INTERVAL_MEDIUM_TICKS;
   return QUEEN_EGG_INTERVAL_BASE_TICKS;
 }
 

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -27,12 +27,20 @@ import { FP_SHIFT, FP_ONE } from '../fixed.js';
 import {
   QUEEN_EGG_INTERVAL_TICKS,
   QUEEN_EGG_FOOD_THRESHOLD,
+  QUEEN_EGG_INTERVAL_DISABLED,
+  QUEEN_EGG_INTERVAL_BASE_TICKS,
+  QUEEN_EGG_INTERVAL_MEDIUM_TICKS,
+  QUEEN_EGG_INTERVAL_FAST_TICKS,
+  QUEEN_EGG_INTERVAL_FLOOR_TICKS,
+  COLONY_SIZE_FLOOR,
+  FOOD_PER_ANT_BASELINE,
   EGG_HATCH_TICKS,
   LARVA_MATURE_TICKS,
   WORKER_BASE_SPEED,
   WORKER_LIFESPAN_TICKS,
   STARVATION_GRACE_TICKS,
 } from '../constants.js';
+import { SIM_VERSION_V21_REPRODUCTION } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // tickQueenEggProduction — CLNY-01
@@ -74,9 +82,36 @@ import {
 // No RNG parameter — egg production is fully deterministic.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// eggIntervalForColony — S4 V21+ surplus-scaled egg interval
+//
+// Returns QUEEN_EGG_INTERVAL_DISABLED (-1) when food is below the gate
+// threshold (Gate 2 absorbs this; returning -1 keeps Gate 1 clean).
+// Returns one of four interval constants based on surplus ratio (×10
+// integer arithmetic — no floats, no intDiv, positive operands safe for
+// Math.trunc).
+// ---------------------------------------------------------------------------
+
+function eggIntervalForColony(colony: ColonyRecord): number {
+  const foodTotal = colonyFoodTotal(colony);
+  if (foodTotal < QUEEN_EGG_FOOD_THRESHOLD) return QUEEN_EGG_INTERVAL_DISABLED;
+  const mouthsRaw = colony.workerCount + colony.larvaeCount + colony.eggCount + 1; // +1 queen
+  const mouths    = Math.max(mouthsRaw, COLONY_SIZE_FLOOR);
+  const denom     = mouths * FOOD_PER_ANT_BASELINE;
+  // eslint-disable-next-line no-restricted-syntax -- integer ×10 ratio; Math.trunc truncates to integer
+  const sX10      = Math.trunc(foodTotal * 10 / denom);
+  if (sX10 >= 100) return QUEEN_EGG_INTERVAL_FLOOR_TICKS;
+  if (sX10 >= 50)  return QUEEN_EGG_INTERVAL_FAST_TICKS;
+  if (sX10 >= 30)  return QUEEN_EGG_INTERVAL_MEDIUM_TICKS;
+  return QUEEN_EGG_INTERVAL_BASE_TICKS;
+}
+
 export function tickQueenEggProduction(world: WorldState, colony: ColonyRecord): void {
-  // Gate 1: tick-modulo interval
-  if ((world.tick % QUEEN_EGG_INTERVAL_TICKS) !== 0) return;
+  // Gate 1: tick-modulo interval (S4 V21+: surplus-scaled; pre-V21: static)
+  const eggInterval = world.simVersion >= SIM_VERSION_V21_REPRODUCTION
+    ? eggIntervalForColony(colony) : QUEEN_EGG_INTERVAL_TICKS;
+  if (eggInterval < 0) return; // QUEEN_EGG_INTERVAL_DISABLED sentinel
+  if ((world.tick % eggInterval) !== 0) return;
 
   // Gate 2: food threshold — issue #15: read TOTAL stockpile (entrance pool +
   // every FoodStorage chamber.foodStored). Pre-#15 this read colony.foodStored

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -98,8 +98,8 @@ function eggIntervalForColony(colony: ColonyRecord): number {
   const mouthsRaw = colony.workerCount + colony.larvaeCount + colony.eggCount + 1; // +1 queen
   const mouths    = Math.max(mouthsRaw, COLONY_SIZE_FLOOR);
   const denom     = mouths * FOOD_PER_ANT_BASELINE;
-  // eslint-disable-next-line no-restricted-syntax -- integer ×10 ratio; Math.trunc truncates to integer
-  const sX10      = Math.trunc(foodTotal * 10 / denom);
+  // eslint-disable-next-line no-restricted-syntax -- PRD §7b integer ratio; | 0 truncates to 32-bit int
+  const sX10      = (foodTotal * 10 / denom) | 0;
   if (sX10 >= 100) return QUEEN_EGG_INTERVAL_FLOOR_TICKS;
   if (sX10 >= 50)  return QUEEN_EGG_INTERVAL_FAST_TICKS;
   if (sX10 >= 30)  return QUEEN_EGG_INTERVAL_MEDIUM_TICKS;

--- a/src/sim/colony/reproduction.test.ts
+++ b/src/sim/colony/reproduction.test.ts
@@ -1,0 +1,479 @@
+// reproduction.test.ts — S4 V21 Reproduction Lever tests
+//
+// Validation targets (plan):
+//   1. Surplus thresholds: crossing 3×/5×/10× boundary changes egg interval
+//   2. Nurse acceleration: larva matures in 1200 ticks with 100% nurse coverage
+//   3. Cap — nurse-side tighter: 3 nurses, 8 larvae → 3 accelerated
+//   4. Cap — cap tighter: 10 nurses, 6 larvae, cap=4 → 4 accelerated
+//   5. V20 replay: pre-V21 simVersion leaves tickLarvaMaturation as no-op
+//   6. D-29 WarFooting: 10× surplus colony reaches AI WarFooting ≥120 ticks earlier
+
+import { describe, it, expect } from 'vitest';
+import { tickQueenEggProduction, tickLifecycleTransitions } from './lifecycle-system.js';
+import { tickLarvaMaturation } from './larva-maturation.js';
+import { createWorldState, SIM_VERSION_V20_SPIDER, SIM_VERSION_V21_REPRODUCTION } from '../types.js';
+import { createColonyRecord } from './colony-store.js';
+import { initAnt } from '../ant/ant-store.js';
+import { AntTask, ChamberType, NursingSubState } from '../enums.js';
+import { Zone, createUndergroundGrid, ugSet, UndergroundTileState } from '../terrain.js';
+import { FP_SHIFT, FP_ONE } from '../fixed.js';
+import {
+  QUEEN_EGG_INTERVAL_TICKS,
+  QUEEN_EGG_FOOD_THRESHOLD,
+  QUEEN_EGG_INTERVAL_BASE_TICKS,
+  QUEEN_EGG_INTERVAL_MEDIUM_TICKS,
+  QUEEN_EGG_INTERVAL_FAST_TICKS,
+  QUEEN_EGG_INTERVAL_FLOOR_TICKS,
+  COLONY_SIZE_FLOOR,
+  FOOD_PER_ANT_BASELINE,
+  LARVA_MATURE_TICKS,
+  LARVA_MATURE_NURSE_ACCELERATION,
+} from '../constants.js';
+import type { WorldState } from '../types.js';
+import type { ColonyRecord } from './colony-store.js';
+
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const COLONY_ID = 1;
+const MAX_TEST_ENTITIES = 512;
+const QUEEN_TILE_X = 8;
+const QUEEN_TILE_Y = 4;
+
+function makeWorld(simVersion: number = SIM_VERSION_V21_REPRODUCTION): WorldState {
+  const world = createWorldState(42, MAX_TEST_ENTITIES);
+  world.simVersion = simVersion;
+  return world;
+}
+
+/**
+ * Set up a colony with a live queen inside a Queen chamber footprint.
+ * Returns the colony and queen entity ID.
+ */
+function setupColony(
+  world: WorldState,
+  foodStored = QUEEN_EGG_FOOD_THRESHOLD,
+): { colony: ColonyRecord; queenId: number } {
+  const queenId = world.nextEntityId++;
+  const posX = (QUEEN_TILE_X << FP_SHIFT) + (FP_ONE >> 1);
+  const posY = (QUEEN_TILE_Y << FP_SHIFT) + (FP_ONE >> 1);
+
+  initAnt(world.ants, queenId, {
+    colonyId: COLONY_ID,
+    posX, posY,
+    task: AntTask.Idle,
+    speed: 0,
+  });
+  world.ants.zone[queenId] = Zone.Underground;
+
+  const colony = createColonyRecord(COLONY_ID, queenId);
+  colony.foodStored = foodStored;
+
+  // Queen chamber sized around the queen's tile.
+  colony.chambers.push({
+    chamberId: 100,
+    chamberType: ChamberType.Queen,
+    foodStored: 0,
+    posX: QUEEN_TILE_X << FP_SHIFT,
+    posY: QUEEN_TILE_Y << FP_SHIFT,
+    width: 2, height: 2,
+  });
+  // Nursery chamber of 12 tiles (4×3) so the reproduction gates pass.
+  colony.chambers.push({
+    chamberId: 101,
+    chamberType: ChamberType.Nursery,
+    foodStored: 0,
+    posX: 0,
+    posY: 0,
+    width: 4, height: 3,
+  });
+
+  // Underground grid so deposit logic can run.
+  const grid = createUndergroundGrid(20, 20);
+  ugSet(grid, QUEEN_TILE_X, QUEEN_TILE_Y, UndergroundTileState.Open);
+  ugSet(grid, 0, 0, UndergroundTileState.Open);
+  world.undergroundGrids[COLONY_ID] = grid;
+  world.colonies[COLONY_ID] = colony;
+
+  return { colony, queenId };
+}
+
+/**
+ * Add a larva at (larvaTileX, larvaTileY) to the colony. Returns the entity ID.
+ */
+function addLarva(
+  world: WorldState,
+  colony: ColonyRecord,
+  larvaTileX = 1,
+  larvaTileY = 1,
+): number {
+  const id = world.nextEntityId++;
+  const posX = (larvaTileX << FP_SHIFT) + (FP_ONE >> 1);
+  const posY = (larvaTileY << FP_SHIFT) + (FP_ONE >> 1);
+  initAnt(world.ants, id, {
+    colonyId: COLONY_ID,
+    posX, posY,
+    task: AntTask.Idle,
+    speed: 0,
+  });
+  world.ants.zone[id] = Zone.Underground;
+  colony.larvae.push(id);
+  colony.larvaeCount += 1;
+  return id;
+}
+
+/**
+ * Add a nurse in Attending substate at (nurseTileX, nurseTileY).
+ */
+function addAttendingNurse(
+  world: WorldState,
+  colony: ColonyRecord,
+  nurseTileX = 1,
+  nurseTileY = 1,
+): number {
+  const id = world.nextEntityId++;
+  const posX = (nurseTileX << FP_SHIFT) + (FP_ONE >> 1);
+  const posY = (nurseTileY << FP_SHIFT) + (FP_ONE >> 1);
+  initAnt(world.ants, id, {
+    colonyId: COLONY_ID,
+    posX, posY,
+    task: AntTask.Nursing,
+    speed: 0,
+  });
+  world.ants.zone[id]    = Zone.Underground;
+  world.ants.subTask[id] = NursingSubState.Attending;
+  world.ants.searchPauseTicks[id] = 0;
+  colony.workers.push(id);
+  colony.workerCount += 1;
+  return id;
+}
+
+// Compute the food amount that produces a given sX10 ratio for COLONY_SIZE_FLOOR mouths.
+function foodForSX10(sX10: number): number {
+  const denom = COLONY_SIZE_FLOOR * FOOD_PER_ANT_BASELINE; // 8 × 60 = 480
+  // eslint-disable-next-line no-restricted-syntax -- test helper; integer division is intentional
+  return Math.ceil((sX10 * denom) / 10);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Surplus thresholds
+// ---------------------------------------------------------------------------
+
+describe('eggIntervalForColony — V21 surplus thresholds', () => {
+  // Pre-threshold (sX10 < 30): BASE interval = 300.
+  // We verify by checking that an egg is laid at a tick that's a multiple of
+  // the EXPECTED interval but NOT at a tick that's off-cycle.
+
+  it('V20 → unchanged static interval (300 ticks)', () => {
+    const world = makeWorld(SIM_VERSION_V20_SPIDER);
+    const { colony } = setupColony(world, QUEEN_EGG_FOOD_THRESHOLD);
+    world.tick = QUEEN_EGG_INTERVAL_TICKS; // 300
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(1);
+
+    // Off-cycle tick with V20 still uses static interval.
+    world.tick = QUEEN_EGG_INTERVAL_MEDIUM_TICKS; // 250 — NOT a multiple of 300
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(1); // no new egg
+  });
+
+  it('V21, lean food (base interval=300): lays at 300, not at 250', () => {
+    const world = makeWorld();
+    const { colony } = setupColony(world, QUEEN_EGG_FOOD_THRESHOLD); // sX10 = 16 → BASE
+    world.tick = QUEEN_EGG_INTERVAL_BASE_TICKS; // 300
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(1);
+
+    // 250 is not a multiple of 300.
+    world.tick = QUEEN_EGG_INTERVAL_MEDIUM_TICKS; // 250
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(1);
+  });
+
+  it('V21, 3× surplus (medium interval=250): lays at 250, not at 300', () => {
+    // sX10 >= 30: food = foodForSX10(30) = ceil(30*480/10) = ceil(1440) = 1440
+    const world = makeWorld();
+    const { colony } = setupColony(world, foodForSX10(30));
+    world.tick = QUEEN_EGG_INTERVAL_MEDIUM_TICKS; // 250
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(1);
+
+    // 300 is also a multiple of nothing we expect — actually 300 % 250 = 50 ≠ 0
+    // so confirm no second egg at 300.
+    // Reset colony eggs for clean count.
+    colony.eggs.length = 0; colony.eggCount = 0;
+    world.tick = QUEEN_EGG_INTERVAL_BASE_TICKS; // 300 — not a multiple of 250
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(0);
+  });
+
+  it('V21, 5× surplus (fast interval=200): lays at 200, not at 250', () => {
+    // sX10 >= 50: food = foodForSX10(50) = ceil(50*480/10) = 2400
+    const world = makeWorld();
+    const { colony } = setupColony(world, foodForSX10(50));
+    world.tick = QUEEN_EGG_INTERVAL_FAST_TICKS; // 200
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(1);
+
+    colony.eggs.length = 0; colony.eggCount = 0;
+    world.tick = QUEEN_EGG_INTERVAL_MEDIUM_TICKS; // 250 — not a multiple of 200
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(0);
+  });
+
+  it('V21, 10× surplus (floor interval=150): lays at 150, not at 200', () => {
+    // sX10 >= 100: food = foodForSX10(100) = ceil(100*480/10) = 4800
+    const world = makeWorld();
+    const { colony } = setupColony(world, foodForSX10(100));
+    world.tick = QUEEN_EGG_INTERVAL_FLOOR_TICKS; // 150
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(1);
+
+    colony.eggs.length = 0; colony.eggCount = 0;
+    world.tick = QUEEN_EGG_INTERVAL_FAST_TICKS; // 200 — not a multiple of 150
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(0);
+  });
+
+  it('V21, food below threshold → no egg (DISABLED sentinel)', () => {
+    const world = makeWorld();
+    const { colony } = setupColony(world, QUEEN_EGG_FOOD_THRESHOLD - 1);
+    world.tick = 0;
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Nurse acceleration: 100% coverage → matures in 1200 ticks
+// ---------------------------------------------------------------------------
+
+describe('tickLarvaMaturation — nurse acceleration', () => {
+  it('larva with 100% adjacent nurse coverage matures in LARVA_MATURE_TICKS / 2 ticks', () => {
+    const world = makeWorld();
+    const { colony } = setupColony(world);
+
+    const larvaId = addLarva(world, colony, 1, 1);
+    addAttendingNurse(world, colony, 1, 1); // same tile — Manhattan-0 ≤ 1
+
+    // The larva has a Nursery chamber (cap=12) in the colony already.
+    // Each tick: tickLifecycleTransitions gives +1 (baseline), tickLarvaMaturation gives +1 (nurse).
+    // Total: +2 per tick → mature at LARVA_MATURE_TICKS / 2 = 1200 ticks.
+
+    // eslint-disable-next-line no-restricted-syntax -- test-only constant; LARVA_MATURE_TICKS is even
+    const halfMature = LARVA_MATURE_TICKS / 2; // 1200
+
+    for (let t = 0; t < halfMature - 1; t++) {
+      tickLifecycleTransitions(world, colony);
+      tickLarvaMaturation(world, colony);
+    }
+    // One tick before maturation: larva should still be alive.
+    expect(world.ants.alive[larvaId]).toBe(1);
+    expect(colony.larvaeCount).toBe(1);
+    expect(colony.workerCount).toBe(1); // the nurse counted as a worker
+
+    // Final tick: promotes.
+    tickLifecycleTransitions(world, colony);
+    tickLarvaMaturation(world, colony);
+
+    expect(colony.larvaeCount).toBe(0);
+    expect(colony.workerCount).toBe(2); // nurse + promoted worker
+    expect(world.ants.task[larvaId]).toBe(AntTask.Idle);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Cap — nurse-side tighter (3 nurses, 8 larvae, cap=12)
+// ---------------------------------------------------------------------------
+
+describe('tickLarvaMaturation — throughput cap (nurse-side binds)', () => {
+  it('3 nurses, 8 larvae, cap=12 → exactly 3 larvae accelerated', () => {
+    const world = makeWorld();
+    const { colony } = setupColony(world);
+    // cap = 12 from the 4×3 Nursery chamber added by setupColony.
+
+    // Add 8 larvae at tile (1,1).
+    const larvaIds: number[] = [];
+    for (let i = 0; i < 8; i++) larvaIds.push(addLarva(world, colony, 1, 1));
+
+    // Add 3 nurses at tile (1,1).
+    for (let i = 0; i < 3; i++) addAttendingNurse(world, colony, 1, 1);
+
+    // Record ages before.
+    const agesBefore = larvaIds.map(id => world.ants.age[id]!);
+
+    // Baseline tick: each larva gets +1.
+    tickLifecycleTransitions(world, colony);
+    // Nurse acceleration: 3 slots available, 3 nurses, cap=12 — nurse-count binds.
+    tickLarvaMaturation(world, colony);
+
+    // After baseline: all larva ages = 1. After nurse pass: 3 have age 2.
+    let acceleratedCount = 0;
+    for (const id of larvaIds) {
+      const ageDelta = world.ants.age[id]! - agesBefore[larvaIds.indexOf(id)]!;
+      if (ageDelta === 1 + LARVA_MATURE_NURSE_ACCELERATION) acceleratedCount++;
+    }
+    expect(acceleratedCount).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Cap — cap tighter (10 nurses, 6 larvae, cap=4)
+// ---------------------------------------------------------------------------
+
+describe('tickLarvaMaturation — throughput cap (cap binds)', () => {
+  it('10 nurses, 6 larvae, cap=4 → exactly 4 larvae accelerated', () => {
+    const world = makeWorld();
+    const { colony } = setupColony(world);
+
+    // Replace the default 4×3 Nursery (cap=12) with a 2×2 (cap=4).
+    const nurseryIdx = colony.chambers.findIndex(c => c.chamberType === ChamberType.Nursery);
+    colony.chambers[nurseryIdx]!.width  = 2;
+    colony.chambers[nurseryIdx]!.height = 2;
+
+    // Add 6 larvae at tile (1,1).
+    const larvaIds: number[] = [];
+    for (let i = 0; i < 6; i++) larvaIds.push(addLarva(world, colony, 1, 1));
+
+    // Add 10 nurses at tile (1,1).
+    for (let i = 0; i < 10; i++) addAttendingNurse(world, colony, 1, 1);
+
+    const agesBefore = larvaIds.map(id => world.ants.age[id]!);
+
+    tickLifecycleTransitions(world, colony);
+    tickLarvaMaturation(world, colony);
+
+    let acceleratedCount = 0;
+    for (let i = 0; i < larvaIds.length; i++) {
+      const id = larvaIds[i]!;
+      const ageDelta = world.ants.age[id]! - agesBefore[i]!;
+      if (ageDelta === 1 + LARVA_MATURE_NURSE_ACCELERATION) acceleratedCount++;
+    }
+    expect(acceleratedCount).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. V20 replay: pre-V21 tickLarvaMaturation is a no-op
+// ---------------------------------------------------------------------------
+
+describe('tickLarvaMaturation — V20 no-op (replay safety)', () => {
+  it('does not accelerate larvae in a V20 world', () => {
+    const world = makeWorld(SIM_VERSION_V20_SPIDER);
+    const { colony } = setupColony(world);
+
+    const larvaId = addLarva(world, colony, 1, 1);
+    addAttendingNurse(world, colony, 1, 1);
+
+    tickLifecycleTransitions(world, colony);
+    const ageAfterBaseline = world.ants.age[larvaId]!;
+
+    // tickLarvaMaturation under V20 must be a no-op.
+    tickLarvaMaturation(world, colony);
+
+    expect(world.ants.age[larvaId]).toBe(ageAfterBaseline);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. D-29: 10× surplus colony reaches workerCount=10 ≥120 ticks earlier
+//
+// Demonstrates that faster egg interval (150 vs 300 ticks) from the
+// food-surplus lever leads to a measurable reproduction advantage.
+//
+// Setup: colony starts with 9 workers, queen in Queen chamber, Nursery
+// chamber present. Food is pinned each tick. Runs tickQueenEggProduction +
+// tickLifecycleTransitions + tickLarvaMaturation per "tick" and records
+// the sim tick when workerCount reaches 10 (one new worker from reproduction).
+//
+// Expected timing (no nurse adjacency, so no acceleration):
+//   Lean  (interval=300): first egg at t=300, larva at t=1500, worker at t=3900
+//   Rich  (interval=150): first egg at t=150, larva at t=1350, worker at t=3750
+//   Delta: 150 ticks ≥ MIN_TICK_DELTA (120)
+// ---------------------------------------------------------------------------
+
+describe('D-29 WarFooting — reproduction speed advantage', () => {
+  function makeD29World(foodLevel: number): { world: WorldState; colony: ColonyRecord } {
+    const world = makeWorld(SIM_VERSION_V21_REPRODUCTION);
+    world.tick = 0;
+    const { colony } = setupColony(world, foodLevel);
+
+    // Place queen at QUEEN_TILE_X, QUEEN_TILE_Y (inside the Queen chamber from setupColony).
+    // Gate 6 (queen-in-chamber) is already satisfied by setupColony.
+
+    // Add 9 pre-existing workers (workerCount = 9).
+    for (let i = 0; i < 9; i++) {
+      const id = world.nextEntityId++;
+      initAnt(world.ants, id, {
+        colonyId: COLONY_ID,
+        posX: (QUEEN_TILE_X << FP_SHIFT) + (FP_ONE >> 1),
+        posY: (QUEEN_TILE_Y << FP_SHIFT) + (FP_ONE >> 1),
+        task: AntTask.Idle,
+        speed: 0,
+      });
+      world.ants.zone[id] = Zone.Underground;
+      colony.workers.push(id);
+      colony.workerCount += 1;
+    }
+    return { world, colony };
+  }
+
+  it(
+    '10× surplus colony reaches workerCount=10 ≥120 ticks before lean colony',
+    () => {
+      const MAX_TICKS = 8400;
+      const MIN_TICK_DELTA = 120;
+
+      // With 9 workers + queen (mouths = max(10, COLONY_SIZE_FLOOR=8) = 10):
+      //   denom = 10 × FOOD_PER_ANT_BASELINE (60) = 600
+      //   Lean: food=768  → sX10 = floor(768×10/600) = 12 → BASE interval (300)
+      //   Rich: food=6000 → sX10 = floor(6000×10/600) = 100 → FLOOR interval (150)
+      const LEAN_FOOD = QUEEN_EGG_FOOD_THRESHOLD; // 768
+      // foodForSX10(100) = 4800 with 8 mouths (COLONY_SIZE_FLOOR), but with 10 mouths
+      // (9 workers + queen) the threshold for FLOOR interval needs food ≥ 6000.
+      const RICH_FOOD_10X = 6000; // sX10 = floor(6000×10/600) = 100 → FLOOR (150)
+
+      const { world: worldA, colony: colonyA } = makeD29World(LEAN_FOOD);
+      const { world: worldB, colony: colonyB } = makeD29World(RICH_FOOD_10X);
+
+      let reachTickA = -1;
+      let reachTickB = -1;
+
+      for (let t = 1; t < MAX_TICKS; t++) {
+        // Pin food so the surplus tier stays constant across the run.
+        colonyA.foodStored = LEAN_FOOD;
+        colonyB.foodStored = RICH_FOOD_10X;
+
+        worldA.tick = t;
+        worldB.tick = t;
+
+        tickQueenEggProduction(worldA, colonyA);
+        tickLifecycleTransitions(worldA, colonyA);
+        tickLarvaMaturation(worldA, colonyA);
+
+        tickQueenEggProduction(worldB, colonyB);
+        tickLifecycleTransitions(worldB, colonyB);
+        tickLarvaMaturation(worldB, colonyB);
+
+        if (reachTickA < 0 && colonyA.workerCount >= 10) reachTickA = t;
+        if (reachTickB < 0 && colonyB.workerCount >= 10) reachTickB = t;
+
+        if (reachTickA >= 0 && reachTickB >= 0) break;
+      }
+
+      expect(
+        reachTickB,
+        `Rich colony never reached workerCount=10 within ${MAX_TICKS} ticks`,
+      ).toBeGreaterThan(0);
+
+      const delta = reachTickA - reachTickB;
+      expect(
+        delta,
+        `Expected rich colony to reach 10 workers ≥${MIN_TICK_DELTA} ticks before lean ` +
+        `(lean=${reachTickA}, rich=${reachTickB}, delta=${delta})`,
+      ).toBeGreaterThanOrEqual(MIN_TICK_DELTA);
+    },
+  );
+});

--- a/src/sim/colony/reproduction.test.ts
+++ b/src/sim/colony/reproduction.test.ts
@@ -438,6 +438,12 @@ describe('D-29 WarFooting — reproduction speed advantage', () => {
       const { world: worldA, colony: colonyA } = makeD29World(LEAN_FOOD);
       const { world: worldB, colony: colonyB } = makeD29World(RICH_FOOD_10X);
 
+      // Reset queenLastEggTick so neither world lays at t=1 (default=-300 would
+      // give elapsed=301>=300, firing both worlds at the same tick and masking the
+      // interval difference). Setting to 0 means lean lays at t=300, rich at t=150.
+      colonyA.queenLastEggTick = 0;
+      colonyB.queenLastEggTick = 0;
+
       let reachTickA = -1;
       let reachTickB = -1;
 

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -20,11 +20,55 @@ export const LARVA_MATURE_TICKS = 2400;
 /** PRD §9c — Worker lifespan: effectively immortal (INT32_MAX ticks). */
 export const WORKER_LIFESPAN_TICKS = 0x7FFFFFFF;
 
-/** PRD §9c — Ticks between queen egg-laying events. */
+/** PRD §9c — Ticks between queen egg-laying events (pre-V21 static value). */
 export const QUEEN_EGG_INTERVAL_TICKS = 300;
 
 /** PRD §9c — Minimum food units (fp) the colony must hold for queen to lay. */
 export const QUEEN_EGG_FOOD_THRESHOLD = 768; // 3 × FP_ONE
+
+// ---------------------------------------------------------------------------
+// S4 (V21) — Reproduction lever: surplus-scaled egg interval
+// ---------------------------------------------------------------------------
+
+/** S4 — Sentinel returned by eggIntervalForColony when food is below the surplus gate. */
+export const QUEEN_EGG_INTERVAL_DISABLED = -1;
+/** S4 — Egg interval at < 3× surplus (matches pre-V21 static value). */
+export const QUEEN_EGG_INTERVAL_BASE_TICKS = 300;
+/** S4 — Egg interval at ≥ 3× surplus. */
+export const QUEEN_EGG_INTERVAL_MEDIUM_TICKS = 250;
+/** S4 — Egg interval at ≥ 5× surplus. */
+export const QUEEN_EGG_INTERVAL_FAST_TICKS = 200;
+/** S4 — Surplus-curve floor at ≥ 10× surplus (pre-tier floor; S5 MIN_EGG_INTERVAL_TICKS = 100 clamps post-tier). */
+export const QUEEN_EGG_INTERVAL_FLOOR_TICKS = 150;
+/**
+ * S4 — Absolute post-tier egg-interval floor. S5's brood-production modifier can push
+ * the effective interval below QUEEN_EGG_INTERVAL_FLOOR_TICKS = 150; this is the hard clamp.
+ * Cross-stage dependency: S5 stage doc references this constant — it must be defined here.
+ */
+export const MIN_EGG_INTERVAL_TICKS = 100;
+/**
+ * S4 — Minimum mouths-to-feed divisor in the surplus formula.
+ * Prevents MEDIUM tier firing on a 4-entity starter colony at the 768-FP gate.
+ */
+export const COLONY_SIZE_FLOOR = 8;
+/**
+ * S4 — Food-per-entity denominator for the surplus ratio.
+ * surplusX10 = Math.trunc(colonyFoodTotal * 10 / (mouths × FOOD_PER_ANT_BASELINE)).
+ * TELEMETRY_GATED: refine from Phase 4 playtest data.
+ */
+export const FOOD_PER_ANT_BASELINE = 60;
+
+// ---------------------------------------------------------------------------
+// S4 (V21) — Nurse Attending substate: maturation acceleration
+// ---------------------------------------------------------------------------
+
+/** S4 — Extra maturation ticks per tick while a nurse is Attending adjacent to a larva. */
+export const LARVA_MATURE_NURSE_ACCELERATION = 1;
+/**
+ * S4 — Ticks a nurse dwells at the Nursery tile after depositing brood (Attending substate).
+ * 30 sim-seconds. TELEMETRY_GATED: refine from Phase 4 playtest data.
+ */
+export const NURSE_ATTEND_DWELL_TICKS = 600;
 
 /**
  * PRD §9c — Ticks an ant can survive with no food before dying.

--- a/src/sim/enums.test.ts
+++ b/src/sim/enums.test.ts
@@ -102,8 +102,12 @@ describe('NursingSubState discriminants (PRD §1)', () => {
     expect(NursingSubState.Feeding).toBe(1);
   });
 
-  it('NursingSubState has exactly 2 members (regression guard)', () => {
-    expect(Object.keys(NursingSubState).length).toBe(2);
+  it('NursingSubState.Attending === 2 (S4 V21+ dwell substate)', () => {
+    expect(NursingSubState.Attending).toBe(2);
+  });
+
+  it('NursingSubState has exactly 3 members (regression guard — updated S4)', () => {
+    expect(Object.keys(NursingSubState).length).toBe(3);
   });
 });
 

--- a/src/sim/enums.ts
+++ b/src/sim/enums.ts
@@ -53,6 +53,7 @@ export type DiggingSubState = typeof DiggingSubState[keyof typeof DiggingSubStat
 export const NursingSubState = {
   MovingToBrood: 0,
   Feeding:       1, // PRD §1 line 84 — member is `Feeding`, NOT `FeedingBrood`
+  Attending:     2, // S4 V21+ — nurse dwells at Nursery after deposit; accelerates adjacent larvae
 } as const;
 export type NursingSubState = typeof NursingSubState[keyof typeof NursingSubState];
 

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -47,6 +47,7 @@ import {
   tickQueenEggProduction,
   tickLifecycleTransitions,
 } from './colony/lifecycle-system.js';
+import { tickLarvaMaturation } from './colony/larva-maturation.js';
 import {
   tickPheromoneDeposit,
   tickAntMovement,
@@ -744,6 +745,8 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
 
     // Step 7: Lifecycle transitions (egg→larva→worker aging + promotion)
     tickLifecycleTransitions(world, colony);
+    // S4 V21+: nurse-acceleration pass (no-op pre-V21; see larva-maturation.ts)
+    tickLarvaMaturation(world, colony);
 
     // Step 8: Behavior allocation (re-run after lifecycle; handles new matures + deaths from step 7)
     const brood8 = colony.eggCount + colony.larvaeCount;

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1,6 +1,6 @@
 // src/sim/tick.ts — Phase 9 19-step tick dispatcher.
 import type { WorldState } from './types.js';
-import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY, SIM_VERSION_V11_DEFENSIVE_BUNDLE, SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX, SIM_VERSION_V19_AI_STATE, SIM_VERSION_V20_SPIDER } from './types.js';
+import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY, SIM_VERSION_V11_DEFENSIVE_BUNDLE, SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX, SIM_VERSION_V19_AI_STATE, SIM_VERSION_V20_SPIDER, SIM_VERSION_V21_REPRODUCTION } from './types.js';
 import { tickSpider } from './spider.js';
 import { MAX_COMMANDS_PER_TICK, type SimCommand } from './commands.js';
 import { GameOutcome, checkQueenDeath } from './game-over.js';
@@ -42,6 +42,7 @@ import {
   checkEntranceCompletion,
   hasCompletedChamber,
   isFoodChamberDepositable,
+  colonyFoodTotal,
 } from './colony/colony-system.js';
 import {
   tickQueenEggProduction,
@@ -757,6 +758,18 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     colony.computedAllocation.dig    = alloc8.dig;
     colony.computedAllocation.fight  = alloc8.fight;
     colony.nurseCount = alloc8.nurse;
+    // S4 V21+ starvation escape hatch: when the colony has no food AND every
+    // worker is allocated as a nurse (forage===0), demote one nurse to forager
+    // so the colony isn't starvation-locked. This covers the small-colony case
+    // where computeNurseCount's ceil(workers/4) cap assigns the only worker as
+    // a nurse, leaving zero foragers regardless of food level.
+    if (world.simVersion >= SIM_VERSION_V21_REPRODUCTION &&
+        alloc8.forage === 0 && alloc8.nurse > 0 &&
+        colonyFoodTotal(colony) === 0) {
+      colony.computedAllocation.nurse  -= 1;
+      colony.computedAllocation.forage  = 1;
+      colony.nurseCount -= 1;
+    }
   }
 
   // Step 5 extension: dead-digger tile reversion (global pass, after per-colony death cleanup)

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -259,7 +259,13 @@ export const SIM_VERSION_V19_AI_STATE = 19 as const;
  * Adds world.spider (SpiderState | null), world.spiderPriorityColonyId, world.scatterReticleTile.
  */
 export const SIM_VERSION_V20_SPIDER = 20 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V20_SPIDER;
+/**
+ * V21 (S4) — Reproduction lever: surplus-scaled egg interval, nurse Attending
+ * substate with maturation acceleration, nursery throughput cap.
+ * No new WorldState fields; all state derived from existing food/colony/nurse data.
+ */
+export const SIM_VERSION_V21_REPRODUCTION = 21 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V21_REPRODUCTION;
 
 
 /**

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -767,6 +767,7 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
     d.reconcileCountdown   = s.reconcileCountdown;
     d.killCount            = s.killCount;
     d.priorityFoodPileId   = s.priorityFoodPileId;
+    d.queenLastEggTick     = s.queenLastEggTick;
 
     // Bucket arrays — reuse via length truncation + index copy (no new array)
     d.eggs.length = s.eggs.length;


### PR DESCRIPTION
## Summary

- **Food-surplus egg interval** (`eggIntervalForColony`): queen lays eggs every 150–300 ticks depending on colony food surplus (×10 integer ratio). 300 ticks at lean food, 150 ticks at ≥10× surplus. TELEMETRY_GATED tuning knob: `FOOD_PER_ANT_BASELINE = 60`.
- **Nurse Attending substate** (`NursingSubState.Attending = 2`): after depositing brood in the Nursery, nurses dwell at the tile for 600 ticks (`NURSE_ATTEND_DWELL_TICKS`) before returning to Idle. Previously they released immediately.
- **Nursery throughput cap** (`tickLarvaMaturation`): new second pass per tick applies +1 extra age to up to N larvae (N = largest completed Nursery tile count) when an adjacent Attending/Feeding nurse is found. At 100% nurse coverage, maturation drops from 2400 ticks to 1200 ticks.

All behavior is gated on `SIM_VERSION_V21_REPRODUCTION = 21`. Pre-V21 saves replay byte-identical.

| D-block | Files changed | Test added |
|---|---|---|
| Egg interval helper | `lifecycle-system.ts`, `constants.ts` | Threshold tests in `reproduction.test.ts` |
| Attending substate | `enums.ts`, `ant-system.ts` | `enums.test.ts` enum regression guard (updated 2→3) |
| Maturation acceleration | `larva-maturation.ts` (new), `colony-system.ts`, `tick.ts` | Nurse acceleration + cap tests |
| V21 sentinel | `types.ts` | V20 replay no-op test |
| D-29 integration | — | D-29 reproduction speed advantage ≥120-tick delta |

**Internal review:** 3 cycles; 2 bugs found and fixed: (1) Attending handler in `tickNurseActions` lacked V21 gate, (2) carry-drop abort path in `tickLarvaMaturation` didn't zero `searchPauseTicks[carrierId]`, causing phantom Forager search-pause.

## Test plan

- [ ] All 2181 existing tests pass (no regression)
- [ ] 11 new unit tests pass: surplus thresholds, nurse acceleration, throughput cap (nurse-side and cap-side), V20 no-op replay, D-29 ≥120-tick advantage
- [ ] TypeScript clean
- [ ] S5 implementer note: must use `SIM_VERSION_V22_DIFFICULTY` (V20 and V21 are already claimed); `MIN_EGG_INTERVAL_TICKS = 100` is now defined in `constants.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)