### PR TITLE
feat(s6): diegetic polish + light onboarding

### DIFF
--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -429,7 +429,7 @@ export function drawSurfaceEntities(
         1,
       );
       // S6: linear tint gradient pale (#ffeecc) → deep red (#cc2020) by hungerFraction.
-      const tint = lerpColor(0xffeecccc, 0xcc2020, hungerFraction);
+      const tint = lerpColor(0xffeecc, 0xcc2020, hungerFraction);
 
       sprites.drawSpider({ x: spiderScreenX, y: spiderScreenY, tint });
 

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -32,6 +32,7 @@ import {
   COLOR_RALLY_POINT,
   COLOR_FIGHTER_TINT,
   COLOR_CONTESTED_TILE,
+  COLOR_NEUTRAL_CONTESTED_GLOW,
   lerpColor,
 } from './sprites.js';
 import {
@@ -138,6 +139,9 @@ export function drawSurfaceEntities(
   cam: CameraState,
   pendingEntrance: { tileX: number; tileY: number } | null = null,
   facing?: AntFacingCache,
+  frameTimeMs: number = 0,
+  contestedGlowFrames?: Map<number, number>,
+  currentFrame: number = 0,
 ): void {
   const left = Math.floor(cam.x - cam.viewportWidth  / 2);
   const top  = Math.floor(cam.y - cam.viewportHeight / 2);
@@ -245,9 +249,9 @@ export function drawSurfaceEntities(
     }
   }
 
-  // --- Contested tile glow (S1) ---
-  // Draw a faint orange tint under ants on tiles where 2+ colonies meet.
-  // Two-pass: first collect contested surface tiles, then draw glows before ants.
+  // --- Surface contested tile glow (S1 → S6 polished) ---
+  // S6: surface combat uses COLOR_NEUTRAL_CONTESTED_GLOW (yellow) instead of
+  // the raw orange. A 5-frame fade-out is tracked via contestedGlowFrames.
   {
     const tileColony = new Map<number, number>(); // tileKey → first colonyId
     const contested  = new Set<number>();
@@ -263,28 +267,76 @@ export function drawSurfaceEntities(
       if (existing === undefined) tileColony.set(key, cid);
       else if (existing !== cid) contested.add(key);
     }
-    for (const key of contested) {
+    // Stamp active contested tiles with the current frame number.
+    if (contestedGlowFrames) {
+      for (const key of contested) {
+        contestedGlowFrames.set(key, currentFrame);
+      }
+    }
+    // Draw glows for all tiles that were contested within the last 5 frames.
+    const GLOW_FADE_FRAMES = 5;
+    const tilesToDraw = contestedGlowFrames ? contestedGlowFrames : null;
+    const drawKeys = tilesToDraw
+      ? Array.from(tilesToDraw.entries())
+          .filter(([, frame]) => currentFrame - frame < GLOW_FADE_FRAMES)
+          .map(([key]) => key)
+      : Array.from(contested);
+    for (const key of drawKeys) {
       const tx = key & 0xffff;
       const ty = (key >> 16) & 0xffff;
       const sx = (tx - left) * TILE_SIZE_PX;
       const sy = (ty - top)  * TILE_SIZE_PX;
       if (sx < -TILE_SIZE_PX || sx > canvasW || sy < -TILE_SIZE_PX || sy > canvasH) continue;
-      gfx.fillStyle(COLOR_CONTESTED_TILE, 0.25);
-      gfx.fillRect(sx, sy, TILE_SIZE_PX, TILE_SIZE_PX);
+      // Fade alpha based on frames since last seen.
+      const framesAgo = tilesToDraw ? (currentFrame - (tilesToDraw.get(key) ?? currentFrame)) : 0;
+      const alpha_g = 0.15 * (1 - framesAgo / GLOW_FADE_FRAMES);
+      if (alpha_g <= 0) continue;
+      // Soft edge: draw the center tile at full alpha, then draw 1px-thin
+      // border rects at half alpha to create a soft halo effect.
+      gfx.fillStyle(COLOR_NEUTRAL_CONTESTED_GLOW, alpha_g);
+      gfx.fillRect(sx + 2, sy + 2, TILE_SIZE_PX - 4, TILE_SIZE_PX - 4);
+      gfx.fillStyle(COLOR_NEUTRAL_CONTESTED_GLOW, alpha_g * 0.5);
+      gfx.fillRect(sx,      sy,      TILE_SIZE_PX, 2);
+      gfx.fillRect(sx,      sy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2);
+      gfx.fillRect(sx,      sy + 2,  2, TILE_SIZE_PX - 4);
+      gfx.fillRect(sx + TILE_SIZE_PX - 2, sy + 2, 2, TILE_SIZE_PX - 4);
+    }
+    // Prune stale entries so the map doesn't grow without bound.
+    if (tilesToDraw) {
+      for (const [key, frame] of tilesToDraw) {
+        if (currentFrame - frame >= GLOW_FADE_FRAMES) tilesToDraw.delete(key);
+      }
     }
   }
 
-  // --- Hunt reticle (S3) ---
-  // Draw a red tile overlay at the spider's locked target during Hunting/Striking.
-  // Drawn before ants so workers on the target tile are visible over the reticle.
-  // world.scatterReticleTile is the one-tick-lag shadow field written by tickSpider.
+  // --- Hunt reticle (S3 → S6 polished) ---
+  // S6: deep red border with animated alpha pulse; subtle fill at 0.3 alpha.
   if (curr.scatterReticleTile !== null) {
     const { x: rtx, y: rty } = curr.scatterReticleTile;
     const rsx = (rtx - left) * TILE_SIZE_PX;
     const rsy = (rty - top)  * TILE_SIZE_PX;
     if (rsx > -TILE_SIZE_PX && rsx < canvasW && rsy > -TILE_SIZE_PX && rsy < canvasH) {
-      gfx.fillStyle(0xFF2200, 0.45);
-      gfx.fillRect(rsx, rsy, TILE_SIZE_PX, TILE_SIZE_PX);
+      // Pulse: alpha oscillates between 0.4 and 0.7 at 1 Hz.
+      const pulse = 0.55 + 0.15 * Math.sin((2 * Math.PI * frameTimeMs) / 1000);
+      // Scale: 1.0–1.05× on pulse (shift origin to tile center).
+      const scalePulse = 1.0 + 0.025 * Math.sin((2 * Math.PI * frameTimeMs) / 1000);
+      const sizeOffset = (TILE_SIZE_PX * (scalePulse - 1)) / 2;
+      // Tile fill at 0.3 alpha.
+      gfx.fillStyle(0xcc1010, 0.3);
+      gfx.fillRect(
+        rsx - sizeOffset, rsy - sizeOffset,
+        TILE_SIZE_PX * scalePulse, TILE_SIZE_PX * scalePulse,
+      );
+      // Border at pulsed alpha: draw as 2-px edge strips.
+      const bw = TILE_SIZE_PX * scalePulse;
+      const bh = TILE_SIZE_PX * scalePulse;
+      const bx = rsx - sizeOffset;
+      const by = rsy - sizeOffset;
+      gfx.fillStyle(0xcc1010, pulse);
+      gfx.fillRect(bx,          by,          bw, 2);
+      gfx.fillRect(bx,          by + bh - 2, bw, 2);
+      gfx.fillRect(bx,          by + 2,      2,  bh - 4);
+      gfx.fillRect(bx + bw - 2, by + 2,      2,  bh - 4);
     }
   }
 
@@ -376,18 +428,28 @@ export function drawSurfaceEntities(
         curr.spider.hungerTicks / SPIDER_HUNGER_MAX_TICKS[curr.simVersion >= SIM_VERSION_V22_DIFFICULTY ? tierIndex(curr.difficulty) : NORMAL_TIER_INDEX],
         1,
       );
-      const tint = lerpColor(0xCCCCCC, 0xFF3300, hungerFraction);
+      // S6: linear tint gradient pale (#ffeecc) → deep red (#cc2020) by hungerFraction.
+      const tint = lerpColor(0xffeecccc, 0xcc2020, hungerFraction);
 
       sprites.drawSpider({ x: spiderScreenX, y: spiderScreenY, tint });
 
-      // Hunger ring: appears at 70% hunger, fades in to full alpha at 100%.
+      // Hunger ring (S3 → S6 polished):
+      // Appears at 70% hunger, fades in to full alpha at 100%.
+      // At ≥80%, an additional faster pulse (0.5 Hz) signals rampage warning.
       if (hungerFraction > 0.7) {
-        const ringAlpha = ((hungerFraction - 0.7) / 0.3) * 0.85;
+        const baseRingAlpha = ((hungerFraction - 0.7) / 0.3) * 0.85;
+        // S6: rampage warning pulse at ≥80% hunger.
+        const rampagePulse = hungerFraction >= 0.8
+          ? 0.1 * Math.sin((2 * Math.PI * frameTimeMs) / 2000)
+          : 0;
+        const ringAlpha = Math.min(1, baseRingAlpha + rampagePulse);
         const rl = Math.round(spiderScreenX - SPIDER_SPRITE_WIDTH  / 2);
         const rt = Math.round(spiderScreenY - SPIDER_SPRITE_HEIGHT / 2);
         const rw = SPIDER_SPRITE_WIDTH;
         const rh = SPIDER_SPRITE_HEIGHT;
-        gfx.fillStyle(0xFF4400, ringAlpha);
+        // S6: smooth gradient by color-lerping the ring toward deep red.
+        const ringColor = lerpColor(0xffeecc, 0xcc2020, hungerFraction);
+        gfx.fillStyle(ringColor, ringAlpha);
         gfx.fillRect(rl,          rt,          rw, 2);
         gfx.fillRect(rl,          rt + rh - 2, rw, 2);
         gfx.fillRect(rl,          rt + 2,      2,  rh - 4);

--- a/src/render/draw-underground.ts
+++ b/src/render/draw-underground.ts
@@ -44,6 +44,8 @@ import {
   COLOR_QUEEN_OUTLINE,
   COLOR_FIGHTER_TINT,
   COLOR_CONTESTED_TILE,
+  COLOR_PLAYER_HOME_GLOW,
+  COLOR_ENEMY_HOME_GLOW,
 } from './sprites.js';
 import {
   drawBarrenEarthSubstrate,
@@ -268,6 +270,8 @@ export function drawUndergroundEntities(
   cam: CameraState,
   activeUndergroundColonyId: ColonyId = PLAYER_COLONY_ID,
   facing?: AntFacingCache,
+  undergoundGlowFrames?: Map<number, number>,
+  currentFrame: number = 0,
 ): void {
   const colony = curr.colonies[activeUndergroundColonyId];
   if (colony === undefined) return;
@@ -413,6 +417,72 @@ export function drawUndergroundEntities(
   // Note the asymmetry with the per-active-colony `isQueen` check below: the
   // queen check stays single-colony because queens never cross grids and
   // entity IDs are world-globally unique (no collision risk).
+  // --- Underground home-ground combat tile glow (S6) ---
+  // Per-grid color: blue for player grid, orange for enemy grid.
+  // Fade-out over 5 frames once combat ants leave a tile.
+  {
+    const glowColor = activeUndergroundColonyId === PLAYER_COLONY_ID
+      ? COLOR_PLAYER_HOME_GLOW
+      : COLOR_ENEMY_HOME_GLOW;
+    const BASE_ALPHA = 0.2;
+    const GLOW_FADE_FRAMES = 5;
+
+    // Collect tiles that have ants from 2+ colonies.
+    const tileColony = new Map<number, number>(); // tileKey → first colonyId
+    const contested = new Set<number>();
+    const n = curr.ants.alive.length;
+    for (let id = 0; id < n; id++) {
+      if (!isAlive(curr.ants, id)) continue;
+      if (curr.ants.zone[id] !== 1) continue;
+      if (curr.ants.currentGridColonyId[id] !== activeUndergroundColonyId) continue;
+      const tx = curr.ants.posX[id]! >> 8;
+      const ty = curr.ants.posY[id]! >> 8;
+      const key = (ty << 16) | tx;
+      const cid = curr.ants.colonyId[id]!;
+      const existing = tileColony.get(key);
+      if (existing === undefined) tileColony.set(key, cid);
+      else if (existing !== cid) contested.add(key);
+    }
+    // Stamp active tiles with current frame.
+    if (undergoundGlowFrames) {
+      for (const key of contested) {
+        undergoundGlowFrames.set(key, currentFrame);
+      }
+    }
+    // Draw glows for all contested or recently-contested tiles.
+    const drawKeys = undergoundGlowFrames
+      ? Array.from(undergoundGlowFrames.entries())
+          .filter(([, frame]) => currentFrame - frame < GLOW_FADE_FRAMES)
+          .map(([key]) => key)
+      : Array.from(contested);
+    for (const key of drawKeys) {
+      const tx = key & 0xffff;
+      const ty = (key >> 16) & 0xffff;
+      const sx = (tx - left) * TILE_SIZE_PX;
+      const sy = (ty - top)  * TILE_SIZE_PX;
+      if (sx < -TILE_SIZE_PX || sx > canvasW || sy < -TILE_SIZE_PX || sy > canvasH) continue;
+      const framesAgo = undergoundGlowFrames
+        ? (currentFrame - (undergoundGlowFrames.get(key) ?? currentFrame))
+        : 0;
+      const alpha_g = BASE_ALPHA * (1 - framesAgo / GLOW_FADE_FRAMES);
+      if (alpha_g <= 0) continue;
+      // Soft edge.
+      gfx.fillStyle(glowColor, alpha_g);
+      gfx.fillRect(sx + 2, sy + 2, TILE_SIZE_PX - 4, TILE_SIZE_PX - 4);
+      gfx.fillStyle(glowColor, alpha_g * 0.5);
+      gfx.fillRect(sx,      sy,      TILE_SIZE_PX, 2);
+      gfx.fillRect(sx,      sy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2);
+      gfx.fillRect(sx,      sy + 2,  2, TILE_SIZE_PX - 4);
+      gfx.fillRect(sx + TILE_SIZE_PX - 2, sy + 2, 2, TILE_SIZE_PX - 4);
+    }
+    // Prune stale entries.
+    if (undergoundGlowFrames) {
+      for (const [key, frame] of undergoundGlowFrames) {
+        if (currentFrame - frame >= GLOW_FADE_FRAMES) undergoundGlowFrames.delete(key);
+      }
+    }
+  }
+
   const broodIds = new Set<number>();
   for (const c of Object.values(curr.colonies)) {
     if (c === undefined) continue;

--- a/src/render/draw-underground.ts
+++ b/src/render/draw-underground.ts
@@ -437,7 +437,9 @@ export function drawUndergroundEntities(
       if (curr.ants.currentGridColonyId[id] !== activeUndergroundColonyId) continue;
       const tx = curr.ants.posX[id]! >> 8;
       const ty = curr.ants.posY[id]! >> 8;
-      const key = (ty << 16) | tx;
+      // Include activeUndergroundColonyId in the high byte so entries for
+      // different colony views don't collide when the player switches grids.
+      const key = (activeUndergroundColonyId << 24) | (ty << 16) | tx;
       const cid = curr.ants.colonyId[id]!;
       const existing = tileColony.get(key);
       if (existing === undefined) tileColony.set(key, cid);
@@ -452,12 +454,14 @@ export function drawUndergroundEntities(
     // Draw glows for all contested or recently-contested tiles.
     const drawKeys = undergoundGlowFrames
       ? Array.from(undergoundGlowFrames.entries())
-          .filter(([, frame]) => currentFrame - frame < GLOW_FADE_FRAMES)
+          .filter(([key, frame]) =>
+            (key >>> 24) === activeUndergroundColonyId &&
+            currentFrame - frame < GLOW_FADE_FRAMES)
           .map(([key]) => key)
       : Array.from(contested);
     for (const key of drawKeys) {
-      const tx = key & 0xffff;
-      const ty = (key >> 16) & 0xffff;
+      const tx = key & 0xff;         // bits 0-7; tx max = 127
+      const ty = (key >> 16) & 0xff; // bits 16-23; top byte (24+) holds colony ID
       const sx = (tx - left) * TILE_SIZE_PX;
       const sy = (ty - top)  * TILE_SIZE_PX;
       if (sx < -TILE_SIZE_PX || sx > canvasW || sy < -TILE_SIZE_PX || sy > canvasH) continue;

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -61,6 +61,7 @@ import {
   PLAYER_START_X, PLAYER_START_Y,
   SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT,
   UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT,
+  STARVATION_GRACE_TICKS,
 } from '../sim/constants.js';
 import { GameOutcome } from '../sim/game-over.js';
 import { drawSurfaceTerrain, drawSurfaceEntities, type GfxLike } from './draw-surface.js';
@@ -592,12 +593,15 @@ export class GameScene extends Phaser.Scene {
       }
 
       if (ev.type === 'ai_state_transition' && ev.payload.to === 'Invading') {
-        // Belt-and-suspenders: invasion_start is the primary trigger above;
-        // this handles any Invading transition not paired with invasion_start
-        // and also surfaces the caption on this fallback path.
+        // Belt-and-suspenders: invasion_start is the primary trigger above.
+        // This handles any Invading transition not paired with invasion_start.
+        // Gate flash + caption on checkAndTrigger so they fire exactly once:
+        // when invasion_start already fired the caption this pass, captionText
+        // is null and neither flash nor caption fires again here.
         const captionText = checkAndTrigger('aiInvading');
-        if (captionText && uiScene) {
-          uiScene.showCaption(captionText, CANVAS_W / 2, 60);
+        if (captionText) {
+          triggerScreenEdgeFlash(this, 'right', CANVAS_W, CANVAS_H);
+          if (uiScene) uiScene.showCaption(captionText, CANVAS_W / 2, 60);
         }
       }
     }
@@ -635,10 +639,12 @@ export class GameScene extends Phaser.Scene {
     }
     this.prevQueenCombinedHp = combinedHp;
 
-    // Starvation onset.
+    // Starvation onset. The timer starts at STARVATION_GRACE_TICKS (300) and
+    // decrements only when the queen fails to eat; < STARVATION_GRACE_TICKS means
+    // at least one feeding failed (starvation has actually started).
     if (
       !this.queenStarvationTriggered &&
-      playerColony.queenStarvationTimer > 0 &&
+      playerColony.queenStarvationTimer < STARVATION_GRACE_TICKS &&
       this.world.tick > QUEEN_DAMAGE_SUPPRESS_TICKS
     ) {
       this.queenStarvationTriggered = true;
@@ -742,6 +748,23 @@ export class GameScene extends Phaser.Scene {
     this.world = nextWorld;
     this.currentDifficulty = nextWorld.difficulty; // S5 — restore difficulty from save
     this.resumedFromSave = true;
+    // Seed the render event cursor from the saved world so the first render
+    // frame after resume doesn't replay historical events as new and re-fire
+    // screen flashes / captions for invasions that already happened.
+    if (nextWorld.events.length > 0) {
+      this.lastProcessedEventTick = nextWorld.events.reduce(
+        (m, e) => (e.tick > m ? e.tick : m), -1,
+      );
+    }
+    // If the queen's starvation timer was already running at save time, mark the
+    // starvation caption as triggered so the first render frame after resume does
+    // not fire a spurious flash + onboarding caption for a condition that already
+    // started before the save.
+    const playerColonyOnLoad = nextWorld.colonies[PLAYER_COLONY_ID];
+    if (playerColonyOnLoad &&
+        playerColonyOnLoad.queenStarvationTimer < STARVATION_GRACE_TICKS) {
+      this.queenStarvationTriggered = true;
+    }
     // SCEN-06 replay truth: restore inputLog completely so the continued session
     // can be replayed byte-for-byte from (seed, inputLog) per Plan 04 Task 1.
     for (const c of loaded.inputLog) this.inputLog.push(c);

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -575,8 +575,12 @@ export class GameScene extends Phaser.Scene {
 
       if (ev.type === 'ai_state_transition' && ev.payload.to === 'Invading') {
         // Belt-and-suspenders: invasion_start is the primary trigger above;
-        // this handles any Invading transition not paired with invasion_start.
-        checkAndTrigger('aiInvading'); // idempotent — no-op if already triggered
+        // this handles any Invading transition not paired with invasion_start
+        // and also surfaces the caption on this fallback path.
+        const captionText = checkAndTrigger('aiInvading');
+        if (captionText && uiScene) {
+          uiScene.showCaption(captionText, CANVAS_W / 2, 60);
+        }
       }
     }
 
@@ -746,6 +750,9 @@ export class GameScene extends Phaser.Scene {
         // S6: fire first-occurrence captions for player command types.
         const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9 | null;
         for (const cmd of cmds) {
+          // Only fire onboarding captions for player-issued commands; AI colonies
+          // enqueue commands in the same drain pass and would consume captions early.
+          if ('colonyId' in cmd && cmd.colonyId !== PLAYER_COLONY_ID) continue;
           if (cmd.type === 'MarkDigTile') {
             const text = checkAndTrigger('dig');
             if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -121,10 +121,20 @@ import {
   type UndergroundInputState,
 } from '../input/underground-input.js';
 import { hideContextMenu } from './context-menu-state.js';
+import { buildPlaytraceSummary, type GameOutcomeLabel } from './summary-builder.js';
+import { checkAndTrigger, resetCaptions } from './onboarding-captions.js';
+import {
+  triggerScreenEdgeFlash,
+  triggerQueenDamagePulse,
+  inferFlashDirection,
+  QUEEN_DAMAGE_SUPPRESS_TICKS,
+} from './screen-effects.js';
+import { ChamberType } from '../sim/enums.js';
+import { CANVAS_W, CANVAS_H } from './sprites.js';
 // UIScenePhase9 — subset of UIScene public API added in Plan 06 Task 3.
 // Typed here to avoid circular imports; UIScene implements these methods.
 interface UIScenePhase9 {
-  showGameOverOverlay(outcome: GameOutcome, cause: import('./ui-scene-logic.js').QueenDeathCause, onRestart: () => void): void;
+  showGameOverOverlay(outcome: GameOutcome, cause: import('./ui-scene-logic.js').QueenDeathCause, onRestart: () => void, narrativeSeed?: string | null): void;
   hideGameOverOverlay(): void;
   showSavePromptOverlay(callbacks: { onContinue: () => void; onNewGame: () => void }): void;
   hideSavePromptOverlay(): void;
@@ -164,6 +174,8 @@ interface UIScenePhase9 {
   // S5 — difficulty select overlay. Shown before every new game.
   showDifficultySelectOverlay(callbacks: { onSelect: (d: 'Easy' | 'Normal' | 'Hard') => void }): void;
   hideDifficultySelectOverlay(): void;
+  // S6 — first-occurrence caption overlay (light onboarding).
+  showCaption(text: string, screenX: number, screenY: number): void;
 }
 import type { SimCommand } from '../sim/commands.js';
 
@@ -217,6 +229,14 @@ export class GameScene extends Phaser.Scene {
   // below set the same field directly. Narrowed to the cycle set so the
   // type aligns with PauseMenuLayout's SpeedMultiplier.
   private speedMultiplier: 1 | 2 | 4 = 1;
+
+  // S6 — render-side scratch (per-session, reset in resetSessionState).
+  private nextEventIndex = 0;           // event cursor for consumeEventsForRender
+  private prevQueenCombinedHp: number | null = null; // queen HP tracking for damage pulse
+  private queenStarvationTriggered = false;           // starvation onset caption/pulse guard
+  private renderFrame = 0;              // frame counter for glow fade maps
+  private readonly contestedGlowFrames: Map<number, number> = new Map();  // surface glow fade
+  private readonly undergroundGlowFrames: Map<number, number> = new Map(); // underground glow fade
 
   // Issue #122 / ADR 0013 — playtrace upload state. The endpoint string is
   // sourced from the registry (set by main.ts from VITE_PLAYTRACE_ENDPOINT
@@ -479,6 +499,13 @@ export class GameScene extends Phaser.Scene {
     // would lock a freshly-spawned ant into the prior ant's direction until
     // the smoothing relaxes. Clearing here keeps boot visually clean.
     this.antFacingCache.reset();
+    // S6 — reset per-session render-side scratch.
+    this.nextEventIndex = 0;
+    this.prevQueenCombinedHp = null;
+    this.queenStarvationTriggered = false;
+    this.contestedGlowFrames.clear();
+    this.undergroundGlowFrames.clear();
+    resetCaptions();
     // Issue #122 — rotate the session UUID so each (re)start gets its own
     // telemetry row server-side.
     //
@@ -493,6 +520,127 @@ export class GameScene extends Phaser.Scene {
       typeof crypto !== 'undefined' && 'randomUUID' in crypto
         ? crypto.randomUUID()
         : '';
+  }
+
+  // ---------------------------------------------------------------------------
+  // S6 — render-side event cursor and queen status checks
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Drain world.events from the last-seen index, dispatching each new event
+   * to render-side effects (screen flash, camera nudge, captions).
+   * Called once per render frame while Playing.
+   */
+  private consumeEventsForRender(): void {
+    if (!this.world) return;
+    const events = this.world.events;
+    // Defensive: clamp if events shrank (replay reset).
+    if (this.nextEventIndex > events.length) this.nextEventIndex = events.length;
+    const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9 | null;
+
+    for (let i = this.nextEventIndex; i < events.length; i++) {
+      const ev = events[i];
+      if (!ev) continue;
+
+      if (ev.type === 'invasion_start') {
+        // Screen-edge flash in the direction of the invasion entrance.
+        const playerColony = this.world.colonies[PLAYER_COLONY_ID];
+        const queenChamber = playerColony?.chambers.find(ch => ch.chamberType === ChamberType.Queen);
+        if (queenChamber) {
+          const queenTileX = queenChamber.posX >> 8;
+          const queenTileY = queenChamber.posY >> 8;
+          const direction = inferFlashDirection(
+            queenTileX, queenTileY,
+            ev.payload.rallyTile?.x ?? queenTileX,
+            ev.payload.rallyTile?.y ?? queenTileY,
+          );
+          triggerScreenEdgeFlash(this, direction, CANVAS_W, CANVAS_H);
+        } else {
+          triggerScreenEdgeFlash(this, 'right', CANVAS_W, CANVAS_H);
+        }
+        // Caption #7: first AI invasion.
+        const captionText = checkAndTrigger('aiInvading');
+        if (captionText && uiScene) {
+          uiScene.showCaption(captionText, CANVAS_W / 2, 60);
+        }
+      }
+
+      if (ev.type === 'spider_rampage_start') {
+        // Caption #8: first spider rampage.
+        const captionText = checkAndTrigger('spiderRampage');
+        if (captionText && uiScene) {
+          uiScene.showCaption(captionText, CANVAS_W / 2, 60);
+        }
+      }
+
+      if (ev.type === 'ai_state_transition' && ev.payload.to === 'Invading') {
+        // Belt-and-suspenders: invasion_start is the primary trigger above;
+        // this handles any Invading transition not paired with invasion_start.
+        checkAndTrigger('aiInvading'); // idempotent — no-op if already triggered
+      }
+    }
+
+    this.nextEventIndex = events.length;
+  }
+
+  /**
+   * Check per-frame world state for queen damage pulse and starvation onset.
+   * Also fires world-state-based captions (spider visible, spiderPriority, etc.).
+   * Called once per render frame while Playing.
+   */
+  private checkQueenStatusForEffects(): void {
+    if (!this.world) return;
+    const playerColony = this.world.colonies[PLAYER_COLONY_ID];
+    if (!playerColony) return;
+    const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9 | null;
+
+    // Queen damage pulse.
+    const queenId = playerColony.queenEntityId;
+    const hp = this.world.ants.hp[queenId] ?? 0;
+    const bonusHp = this.world.ants.homeGroundBonusHp[queenId] ?? 0;
+    const combinedHp = hp + bonusHp;
+    if (
+      this.prevQueenCombinedHp !== null &&
+      combinedHp < this.prevQueenCombinedHp &&
+      this.world.tick > QUEEN_DAMAGE_SUPPRESS_TICKS
+    ) {
+      triggerQueenDamagePulse(this.cameras.main);
+      // Caption #9: first queen damage.
+      const captionText = checkAndTrigger('queenDamage');
+      if (captionText && uiScene) {
+        uiScene.showCaption(captionText, CANVAS_W / 2, CANVAS_H / 2 - 40);
+      }
+    }
+    this.prevQueenCombinedHp = combinedHp;
+
+    // Starvation onset.
+    if (
+      !this.queenStarvationTriggered &&
+      playerColony.queenStarvationTimer > 0 &&
+      this.world.tick > QUEEN_DAMAGE_SUPPRESS_TICKS
+    ) {
+      this.queenStarvationTriggered = true;
+      triggerQueenDamagePulse(this.cameras.main);
+      // Caption #10: queen starvation onset.
+      const captionText = checkAndTrigger('queenStarvation');
+      if (captionText && uiScene) {
+        uiScene.showCaption(captionText, CANVAS_W / 2, CANVAS_H / 2 - 40);
+      }
+    }
+
+    // World-state-based captions.
+    if (this.world.spider !== null) {
+      const captionText = checkAndTrigger('spider');
+      if (captionText && uiScene) {
+        uiScene.showCaption(captionText, CANVAS_W / 2, 60);
+      }
+    }
+    if (this.world.spiderPriorityColonyId !== null) {
+      const captionText = checkAndTrigger('spiderPriority');
+      if (captionText && uiScene) {
+        uiScene.showCaption(captionText, CANVAS_W / 2, 60);
+      }
+    }
   }
 
   private bootFresh(difficulty: 'Easy' | 'Normal' | 'Hard' = 'Normal'): void {
@@ -595,6 +743,24 @@ export class GameScene extends Phaser.Scene {
       onAfterDrain: (cmds) => {
         // SCEN-06 replay truth: never truncate — appendInputLog handles all commands
         appendInputLog(this.inputLog, cmds);
+        // S6: fire first-occurrence captions for player command types.
+        const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9 | null;
+        for (const cmd of cmds) {
+          if (cmd.type === 'MarkDigTile') {
+            const text = checkAndTrigger('dig');
+            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);
+          } else if (cmd.type === 'PlaceChamber') {
+            const chamberTypeName = String(cmd.chamberType) as string;
+            const text = checkAndTrigger('chamber', chamberTypeName);
+            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);
+          } else if (cmd.type === 'MarkFoodPile') {
+            const text = checkAndTrigger('foodMark');
+            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);
+          } else if (cmd.type === 'SetRallyPoint') {
+            const text = checkAndTrigger('rally');
+            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);
+          }
+        }
       },
       onTickOutcome: (outcome) => {
         this.currentOutcome = outcome;
@@ -622,6 +788,15 @@ export class GameScene extends Phaser.Scene {
         }
         this.currentCause = cause;
 
+        // S6: build narrative for the loss screen.
+        const outcomeLabel: GameOutcomeLabel | undefined =
+          outcome === GameOutcome.Victory          ? 'Victory'
+          : outcome === GameOutcome.Defeat         ? 'Defeat'
+          : outcome === GameOutcome.MutualDestruction ? 'MutualDestruction'
+          : undefined;
+        const summary = buildPlaytraceSummary(this.world, this.resumedFromSave, outcomeLabel);
+        const narrativeSeed = summary.outcomeAttribution.narrativeSeed;
+
         const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
         // Issue #122 — when the playtrace feature is enabled, the survey
         // overlay replaces the bare game-over panel at end-of-game. Skip
@@ -631,7 +806,7 @@ export class GameScene extends Phaser.Scene {
         if (this.playtraceEndpoint !== '') {
           this.openSurveyOverlay(false /* quitFromPauseMenu */);
         } else {
-          uiScene.showGameOverOverlay(outcome, cause, () => this.restartGame());
+          uiScene.showGameOverOverlay(outcome, cause, () => this.restartGame(), narrativeSeed);
         }
       },
       getMsPerTick: () => MS_PER_TICK / this.speedMultiplier,
@@ -953,6 +1128,13 @@ export class GameScene extends Phaser.Scene {
     const worldH = this.viewState.activeView === 'surface' ? SURFACE_GRID_HEIGHT : UNDERGROUND_GRID_HEIGHT;
     clampCamera(cam, worldW, worldH);
 
+    // S6: advance render frame counter and drain events for render effects.
+    this.renderFrame++;
+    if (this.gamePhase === GamePhase.Playing) {
+      this.consumeEventsForRender();
+      this.checkQueenStatusForEffects();
+    }
+
     // Draw world.
     const alpha = this.gameLoop.accumulatorMs / MS_PER_TICK;
     const gfx = this.gfx as unknown as GfxLike;
@@ -996,6 +1178,9 @@ export class GameScene extends Phaser.Scene {
         cam,
         pending,
         this.antFacingCache,
+        this.time.now,          // S6: frameTimeMs for reticle/hunger pulse
+        this.contestedGlowFrames, // S6: surface glow fade map
+        this.renderFrame,       // S6: current render frame
       );
     } else {
       drawUndergroundTerrain(gfx, this.world, cam, this.viewState.activeUndergroundColonyId);
@@ -1011,6 +1196,8 @@ export class GameScene extends Phaser.Scene {
         cam,
         this.viewState.activeUndergroundColonyId,
         this.antFacingCache,
+        this.undergroundGlowFrames, // S6: underground glow fade map
+        this.renderFrame,           // S6: current render frame
       );
     }
     this.antSprites.endFrame();

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -375,6 +375,10 @@ export class GameScene extends Phaser.Scene {
       if (this.gamePhase !== GamePhase.Playing) return;
       if (this.viewState.activeView !== 'underground') return;
       toggleUndergroundColony(this.viewState);
+      // Clear stale glow entries from the previous colony grid — tile keys are
+      // not scoped to a colony, so entries from one grid must not bleed into
+      // the other when the view switches.
+      this.undergroundGlowFrames.clear();
     });
 
     // 09 excursion-foraging follow-up — F9 exports a debug snapshot JSON

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -231,7 +231,7 @@ export class GameScene extends Phaser.Scene {
   private speedMultiplier: 1 | 2 | 4 = 1;
 
   // S6 — render-side scratch (per-session, reset in resetSessionState).
-  private nextEventIndex = 0;           // event cursor for consumeEventsForRender
+  private lastProcessedEventTick = -1;  // tick-based cursor for consumeEventsForRender
   private prevQueenCombinedHp: number | null = null; // queen HP tracking for damage pulse
   private queenStarvationTriggered = false;           // starvation onset caption/pulse guard
   private renderFrame = 0;              // frame counter for glow fade maps
@@ -500,7 +500,7 @@ export class GameScene extends Phaser.Scene {
     // the smoothing relaxes. Clearing here keeps boot visually clean.
     this.antFacingCache.reset();
     // S6 — reset per-session render-side scratch.
-    this.nextEventIndex = 0;
+    this.lastProcessedEventTick = -1;
     this.prevQueenCombinedHp = null;
     this.queenStarvationTriggered = false;
     this.contestedGlowFrames.clear();
@@ -534,13 +534,27 @@ export class GameScene extends Phaser.Scene {
   private consumeEventsForRender(): void {
     if (!this.world) return;
     const events = this.world.events;
-    // Defensive: clamp if events shrank (replay reset).
-    if (this.nextEventIndex > events.length) this.nextEventIndex = events.length;
+    if (events.length === 0) return;
     const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9 | null;
 
-    for (let i = this.nextEventIndex; i < events.length; i++) {
+    // Use tick-based filtering rather than an array-index cursor. The event
+    // buffer evicts old combat_kills via splice when it reaches capacity, which
+    // shifts array indices and makes a length-based cursor stale. Tick-based
+    // filtering is invariant to splice position because structural events
+    // (invasion_start, spider_rampage_start, etc.) are never evicted.
+    //
+    // Safety of `ev.tick <= lastProcessedEventTick` (strict skip on boundary tick):
+    // All sim ticks for a render frame complete synchronously before this method
+    // runs. A tick N emits all its events in one call; there is no mechanism for
+    // a tick-N event to arrive in a later render frame. Same-tick events are
+    // therefore always fully present when we first scan that tick, and
+    // `lastProcessedEventTick` only advances after all of them are processed.
+    // `resetSessionState()` is the only path that resets this field to -1.
+    let maxTickSeen = this.lastProcessedEventTick;
+    for (let i = 0; i < events.length; i++) {
       const ev = events[i];
-      if (!ev) continue;
+      if (!ev || ev.tick <= this.lastProcessedEventTick) continue;
+      if (ev.tick > maxTickSeen) maxTickSeen = ev.tick;
 
       if (ev.type === 'invasion_start') {
         // Screen-edge flash in the direction of the invasion entrance.
@@ -584,7 +598,7 @@ export class GameScene extends Phaser.Scene {
       }
     }
 
-    this.nextEventIndex = events.length;
+    this.lastProcessedEventTick = maxTickSeen;
   }
 
   /**
@@ -757,7 +771,12 @@ export class GameScene extends Phaser.Scene {
             const text = checkAndTrigger('dig');
             if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);
           } else if (cmd.type === 'PlaceChamber') {
-            const chamberTypeName = String(cmd.chamberType) as string;
+            const chamberTypeLabel: Record<number, string> = {
+              [ChamberType.Queen]: 'Queen',
+              [ChamberType.Nursery]: 'Nursery',
+              [ChamberType.FoodStorage]: 'Food Storage',
+            };
+            const chamberTypeName = chamberTypeLabel[cmd.chamberType] ?? `chamber type ${cmd.chamberType}`;
             const text = checkAndTrigger('chamber', chamberTypeName);
             if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);
           } else if (cmd.type === 'MarkFoodPile') {

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -651,7 +651,10 @@ export class GameScene extends Phaser.Scene {
     }
 
     // World-state-based captions.
-    if (this.world.spider !== null) {
+    // Gate spider caption on Hunting/Striking — spider exists from tick 0 while
+    // Patrolling, so triggering on mere existence fires before any visible threat.
+    const spiderState = this.world.spider?.state;
+    if (spiderState === 'Hunting' || spiderState === 'Striking') {
       const captionText = checkAndTrigger('spider');
       if (captionText && uiScene) {
         uiScene.showCaption(captionText, CANVAS_W / 2, 60);

--- a/src/render/onboarding-captions.test.ts
+++ b/src/render/onboarding-captions.test.ts
@@ -1,0 +1,132 @@
+// onboarding-captions.test.ts — S6 coverage for the first-occurrence caption registry.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { checkAndTrigger, resetCaptions, triggered } from './onboarding-captions.js';
+
+// Always start each test with a clean slate.
+beforeEach(() => {
+  resetCaptions();
+});
+
+// ---------------------------------------------------------------------------
+// First-trigger behaviour
+// ---------------------------------------------------------------------------
+
+describe('checkAndTrigger — first occurrence', () => {
+  it('returns non-null text on the first call for every key', () => {
+    const keys = [
+      'dig', 'chamber', 'spider', 'foodMark', 'rally',
+      'spiderPriority', 'aiInvading', 'spiderRampage',
+      'queenDamage', 'queenStarvation',
+    ] as const;
+    for (const key of keys) {
+      resetCaptions();
+      const result = checkAndTrigger(key);
+      expect(result, `key="${key}" should return text on first call`).not.toBeNull();
+      expect(typeof result).toBe('string');
+    }
+  });
+
+  it('returns the expected text for "dig"', () => {
+    expect(checkAndTrigger('dig')).toBe('Your workers will excavate the marked tile.');
+  });
+
+  it('returns the expected text for "spider"', () => {
+    expect(checkAndTrigger('spider')).toBe('A spider is hunting. Right-click it to mark as priority.');
+  });
+
+  it('returns the expected text for "queenDamage"', () => {
+    expect(checkAndTrigger('queenDamage')).toBe('Your queen is in danger.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Second-call suppression
+// ---------------------------------------------------------------------------
+
+describe('checkAndTrigger — second call returns null', () => {
+  it('dig: second call is null', () => {
+    checkAndTrigger('dig');
+    expect(checkAndTrigger('dig')).toBeNull();
+  });
+
+  it('spider: second call is null', () => {
+    checkAndTrigger('spider');
+    expect(checkAndTrigger('spider')).toBeNull();
+  });
+
+  it('each key suppresses independently (one key fired does not affect another)', () => {
+    checkAndTrigger('dig');
+    // rally has not been triggered yet
+    expect(checkAndTrigger('rally')).not.toBeNull();
+    // but dig is now suppressed
+    expect(checkAndTrigger('dig')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resetCaptions
+// ---------------------------------------------------------------------------
+
+describe('resetCaptions', () => {
+  it('clears all triggered flags so keys fire again', () => {
+    checkAndTrigger('dig');
+    checkAndTrigger('spider');
+    resetCaptions();
+    expect(triggered.size).toBe(0);
+    expect(checkAndTrigger('dig')).not.toBeNull();
+    expect(checkAndTrigger('spider')).not.toBeNull();
+  });
+
+  it('a key returns its text again after reset', () => {
+    const first = checkAndTrigger('queenStarvation');
+    resetCaptions();
+    const second = checkAndTrigger('queenStarvation');
+    expect(first).toBe(second);
+    expect(first).toBe('Your queen is growing hungry.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chamber text substitution
+// ---------------------------------------------------------------------------
+
+describe('checkAndTrigger — chamber type substitution', () => {
+  it('replaces [Chamber Type] with the provided override text', () => {
+    const result = checkAndTrigger('chamber', 'Nursery');
+    expect(result).toBe('Chambers give workers and brood a purpose. This one is a Nursery.');
+  });
+
+  it('replaces [Chamber Type] with "Food Storage"', () => {
+    const result = checkAndTrigger('chamber', 'Food Storage');
+    expect(result).toBe('Chambers give workers and brood a purpose. This one is a Food Storage.');
+  });
+
+  it('returns the raw template when no override is passed', () => {
+    const result = checkAndTrigger('chamber');
+    expect(result).toContain('[Chamber Type]');
+  });
+
+  it('substitution only happens on first trigger; second call still returns null', () => {
+    checkAndTrigger('chamber', 'Queen');
+    expect(checkAndTrigger('chamber', 'Nursery')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// triggered map state
+// ---------------------------------------------------------------------------
+
+describe('triggered map state', () => {
+  it('is empty before any captions fire', () => {
+    expect(triggered.size).toBe(0);
+  });
+
+  it('records each triggered key', () => {
+    checkAndTrigger('dig');
+    checkAndTrigger('rally');
+    expect(triggered.get('dig')).toBe(true);
+    expect(triggered.get('rally')).toBe(true);
+    expect(triggered.has('spider')).toBe(false);
+  });
+});

--- a/src/render/onboarding-captions.test.ts
+++ b/src/render/onboarding-captions.test.ts
@@ -32,7 +32,7 @@ describe('checkAndTrigger — first occurrence', () => {
   });
 
   it('returns the expected text for "spider"', () => {
-    expect(checkAndTrigger('spider')).toBe('A spider is hunting. Right-click it to mark as priority.');
+    expect(checkAndTrigger('spider')).toBe('A spider is hunting your ants. Use fighters to protect your queen.');
   });
 
   it('returns the expected text for "queenDamage"', () => {

--- a/src/render/onboarding-captions.ts
+++ b/src/render/onboarding-captions.ts
@@ -20,7 +20,7 @@ export type CaptionKey =
 const CAPTION_TEXTS: Record<CaptionKey, string> = {
   dig:             'Your workers will excavate the marked tile.',
   chamber:         'Chambers give workers and brood a purpose. This one is a [Chamber Type].',
-  spider:          'A spider is hunting. Right-click it to mark as priority.',
+  spider:          'A spider is hunting your ants. Use fighters to protect your queen.',
   foodMark:        'Your foragers will prioritize this pile.',
   rally:           'Fighters will converge here.',
   spiderPriority:  'Your fighters are engaging the spider.',

--- a/src/render/onboarding-captions.ts
+++ b/src/render/onboarding-captions.ts
@@ -1,0 +1,55 @@
+// onboarding-captions.ts — S6: first-occurrence caption registry (light onboarding).
+//
+// Tracks which of the 10 first-occurrence captions have fired this session.
+// All state is render-side; nothing persists to WorldState or saves.
+// Reset on every new round (including same-seed rematch) so each session
+// starts fresh (Q6 DEFAULT_ACCEPTED).
+
+export type CaptionKey =
+  | 'dig'
+  | 'chamber'
+  | 'spider'
+  | 'foodMark'
+  | 'rally'
+  | 'spiderPriority'
+  | 'aiInvading'
+  | 'spiderRampage'
+  | 'queenDamage'
+  | 'queenStarvation';
+
+const CAPTION_TEXTS: Record<CaptionKey, string> = {
+  dig:             'Your workers will excavate the marked tile.',
+  chamber:         'Chambers give workers and brood a purpose. This one is a [Chamber Type].',
+  spider:          'A spider is hunting. Right-click it to mark as priority.',
+  foodMark:        'Your foragers will prioritize this pile.',
+  rally:           'Fighters will converge here.',
+  spiderPriority:  'Your fighters are engaging the spider.',
+  aiInvading:      'The enemy is attacking your hive.',
+  spiderRampage:   'The spider has gone hungry and is in the tunnels.',
+  queenDamage:     'Your queen is in danger.',
+  queenStarvation: 'Your queen is growing hungry.',
+};
+
+// Exported so game-scene.ts can reset on round start.
+export const triggered: Map<CaptionKey, boolean> = new Map();
+
+export function resetCaptions(): void {
+  triggered.clear();
+}
+
+/**
+ * Check if a caption should fire for the first time this session.
+ * Returns the text to display, or null if the caption already triggered.
+ *
+ * For the 'chamber' key, pass the chamber type name as `textOverride` to
+ * substitute it into the "[Chamber Type]" placeholder.
+ */
+export function checkAndTrigger(key: CaptionKey, textOverride?: string): string | null {
+  if (triggered.get(key)) return null;
+  triggered.set(key, true);
+  const base = CAPTION_TEXTS[key];
+  if (textOverride !== undefined) {
+    return base.replace('[Chamber Type]', textOverride);
+  }
+  return base;
+}

--- a/src/render/playtrace-upload.ts
+++ b/src/render/playtrace-upload.ts
@@ -403,7 +403,7 @@ async function buildPayloadWithDowngrade(
   // void-casting submitPlaytrace, so the live world is mutated during the
   // async tail of this function.
   const capturedEvents: SimEvent[] = input.world.events.slice();
-  const capturedSummary = buildPlaytraceSummary(input.world, input.resumedFromSave);
+  const capturedSummary = buildPlaytraceSummary(input.world, input.resumedFromSave, outcomeToWire(input.outcome));
   const fullSnap = buildDebugSnapshot(input.world, input.seed, input.inputLog);
   const fullEnvelope = buildPlaytraceEnvelope(input, fullSnap, capturedEvents, capturedSummary);
 

--- a/src/render/screen-effects.test.ts
+++ b/src/render/screen-effects.test.ts
@@ -1,0 +1,71 @@
+// screen-effects.test.ts — S6 smoke tests for the screen-effects module.
+//
+// Verifies constants export at expected values and that inferFlashDirection
+// returns the correct screen edge for directional inputs.
+// triggerScreenEdgeFlash and triggerQueenDamagePulse are Phaser-dependent;
+// they are not tested here (render-only, tested manually per the S6 plan).
+
+import { describe, it, expect } from 'vitest';
+import {
+  SCREEN_EDGE_FLASH_DURATION_MS,
+  QUEEN_DAMAGE_PULSE_DURATION_MS,
+  QUEEN_DAMAGE_SUPPRESS_TICKS,
+  inferFlashDirection,
+} from './screen-effects.js';
+
+describe('screen-effects constants', () => {
+  it('SCREEN_EDGE_FLASH_DURATION_MS is 2000', () => {
+    expect(SCREEN_EDGE_FLASH_DURATION_MS).toBe(2000);
+  });
+
+  it('QUEEN_DAMAGE_PULSE_DURATION_MS is 200', () => {
+    expect(QUEEN_DAMAGE_PULSE_DURATION_MS).toBe(200);
+  });
+
+  it('QUEEN_DAMAGE_SUPPRESS_TICKS is 40', () => {
+    expect(QUEEN_DAMAGE_SUPPRESS_TICKS).toBe(40);
+  });
+});
+
+describe('inferFlashDirection', () => {
+  // Queen at (10, 10); entrance at various positions
+
+  it('entrance directly to the right → "right"', () => {
+    expect(inferFlashDirection(10, 10, 20, 10)).toBe('right');
+  });
+
+  it('entrance directly to the left → "left"', () => {
+    expect(inferFlashDirection(10, 10, 0, 10)).toBe('left');
+  });
+
+  it('entrance directly below → "bottom"', () => {
+    expect(inferFlashDirection(10, 10, 10, 20)).toBe('bottom');
+  });
+
+  it('entrance directly above → "top"', () => {
+    expect(inferFlashDirection(10, 10, 10, 0)).toBe('top');
+  });
+
+  it('diagonal: larger dx than dy → horizontal axis wins', () => {
+    // dx=10, dy=3 → right
+    expect(inferFlashDirection(0, 0, 10, 3)).toBe('right');
+  });
+
+  it('diagonal: larger dy than dx → vertical axis wins', () => {
+    // dx=3, dy=10 → bottom
+    expect(inferFlashDirection(0, 0, 3, 10)).toBe('bottom');
+  });
+
+  it('equal |dx| and |dy| → horizontal wins (dx >= dy branch)', () => {
+    // dx=5, dy=5 → right (Math.abs(dx) >= Math.abs(dy))
+    expect(inferFlashDirection(0, 0, 5, 5)).toBe('right');
+  });
+
+  it('left diagonal: larger |dx| negative → "left"', () => {
+    expect(inferFlashDirection(10, 5, 2, 6)).toBe('left');
+  });
+
+  it('top diagonal: larger |dy| negative → "top"', () => {
+    expect(inferFlashDirection(5, 10, 6, 2)).toBe('top');
+  });
+});

--- a/src/render/screen-effects.ts
+++ b/src/render/screen-effects.ts
@@ -1,0 +1,87 @@
+// screen-effects.ts — S6: full-screen and screen-edge visual cues.
+//
+// Render-side only. All effects use Phaser camera/scene APIs.
+// No sim state is read or mutated here.
+
+/** Duration (ms) for the screen-edge invasion flash before it fully fades. */
+export const SCREEN_EDGE_FLASH_DURATION_MS = 2000;
+
+/** Duration (ms) for the full-screen queen damage pulse (camera.flash). */
+export const QUEEN_DAMAGE_PULSE_DURATION_MS = 200;
+
+/** Ticks to suppress queen damage pulse at round start (2 sim-seconds at 20 Hz). */
+export const QUEEN_DAMAGE_SUPPRESS_TICKS = 40;
+
+export type FlashDirection = 'top' | 'bottom' | 'left' | 'right';
+
+/**
+ * Trigger a faint red rectangle flash on the screen edge corresponding to
+ * the direction of an incoming invasion. Fades out over SCREEN_EDGE_FLASH_DURATION_MS.
+ *
+ * @param scene     Phaser Scene (for add.graphics + tweens).
+ * @param direction Which screen edge to flash.
+ * @param canvasW   Canvas width in pixels.
+ * @param canvasH   Canvas height in pixels.
+ */
+export function triggerScreenEdgeFlash(
+  scene: Phaser.Scene,
+  direction: FlashDirection,
+  canvasW: number,
+  canvasH: number,
+): void {
+  const THICKNESS = 20;
+  const gfx = scene.add.graphics();
+  gfx.setDepth(50);
+  gfx.fillStyle(0xff0000, 0.25);
+
+  if (direction === 'top') {
+    gfx.fillRect(0, 0, canvasW, THICKNESS);
+  } else if (direction === 'bottom') {
+    gfx.fillRect(0, canvasH - THICKNESS, canvasW, THICKNESS);
+  } else if (direction === 'left') {
+    gfx.fillRect(0, 0, THICKNESS, canvasH);
+  } else {
+    gfx.fillRect(canvasW - THICKNESS, 0, THICKNESS, canvasH);
+  }
+
+  scene.tweens.add({
+    targets: gfx,
+    alpha: 0,
+    duration: SCREEN_EDGE_FLASH_DURATION_MS,
+    ease: 'Linear',
+    onComplete: () => { gfx.destroy(); },
+  });
+}
+
+/**
+ * Trigger a brief full-screen red flash using Phaser's built-in camera.flash().
+ * Idempotent: Phaser ignores overlapping flash calls.
+ *
+ * @param camera Phaser main camera.
+ */
+export function triggerQueenDamagePulse(camera: Phaser.Cameras.Scene2D.Camera): void {
+  camera.flash(QUEEN_DAMAGE_PULSE_DURATION_MS, 255, 0, 0, true);
+}
+
+/**
+ * Determine which screen edge corresponds to the direction from the queen
+ * chamber toward the threatened entrance.
+ *
+ * @param queenTileX Queen chamber center tile X.
+ * @param queenTileY Queen chamber center tile Y.
+ * @param entranceTileX Invasion entrance tile X.
+ * @param entranceTileY Invasion entrance tile Y.
+ */
+export function inferFlashDirection(
+  queenTileX: number,
+  queenTileY: number,
+  entranceTileX: number,
+  entranceTileY: number,
+): FlashDirection {
+  const dx = entranceTileX - queenTileX;
+  const dy = entranceTileY - queenTileY;
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return dx >= 0 ? 'right' : 'left';
+  }
+  return dy >= 0 ? 'bottom' : 'top';
+}

--- a/src/render/screen-effects.ts
+++ b/src/render/screen-effects.ts
@@ -31,6 +31,7 @@ export function triggerScreenEdgeFlash(
 ): void {
   const THICKNESS = 20;
   const gfx = scene.add.graphics();
+  gfx.setScrollFactor(0); // pin to viewport — graphics default to world coords
   gfx.setDepth(50);
   gfx.fillStyle(0xff0000, 0.25);
 

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -57,6 +57,11 @@ export const COLOR_FIGHTER_TINT = 0xff4444;
 /** S1 — Faint tile tint drawn under ants on contested tiles (alpha < 0.3). */
 export const COLOR_CONTESTED_TILE = 0xff6600;
 
+/** S6 — Home-ground glow colors for per-grid combat tile highlight. */
+export const COLOR_PLAYER_HOME_GLOW        = 0x3060a0; // blue — player underground tiles
+export const COLOR_ENEMY_HOME_GLOW         = 0xa06030; // orange — enemy underground tiles
+export const COLOR_NEUTRAL_CONTESTED_GLOW  = 0xa0a030; // yellow — surface contested tiles
+
 /** PRD §7g — Underground solid (unexcavated) tile color. */
 export const COLOR_UNDERGROUND_SOLID = 0x2d1a0a;
 

--- a/src/render/summary-builder.test.ts
+++ b/src/render/summary-builder.test.ts
@@ -130,10 +130,22 @@ describe('buildOutcomeAttribution — queen_death narratives', () => {
     expect(result.narrativeSeed).toBe('Both queens died in the same final fight.');
   });
 
-  it('cause === null → primaryCause null, narrativeSeed "Your colony has fallen."', () => {
+  it('cause === null with no gameOutcome → defeat fallback narrative', () => {
     const result = buildOutcomeAttribution([queenDeathEvent(null)]);
     expect(result.primaryCause).toBeNull();
     expect(result.narrativeSeed).toBe('Your colony has fallen.');
+  });
+
+  it('cause === null with Victory gameOutcome → enemy-fell narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent(null)], 'Victory');
+    expect(result.primaryCause).toBeNull();
+    expect(result.narrativeSeed).toBe('The enemy colony has fallen.');
+  });
+
+  it('cause === null with MutualDestruction gameOutcome → both-fell narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent(null)], 'MutualDestruction');
+    expect(result.primaryCause).toBeNull();
+    expect(result.narrativeSeed).toBe('Both queens fell in the final battle.');
   });
 });
 

--- a/src/render/summary-builder.test.ts
+++ b/src/render/summary-builder.test.ts
@@ -103,29 +103,59 @@ describe('buildOutcomeAttribution — round_end before queen_death', () => {
 // queen_death narrative strings (updated in S6)
 // ---------------------------------------------------------------------------
 
-describe('buildOutcomeAttribution — queen_death narratives', () => {
-  it('InvasionKill → invasion narrative', () => {
-    const result = buildOutcomeAttribution([queenDeathEvent('InvasionKill')]);
+describe('buildOutcomeAttribution — queen_death narratives (Defeat perspective)', () => {
+  it('InvasionKill → player-loss invasion narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('InvasionKill')], 'Defeat');
     expect(result.primaryCause).toBe('InvasionKill');
     expect(result.narrativeSeed).toBe(
       'Enemy fighters broke through a tunnel entrance and reached your queen.',
     );
   });
 
-  it('SpiderRampage → spider narrative', () => {
-    const result = buildOutcomeAttribution([queenDeathEvent('SpiderRampage')]);
+  it('SpiderRampage → player-loss spider narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('SpiderRampage')], 'Defeat');
     expect(result.primaryCause).toBe('SpiderRampage');
     expect(result.narrativeSeed).toBe('The spider reached your nursery and killed the queen.');
   });
 
-  it('Starvation → starvation narrative', () => {
-    const result = buildOutcomeAttribution([queenDeathEvent('Starvation')]);
+  it('Starvation → player-loss starvation narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('Starvation')], 'Defeat');
     expect(result.primaryCause).toBe('Starvation');
     expect(result.narrativeSeed).toBe('Your queen starved after the colony ran out of food.');
   });
 
-  it('MutualDestruction → mutual destruction narrative', () => {
-    const result = buildOutcomeAttribution([queenDeathEvent('MutualDestruction')]);
+  it('MutualDestruction → symmetric narrative (same for both outcomes)', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('MutualDestruction')], 'Defeat');
+    expect(result.primaryCause).toBe('MutualDestruction');
+    expect(result.narrativeSeed).toBe('Both queens died in the same final fight.');
+  });
+});
+
+describe('buildOutcomeAttribution — queen_death narratives (Victory perspective)', () => {
+  it('InvasionKill Victory → enemy-queen narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('InvasionKill')], 'Victory');
+    expect(result.primaryCause).toBe('InvasionKill');
+    expect(result.narrativeSeed).toBe('Your fighters broke through to the enemy queen.');
+  });
+
+  it('SpiderRampage Victory → enemy spider narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('SpiderRampage')], 'Victory');
+    expect(result.primaryCause).toBe('SpiderRampage');
+    expect(result.narrativeSeed).toBe(
+      'The spider reached the enemy nursery and killed their queen.',
+    );
+  });
+
+  it('Starvation Victory → enemy starvation narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('Starvation')], 'Victory');
+    expect(result.primaryCause).toBe('Starvation');
+    expect(result.narrativeSeed).toBe(
+      'The enemy queen starved after their colony ran out of food.',
+    );
+  });
+
+  it('MutualDestruction Victory → same symmetric narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('MutualDestruction')], 'Victory');
     expect(result.primaryCause).toBe('MutualDestruction');
     expect(result.narrativeSeed).toBe('Both queens died in the same final fight.');
   });

--- a/src/render/summary-builder.test.ts
+++ b/src/render/summary-builder.test.ts
@@ -1,0 +1,167 @@
+// summary-builder.test.ts — S6 coverage for buildOutcomeAttribution().
+//
+// Tests the tiebreak paths added in S6, the updated queen_death narrative
+// strings, the null-cause fallback, and the no-events base case.
+
+import { describe, it, expect } from 'vitest';
+import { buildOutcomeAttribution } from './summary-builder.js';
+import type { SimEvent } from '../sim/telemetry.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function roundEndEvent(
+  reason: 'TimeoutTiebreak' | 'StalemateTiebreak',
+  playerWorkerCount: number,
+  aiWorkerCount: number,
+): SimEvent {
+  return { tick: 1200, type: 'round_end', payload: { reason, playerWorkerCount, aiWorkerCount } };
+}
+
+function queenDeathEvent(cause: 'InvasionKill' | 'SpiderRampage' | 'Starvation' | 'MutualDestruction' | null): SimEvent {
+  return {
+    tick: 500,
+    type: 'queen_death',
+    payload: { cause, location: { x: 0, y: 0, grid: 'underground' }, aiStateAtTime: null },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TimeoutTiebreak
+// ---------------------------------------------------------------------------
+
+describe('buildOutcomeAttribution — TimeoutTiebreak', () => {
+  it('player has more workers → outlasted narrative', () => {
+    const result = buildOutcomeAttribution([roundEndEvent('TimeoutTiebreak', 10, 5)]);
+    expect(result.primaryCause).toBe('TimeoutTiebreak');
+    expect(result.narrativeSeed).toBe('The round timed out; your colony outlasted the enemy.');
+  });
+
+  it('AI has more workers → enemy outlasted narrative', () => {
+    const result = buildOutcomeAttribution([roundEndEvent('TimeoutTiebreak', 3, 8)]);
+    expect(result.primaryCause).toBe('TimeoutTiebreak');
+    expect(result.narrativeSeed).toBe('The round timed out; the enemy colony outlasted yours.');
+  });
+
+  it('equal worker counts → evenly matched narrative', () => {
+    const result = buildOutcomeAttribution([roundEndEvent('TimeoutTiebreak', 5, 5)]);
+    expect(result.primaryCause).toBe('TimeoutTiebreak');
+    expect(result.narrativeSeed).toBe('Both colonies were evenly matched when time ran out.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StalemateTiebreak
+// ---------------------------------------------------------------------------
+
+describe('buildOutcomeAttribution — StalemateTiebreak', () => {
+  it('Victory gameOutcome → enemy starved first narrative', () => {
+    const result = buildOutcomeAttribution([roundEndEvent('StalemateTiebreak', 0, 0)], 'Victory');
+    expect(result.primaryCause).toBe('StalemateTiebreak');
+    expect(result.narrativeSeed).toBe('Both colonies ran out of food; the enemy starved first.');
+  });
+
+  it('Defeat gameOutcome → player queen starved narrative', () => {
+    const result = buildOutcomeAttribution([roundEndEvent('StalemateTiebreak', 0, 0)], 'Defeat');
+    expect(result.primaryCause).toBe('StalemateTiebreak');
+    expect(result.narrativeSeed).toBe('Both colonies ran out of food; your queen starved first.');
+  });
+
+  it('no gameOutcome provided → draw narrative', () => {
+    const result = buildOutcomeAttribution([roundEndEvent('StalemateTiebreak', 0, 0)]);
+    expect(result.primaryCause).toBe('StalemateTiebreak');
+    expect(result.narrativeSeed).toBe('Both colonies ran out of food and the round ended in a draw.');
+  });
+
+  it('MutualDestruction gameOutcome → draw narrative (not Victory/Defeat)', () => {
+    const result = buildOutcomeAttribution(
+      [roundEndEvent('StalemateTiebreak', 0, 0)],
+      'MutualDestruction',
+    );
+    expect(result.primaryCause).toBe('StalemateTiebreak');
+    expect(result.narrativeSeed).toBe('Both colonies ran out of food and the round ended in a draw.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// round_end takes priority over queen_death when both are present
+// ---------------------------------------------------------------------------
+
+describe('buildOutcomeAttribution — round_end before queen_death', () => {
+  it('round_end is returned even when a queen_death event also exists', () => {
+    const events: SimEvent[] = [
+      roundEndEvent('TimeoutTiebreak', 7, 2),
+      { tick: 501, type: 'queen_death', payload: { cause: 'Starvation', location: { x: 0, y: 0, grid: 'underground' }, aiStateAtTime: null } },
+    ];
+    const result = buildOutcomeAttribution(events);
+    expect(result.primaryCause).toBe('TimeoutTiebreak');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// queen_death narrative strings (updated in S6)
+// ---------------------------------------------------------------------------
+
+describe('buildOutcomeAttribution — queen_death narratives', () => {
+  it('InvasionKill → invasion narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('InvasionKill')]);
+    expect(result.primaryCause).toBe('InvasionKill');
+    expect(result.narrativeSeed).toBe(
+      'Enemy fighters broke through a tunnel entrance and reached your queen.',
+    );
+  });
+
+  it('SpiderRampage → spider narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('SpiderRampage')]);
+    expect(result.primaryCause).toBe('SpiderRampage');
+    expect(result.narrativeSeed).toBe('The spider reached your nursery and killed the queen.');
+  });
+
+  it('Starvation → starvation narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('Starvation')]);
+    expect(result.primaryCause).toBe('Starvation');
+    expect(result.narrativeSeed).toBe('Your queen starved after the colony ran out of food.');
+  });
+
+  it('MutualDestruction → mutual destruction narrative', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent('MutualDestruction')]);
+    expect(result.primaryCause).toBe('MutualDestruction');
+    expect(result.narrativeSeed).toBe('Both queens died in the same final fight.');
+  });
+
+  it('cause === null → primaryCause null, narrativeSeed "Your colony has fallen."', () => {
+    const result = buildOutcomeAttribution([queenDeathEvent(null)]);
+    expect(result.primaryCause).toBeNull();
+    expect(result.narrativeSeed).toBe('Your colony has fallen.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No events
+// ---------------------------------------------------------------------------
+
+describe('buildOutcomeAttribution — no events', () => {
+  it('returns {primaryCause: null, narrativeSeed: null} when events array is empty', () => {
+    const result = buildOutcomeAttribution([]);
+    expect(result.primaryCause).toBeNull();
+    expect(result.narrativeSeed).toBeNull();
+  });
+
+  it('returns {null, null} when events contain no relevant types', () => {
+    const events: SimEvent[] = [
+      {
+        tick: 10,
+        type: 'combat_kill',
+        payload: {
+          killer: { kind: 'Ant', id: 1, colonyId: 2 as never },
+          victim: { kind: 'Ant', id: 2, colonyId: 1 as never },
+          location: { x: 5, y: 5, grid: 'surface' },
+        },
+      },
+    ];
+    const result = buildOutcomeAttribution(events);
+    expect(result.primaryCause).toBeNull();
+    expect(result.narrativeSeed).toBeNull();
+  });
+});

--- a/src/render/summary-builder.ts
+++ b/src/render/summary-builder.ts
@@ -167,7 +167,17 @@ export function buildOutcomeAttribution(
     if (ev.type === 'queen_death') {
       const cause = ev.payload.cause;
       if (cause === null) {
-        return { primaryCause: null, narrativeSeed: 'Your colony has fallen.' };
+        // Legacy traces (simVersion < V16) omit cause; derive direction from gameOutcome
+        // so a Victory doesn't display a defeat line.
+        let narrative: string;
+        if (gameOutcome === 'Victory') {
+          narrative = 'The enemy colony has fallen.';
+        } else if (gameOutcome === 'MutualDestruction') {
+          narrative = 'Both queens fell in the final battle.';
+        } else {
+          narrative = 'Your colony has fallen.';
+        }
+        return { primaryCause: null, narrativeSeed: narrative };
       }
       const narratives: Record<string, string> = {
         InvasionKill:      'Enemy fighters broke through a tunnel entrance and reached your queen.',

--- a/src/render/summary-builder.ts
+++ b/src/render/summary-builder.ts
@@ -179,12 +179,20 @@ export function buildOutcomeAttribution(
         }
         return { primaryCause: null, narrativeSeed: narrative };
       }
-      const narratives: Record<string, string> = {
+      // queen_death can describe either queen; use gameOutcome to pick perspective.
+      const victoryNarratives: Record<string, string> = {
+        InvasionKill:      'Your fighters broke through to the enemy queen.',
+        SpiderRampage:     'The spider reached the enemy nursery and killed their queen.',
+        Starvation:        'The enemy queen starved after their colony ran out of food.',
+        MutualDestruction: 'Both queens died in the same final fight.',
+      };
+      const defeatNarratives: Record<string, string> = {
         InvasionKill:      'Enemy fighters broke through a tunnel entrance and reached your queen.',
         SpiderRampage:     'The spider reached your nursery and killed the queen.',
         Starvation:        'Your queen starved after the colony ran out of food.',
         MutualDestruction: 'Both queens died in the same final fight.',
       };
+      const narratives = gameOutcome === 'Victory' ? victoryNarratives : defeatNarratives;
       return {
         primaryCause: cause,
         narrativeSeed: narratives[cause] ?? null,

--- a/src/render/summary-builder.ts
+++ b/src/render/summary-builder.ts
@@ -124,18 +124,56 @@ function buildStrategySignals(world: WorldState): StrategySignals {
   };
 }
 
-function buildOutcomeAttribution(events: SimEvent[]): OutcomeAttribution {
+// S6: game outcome label passed in from game-scene when available,
+// used to pick the tiebreak narrative for StalemateTiebreak.
+export type GameOutcomeLabel = 'Victory' | 'Defeat' | 'MutualDestruction';
+
+export function buildOutcomeAttribution(
+  events: SimEvent[],
+  gameOutcome?: GameOutcomeLabel,
+): OutcomeAttribution {
+  // S6: check for S5 tiebreak events first (round_end fires before queen_death in tick order).
+  for (const ev of events) {
+    if (ev.type === 'round_end') {
+      const { reason } = ev.payload;
+      if (reason === 'TimeoutTiebreak') {
+        const { playerWorkerCount, aiWorkerCount } = ev.payload;
+        let narrative: string;
+        if (playerWorkerCount > aiWorkerCount) {
+          narrative = 'The round timed out; your colony outlasted the enemy.';
+        } else if (aiWorkerCount > playerWorkerCount) {
+          narrative = 'The round timed out; the enemy colony outlasted yours.';
+        } else {
+          narrative = 'Both colonies were evenly matched when time ran out.';
+        }
+        return { primaryCause: 'TimeoutTiebreak', narrativeSeed: narrative };
+      } else {
+        // StalemateTiebreak: S5 always returns MutualDestruction; distinguish
+        // by gameOutcome if provided, otherwise use a neutral fallback.
+        let narrative: string;
+        if (gameOutcome === 'Victory') {
+          narrative = 'Both colonies ran out of food; the enemy starved first.';
+        } else if (gameOutcome === 'Defeat') {
+          narrative = 'Both colonies ran out of food; your queen starved first.';
+        } else {
+          narrative = 'Both colonies ran out of food and the round ended in a draw.';
+        }
+        return { primaryCause: 'StalemateTiebreak', narrativeSeed: narrative };
+      }
+    }
+  }
+  // S6: updated queen_death narrative strings (more descriptive than S0b's).
   for (const ev of events) {
     if (ev.type === 'queen_death') {
       const cause = ev.payload.cause;
       if (cause === null) {
-        return { primaryCause: null, narrativeSeed: null };
+        return { primaryCause: null, narrativeSeed: 'Your colony has fallen.' };
       }
       const narratives: Record<string, string> = {
-        InvasionKill: 'The enemy colony overran your nest',
-        SpiderRampage: 'A spider rampage reached your queen',
-        Starvation: 'Your colony starved',
-        MutualDestruction: 'Both queens fell at the same time',
+        InvasionKill:      'Enemy fighters broke through a tunnel entrance and reached your queen.',
+        SpiderRampage:     'The spider reached your nursery and killed the queen.',
+        Starvation:        'Your queen starved after the colony ran out of food.',
+        MutualDestruction: 'Both queens died in the same final fight.',
       };
       return {
         primaryCause: cause,
@@ -207,10 +245,12 @@ function buildTunableObserved(events: SimEvent[]): TunableObserved {
  * @param world          - The terminal WorldState (post-outcome).
  * @param resumedFromSave - True if the session was loaded from a save; causes
  *                         eventsCoverage to be 'since_load'.
+ * @param gameOutcome    - S6: optional outcome label for tiebreak narrative selection.
  */
 export function buildPlaytraceSummary(
   world: WorldState,
   resumedFromSave: boolean,
+  gameOutcome?: GameOutcomeLabel,
 ): PlaytraceSummary {
   const events = world.events;
 
@@ -221,7 +261,7 @@ export function buildPlaytraceSummary(
 
   return {
     strategySignals: buildStrategySignals(world),
-    outcomeAttribution: buildOutcomeAttribution(events),
+    outcomeAttribution: buildOutcomeAttribution(events, gameOutcome),
     combatAggregate: buildCombatAggregate(events),
     tunableObserved: buildTunableObserved(events),
     eventOverflow: {

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -925,7 +925,12 @@ export class UIScene extends Phaser.Scene {
   // Phase 9 Plan 06 — GameOver overlay
   // ---------------------------------------------------------------------------
 
-  public showGameOverOverlay(outcome: GameOutcome, cause: QueenDeathCause, onRestart: () => void): void {
+  public showGameOverOverlay(
+    outcome: GameOutcome,
+    cause: QueenDeathCause,
+    onRestart: () => void,
+    narrativeSeed?: string | null,
+  ): void {
     this.hideGameOverOverlay(); // clear any prior instance first
 
     const W = 800;
@@ -945,12 +950,17 @@ export class UIScene extends Phaser.Scene {
     title.setOrigin(0.5);
     title.setDepth(21);
 
-    // Cause line — why the relevant queen died.
-    const causeText = formatCauseSubtitle(outcome, cause);
+    // S6: prefer narrativeSeed from summary-builder; fall back to formatCauseSubtitle
+    // for pre-V22 saves or cases where buildPlaytraceSummary returns null.
+    const causeText = (narrativeSeed != null && narrativeSeed !== '')
+      ? narrativeSeed
+      : formatCauseSubtitle(outcome, cause);
     const causeLabel = this.add.text(W / 2, H / 2 - 25, causeText, {
-      fontSize: '20px',
+      fontSize: '18px',
       fontFamily: 'monospace',
       color: '#ffffff',
+      wordWrap: { width: 680 },
+      align: 'center',
     });
     causeLabel.setOrigin(0.5);
     causeLabel.setDepth(21);
@@ -961,8 +971,8 @@ export class UIScene extends Phaser.Scene {
     const world = this.getWorld();
     const playerColony = world?.colonies[_PLAYER_COLONY_ID];
     const killCount = playerColony?.killCount ?? 0;
-    const subtitle = this.add.text(W / 2, H / 2 + 10, formatKillStatsSubtitle(killCount), {
-      fontSize: '18px',
+    const subtitle = this.add.text(W / 2, H / 2 + 20, formatKillStatsSubtitle(killCount), {
+      fontSize: '16px',
       fontFamily: 'monospace',
       color: '#cccccc',
     });
@@ -992,6 +1002,40 @@ export class UIScene extends Phaser.Scene {
 
     this.gameOverGroup = [bg, title, causeLabel, subtitle, btnBg, btnLabel];
     this.recomputeActiveOverlay();
+  }
+
+  // S6 — first-occurrence caption overlay (light onboarding).
+  public showCaption(text: string, screenX: number, screenY: number): void {
+    const captionText = this.add.text(screenX, screenY, text, {
+      fontSize: '14px',
+      fontFamily: 'monospace',
+      color: '#ffffcc',
+      backgroundColor: '#00000088',
+      padding: { x: 8, y: 4 },
+      align: 'center',
+      wordWrap: { width: 500 },
+    });
+    captionText.setOrigin(0.5, 0.5);
+    captionText.setDepth(30);
+    captionText.setAlpha(0);
+
+    // Fade in, hold, fade out over 1500ms total.
+    this.tweens.add({
+      targets: captionText,
+      alpha: { from: 0, to: 1 },
+      duration: 300,
+      ease: 'Linear',
+      onComplete: () => {
+        this.tweens.add({
+          targets: captionText,
+          alpha: { from: 1, to: 0 },
+          duration: 400,
+          delay: 800,
+          ease: 'Linear',
+          onComplete: () => { captionText.destroy(); },
+        });
+      },
+    });
   }
 
   public hideGameOverOverlay(): void {


### PR DESCRIPTION
## Summary

S6-Polish render-only pass. No sim version bump.

- **Part A — Polished visualizations**: Spider reticle gains sine-wave alpha pulse and scale animation when Hunting/Striking; hunger ring uses linear color gradient from pale to deep red with a secondary faster pulse at ≥80% hunger. Combat tile glow is now per-grid (blue for player underground, orange for enemy underground, yellow for surface contested) with 5-frame fade-out tracking.
- **Part B — New Phase-6 cues**: Full-screen red flash on queen HP drop (suppressed first 40 ticks); screen-edge red flash on invasion events with direction inferred from entrance vs. queen chamber position; event cursor (`nextEventIndex`) drains `world.events` each render frame to dispatch effects and captions.
- **Part C — Loss-screen attribution**: `buildOutcomeAttribution()` now handles S5 tiebreak events (`round_end` with `TimeoutTiebreak`/`StalemateTiebreak`) before falling through to `queen_death` narratives. `showGameOverOverlay` receives `narrativeSeed` and displays it as a subtitle.
- **Part D — First-occurrence captions**: 10-key registry in `onboarding-captions.ts`; each caption fires exactly once per session (reset per round). Captions are triggered from command dispatch (dig, chamber, food mark, rally) and per-frame checks (spider visible, spider priority, AI invading, spider rampage, queen damage, queen starvation).

## Test plan

- [ ] `npm run test` — 2243 tests passing, 76 files
- [ ] `npm run test:coverage` — all gates ≥80% (Statements 89.71%, Branches 82.97%, Functions 94.76%, Lines 92.29%)
- [ ] Manual: trigger invasion → screen edge flashes on correct side
- [ ] Manual: let queen take damage → full-screen red pulse; no pulse in first 2 sim-seconds
- [ ] Manual: first dig → caption appears; second dig same session → no caption
- [ ] Manual: loss screen shows `narrativeSeed` narrative text

## Files changed

| File | Change |
|---|---|
| `src/render/sprites.ts` | Add 3 glow color constants |
| `src/render/draw-surface.ts` | Spider reticle pulse + hunger ring gradient; contested glow with per-grid color + fade |
| `src/render/draw-underground.ts` | Underground home-ground combat tile glow pass |
| `src/render/game-scene.ts` | Event cursor; queen HP tracking; event dispatch; loss-screen narrative; caption wiring |
| `src/render/ui-scene.ts` | `showCaption()`; `showGameOverOverlay` receives `narrativeSeed` |
| `src/render/summary-builder.ts` | Tiebreak + updated queen_death narrative strings; `buildOutcomeAttribution` exported |
| `src/render/screen-effects.ts` *(new)* | Screen-edge flash; queen damage pulse; `inferFlashDirection` |
| `src/render/onboarding-captions.ts` *(new)* | Caption registry + `checkAndTrigger` + `resetCaptions` |
| `src/render/summary-builder.test.ts` *(new)* | 14 tests: all tiebreak paths, queen_death strings, null fallback |
| `src/render/onboarding-captions.test.ts` *(new)* | 16 tests: per-key, suppression, reset, chamber substitution |
| `src/render/screen-effects.test.ts` *(new)* | 12 smoke tests: constants + inferFlashDirection |

🤖 Generated with [Claude Code](https://claude.com/claude-code)