### PR TITLE
feat(s5): difficulty tier system — Easy/Normal/Hard with AI brood modifier and tiebreaks (V22)

### DIFF
--- a/scripts/analyze-snapshot.ts
+++ b/scripts/analyze-snapshot.ts
@@ -130,6 +130,15 @@ const snapshotDifficulty = (debug.snapshot as { difficulty?: unknown }).difficul
 const replayDifficulty: 'Easy' | 'Normal' | 'Hard' =
   snapshotDifficulty === 'Easy' || snapshotDifficulty === 'Hard' ? snapshotDifficulty : 'Normal';
 const replay = createScenario(debug.seed, replayDifficulty);
+// Restore simVersion from snapshot so version-gated paths (tiebreaks, brood modifier, etc.)
+// match the original session. createScenario always starts at LATEST_SIM_VERSION; without this
+// a pre-V22 snapshot replayed on V22 code would have V22 paths active, causing divergence.
+const snapshotSimVersion = (debug.snapshot as { simVersion?: unknown }).simVersion;
+if (typeof snapshotSimVersion === 'number' && Number.isInteger(snapshotSimVersion) && snapshotSimVersion > 0) {
+  replay.simVersion = snapshotSimVersion;
+} else {
+  console.warn(`[analyze-snapshot] Could not restore simVersion from snapshot (got ${String(snapshotSimVersion)}); replay runs at LATEST_SIM_VERSION — byte-equality may fail for pre-V22 captures.`);
+}
 
 const byTick: typeof debug.inputLog[] = [];
 for (let i = 0; i < debug.inputLog.length; i++) {

--- a/scripts/analyze-snapshot.ts
+++ b/scripts/analyze-snapshot.ts
@@ -125,7 +125,11 @@ console.log('');
 
 console.log(`Replaying from seed for ${debug.tick} ticks...`);
 const replayStart = Date.now();
-const replay = createScenario(debug.seed);
+// S5: pass difficulty from snapshot so non-Normal replays don't diverge (SCEN-06).
+const snapshotDifficulty = (debug.snapshot as { difficulty?: unknown }).difficulty;
+const replayDifficulty: 'Easy' | 'Normal' | 'Hard' =
+  snapshotDifficulty === 'Easy' || snapshotDifficulty === 'Hard' ? snapshotDifficulty : 'Normal';
+const replay = createScenario(debug.seed, replayDifficulty);
 
 const byTick: typeof debug.inputLog[] = [];
 for (let i = 0; i < debug.inputLog.length; i++) {

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -429,6 +429,8 @@ interface SerializedColony {
   foodFlowFieldDirty?: boolean;  // Issue #15 — defaults false on old saves
   killCount: number;   // Plan 09-01
   priorityFoodPileId: FoodPileId | null;  // Phase 9 / PRD §3d — per-colony priority food target
+  /** S5 V22 — brood-interval numerator. Optional; defaults to 4 (Normal = identity) on old saves. */
+  eggIntervalNumerator?: number;
 }
 
 interface SerializedGrid { width: number; height: number; data: number[] }
@@ -527,6 +529,8 @@ export interface SerializedWorldState {
   spiderPriorityColonyId?: number | null;
   /** S3 — preserved through save/reload; null for pre-V20 saves. */
   scatterReticleTile?: { x: number; y: number } | null;
+  /** S5 — optional for backward compat with pre-V22 saves; defaults to 'Normal' on load. */
+  difficulty?: 'Easy' | 'Normal' | 'Hard';
 }
 
 // ---------------------------------------------------------------------------
@@ -631,6 +635,7 @@ function serializeColony(c: ColonyRecord): SerializedColony {
     foodFlowFieldDirty:   c.foodFlowFieldDirty,
     killCount:            c.killCount,
     priorityFoodPileId:   c.priorityFoodPileId,
+    eggIntervalNumerator: c.eggIntervalNumerator,
   };
 }
 
@@ -685,6 +690,8 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
     spider: world.spider === null ? null : { ...world.spider },
     spiderPriorityColonyId: world.spiderPriorityColonyId,
     scatterReticleTile: world.scatterReticleTile === null ? null : { ...world.scatterReticleTile },
+    // S5 — difficulty tier.
+    difficulty: world.difficulty,
     // S2 — AI state machine records. operationFighterIds stored as number[].
     aiState: world.aiState.map((rec) => ({
       colonyId: rec.colonyId,
@@ -976,6 +983,9 @@ function deserializeColony(s: SerializedColony): ColonyRecord {
   c.killCount            = s.killCount;
   c.priorityFoodPileId   = s.priorityFoodPileId ?? null;
   c.queenLastEggTick     = s.queenLastEggTick ?? -300; // old saves: default to -QUEEN_EGG_INTERVAL_BASE_TICKS so queen can lay on first eligible tick
+  // Valid difficulty numerators are 3, 4, 5. Reject any out-of-range value (tampered save or future compat).
+  c.eggIntervalNumerator = (s.eggIntervalNumerator === 3 || s.eggIntervalNumerator === 4 || s.eggIntervalNumerator === 5)
+    ? s.eggIntervalNumerator : 4;
   // Issue #101 — validate chamber records before they reach the runtime.
   // Done after the spread so the validator inspects the persisted shape;
   // throw aborts deserializeWorldState's map() and propagates to bootFromSave.
@@ -1410,6 +1420,8 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
       s.droppedStructuralCount >= 0
         ? s.droppedStructuralCount
         : 0,
+    // S5 — difficulty tier; default 'Normal' for pre-V22 saves that omit the field.
+    difficulty: (s.difficulty === 'Easy' || s.difficulty === 'Hard') ? s.difficulty : 'Normal',
   };
 }
 

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -46,7 +46,8 @@ import {
   SPIDER_SPRITE_WIDTH,
 } from './ant-sprite-layer.js';
 import { SPIDER_HUNGER_MAX_TICKS } from '../sim/constants.js';
-import { NORMAL_TIER_INDEX } from '../sim/ai-state.js';
+import { NORMAL_TIER_INDEX, tierIndex } from '../sim/ai-state.js';
+import { SIM_VERSION_V22_DIFFICULTY } from '../sim/types.js';
 
 // ---------------------------------------------------------------------------
 // GfxLike — minimal Graphics interface (Phaser.GameObjects.Graphics satisfies this)
@@ -371,9 +372,8 @@ export function drawSurfaceEntities(
     if (spiderScreenX > -SPIDER_SPRITE_WIDTH  && spiderScreenX < canvasW + SPIDER_SPRITE_WIDTH
       && spiderScreenY > -SPIDER_SPRITE_HEIGHT && spiderScreenY < canvasH + SPIDER_SPRITE_HEIGHT) {
 
-      // S5 will replace NORMAL_TIER_INDEX with tierIndex(world.difficulty).
       const hungerFraction = Math.min(
-        curr.spider.hungerTicks / SPIDER_HUNGER_MAX_TICKS[NORMAL_TIER_INDEX],
+        curr.spider.hungerTicks / SPIDER_HUNGER_MAX_TICKS[curr.simVersion >= SIM_VERSION_V22_DIFFICULTY ? tierIndex(curr.difficulty) : NORMAL_TIER_INDEX],
         1,
       );
       const tint = lerpColor(0xCCCCCC, 0xFF3300, hungerFraction);

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -161,6 +161,9 @@ interface UIScenePhase9 {
     onRetry(): void;
   }): void;
   hideSurveyOverlay(): void;
+  // S5 — difficulty select overlay. Shown before every new game.
+  showDifficultySelectOverlay(callbacks: { onSelect: (d: 'Easy' | 'Normal' | 'Hard') => void }): void;
+  hideDifficultySelectOverlay(): void;
 }
 import type { SimCommand } from '../sim/commands.js';
 
@@ -193,6 +196,8 @@ export class GameScene extends Phaser.Scene {
   private gamePhase: GamePhase = GamePhase.Playing;
   private currentOutcome: GameOutcome = GameOutcome.None;
   private currentCause: import('./ui-scene-logic.js').QueenDeathCause = null;
+  // S5 — difficulty chosen by the player before each new game; preserved for retry.
+  private currentDifficulty: 'Easy' | 'Normal' | 'Hard' = 'Normal';
   private aiColonyIds: ReturnType<typeof deriveAIColonyIds> = [];
   private readonly inputLog: SimCommand[] = [];
   private lastAutosaveMs: number = 0;
@@ -398,11 +403,11 @@ export class GameScene extends Phaser.Scene {
         onContinue: () => this.bootFromSave(),
         onNewGame: () => {
           deleteSave();
-          this.bootFresh();
+          this.showDifficultySelectThenBoot();
         },
       });
     } else {
-      this.bootFresh();
+      this.showDifficultySelectThenBoot();
     }
 
     // Lifecycle signal — preload assets are loaded (we're in create()), the
@@ -490,15 +495,24 @@ export class GameScene extends Phaser.Scene {
         : '';
   }
 
-  private bootFresh(): void {
+  private bootFresh(difficulty: 'Easy' | 'Normal' | 'Hard' = 'Normal'): void {
     this.resetSessionState();
+    this.currentDifficulty = difficulty;
     // W1: seed formula — Date.now() is ~1.7e12, exceeds int32. Bitmask-clamp to positive int32.
     // Bitwise ops truncate to int32; 0x7fffffff mask ensures sign bit is clear.
     const seed = generateFreshSeed(Date.now());
     this.currentSeed = seed;
     // createScenario creates BOTH colonies (PLAYER_COLONY_ID + ENEMY_COLONY_ID) unconditionally.
-    this.world = createScenario(seed);
+    this.world = createScenario(seed, difficulty);
     this.finishBoot();
+  }
+
+  // S5 — show difficulty selector then boot. Used for every new-game path.
+  private showDifficultySelectThenBoot(): void {
+    const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
+    uiScene.showDifficultySelectOverlay({
+      onSelect: (d) => this.bootFresh(d),
+    });
   }
 
   private bootFromSave(): void {
@@ -550,6 +564,7 @@ export class GameScene extends Phaser.Scene {
     }
     this.currentSeed = loaded.seed;
     this.world = nextWorld;
+    this.currentDifficulty = nextWorld.difficulty; // S5 — restore difficulty from save
     this.resumedFromSave = true;
     // SCEN-06 replay truth: restore inputLog completely so the continued session
     // can be replayed byte-for-byte from (seed, inputLog) per Plan 04 Task 1.
@@ -773,7 +788,8 @@ export class GameScene extends Phaser.Scene {
     this.currentCause = null;
     this.resetSessionState();
     this.currentSeed = seed;
-    this.world = createScenario(seed);
+    // S5: retry preserves the previous game's difficulty (same seed + same difficulty).
+    this.world = createScenario(seed, this.currentDifficulty);
     this.finishBoot();
     if (wasSuspended) {
       this.autosaveSuspended = true;
@@ -874,13 +890,18 @@ export class GameScene extends Phaser.Scene {
     }
     this.currentOutcome = GameOutcome.None;
     this.currentCause = null;
-    // bootFresh → finishBoot resumes the loop; this is the authoritative restart path.
-    this.bootFresh();
-    if (wasSuspended) {
-      this.autosaveSuspended = true;
-    }
     const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
     uiScene.hideGameOverOverlay();
+    // S5: show difficulty selector before creating the new world.
+    // bootFresh is invoked inside the callback so wasSuspended is captured.
+    uiScene.showDifficultySelectOverlay({
+      onSelect: (d) => {
+        this.bootFresh(d);
+        if (wasSuspended) {
+          this.autosaveSuspended = true;
+        }
+      },
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -508,7 +508,10 @@ export class GameScene extends Phaser.Scene {
   }
 
   // S5 — show difficulty selector then boot. Used for every new-game path.
+  // Sets gamePhase to SavePrompt so update() returns early (line ~913 guard)
+  // before this.gameLoop is initialized by bootFresh → finishBoot.
   private showDifficultySelectThenBoot(): void {
+    this.gamePhase = GamePhase.SavePrompt;
     const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
     uiScene.showDifficultySelectOverlay({
       onSelect: (d) => this.bootFresh(d),

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -576,7 +576,7 @@ export class GameScene extends Phaser.Scene {
   }
 
   private finishBoot(): void {
-    this.prevState = createScenario(this.currentSeed);
+    this.prevState = createScenario(this.currentSeed, this.currentDifficulty);
     copyWorldState(this.world, this.prevState);
 
     // B1: world.colonies is a PLAIN OBJECT per ADR-0006.
@@ -897,6 +897,7 @@ export class GameScene extends Phaser.Scene {
     uiScene.hideGameOverOverlay();
     // S5: show difficulty selector before creating the new world.
     // bootFresh is invoked inside the callback so wasSuspended is captured.
+    this.gamePhase = GamePhase.SavePrompt; // prevent update() from ticking the old world during overlay
     uiScene.showDifficultySelectOverlay({
       onSelect: (d) => {
         this.bootFresh(d);

--- a/src/render/minimap.test.ts
+++ b/src/render/minimap.test.ts
@@ -198,6 +198,7 @@ const stubColonies: WorldState['colonies'] = {
     killCount: 0,
     priorityFoodPileId: null,
     queenLastEggTick: -300,
+    eggIntervalNumerator: 4,
   } as WorldState['colonies'][number],
 };
 

--- a/src/render/playtrace-upload.ts
+++ b/src/render/playtrace-upload.ts
@@ -201,8 +201,12 @@ export function truncateFreeText(s: string): string {
  *  snapshot (or null for survey-only). Pure — no fetch, no compression.
  *  Exported for the downgrade-fallback unit test. */
 /** Derive the RoundEndReason from the event buffer. Returns null when no
- *  queen_death event was emitted (quit from pause menu, or pre-S1 round). */
+ *  terminal event was emitted (quit from pause menu, or pre-S1 round).
+ *  S5: round_end tiebreak events take priority; checked before queen_death. */
 function deriveRoundEndReason(events: SimEvent[]): RoundEndReason | null {
+  for (const ev of events) {
+    if (ev.type === 'round_end') return ev.payload.reason;
+  }
   for (const ev of events) {
     if (ev.type === 'queen_death') return 'QueenDeath';
   }

--- a/src/render/summary-builder.ts
+++ b/src/render/summary-builder.ts
@@ -230,7 +230,7 @@ export function buildPlaytraceSummary(
       droppedCombatKill,
       droppedStructural,
     },
-    difficulty: null, // difficulty tiers land in S5
+    difficulty: world.difficulty,
     eventsCoverage: resumedFromSave
       ? 'since_load'
       : totalEmitted > 0

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -98,6 +98,10 @@ export const SAVE_PROMPT_CONTINUE_RECT = { x: 300, y: 280, w: 120, h: 32 } as co
 export const SAVE_PROMPT_NEW_GAME_RECT = { x: 300, y: 320, w: 120, h: 32 } as const;
 /** Canvas-local rect for the GameOver "Restart" button. */
 export const GAME_OVER_RESTART_RECT    = { x: 300, y: 345, w: 120, h: 32 } as const;
+/** Canvas-local rects for the DifficultySelect buttons (Easy / Normal / Hard). */
+export const DIFFICULTY_EASY_RECT   = { x: 220, y: 260, w: 140, h: 40 } as const;
+export const DIFFICULTY_NORMAL_RECT = { x: 330, y: 260, w: 140, h: 40 } as const;
+export const DIFFICULTY_HARD_RECT   = { x: 440, y: 260, w: 140, h: 40 } as const;
 import {
   createSliderDragState,
   drawSlider,
@@ -307,6 +311,7 @@ export class UIScene extends Phaser.Scene {
   // Phase 9 Plan 06 — overlay groups (null = overlay not currently shown)
   private gameOverGroup: Phaser.GameObjects.GameObject[] = [];
   private savePromptGroup: Phaser.GameObjects.GameObject[] = [];
+  private difficultySelectGroup: Phaser.GameObjects.GameObject[] = [];
   // Issue #116 — pause menu overlay state. Empty group means "not visible";
   // page tracks which sub-screen is currently rendered. callbacks/saveLoadEnabled
   // are captured at show time so we can re-render on page navigation without
@@ -1081,6 +1086,88 @@ export class UIScene extends Phaser.Scene {
   }
 
   // ---------------------------------------------------------------------------
+  // S5 — Difficulty select overlay
+  //
+  // Shown before every new game. Player chooses Easy / Normal / Hard; the
+  // choice is passed to createScenario via the onSelect callback. No cancel
+  // button — the player must choose before the world is created.
+  // ---------------------------------------------------------------------------
+
+  public showDifficultySelectOverlay(callbacks: { onSelect: (d: 'Easy' | 'Normal' | 'Hard') => void }): void {
+    this.hideDifficultySelectOverlay();
+
+    const W = 800;
+    const H = 592;
+
+    const bg = this.add.rectangle(W / 2, H / 2, W, H, 0x000000, 0.75);
+    bg.setInteractive();
+    bg.setDepth(20);
+
+    const title = this.add.text(W / 2, H / 2 - 100, 'Choose Difficulty', {
+      fontSize: '28px', fontFamily: 'monospace', color: '#ffffff',
+    });
+    title.setOrigin(0.5);
+    title.setDepth(21);
+
+    const subtitle = this.add.text(W / 2, H / 2 - 60, 'Affects the enemy colony\'s aggression and reproduction rate.', {
+      fontSize: '13px', fontFamily: 'monospace', color: '#aaaaaa',
+    });
+    subtitle.setOrigin(0.5);
+    subtitle.setDepth(21);
+
+    const makeButton = (
+      label: string,
+      desc: string,
+      rect: { x: number; y: number; w: number; h: number },
+      color: number,
+      difficulty: 'Easy' | 'Normal' | 'Hard',
+    ): Phaser.GameObjects.GameObject[] => {
+      const btnBg = this.add.rectangle(
+        rect.x + rect.w / 2, rect.y + rect.h / 2,
+        rect.w, rect.h, color, 1,
+      );
+      btnBg.setInteractive();
+      btnBg.setDepth(21);
+      btnBg.on('pointerdown', () => {
+        this.hideDifficultySelectOverlay();
+        callbacks.onSelect(difficulty);
+      });
+
+      const btnLabel = this.add.text(rect.x + rect.w / 2, rect.y + 12, label, {
+        fontSize: '15px', fontFamily: 'monospace', color: '#ffffff',
+      });
+      btnLabel.setOrigin(0.5, 0);
+      btnLabel.setDepth(22);
+
+      const btnDesc = this.add.text(rect.x + rect.w / 2, rect.y + 28, desc, {
+        fontSize: '10px', fontFamily: 'monospace', color: '#cccccc',
+        wordWrap: { width: rect.w - 8 },
+      });
+      btnDesc.setOrigin(0.5, 0);
+      btnDesc.setDepth(22);
+
+      return [btnBg, btnLabel, btnDesc];
+    };
+
+    const easyR = DIFFICULTY_EASY_RECT;
+    const normR = DIFFICULTY_NORMAL_RECT;
+    const hardR = DIFFICULTY_HARD_RECT;
+
+    const easyObjs  = makeButton('Easy',   'Slower AI', easyR, 0x226622, 'Easy');
+    const normObjs  = makeButton('Normal', 'Balanced',  normR, 0x224466, 'Normal');
+    const hardObjs  = makeButton('Hard',   'Faster AI', hardR, 0x662222, 'Hard');
+
+    this.difficultySelectGroup = [bg, title, subtitle, ...easyObjs, ...normObjs, ...hardObjs];
+    this.recomputeActiveOverlay();
+  }
+
+  public hideDifficultySelectOverlay(): void {
+    for (const obj of this.difficultySelectGroup) obj.destroy();
+    this.difficultySelectGroup = [];
+    this.recomputeActiveOverlay();
+  }
+
+  // ---------------------------------------------------------------------------
   // Issue #116 — Pause menu overlay
   //
   // Same Phaser-overlay-on-UIScene pattern as SavePrompt and GameOver: a
@@ -1562,6 +1649,7 @@ export class UIScene extends Phaser.Scene {
     else if (this.pauseMenuGroup.length > 0) setActiveOverlay('pause-menu');
     else if (this.gameOverGroup.length > 0) setActiveOverlay('game-over');
     else if (this.savePromptGroup.length > 0) setActiveOverlay('save-prompt');
+    else if (this.difficultySelectGroup.length > 0) setActiveOverlay('save-prompt'); // reuse 'save-prompt' HUD state
     else setActiveOverlay('none');
   }
 

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -99,9 +99,9 @@ export const SAVE_PROMPT_NEW_GAME_RECT = { x: 300, y: 320, w: 120, h: 32 } as co
 /** Canvas-local rect for the GameOver "Restart" button. */
 export const GAME_OVER_RESTART_RECT    = { x: 300, y: 345, w: 120, h: 32 } as const;
 /** Canvas-local rects for the DifficultySelect buttons (Easy / Normal / Hard). */
-export const DIFFICULTY_EASY_RECT   = { x: 220, y: 260, w: 140, h: 40 } as const;
+export const DIFFICULTY_EASY_RECT   = { x: 180, y: 260, w: 140, h: 40 } as const;
 export const DIFFICULTY_NORMAL_RECT = { x: 330, y: 260, w: 140, h: 40 } as const;
-export const DIFFICULTY_HARD_RECT   = { x: 440, y: 260, w: 140, h: 40 } as const;
+export const DIFFICULTY_HARD_RECT   = { x: 480, y: 260, w: 140, h: 40 } as const;
 import {
   createSliderDragState,
   drawSlider,

--- a/src/sim/ai-state.test.ts
+++ b/src/sim/ai-state.test.ts
@@ -20,6 +20,7 @@ import {
   playerWorkerCount,
   createDefaultAIStateRecord,
   NORMAL_TIER_INDEX,
+  tierIndex,
 } from './ai-state.js';
 import { killAnt } from './combat.js';
 import { initAnt } from './ant/ant-store.js';
@@ -417,5 +418,24 @@ describe('createDefaultAIStateRecord', () => {
     expect(rec.operationFighterIds[0]).toBe(-1);
     expect(rec.invasionRallyTileX).toBe(-1);
     expect(rec.invasionRallyTileY).toBe(-1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S5 (V22) — tierIndex
+// ---------------------------------------------------------------------------
+
+describe('tierIndex', () => {
+  it('maps Easy to 0', () => {
+    expect(tierIndex('Easy')).toBe(0);
+  });
+
+  it('maps Normal to 1 (same as NORMAL_TIER_INDEX)', () => {
+    expect(tierIndex('Normal')).toBe(1);
+    expect(tierIndex('Normal')).toBe(NORMAL_TIER_INDEX);
+  });
+
+  it('maps Hard to 2', () => {
+    expect(tierIndex('Hard')).toBe(2);
   });
 });

--- a/src/sim/ai-state.ts
+++ b/src/sim/ai-state.ts
@@ -4,10 +4,11 @@
 // Render-side ai-controller.ts calls these helpers; it never writes world.aiState.* directly.
 // Per CF-P0-004 / ADR-0007: sim owns mutation and event emission; render owns policy.
 //
-// QC Pass 4 AR-P0-001: S2 V17 ships Normal-only tier reads. S5 V20 refactors to
-// tierIndex(world.difficulty) at every NORMAL_TIER_INDEX lookup site.
+// QC Pass 4 AR-P0-001: S2 V17 ships Normal-only tier reads. S5 V22 gates all
+// NORMAL_TIER_INDEX lookup sites on SIM_VERSION_V22_DIFFICULTY and uses tierIndex(world.difficulty).
 
 import type { WorldState, AIState, AIStateRecord } from './types.js';
+import { SIM_VERSION_V22_DIFFICULTY } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 import type { ClearRallyPointCommand } from './commands.js';
 import { emitEvent } from './telemetry.js';
@@ -36,8 +37,19 @@ import {
 } from './constants.js';
 
 
-// QC Pass 4 AR-P0-001: Normal-only tier index. S5 V20 replaces this with tierIndex(world.difficulty).
+// QC Pass 4 AR-P0-001: Normal-only tier index. Used for pre-V22 saves; V22+ uses tierIndex(world.difficulty).
 export const NORMAL_TIER_INDEX = 1 as const;
+
+/**
+ * S5 (V22) — Map player-selected difficulty to a 0-based tier index for
+ * per-difficulty constant arrays (e.g. AI_WARFOOTING_FIGHTER_THRESHOLD).
+ * Easy=0, Normal=1, Hard=2.
+ */
+export function tierIndex(difficulty: WorldState['difficulty']): 0 | 1 | 2 {
+  if (difficulty === 'Easy') return 0;
+  if (difficulty === 'Hard') return 2;
+  return 1;
+}
 
 // ---------------------------------------------------------------------------
 // Helper: create a fresh AIStateRecord at defensive defaults (pre-V17 migration)
@@ -260,7 +272,7 @@ function _tryTransitionPeacetimeToWarFooting(
 
   // CF-P1-010: aiReady AND (ageReady OR frontageReady)
   const aiReady =
-    fighters >= AI_WARFOOTING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX] &&
+    fighters >= AI_WARFOOTING_FIGHTER_THRESHOLD[world.simVersion >= SIM_VERSION_V22_DIFFICULTY ? tierIndex(world.difficulty) : NORMAL_TIER_INDEX] &&
     foodStored * 100 >= foodCap * AI_WARFOOTING_FOOD_FRAC_PCT;
 
   const ageReady = world.tick >= AI_WARFOOTING_MIN_TICK;
@@ -288,7 +300,7 @@ function _checkWarFootingToInvading(
   const foodCap = aiFoodCapacity(world, aiColonyId);
 
   if (
-    fighters >= AI_INVADING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX] &&
+    fighters >= AI_INVADING_FIGHTER_THRESHOLD[world.simVersion >= SIM_VERSION_V22_DIFFICULTY ? tierIndex(world.difficulty) : NORMAL_TIER_INDEX] &&
     foodStored * 100 >= foodCap * AI_INVADING_FOOD_FRAC_PCT &&
     world.tick >= AI_INVADING_MIN_TICK
   ) {
@@ -373,7 +385,7 @@ function _checkInvadingToRecovery(
       // ClearRallyPoint. advanceAIState still emits ai_state_transition after this returns.
       aiState.state = 'Recovery';
       aiState.enteredTick = world.tick;
-      aiState.recoveryEndTick = world.tick + AI_RECOVERY_DURATION_TICKS[NORMAL_TIER_INDEX];
+      aiState.recoveryEndTick = world.tick + AI_RECOVERY_DURATION_TICKS[world.simVersion >= SIM_VERSION_V22_DIFFICULTY ? tierIndex(world.difficulty) : NORMAL_TIER_INDEX];
       aiState.invasionStartTick = 0;
       aiState.invasionRallyTileX = -1;
       aiState.invasionRallyTileY = -1;
@@ -432,7 +444,7 @@ function _endInvasion(
   world.commandQueue.push(clearCmd);
   aiState.state = 'Recovery';
   aiState.enteredTick = world.tick;
-  aiState.recoveryEndTick = world.tick + AI_RECOVERY_DURATION_TICKS[NORMAL_TIER_INDEX];
+  aiState.recoveryEndTick = world.tick + AI_RECOVERY_DURATION_TICKS[world.simVersion >= SIM_VERSION_V22_DIFFICULTY ? tierIndex(world.difficulty) : NORMAL_TIER_INDEX];
   aiState.invasionStartTick = 0;
   aiState.invasionRallyTileX = -1;
   aiState.invasionRallyTileY = -1;

--- a/src/sim/colony/colony-store.test.ts
+++ b/src/sim/colony/colony-store.test.ts
@@ -96,10 +96,10 @@ describe('createColonyRecord', () => {
     expect('idleCount' in r).toBe(false);
   });
 
-  it('(11) ColonyRecord Phase 2 factory returns 20 fields (17 Phase 2 + killCount + priorityFoodPileId + queenLastEggTick; Phase 3 extensions are undefined until caller assigns)', () => {
+  it('(11) ColonyRecord Phase 2 factory returns 21 fields (17 Phase 2 + killCount + priorityFoodPileId + queenLastEggTick + eggIntervalNumerator; Phase 3 extensions are undefined until caller assigns)', () => {
     const r = createColonyRecord(1, 0);
-    // Factory returns exactly 20 fields (17 Phase 2 + Phase 9 killCount + Phase 9 priorityFoodPileId + S4 queenLastEggTick)
-    expect(Object.keys(r).length).toBe(20);
+    // 17 Phase 2 + Phase 9 killCount + Phase 9 priorityFoodPileId + S4 queenLastEggTick + S5 eggIntervalNumerator
+    expect(Object.keys(r).length).toBe(21);
   });
 
   it('createColonyRecord initializes killCount to 0', () => {

--- a/src/sim/colony/colony-store.ts
+++ b/src/sim/colony/colony-store.ts
@@ -158,6 +158,13 @@ export interface ColonyRecord {
    *  so the queen can lay on tick 0 (0 - (-300) = 300 ≥ 300). Round-trips
    *  through copyWorldState + save. */
   queenLastEggTick: number;
+
+  /** S5 V22 — brood-interval difficulty multiplier numerator (denominator is always 4).
+   *  Applied as `(eggInterval * eggIntervalNumerator) >> 2` in tickQueenEggProduction.
+   *  Player colony always uses 4 (identity). AI colony numerator set from
+   *  QUEEN_EGG_INTERVAL_DIFFICULTY_NUMERATOR[tier] in createScenario: Easy=5(+25%),
+   *  Normal=4(×1), Hard=3(−25%). Defaults to 4 so pre-V22 saves are unaffected. */
+  eggIntervalNumerator: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -217,6 +224,7 @@ export function createColonyRecord(colonyId: ColonyId, queenEntityId: EntityId):
     killCount:             0,
     priorityFoodPileId:    null,
     queenLastEggTick:      -QUEEN_EGG_INTERVAL_BASE_TICKS,
+    eggIntervalNumerator:  4, // Normal = identity (set per-colony in createScenario for difficulty tiers)
   }) as unknown as ColonyRecord;
 }
 

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -39,8 +39,9 @@ import {
   WORKER_BASE_SPEED,
   WORKER_LIFESPAN_TICKS,
   STARVATION_GRACE_TICKS,
+  MIN_EGG_INTERVAL_TICKS,
 } from '../constants.js';
-import { SIM_VERSION_V21_REPRODUCTION } from '../types.js';
+import { SIM_VERSION_V21_REPRODUCTION, SIM_VERSION_V22_DIFFICULTY } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // tickQueenEggProduction — CLNY-01
@@ -109,9 +110,15 @@ function eggIntervalForColony(colony: ColonyRecord): number {
 
 export function tickQueenEggProduction(world: WorldState, colony: ColonyRecord): void {
   // Gate 1: tick-modulo interval (S4 V21+: surplus-scaled; pre-V21: static)
-  const eggInterval = world.simVersion >= SIM_VERSION_V21_REPRODUCTION
+  let eggInterval = world.simVersion >= SIM_VERSION_V21_REPRODUCTION
     ? eggIntervalForColony(colony) : QUEEN_EGG_INTERVAL_TICKS;
   if (eggInterval < 0) return; // QUEEN_EGG_INTERVAL_DISABLED sentinel
+  // S5 (V22): apply per-colony brood-interval numerator (set in createScenario from difficulty tier).
+  // Integer-only: (interval * numerator) >> 2; numerator=4 is identity. Hard floor: MIN_EGG_INTERVAL_TICKS.
+  if (world.simVersion >= SIM_VERSION_V22_DIFFICULTY) {
+    eggInterval = (eggInterval * colony.eggIntervalNumerator) >> 2;
+    if (eggInterval < MIN_EGG_INTERVAL_TICKS) eggInterval = MIN_EGG_INTERVAL_TICKS;
+  }
   // V21+: elapsed-since-last-lay prevents spurious double-lays when the surplus
   // tier changes mid-cycle (e.g., interval drops from 300→200 at tick 301 after
   // a lay at tick 300; modulo would fire again at tick 400, only 100 ticks later).

--- a/src/sim/colony/reproduction.test.ts
+++ b/src/sim/colony/reproduction.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import { tickQueenEggProduction, tickLifecycleTransitions } from './lifecycle-system.js';
 import { tickLarvaMaturation } from './larva-maturation.js';
-import { createWorldState, SIM_VERSION_V20_SPIDER, SIM_VERSION_V21_REPRODUCTION } from '../types.js';
+import { createWorldState, SIM_VERSION_V20_SPIDER, SIM_VERSION_V21_REPRODUCTION, SIM_VERSION_V22_DIFFICULTY } from '../types.js';
 import { createColonyRecord } from './colony-store.js';
 import { initAnt } from '../ant/ant-store.js';
 import { AntTask, ChamberType, NursingSubState } from '../enums.js';
@@ -28,9 +28,10 @@ import {
   FOOD_PER_ANT_BASELINE,
   LARVA_MATURE_TICKS,
   LARVA_MATURE_NURSE_ACCELERATION,
+  MIN_EGG_INTERVAL_TICKS,
 } from '../constants.js';
 import type { WorldState } from '../types.js';
-import type { ColonyRecord } from './colony-store.js';
+import type { ColonyRecord, ColonyId } from './colony-store.js';
 
 
 // ---------------------------------------------------------------------------
@@ -482,4 +483,103 @@ describe('D-29 WarFooting — reproduction speed advantage', () => {
       ).toBeGreaterThanOrEqual(MIN_TICK_DELTA);
     },
   );
+});
+
+// ---------------------------------------------------------------------------
+// 7. V22 difficulty brood modifier — AI egg interval scaling
+// ---------------------------------------------------------------------------
+
+describe('V22 difficulty brood modifier — AI egg interval', () => {
+  const AI_COLONY_ID = 2;
+
+  function setupAIColony(world: WorldState, foodStored = foodForSX10(100)): ColonyRecord {
+    const queenId = world.nextEntityId++;
+    const posX = (QUEEN_TILE_X << FP_SHIFT) + (FP_ONE >> 1);
+    const posY = (QUEEN_TILE_Y << FP_SHIFT) + (FP_ONE >> 1);
+    initAnt(world.ants, queenId, { colonyId: AI_COLONY_ID, posX, posY, task: AntTask.Idle, speed: 0 });
+    world.ants.zone[queenId] = Zone.Underground;
+
+    const colony = createColonyRecord(AI_COLONY_ID as ColonyId, queenId);
+    colony.foodStored = foodStored;
+    colony.queenLastEggTick = 0; // prevent default -300 from firing early
+    colony.chambers.push({
+      chamberId: 200,
+      chamberType: ChamberType.Queen,
+      foodStored: 0,
+      posX: QUEEN_TILE_X << FP_SHIFT,
+      posY: QUEEN_TILE_Y << FP_SHIFT,
+      width: 2, height: 2,
+    });
+    colony.chambers.push({
+      chamberId: 201,
+      chamberType: ChamberType.Nursery,
+      foodStored: 0,
+      posX: 0, posY: 0,
+      width: 4, height: 3,
+    });
+    const grid = createUndergroundGrid(20, 20);
+    ugSet(grid, QUEEN_TILE_X, QUEEN_TILE_Y, UndergroundTileState.Open);
+    ugSet(grid, 0, 0, UndergroundTileState.Open);
+    world.undergroundGrids[AI_COLONY_ID] = grid;
+    world.colonies[AI_COLONY_ID] = colony;
+    return colony;
+  }
+
+  it('eggIntervalNumerator=3 (Hard): lays at tick 112 (150*3>>2=112), not at 111', () => {
+    const world = makeWorld(SIM_VERSION_V22_DIFFICULTY);
+    const colony = setupAIColony(world);
+    colony.eggIntervalNumerator = 3; // Hard
+
+    world.tick = 111;
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(0);
+
+    world.tick = 112;
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(1);
+  });
+
+  it('eggIntervalNumerator=4 (Normal): interval unchanged — lays at 150, not at 149', () => {
+    const world = makeWorld(SIM_VERSION_V22_DIFFICULTY);
+    const colony = setupAIColony(world);
+    // default eggIntervalNumerator=4 (identity: 150*4>>2=150)
+
+    world.tick = 149;
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(0);
+
+    world.tick = 150;
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(1);
+  });
+
+  it('eggIntervalNumerator=5 (Easy): lays at tick 187 (150*5>>2=187), not at 150', () => {
+    const world = makeWorld(SIM_VERSION_V22_DIFFICULTY);
+    const colony = setupAIColony(world);
+    colony.eggIntervalNumerator = 5; // Easy
+
+    world.tick = 150; // would fire at Normal (numerator=4) but not Easy
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(0);
+
+    world.tick = 187;
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(1);
+  });
+
+  it('pre-V22 (V21): eggIntervalNumerator=3 is ignored — interval unchanged at 150 ticks', () => {
+    const world = makeWorld(SIM_VERSION_V21_REPRODUCTION);
+    const colony = setupAIColony(world);
+    colony.eggIntervalNumerator = 3; // Hard, but V22 gate not active
+
+    world.tick = 150;
+    tickQueenEggProduction(world, colony);
+    expect(colony.eggCount).toBe(1); // no V22 modifier → fires at 150
+  });
+
+  it('Hard modifier (numerator=3) keeps interval above MIN_EGG_INTERVAL_TICKS (100)', () => {
+    // floor interval=150, Hard: 150*3>>2=112 > 100 — clamp does not fire in standard play.
+    expect((QUEEN_EGG_INTERVAL_FLOOR_TICKS * 3) >> 2).toBeGreaterThanOrEqual(MIN_EGG_INTERVAL_TICKS);
+    expect(MIN_EGG_INTERVAL_TICKS).toBe(100);
+  });
 });

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -59,6 +59,35 @@ export const COLONY_SIZE_FLOOR = 8;
 export const FOOD_PER_ANT_BASELINE = 60;
 
 // ---------------------------------------------------------------------------
+// S5 (V22) — Difficulty tier: brood modifier and tiebreak thresholds
+// ---------------------------------------------------------------------------
+
+/**
+ * S5 — Per-difficulty scale for AI colony egg interval. Indexed [Easy, Normal, Hard].
+ * Applied as `(interval * numerator) >> 2` (integer-only multiply+shift, no division operator).
+ * Easy=5/4=1.25× (slower), Normal=4/4=1.0× (unchanged), Hard=3/4=0.75× (faster).
+ * At Hard and ≥10× surplus: 150 * 3 >> 2 = 112 ticks — below QUEEN_EGG_INTERVAL_FLOOR_TICKS
+ * (150) but above MIN_EGG_INTERVAL_TICKS (100). Applied to AI colony only; player always
+ * uses the unmodified surplus-curve result.
+ */
+export const QUEEN_EGG_INTERVAL_DIFFICULTY_NUMERATOR = [5, 4, 3] as const;
+
+/**
+ * S5 — Match time cap in ticks. Both queens surviving to this tick triggers
+ * TimeoutTiebreak; winner determined by living worker count.
+ * 24 000 ticks = 20 minutes at 20 Hz.
+ */
+export const MATCH_TIMEOUT_TICKS = 24_000;
+
+/**
+ * S5 — Colony food-store threshold (fixed-point) below which a colony is
+ * considered "too starved to recover" for Stalemate detection.
+ * Both colonies must be below this threshold AND all food piles must be gone.
+ * 512 fp = 2 × FP_ONE = 2 food units.
+ */
+export const STALEMATE_FOOD_THRESHOLD_FP = 512;
+
+// ---------------------------------------------------------------------------
 // S4 (V21) — Nurse Attending substate: maturation acceleration
 // ---------------------------------------------------------------------------
 

--- a/src/sim/game-over.test.ts
+++ b/src/sim/game-over.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { GameOutcome, checkQueenDeath } from './game-over.js';
-import { createWorldState, allocateEntityId } from './types.js';
+import { GameOutcome, checkQueenDeath, checkTiebreaks } from './game-over.js';
+import { createWorldState, allocateEntityId, SIM_VERSION_V22_DIFFICULTY, SIM_VERSION_V21_REPRODUCTION } from './types.js';
 import { createColonyRecord } from './colony/colony-store.js';
 import { initAnt } from './ant/ant-store.js';
 import { AntTask } from './enums.js';
 import type { ColonyId } from './colony/colony-store.js';
 import type { WorldState } from './types.js';
+import { MATCH_TIMEOUT_TICKS, STALEMATE_FOOD_THRESHOLD_FP } from './constants.js';
 
 function makeWorldWith2Colonies(): { world: WorldState; queen1: number; queen2: number } {
   const world = createWorldState(42);
@@ -101,5 +102,150 @@ describe('game-over detection', () => {
       world.ants.alive[queen2] = 0;
       expect(checkQueenDeath(world)).toBe(GameOutcome.Victory);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S5 (V22) — checkTiebreaks
+// ---------------------------------------------------------------------------
+
+function makeV22WorldWith2Colonies(playerColonyId = 1, aiColonyId = 2): {
+  world: WorldState;
+  queen1: number;
+  queen2: number;
+  addWorker: (colonyId: number) => number;
+} {
+  const world = createWorldState(42);
+  world.simVersion = SIM_VERSION_V22_DIFFICULTY;
+  world.difficulty = 'Normal';
+  // Default food pile prevents spurious stalemate in tests that only check other conditions.
+  // Stalemate tests explicitly set world.foodPiles = [] to override this.
+  world.foodPiles = [{ foodPileId: 1, tileX: 10, tileY: 10, pickupsRemaining: 1, pickupsInitial: 1 }];
+
+  const queen1 = allocateEntityId(world);
+  initAnt(world.ants, queen1, { colonyId: playerColonyId, posX: 0, posY: 0, task: AntTask.Idle, subTask: 0, speed: 0 });
+  const c1 = createColonyRecord(playerColonyId as ColonyId, queen1);
+  c1.entrances = []; c1.rallyPoint = null; c1.digFlowFieldDirty = false;
+  world.colonies[playerColonyId] = c1;
+
+  const queen2 = allocateEntityId(world);
+  initAnt(world.ants, queen2, { colonyId: aiColonyId, posX: 0, posY: 0, task: AntTask.Idle, subTask: 0, speed: 0 });
+  const c2 = createColonyRecord(aiColonyId as ColonyId, queen2);
+  c2.entrances = []; c2.rallyPoint = null; c2.digFlowFieldDirty = false;
+  world.colonies[aiColonyId] = c2;
+
+  const addWorker = (colonyId: number): number => {
+    const id = allocateEntityId(world);
+    initAnt(world.ants, id, { colonyId: colonyId as ColonyId, posX: 1, posY: 1, task: AntTask.Idle, subTask: 0, speed: 0 });
+    return id;
+  };
+
+  return { world, queen1, queen2, addWorker };
+}
+
+describe('checkTiebreaks (S5 V22)', () => {
+  it('returns None for pre-V22 worlds', () => {
+    const { world } = makeV22WorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V21_REPRODUCTION;
+    world.tick = MATCH_TIMEOUT_TICKS;
+    expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.None);
+  });
+
+  it('returns None when tick is below timeout cap', () => {
+    const { world } = makeV22WorldWith2Colonies();
+    world.tick = MATCH_TIMEOUT_TICKS - 1;
+    expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.None);
+  });
+
+  describe('Timeout tiebreak', () => {
+    it('returns MutualDestruction when worker counts are equal', () => {
+      const { world, addWorker } = makeV22WorldWith2Colonies();
+      world.tick = MATCH_TIMEOUT_TICKS;
+      addWorker(1); addWorker(2); // one worker each
+      expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.MutualDestruction);
+    });
+
+    it('returns Victory when player has more workers', () => {
+      const { world, addWorker } = makeV22WorldWith2Colonies();
+      world.tick = MATCH_TIMEOUT_TICKS;
+      addWorker(1); addWorker(1); addWorker(2); // 2 player vs 1 AI
+      expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.Victory);
+    });
+
+    it('returns Defeat when AI has more workers', () => {
+      const { world, addWorker } = makeV22WorldWith2Colonies();
+      world.tick = MATCH_TIMEOUT_TICKS;
+      addWorker(1); addWorker(2); addWorker(2); // 1 player vs 2 AI
+      expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.Defeat);
+    });
+
+    it('emits a round_end event with reason TimeoutTiebreak', () => {
+      const { world } = makeV22WorldWith2Colonies();
+      world.tick = MATCH_TIMEOUT_TICKS;
+      checkTiebreaks(world, 1 as ColonyId);
+      const ev = world.events.find((e) => e.type === 'round_end');
+      expect(ev).toBeDefined();
+      if (ev && ev.type === 'round_end') {
+        expect(ev.payload.reason).toBe('TimeoutTiebreak');
+      }
+    });
+  });
+
+  describe('Stalemate tiebreak', () => {
+    it('returns None when food piles remain on the map', () => {
+      const { world } = makeV22WorldWith2Colonies();
+      world.foodPiles = [{ foodPileId: 99, tileX: 5, tileY: 5, pickupsRemaining: 1, pickupsInitial: 1 }];
+      // both colonies below threshold
+      expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.None);
+    });
+
+    it('returns None when one colony has food above threshold', () => {
+      const { world } = makeV22WorldWith2Colonies();
+      world.foodPiles = [];
+      world.colonies[1]!.foodStored = STALEMATE_FOOD_THRESHOLD_FP + 100;
+      world.colonies[2]!.foodStored = 0;
+      expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.None);
+    });
+
+    it('returns MutualDestruction when food depleted and both colonies starving', () => {
+      const { world } = makeV22WorldWith2Colonies();
+      world.foodPiles = [];
+      world.colonies[1]!.foodStored = 0;
+      world.colonies[2]!.foodStored = 0;
+      expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.MutualDestruction);
+    });
+
+    it('emits a round_end event with reason StalemateTiebreak', () => {
+      const { world } = makeV22WorldWith2Colonies();
+      world.foodPiles = [];
+      world.colonies[1]!.foodStored = 0;
+      world.colonies[2]!.foodStored = 0;
+      checkTiebreaks(world, 1 as ColonyId);
+      const ev = world.events.find((e) => e.type === 'round_end');
+      expect(ev).toBeDefined();
+      if (ev && ev.type === 'round_end') {
+        expect(ev.payload.reason).toBe('StalemateTiebreak');
+      }
+    });
+
+    it('timeout takes priority over stalemate when both conditions are met', () => {
+      const { world } = makeV22WorldWith2Colonies();
+      world.tick = MATCH_TIMEOUT_TICKS;
+      world.foodPiles = [];
+      world.colonies[1]!.foodStored = 0;
+      world.colonies[2]!.foodStored = 0;
+      checkTiebreaks(world, 1 as ColonyId);
+      const ev = world.events.find((e) => e.type === 'round_end');
+      if (ev && ev.type === 'round_end') {
+        expect(ev.payload.reason).toBe('TimeoutTiebreak');
+      }
+    });
+  });
+
+  it('returns None when AI queen is dead (checkQueenDeath handles that, not checkTiebreaks)', () => {
+    const { world, queen2 } = makeV22WorldWith2Colonies();
+    world.tick = MATCH_TIMEOUT_TICKS;
+    world.ants.alive[queen2] = 0;
+    expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.None);
   });
 });

--- a/src/sim/game-over.test.ts
+++ b/src/sim/game-over.test.ts
@@ -137,6 +137,9 @@ function makeV22WorldWith2Colonies(playerColonyId = 1, aiColonyId = 2): {
   const addWorker = (colonyId: number): number => {
     const id = allocateEntityId(world);
     initAnt(world.ants, id, { colonyId: colonyId as ColonyId, posX: 1, posY: 1, task: AntTask.Idle, subTask: 0, speed: 0 });
+    // Must push into colony.workers so livingWorkerCount (which iterates colony.workers) sees this ant.
+    world.colonies[colonyId]!.workers.push(id);
+    world.colonies[colonyId]!.workerCount += 1;
     return id;
   };
 

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -302,18 +302,16 @@ function colonyFoodWithCarried(world: WorldState, colony: ColonyRecord): number 
 }
 
 /**
- * Count living non-queen ants for a given colony (workers only).
- * Iterates the full ants store — acceptable at end-of-game only (called once).
+ * Count living workers for a given colony (excludes queen, eggs, and larvae).
+ * Uses colony.workers bucket — eggs/larvae have alive===1 in world.ants but are
+ * not workers, so iterating world.ants directly would overcount.
  */
 function livingWorkerCount(world: WorldState, colonyId: ColonyId): number {
   const colony = world.colonies[colonyId];
   if (colony === undefined) return 0;
-  const queenId = colony.queenEntityId;
   let count = 0;
-  for (let id = 0; id < world.ants.alive.length; id++) {
-    if (world.ants.alive[id] === 1 && world.ants.colonyId[id] === colonyId && id !== queenId) {
-      count += 1;
-    }
+  for (const id of colony.workers) {
+    if (world.ants.alive[id] === 1) count += 1;
   }
   return count;
 }

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -351,11 +351,10 @@ export function checkTiebreaks(world: WorldState, playerColonyId: ColonyId): Gam
   }
   if (aiColonyId === null || aiColony === null) return GameOutcome.None;
 
-  const playerWorkers = livingWorkerCount(world, playerColonyId);
-  const aiWorkers = livingWorkerCount(world, aiColonyId);
-
   // --- Timeout: both queens alive at the match time cap ---
   if (world.tick >= MATCH_TIMEOUT_TICKS) {
+    const playerWorkers = livingWorkerCount(world, playerColonyId);
+    const aiWorkers = livingWorkerCount(world, aiColonyId);
     emitEvent(world, {
       tick: world.tick,
       type: 'round_end',
@@ -372,6 +371,8 @@ export function checkTiebreaks(world: WorldState, playerColonyId: ColonyId): Gam
     colonyFoodWithCarried(world, playerColony) < STALEMATE_FOOD_THRESHOLD_FP &&
     colonyFoodWithCarried(world, aiColony) < STALEMATE_FOOD_THRESHOLD_FP
   ) {
+    const playerWorkers = livingWorkerCount(world, playerColonyId);
+    const aiWorkers = livingWorkerCount(world, aiColonyId);
     emitEvent(world, {
       tick: world.tick,
       type: 'round_end',

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -2,6 +2,8 @@
 // S0b: emits queen_death SimEvent on first detection (cause: null for pre-V16 saves).
 // S1: reads pendingQueenDeathContexts (written by killAnt) to fill in cause=InvasionKill.
 // S2: two-pass loop for MutualDestruction; reads aiState for aiStateAtTime; full inferCause.
+// S5 (V22): checkTiebreaks — Timeout (both queens survive to MATCH_TIMEOUT_TICKS) and
+//           Stalemate (all surface food gone + both colonies below STALEMATE_FOOD_THRESHOLD_FP).
 
 export const GameOutcome = {
   None: 0,
@@ -14,8 +16,14 @@ export type GameOutcome = typeof GameOutcome[keyof typeof GameOutcome];
 import type { WorldState, AIState } from './types.js';
 import type { ColonyId, ColonyRecord } from './colony/colony-store.js';
 import { emitEvent } from './telemetry.js';
-import { SIM_VERSION_V16_COMBAT_HPDPS, SIM_VERSION_V19_AI_STATE } from './types.js';
+import { SIM_VERSION_V16_COMBAT_HPDPS, SIM_VERSION_V19_AI_STATE, SIM_VERSION_V22_DIFFICULTY } from './types.js';
 import { FP_SHIFT } from './fixed.js';
+import { colonyFoodTotal } from './colony/colony-system.js';
+import {
+  PLAYER_COLONY_ID,
+  MATCH_TIMEOUT_TICKS,
+  STALEMATE_FOOD_THRESHOLD_FP,
+} from './constants.js';
 
 /**
  * S2 — infer queen_death cause from the kill context and game outcome.
@@ -270,4 +278,90 @@ function _isQueenAliveAndEmitLegacy(world: WorldState, colony: ColonyRecord): bo
     return false;
   }
   return true;
+}
+
+// ---------------------------------------------------------------------------
+// S5 (V22) — Tiebreak detection: Timeout and Stalemate
+// ---------------------------------------------------------------------------
+
+/**
+ * Count living non-queen ants for a given colony (workers only).
+ * Iterates the full ants store — acceptable at end-of-game only (called once).
+ */
+function livingWorkerCount(world: WorldState, colonyId: ColonyId): number {
+  const colony = world.colonies[colonyId];
+  if (colony === undefined) return 0;
+  const queenId = colony.queenEntityId;
+  let count = 0;
+  for (let id = 0; id < world.ants.alive.length; id++) {
+    if (world.ants.alive[id] === 1 && world.ants.colonyId[id] === colonyId && id !== queenId) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * S5 (V22) — Check tiebreak conditions when both queens are still alive.
+ * Must be called from tick.ts step 18 after checkQueenDeath returns None.
+ *
+ * Timeout: both queens survive to MATCH_TIMEOUT_TICKS; winner by living worker count.
+ * Stalemate: all surface food piles depleted AND both colonies below STALEMATE_FOOD_THRESHOLD_FP.
+ *
+ * Returns GameOutcome.None if no tiebreak condition is met, or if world.simVersion < V22.
+ * Emits a 'round_end' SimEvent for playtrace roundEndReason attribution.
+ */
+export function checkTiebreaks(world: WorldState, playerColonyId: ColonyId): GameOutcome {
+  if (world.simVersion < SIM_VERSION_V22_DIFFICULTY) return GameOutcome.None;
+
+  // Only fires when both queens are alive (checkQueenDeath already handled queen deaths).
+  const playerColony = world.colonies[playerColonyId];
+  if (playerColony === undefined) return GameOutcome.None;
+  if (world.ants.alive[playerColony.queenEntityId] !== 1) return GameOutcome.None;
+
+  // Find AI colony (first non-player colony).
+  let aiColonyId: ColonyId | null = null;
+  let aiColony: ColonyRecord | null = null;
+  for (const key in world.colonies) {
+    if (!Object.hasOwn(world.colonies, key)) continue;
+    const cid = Number(key) as ColonyId;
+    if (cid === playerColonyId) continue;
+    const col = world.colonies[cid]!;
+    if (world.ants.alive[col.queenEntityId] !== 1) return GameOutcome.None; // AI queen dead → not a tiebreak
+    aiColonyId = cid;
+    aiColony = col;
+    break;
+  }
+  if (aiColonyId === null || aiColony === null) return GameOutcome.None;
+
+  const playerWorkers = livingWorkerCount(world, playerColonyId);
+  const aiWorkers = livingWorkerCount(world, aiColonyId);
+
+  // --- Timeout: both queens alive at the match time cap ---
+  if (world.tick >= MATCH_TIMEOUT_TICKS) {
+    emitEvent(world, {
+      tick: world.tick,
+      type: 'round_end',
+      payload: { reason: 'TimeoutTiebreak', playerWorkerCount: playerWorkers, aiWorkerCount: aiWorkers },
+    });
+    if (playerWorkers > aiWorkers) return GameOutcome.Victory;
+    if (aiWorkers > playerWorkers) return GameOutcome.Defeat;
+    return GameOutcome.MutualDestruction;
+  }
+
+  // --- Stalemate: no food on the map AND both colonies starving ---
+  if (
+    world.foodPiles.length === 0 &&
+    colonyFoodTotal(playerColony) < STALEMATE_FOOD_THRESHOLD_FP &&
+    colonyFoodTotal(aiColony) < STALEMATE_FOOD_THRESHOLD_FP
+  ) {
+    emitEvent(world, {
+      tick: world.tick,
+      type: 'round_end',
+      payload: { reason: 'StalemateTiebreak', playerWorkerCount: playerWorkers, aiWorkerCount: aiWorkers },
+    });
+    return GameOutcome.MutualDestruction;
+  }
+
+  return GameOutcome.None;
 }

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -285,6 +285,23 @@ function _isQueenAliveAndEmitLegacy(world: WorldState, colony: ColonyRecord): bo
 // ---------------------------------------------------------------------------
 
 /**
+ * Colony food total including food currently carried by living ants.
+ * `colonyFoodTotal` (colony-system) covers stored+chamber food but not in-transit food,
+ * which must be counted to avoid triggering a false stalemate on the tick the last
+ * pile is collected (foragers may carry enough food for the colony to recover).
+ */
+function colonyFoodWithCarried(world: WorldState, colony: ColonyRecord): number {
+  let total = colonyFoodTotal(colony);
+  const cid = colony.colonyId;
+  for (let id = 0; id < world.ants.alive.length; id++) {
+    if (world.ants.alive[id] === 1 && world.ants.colonyId[id] === cid) {
+      total += world.ants.foodCarrying[id] as number;
+    }
+  }
+  return total;
+}
+
+/**
  * Count living non-queen ants for a given colony (workers only).
  * Iterates the full ants store — acceptable at end-of-game only (called once).
  */
@@ -349,11 +366,11 @@ export function checkTiebreaks(world: WorldState, playerColonyId: ColonyId): Gam
     return GameOutcome.MutualDestruction;
   }
 
-  // --- Stalemate: no food on the map AND both colonies starving ---
+  // --- Stalemate: no food on the map AND both colonies starving (including carried food) ---
   if (
     world.foodPiles.length === 0 &&
-    colonyFoodTotal(playerColony) < STALEMATE_FOOD_THRESHOLD_FP &&
-    colonyFoodTotal(aiColony) < STALEMATE_FOOD_THRESHOLD_FP
+    colonyFoodWithCarried(world, playerColony) < STALEMATE_FOOD_THRESHOLD_FP &&
+    colonyFoodWithCarried(world, aiColony) < STALEMATE_FOOD_THRESHOLD_FP
   ) {
     emitEvent(world, {
       tick: world.tick,

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -11,7 +11,7 @@
 
 import type { WorldState, SpiderState } from './types.js';
 import { createWorldState, allocateEntityId } from './types.js';
-import { createDefaultAIStateRecord } from './ai-state.js';
+import { createDefaultAIStateRecord, tierIndex } from './ai-state.js';
 import { createSurfaceGrid, createUndergroundGrid, SurfaceTileState, UndergroundTileState, ugSet } from './terrain.js';
 import { initAnt } from './ant/ant-store.js';
 import { createColonyRecord } from './colony/colony-store.js';
@@ -45,6 +45,7 @@ import {
   SPIDER_HP_FULL,
   SPIDER_TERRITORY_RADIUS_TILES,
   SPIDER_HUNT_INTERVAL_TICKS,
+  QUEEN_EGG_INTERVAL_DIFFICULTY_NUMERATOR,
 } from './constants.js';
 
 // ---------------------------------------------------------------------------
@@ -316,11 +317,14 @@ function _placeSpider(world: WorldState): SpiderState {
  *   8. Create pheromone grids for each colony (FoodTrail + DangerTrail, both zones)
  *   9. Write back rngState
  *
- * @param seed - Mulberry32 seed for deterministic generation.
+ * @param seed       - Mulberry32 seed for deterministic generation.
+ * @param difficulty - S5 player-selected difficulty tier. Stored on world.difficulty.
+ *                     Defaults to 'Normal' for backward-compatible call sites.
  */
-export function createScenario(seed: number): WorldState {
+export function createScenario(seed: number, difficulty: 'Easy' | 'Normal' | 'Hard' = 'Normal'): WorldState {
   // --- Step 1: Create base WorldState ---
   const world = createWorldState(seed);
+  world.difficulty = difficulty;
 
   // Reconstruct PRNG from seed-derived rngState (PRD §4 integration contract)
   const rng = new Rng(world.rngState);
@@ -349,6 +353,11 @@ export function createScenario(seed: number): WorldState {
   // --- Steps 5-6: Colony initialization (player + enemy) ---
   initColony(world, PLAYER_COLONY_ID, PLAYER_START_X, PLAYER_START_Y, rng);
   initColony(world, ENEMY_COLONY_ID,  ENEMY_START_X,  ENEMY_START_Y,  rng);
+  // S5 (V22): encode difficulty scaling into the AI colony record so lifecycle-system
+  // can apply the numerator without branching on PLAYER_COLONY_ID at runtime.
+  world.colonies[ENEMY_COLONY_ID]!.eggIntervalNumerator =
+    QUEEN_EGG_INTERVAL_DIFFICULTY_NUMERATOR[tierIndex(difficulty)];
+  // Player colony keeps default eggIntervalNumerator=4 (identity).
 
   // --- Step 8: Pheromone grids — all 8 (2 colonies × 2 types × 2 zones) ---
   // All 8 must exist so tick-step lookups never hit a missing key.

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -6,7 +6,8 @@ import type { WorldState, SpiderState } from './types.js';
 import { emitEvent } from './telemetry.js';
 import { pheromoneGridKey, phGet, phSet } from './pheromone/pheromone-store.js';
 import { AntTask, PheromoneType } from './enums.js';
-import { NORMAL_TIER_INDEX } from './ai-state.js';
+import { NORMAL_TIER_INDEX, tierIndex } from './ai-state.js';
+import { SIM_VERSION_V22_DIFFICULTY } from './types.js';
 import {
   SPIDER_HP_FULL,
   SPIDER_HUNT_INTERVAL_TICKS,
@@ -407,7 +408,7 @@ export function tickSpider(world: WorldState): void {
   switch (spider.state) {
     case 'Patrolling': {
       // Hunger check first: rampaging wins over hunting on same tick.
-      if (spider.hungerTicks >= SPIDER_HUNGER_MAX_TICKS[NORMAL_TIER_INDEX]) {
+      if (spider.hungerTicks >= SPIDER_HUNGER_MAX_TICKS[world.simVersion >= SIM_VERSION_V22_DIFFICULTY ? tierIndex(world.difficulty) : NORMAL_TIER_INDEX]) {
         spider.state = 'Rampaging';
         spider.rampageStartTick = world.tick;
         spider.rampageKillsThisRampage = 0;

--- a/src/sim/telemetry.ts
+++ b/src/sim/telemetry.ts
@@ -136,6 +136,20 @@ export type SimEvent =
         };
         location: { x: number; y: number; grid: 'surface' | 'underground' };
       };
+    }
+  | {
+      // S5 (V22) — tiebreak condition reached (timeout or stalemate).
+      // Emitted by checkTiebreaks() in game-over.ts when both queens survive
+      // to MATCH_TIMEOUT_TICKS or all food is exhausted below the stalemate
+      // threshold. deriveRoundEndReason() reads this to populate the playtrace
+      // roundEndReason field.
+      tick: number;
+      type: 'round_end';
+      payload: {
+        reason: 'TimeoutTiebreak' | 'StalemateTiebreak';
+        playerWorkerCount: number;
+        aiWorkerCount: number;
+      };
     };
 
 // ---------------------------------------------------------------------------

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1,9 +1,9 @@
 // src/sim/tick.ts — Phase 9 19-step tick dispatcher.
 import type { WorldState } from './types.js';
-import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY, SIM_VERSION_V11_DEFENSIVE_BUNDLE, SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX, SIM_VERSION_V19_AI_STATE, SIM_VERSION_V20_SPIDER, SIM_VERSION_V21_REPRODUCTION } from './types.js';
+import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V5_CHAMBER_ON_MARKED, SIM_VERSION_V9_CANCEL_DROPS_PENDING, SIM_VERSION_V10_VISIBLE_BROOD_CARRY, SIM_VERSION_V11_DEFENSIVE_BUNDLE, SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX, SIM_VERSION_V19_AI_STATE, SIM_VERSION_V20_SPIDER, SIM_VERSION_V21_REPRODUCTION, SIM_VERSION_V22_DIFFICULTY } from './types.js';
 import { tickSpider } from './spider.js';
 import { MAX_COMMANDS_PER_TICK, type SimCommand } from './commands.js';
-import { GameOutcome, checkQueenDeath } from './game-over.js';
+import { GameOutcome, checkQueenDeath, checkTiebreaks } from './game-over.js';
 import { advanceAIState, setAIRallyOperation } from './ai-state.js';
 import { detectAndResolveCombat } from './combat.js';
 import { Rng } from './rng.js';
@@ -29,6 +29,7 @@ import {
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
   SPIDER_SCATTER_RADIUS_TILES,
+  PLAYER_COLONY_ID,
 } from './constants.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
 import { allocateWorkers, computeDigDemand } from './behavior/allocation-system.js';
@@ -1305,7 +1306,10 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   // ---------------------------------------------------------------------------
   // Step 18: game-over detection (Phase 9 / CMBT-06/07).
   // ---------------------------------------------------------------------------
-  const outcome = checkQueenDeath(world);
+  let outcome = checkQueenDeath(world);
+  if (outcome === GameOutcome.None && world.simVersion >= SIM_VERSION_V22_DIFFICULTY) {
+    outcome = checkTiebreaks(world, PLAYER_COLONY_ID);
+  }
 
   // ---------------------------------------------------------------------------
   // Step 18b: Advance AI state machines (timeout/death transitions).

--- a/src/sim/types.test.ts
+++ b/src/sim/types.test.ts
@@ -29,10 +29,10 @@ describe('WorldState', () => {
       expect(world.rngState).toBe(4294967295);
     });
 
-    it('has exactly twenty-two fields (4 Phase 5 + 3 Phase 6 + 4 Phase 7 + 1 issue #27 + 1 issue #44 + 1 issue #112 + 3 S0b telemetry + 1 S1 pendingQueenDeathContexts + 1 S2 aiState + 3 S3 spider)', () => {
+    it('has exactly twenty-three fields (4 Phase 5 + 3 Phase 6 + 4 Phase 7 + 1 issue #27 + 1 issue #44 + 1 issue #112 + 3 S0b telemetry + 1 S1 pendingQueenDeathContexts + 1 S2 aiState + 3 S3 spider + 1 S5 difficulty)', () => {
       const world = createWorldState(0);
       const keys = Object.keys(world);
-      expect(keys).toHaveLength(22);
+      expect(keys).toHaveLength(23);
       expect(keys).toContain('tick');
       expect(keys).toContain('rngState');
       expect(keys).toContain('nextEntityId');
@@ -54,6 +54,7 @@ describe('WorldState', () => {
       expect(keys).toContain('spider'); // S3
       expect(keys).toContain('spiderPriorityColonyId'); // S3
       expect(keys).toContain('scatterReticleTile'); // S3
+      expect(keys).toContain('difficulty'); // S5
     });
 
     it('issue #44: terrainSeed is a deterministic, non-zero, non-rngState mix of the input seed', () => {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -265,7 +265,17 @@ export const SIM_VERSION_V20_SPIDER = 20 as const;
  * No new WorldState fields; all state derived from existing food/colony/nurse data.
  */
 export const SIM_VERSION_V21_REPRODUCTION = 21 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V21_REPRODUCTION;
+/**
+ * V22 (S5) — Difficulty tier system. Adds WorldState.difficulty ('Easy' | 'Normal' | 'Hard').
+ * Wires difficulty into four AI constants previously hardcoded to Normal-tier index.
+ * Applies a per-difficulty brood modifier to AI colony egg interval (below the V21 150-tick
+ * surplus floor, hard-clamped at MIN_EGG_INTERVAL_TICKS=100).
+ * Adds Timeout and Stalemate tiebreak conditions (checkTiebreaks in game-over.ts).
+ * Pre-V22 saves load with difficulty='Normal'; all V22-gated paths fall back to Normal-tier
+ * behaviour for byte-identical replay of pre-V22 recordings.
+ */
+export const SIM_VERSION_V22_DIFFICULTY = 22 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V22_DIFFICULTY;
 
 
 /**
@@ -410,9 +420,20 @@ export interface WorldState {
    *       no carry happens and brood sits where laid (matches pre-v10
    *       teleport-gate behaviour).
    *
+   *  22 = S5 difficulty tier system. Adds `difficulty` field. Wires difficulty
+   *       into AI constants (tierIndex vs NORMAL_TIER_INDEX), applies a brood-
+   *       production modifier to AI colony egg intervals, and enables Timeout
+   *       and Stalemate tiebreak conditions. Pre-V22 saves load with
+   *       difficulty='Normal' and replay byte-identically.
+   *
    * Round-trips through copyWorldState and save/load.
    */
   simVersion: number;
+
+  /** S5 (V22) — player-selected difficulty. Wired into AI tier arrays and AI brood
+   *  modifier. Pre-V22 saves load as 'Normal'. Round-trips through copyWorldState
+   *  and save/load. */
+  difficulty: 'Easy' | 'Normal' | 'Hard';
 
   /**
    * Issue #44 — terrain decoration seed. Independent of `rngState` so that
@@ -512,6 +533,7 @@ export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIE
     nextEntityId: 0,      // PRD §3 line 130: starts at 0, no recycling
     commandQueue: [],
     simVersion: LATEST_SIM_VERSION,
+    difficulty: 'Normal',
     // Issue #44 — derive terrainSeed from the input seed via Knuth's golden-
     // ratio multiplier so it's a deterministic function of the seed but
     // doesn't equal rngState. Using rngState directly would couple the very-
@@ -560,6 +582,7 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   dst.rngState = src.rngState;
   dst.nextEntityId = src.nextEntityId;
   dst.simVersion = src.simVersion;
+  dst.difficulty = src.difficulty;
   dst.terrainSeed = src.terrainSeed;
   dst.commandQueue = src.commandQueue.slice(); // small in practice (user-input rate) — PRD §3 accepts this as the only Phase 1 allocation
   // events: intentionally not copied into the render double-buffer (prevState).
@@ -768,6 +791,7 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
     d.killCount            = s.killCount;
     d.priorityFoodPileId   = s.priorityFoodPileId;
     d.queenLastEggTick     = s.queenLastEggTick;
+    d.eggIntervalNumerator = s.eggIntervalNumerator;
 
     // Bucket arrays — reuse via length truncation + index copy (no new array)
     d.eggs.length = s.eggs.length;


### PR DESCRIPTION
## Summary

- **Sim version V22**: adds `WorldState.difficulty` ('Easy'|'Normal'|'Hard'), updated from V21 to V22 as LATEST_SIM_VERSION
- **Pre-game difficulty overlay**: Phaser modal (matching save-prompt pattern) shown before every new game and restart; retry reuses previous difficulty
- **AI brood modifier**: `ColonyRecord.eggIntervalNumerator` stores per-colony scaling (Easy=5, Normal=4, Hard=3); lifecycle-system applies `(interval * numerator) >> 2` — integer-only, no division operator; hard floor at `MIN_EGG_INTERVAL_TICKS=100`
- **AI tier-array lookup gates**: warfooting/invading thresholds, recovery duration, spider hunger cap all switch from `NORMAL_TIER_INDEX` to `tierIndex(world.difficulty)` at V22+
- **Timeout tiebreak** (`MATCH_TIMEOUT_TICKS=24000`): both queens survive to tick 24000 → winner by living worker count → Victory/Defeat/MutualDestruction
- **Stalemate tiebreak** (`STALEMATE_FOOD_THRESHOLD_FP=512`): all food piles depleted AND both colonies below threshold → MutualDestruction
- **`round_end` SimEvent**: emitted by `checkTiebreaks()` for playtrace attribution; `deriveRoundEndReason()` checks it before `queen_death`
- **Backward compat**: pre-V22 saves load with `difficulty='Normal'` and `eggIntervalNumerator=4` (identity); all V22-gated paths fall back to Normal-tier behaviour for byte-identical replay

## Test plan

- [ ] `npm run test` — 73 files, 2201 tests pass
- [ ] `npm run test:coverage` — statements 90%, branches 83%, functions 96%, lines 93% (all above 80% gate)
- [ ] `npx tsc --noEmit` — clean
- [ ] Manual: new game → difficulty overlay appears → choose Hard → F9 snapshot shows `difficulty: 'Hard'` and AI colony `eggIntervalNumerator: 3`
- [ ] Manual: continue from save → no difficulty overlay; difficulty loads from save
- [ ] Manual: Hard mode → AI egg interval ~112 ticks vs Normal 150 (visible in F9 snapshot)
- [ ] Manual: retry → same difficulty preserved
- [ ] Manual: run to tick 24000 with both queens alive → tiebreak fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)