### PR TITLE
fix(d3): scope flow-field caches per-world (#160)

### DIFF
--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -489,11 +489,11 @@ export class GameScene extends Phaser.Scene {
     // doc); a fresh start via restartGame should resume normal autosave.
     this.autosaveSuspended = false;
     this.resumedFromSave = false;
-    // tick.ts caches entrance/dig/chamber flow-fields at module scope keyed by
-    // colonyId. bootFresh/bootFromSave replace `world` but those singletons
-    // survive, so a new session with the same colony IDs would otherwise route
-    // ants against the previous world's topology. Clear them here, before the
-    // new world first ticks.
+    // tick.ts owns entrance/dig/chamber flow-field scratch per-world (issue
+    // #160): each WorldState gets its own caches, so bootFresh/bootFromSave
+    // already start the new world with empty caches and this call is no longer
+    // required for cross-world correctness. Kept as an explicit teardown that
+    // drops the retired session's cache eagerly rather than waiting for GC.
     resetFlowFieldCaches();
     // SyncAIState change-detection cache: must be cleared alongside flow-field caches so an
     // in-session bootFromSave whose loaded aiState matches the stale prior-session cache

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -2762,12 +2762,13 @@ describe('Phase 9 tick integration', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Regression: flow-field caches must not leak across worlds/sessions.
-// Module-level entrance/dig/chamber caches keyed by colonyId would otherwise
-// let a second world with the same colonyId inherit the first world's tunnel
-// topology when digFlowFieldDirty=false on the loaded snapshot.
+// Regression: flow-field caches must not leak across worlds/sessions (#160).
+// Caches are now owned per-world (a WeakMap keyed by WorldState in tick.ts), so
+// a second world reusing the same colonyId starts with empty caches instead of
+// inheriting the first world's tunnel topology — even when digFlowFieldDirty is
+// false on the loaded snapshot and without any explicit reset between worlds.
 // ---------------------------------------------------------------------------
-describe('resetFlowFieldCaches — cross-world isolation', () => {
+describe('cross-world flow-field cache isolation', () => {
   // Build a minimal underground-only world where a foraging ant with
   // foodCarrying=0 routes to the nearest open entrance via the entrance
   // flow-field. Different entrance locations in world A vs world B make the
@@ -2866,27 +2867,27 @@ describe('resetFlowFieldCaches — cross-world isolation', () => {
     expect(afterB).toBeGreaterThan(beforeB);  // stepped east toward col 14 in world B
   });
 
-  it('without resetFlowFieldCaches() between worlds, world B would inherit world A topology (negative control)', async () => {
-    // Ensure cache is clean at the start.
+  it('#160 — world B routes per its own topology WITHOUT an explicit reset (per-world caches)', async () => {
+    // Ensure caches are clean at the start.
     resetFlowFieldCaches();
-    // World A: entrance at col 2 — populates caches under colonyId=1.
+    // World A: entrance at col 2 — populates world A's own caches under colonyId=1.
     const { world: worldA } = await makeUndergroundWorldWithFighter(2, 2);
     tick(worldA, []);
 
-    // Intentionally skip resetFlowFieldCaches(). World B has same colonyId=1
-    // but entrance at col 14 and digFlowFieldDirty=false — the firstDigCompute
-    // latch is false (cache has key) so the recompute would be skipped UNLESS
-    // the colony dirties the field. With the latch check on both dig and
-    // entrance caches, a lingering cache is reused — confirming why the reset
-    // call is load-bearing in bootFresh / bootFromSave.
+    // Intentionally skip resetFlowFieldCaches(). World B is a distinct
+    // WorldState object that reuses colonyId=1 with entrance at col 14 and
+    // digFlowFieldDirty=false. Before #160 the flow-field caches were shared
+    // module singletons keyed only by colonyId: the firstDigCompute latch was
+    // false (the cache still held world A's key), so world B inherited world A's
+    // topology and the fighter stepped west toward col 2. Now each world owns
+    // its caches (WeakMap keyed by world object), so world B starts with empty
+    // caches and routes per its own entrance.
     const { world: worldB, antId: antB } = await makeUndergroundWorldWithFighter(14, 14);
     const beforeB = worldB.ants.posX[antB]! >> FP_SHIFT;
     tick(worldB, []);
     const afterB = worldB.ants.posX[antB]! >> FP_SHIFT;
-    // The fighter steps west (toward world A's entrance col 2), NOT east
-    // toward world B's own entrance col 14 — the exact bug fixed by the
-    // reset hook.
-    expect(afterB).toBeLessThan(beforeB);
+    // Steps east toward world B's own entrance col 14 — no stale inheritance.
+    expect(afterB).toBeGreaterThan(beforeB);
 
     // Leave clean state for the next test.
     resetFlowFieldCaches();

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -94,49 +94,62 @@ import type { ColonyId, ColonyRecord } from './colony/colony-store.js';
 import type { FoodPileId } from './food.js';
 
 // ---------------------------------------------------------------------------
-// Module-level scratch state — persists across ticks, not part of WorldState.
-// Created once at module load. Per Open Question 1 in RESEARCH.md.
-// Plan 08 replaces the Phase 06 _stubDigFlowFields with this properly-populated instance.
+// Per-world flow-field scratch (issue #160) — persists across a world's ticks,
+// not part of WorldState (never serialized). Each WorldState owns its own dig/
+// entrance/chamber BFS caches, keyed by world-object identity in the WeakMap
+// below.
+//
+// Previously these were module-level singletons keyed only by colonyId, shared
+// across every world the process ever ticked. A new or deserialized world that
+// reused a prior world's colony ids would inherit the prior topology for any
+// colony whose dirty flags were clear on its first tick — unless every boot/
+// debug/test entry point remembered to call resetFlowFieldCaches() between
+// worlds. Per-world storage makes the simulation self-contained: a fresh or
+// loaded world starts with empty caches and recomputes from its own topology on
+// the first tick, with no dependence on global resets. A WeakMap lets a world's
+// caches be garbage-collected once the world is no longer referenced.
+//
+//   - dig:      seeded from dig-marked tiles; drives dig-worker routing.
+//   - entrance: seeded from open entrance underground tiles; used by empty
+//               foragers to find a tunnel path back to the surface instead of
+//               steering straight-line into dirt.
+//   - chamber:  per-colony food / nursing / queen / nurse-deposit fields; keeps
+//               chamber steering off Solid dirt on bent tunnels (chamber-flow.ts).
 // ---------------------------------------------------------------------------
-const digFlowFields: DigFlowFields = createDigFlowFields();
-// Shared entrance-return flow-field cache. Seeded from open entrance
-// underground tiles; used by underground empty foragers to find a tunnel
-// path back to the surface instead of steering straight-line into dirt.
-const entranceFlowFields: EntranceFlowFields = createEntranceFlowFields();
-// Shared chamber flow-field cache. Two fields per colony: `food` (seeded from
-// FoodStorage chamber Open tiles, read by underground carrying foragers) and
-// `nursing` (seeded from Queen+Nursery chamber Open tiles, read by Nursing
-// ants). Prevents straight-line chamber steering into Solid dirt on bent
-// tunnels (see chamber-flow.ts).
-const chamberFlowFields: ChamberFlowFields = createChamberFlowFields();
+interface FlowFieldCaches {
+  dig: DigFlowFields;
+  entrance: EntranceFlowFields;
+  chamber: ChamberFlowFields;
+}
+
+let cachesByWorld = new WeakMap<WorldState, FlowFieldCaches>();
+
+/** Get (or lazily create) the flow-field scratch owned by `world`. */
+function getFlowFieldCaches(world: WorldState): FlowFieldCaches {
+  let caches = cachesByWorld.get(world);
+  if (caches === undefined) {
+    caches = {
+      dig: createDigFlowFields(),
+      entrance: createEntranceFlowFields(),
+      chamber: createChamberFlowFields(),
+    };
+    cachesByWorld.set(world, caches);
+  }
+  return caches;
+}
 
 /**
- * Clear every module-level flow-field cache keyed by colonyId.
+ * Drop all per-world flow-field scratch.
  *
- * MUST be called between distinct sessions/worlds that may share colony IDs —
- * bootFresh() and bootFromSave() both replace `world` but the singletons above
- * survive across those transitions. Without this reset, a colony in the new
- * world whose `digFlowFieldDirty` is false on the first tick would keep the
- * previous session's entrance/chamber topology in its cache and route ants
- * against the old tunnel layout.
- *
- * In-place deletion preserves the const-bound record identities held by step 9.
+ * As of issue #160 this is no longer required for cross-world correctness —
+ * each world owns its caches via the WeakMap above, so a fresh or loaded world
+ * can never inherit another world's topology. Retained as an explicit teardown
+ * hook (the render layer calls it on boot) and for test isolation. Replacing
+ * the map drops every world's entry at once; abandoned entries would also be
+ * collected on their own once their world is unreferenced.
  */
 export function resetFlowFieldCaches(): void {
-  for (const k in digFlowFields.fields)              delete digFlowFields.fields[k as unknown as ColonyId];
-  for (const k in digFlowFields.queues)              delete digFlowFields.queues[k as unknown as ColonyId];
-  for (const k in entranceFlowFields.fields)         delete entranceFlowFields.fields[k as unknown as ColonyId];
-  for (const k in entranceFlowFields.queues)         delete entranceFlowFields.queues[k as unknown as ColonyId];
-  // Issue #63 — surface entrance flow-field cache also needs reset, otherwise
-  // a session-restart or save-load with different colony IDs leaves stale
-  // arrays resident (codex P2 on PR #92).
-  for (const k in entranceFlowFields.surface)        delete entranceFlowFields.surface[k as unknown as ColonyId];
-  for (const k in entranceFlowFields.surfaceQueues)  delete entranceFlowFields.surfaceQueues[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.food)            delete chamberFlowFields.food[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.nursing)         delete chamberFlowFields.nursing[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.queen)           delete chamberFlowFields.queen[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.nurseDeposit)    delete chamberFlowFields.nurseDeposit[k as unknown as ColonyId];
-  for (const k in chamberFlowFields.queues)          delete chamberFlowFields.queues[k as unknown as ColonyId];
+  cachesByWorld = new WeakMap();
 }
 
 // Suppress unused-import TS error for PendingChamber (used in PlaceChamber case shape)
@@ -216,6 +229,15 @@ function isTileCoord(value: unknown, max: number): boolean {
 }
 
 export function tick(world: WorldState, commands: readonly SimCommand[]): GameOutcome {
+  // Issue #160 — flow-field BFS scratch owned by this world. Lazily created on
+  // the world's first tick and reused across its subsequent ticks; a different
+  // world (fresh boot, save load, or a test world) gets its own caches, so a
+  // reused colony id can never resolve to another world's topology.
+  const caches = getFlowFieldCaches(world);
+  const digFlowFields = caches.dig;
+  const entranceFlowFields = caches.entrance;
+  const chamberFlowFields = caches.chamber;
+
   // Reconstruct Rng from saved state at tick start (PRD §4 contract).
   const rng = new Rng(world.rngState);
 
@@ -773,9 +795,10 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // the field would remain all-zeros and empty foragers would "route" north
     // forever. The chamber flow-fields piggy-back on the same gate — they
     // share the underlying topology, so any signal that dirties dig/entrance
-    // fields dirties them too. `firstDigCompute` also fires after a cross-
-    // session reset via resetFlowFieldCaches(), guaranteeing a fresh/loaded
-    // world never reuses another world's cached topology.
+    // fields dirties them too. Because the caches are owned per-world (issue
+    // #160), `firstDigCompute` is always true on a fresh or loaded world's
+    // first tick, guaranteeing it computes from its own topology rather than
+    // reusing another world's.
     const firstEntranceCompute = !(colony.colonyId in entranceFlowFields.fields);
     const firstDigCompute = !(colony.colonyId in digFlowFields.fields);
 


### PR DESCRIPTION
## Summary

D3 codebase review — PR 2 of 4 (flow-field cache lifecycle).

Fixes **#160**: the dig/entrance/chamber flow-field BFS caches in `src/sim/tick.ts` were module-level singletons keyed only by `colonyId`, shared across every world the process ticked. A fresh or deserialized world that reused a prior world's colony ids would inherit the prior world's tunnel topology for any colony whose `digFlowFieldDirty`/`foodFlowFieldDirty` flags were clear on its first tick — **unless** every boot/debug/test entry point remembered to call `resetFlowFieldCaches()` between worlds. That reliance on a manual global reset is a sharp edge against the determinism contract (replay/save/debug runs could diverge based on unrelated prior simulations).

## What changed

- Store the caches **per-world** in a `WeakMap<WorldState, FlowFieldCaches>`, fetched once at the top of `tick()` via `getFlowFieldCaches(world)` and aliased to the existing `digFlowFields` / `entranceFlowFields` / `chamberFlowFields` locals (so step 9 and the `tickDigExecution` / `tickAntMovement` calls are otherwise untouched).
- Each world now owns its caches: a new or loaded world starts with empty caches and recomputes from its own topology on the first tick, with **no dependence on global resets**. Entries are garbage-collected with their world.
- `resetFlowFieldCaches()` is retained as an explicit teardown hook (now reassigns the map) — still called by the render layer on boot to drop a retired session eagerly — but is no longer load-bearing for correctness.
- Converted the negative-control test that *documented* the old cross-world-bleed hazard into a **positive regression test** for per-world isolation (world B routes per its own entrance without any reset between worlds). Refreshed now-stale comments in `tick.ts`, `tick.test.ts`, and `game-scene.ts`.

## Why a WeakMap (not a WorldState field or object-identity reset)

- A serialized `WorldState` field would couple scratch state to the save format. The WeakMap keeps the caches as pure scratch — never serialized, no `copyWorldState` changes.
- An object-identity "reset the singleton when the world changes" approach was tried and rejected: it thrashes (full BFS recompute every tick) when two worlds are ticked alternately, which the determinism/parity tests do — blowing their 30s budget. Per-world storage is both correct and fast there (each world computes ~once).

## Determinism

Single-world tick output is **byte-identical** to before; only cross-world cache sharing is removed. Caches remain scratch and are never serialized.

## Test plan

- [x] `npm run lint` → clean
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npm test` → 2185/2185 passing (74 files)
- [x] `bash scripts/check-sim-boundary.sh` → clean
- [x] Determinism/parity suite (previously the thrash canary) runs in ~4.5s
- [x] New `#160` per-world isolation regression test in `tick.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)