### PR TITLE
fix(d3): gate descent on entrance blockers (#164, #165)

### DIFF
--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -3631,6 +3631,61 @@ function moveQueens(
 // No Math.floor, no floats, no division. Clamp uses if/else for zero alloc.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Pre-descent gate (#164, #165)
+//
+// Descent (Surface → Underground) is a zone transition performed during step-16
+// movement, which runs BEFORE step-17 combat and step-17.5 spider. Without a
+// gate, an ant standing on an entrance slips underground in the same tick a
+// surface blocker should have stopped or fought it — combat never sees the
+// encounter. This holds the ant on the entrance's surface tile so the relevant
+// combat pass resolves it this tick. Reads only existing WorldState; no RNG,
+// no serialized scratch.
+// ---------------------------------------------------------------------------
+function isDescentBlocked(
+  world: WorldState,
+  task: AntTask,
+  isOwnEntrance: boolean,
+  entranceColony: ColonyRecord,
+  entranceTileX: number,
+  entranceTileY: number,
+): boolean {
+  const ants = world.ants;
+
+  // #165 — rampaging spider blockade. A spider parked on the entrance tile is
+  // the blockade footprint; hold every descender on the surface so step-17.5
+  // spider combat (which only scans the spider's own tile) catches it instead
+  // of letting carriers slip through the zone transition. Applies to any ant.
+  const spider = world.spider;
+  if (spider !== null && spider.state === 'Rampaging') {
+    const sx = spider.posX >> FP_SHIFT;
+    const sy = spider.posY >> FP_SHIFT;
+    if (sx === entranceTileX && sy === entranceTileY) {
+      return true;
+    }
+  }
+
+  // #164 — foreign fighter vs. a surface queen on the entrance tile. In the
+  // pre-Queen-chamber opening state the queen sits on her colony's start tile,
+  // which is also the starting entrance. An invading Fighter must engage her on
+  // the surface (step-17 ant combat buckets both on the shared surface tile)
+  // rather than descend past her unharmed.
+  if (!isOwnEntrance && task === AntTask.Fighting) {
+    const queenId = entranceColony.queenEntityId;
+    if (
+      queenId >= 0 &&
+      ants.alive[queenId] === 1 &&
+      ants.zone[queenId] === Zone.Surface &&
+      (ants.posX[queenId]! >> FP_SHIFT) === entranceTileX &&
+      (ants.posY[queenId]! >> FP_SHIFT) === entranceTileY
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Move every alive ant one step based on its current task and zone.
  *
@@ -4735,6 +4790,15 @@ export function tickAntMovement(
               // Foreign entrance but not a Fighting invader — descent-intent
               // gate rejects (REQ-C3c). Non-Fighting foreign ants stay on
               // the surface.
+              continue;
+            }
+
+            // Pre-descent gate (#164, #165): hold the ant on the surface when
+            // a blocker on the entrance tile should resolve this tick (rampaging
+            // spider blockade, or a surface queen a foreign Fighter must engage).
+            // `continue` skips descent through this entrance; with no other
+            // matching entrance the ant stays on the surface for combat.
+            if (isDescentBlocked(world, task, isOwnEntrance, colony, tileX, tileY)) {
               continue;
             }
 

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -709,6 +709,15 @@ describe('Phase 9 determinism (SC 5) — two-colony parity', () => {
 function buildCrossGridCombatWorld(seed: number): WorldState {
   const world = createScenario(seed);
 
+  // #164 pre-descent gate: createScenario spawns the enemy queen ON her start
+  // tile, which is also the enemy entrance. A foreign Fighter must now engage a
+  // surface queen on an entrance rather than descend past her — which would
+  // block this scenario's underground cross-grid combat. Relocate the enemy
+  // queen off the entrance tile (she holds position — no completed Queen
+  // chamber) so the invader's descent still fires.
+  const enemyQueenId = world.colonies[ENEMY_COLONY_ID]!.queenEntityId;
+  world.ants.posX[enemyQueenId] = (ENEMY_START_X + 6) << FP_SHIFT;
+
   // Spawn 1 player Fighter on the enemy entrance tile (Surface).
   const playerAntId = allocateEntityId(world);
   initAnt(world.ants, playerAntId, {

--- a/src/sim/fighter-rally-hold.test.ts
+++ b/src/sim/fighter-rally-hold.test.ts
@@ -357,6 +357,15 @@ function buildInvasionRallyWorld(
   const rallyTileX = ENEMY_START_X;
   const rallyTileY = ENEMY_START_Y;
 
+  // #164 pre-descent gate: createScenario spawns the enemy queen ON her start
+  // tile, which is also the enemy entrance. A foreign Fighter must now engage a
+  // surface queen on an entrance rather than descend past her. These tests
+  // assert rally-then-descend on a developed colony, so relocate the enemy
+  // queen off the entrance tile (she holds position — no completed Queen
+  // chamber) to keep the descent path clear.
+  const enemyQueenId = world.colonies[ENEMY_COLONY_ID]!.queenEntityId;
+  world.ants.posX[enemyQueenId] = (ENEMY_START_X + 6) << FP_SHIFT;
+
   // Rally the PLAYER colony onto the enemy entrance tile.
   world.colonies[PLAYER_COLONY_ID]!.rallyPoint = {
     tileX: rallyTileX,

--- a/src/sim/invasion-routing.test.ts
+++ b/src/sim/invasion-routing.test.ts
@@ -74,6 +74,15 @@ function buildInvasionWorld(seed = 42): InvasionWorld {
   const enemyEntTileX = ENEMY_START_X;
   const enemyEntTileY = ENEMY_START_Y;
 
+  // #164 pre-descent gate: createScenario spawns the enemy queen ON her start
+  // tile, which is also the enemy entrance. A foreign Fighter must now engage a
+  // surface queen on an entrance rather than descend past her. These tests
+  // exercise the descent/routing mechanic on a developed colony, so relocate
+  // the enemy queen off the entrance tile (she holds position — no completed
+  // Queen chamber) to keep the descent path clear.
+  const enemyQueenId = world.colonies[ENEMY_COLONY_ID]!.queenEntityId;
+  world.ants.posX[enemyQueenId] = (ENEMY_START_X + 6) << FP_SHIFT;
+
   // Place one player-colony ant at the enemy entrance tile. Position uses
   // tile-center fixed-point coords so the tile-lookup (posX >> FP_SHIFT)
   // lands squarely on (enemyEntTileX, enemyEntTileY).

--- a/src/sim/predescent-gate.test.ts
+++ b/src/sim/predescent-gate.test.ts
@@ -1,0 +1,223 @@
+// predescent-gate.test.ts — regression coverage for the pre-descent gate.
+//
+// Descent (Surface → Underground) is a zone transition performed during step-16
+// movement (tickAntMovement), which runs BEFORE step-17 combat and step-17.5
+// spider. Two bugs followed from that ordering:
+//
+//   #164 — a foreign Fighter standing on an enemy entrance could descend past a
+//          queen still sitting on that same surface tile (the pre-Queen-chamber
+//          opening state) before surface combat ever saw the encounter.
+//   #165 — a carrying forager could descend through an entrance a rampaging
+//          spider was blockading before spider combat checked the surface tile.
+//
+// The fix holds the ant on the entrance's surface tile when a blocker occupies
+// it, so the relevant combat pass resolves the encounter the same tick.
+
+import { describe, it, expect } from 'vitest';
+import { createScenario } from './scenario.js';
+import { tick } from './tick.js';
+import { allocateEntityId } from './types.js';
+import type { WorldState, SpiderState } from './types.js';
+import { initAnt } from './ant/ant-store.js';
+import { AntTask, ForagingSubState } from './enums.js';
+import { Zone } from './terrain.js';
+import { FP_SHIFT, FP_ONE } from './fixed.js';
+import {
+  PLAYER_COLONY_ID,
+  ENEMY_COLONY_ID,
+  PLAYER_START_X,
+  PLAYER_START_Y,
+  ENEMY_START_X,
+  ENEMY_START_Y,
+  WORKER_BASE_SPEED,
+  WORKER_LIFESPAN_TICKS,
+  COMBAT_HP_QUEEN,
+  COMBAT_HP_BASE,
+  COMBAT_COOLDOWN_TICKS,
+  SPIDER_HP_FULL,
+} from './constants.js';
+
+const SEED = 4242;
+
+/** Tile-center fixed-point coordinate for a tile index. */
+function center(tile: number): number {
+  return (tile << FP_SHIFT) + (FP_ONE >> 1);
+}
+
+/** Build a Rampaging spider parked on (tileX, tileY). */
+function rampagingSpiderAt(tileX: number, tileY: number, targetColonyId: number): SpiderState {
+  return {
+    state: 'Rampaging',
+    posX: center(tileX),
+    posY: center(tileY),
+    lairTileX: tileX,
+    lairTileY: tileY,
+    territoryRadiusTiles: 24,
+    hp: SPIDER_HP_FULL,
+    attackCooldown: 0,
+    hungerTicks: 0,
+    nextHuntTick: 0,
+    huntStartTick: 0,
+    strikeStartTick: 0,
+    feedingStartTick: 0,
+    retreatStartTick: 0,
+    rampageStartTick: 0,
+    huntTargetTileX: -1,
+    huntTargetTileY: -1,
+    killsThisStrike: 0,
+    rampageKillsThisRampage: 0,
+    rampageTargetColonyId: targetColonyId,
+  };
+}
+
+/** Spawn a player Fighter on the enemy entrance tile, rallied so it holds. */
+function spawnInvaderOnEnemyEntrance(world: WorldState): number {
+  const id = allocateEntityId(world);
+  initAnt(world.ants, id, {
+    colonyId: PLAYER_COLONY_ID,
+    posX:     center(ENEMY_START_X),
+    posY:     center(ENEMY_START_Y),
+    task:     AntTask.Fighting,
+    subTask:  0,
+    speed:    WORKER_BASE_SPEED,
+    lifespan: WORKER_LIFESPAN_TICKS,
+    zone:     Zone.Surface,
+  });
+  world.colonies[PLAYER_COLONY_ID]!.workers.push(id);
+  world.colonies[PLAYER_COLONY_ID]!.workerCount += 1;
+  // Rally + fight ratio > 0 so recall logic doesn't fire and the fighter holds
+  // on the entrance tile rather than walking home.
+  world.colonies[PLAYER_COLONY_ID]!.rallyPoint = { tileX: ENEMY_START_X, tileY: ENEMY_START_Y };
+  world.colonies[PLAYER_COLONY_ID]!.targetRatio.fight = 5;
+  return id;
+}
+
+/** Spawn a player carrying-forager on the player entrance tile. */
+function spawnCarrierOnPlayerEntrance(world: WorldState): number {
+  const id = allocateEntityId(world);
+  initAnt(world.ants, id, {
+    colonyId: PLAYER_COLONY_ID,
+    posX:     center(PLAYER_START_X),
+    posY:     center(PLAYER_START_Y),
+    task:     AntTask.Foraging,
+    subTask:  ForagingSubState.CarryingFood,
+    speed:    WORKER_BASE_SPEED,
+    lifespan: WORKER_LIFESPAN_TICKS,
+    hp:       COMBAT_HP_BASE,
+    zone:     Zone.Surface,
+  });
+  world.ants.foodCarrying[id] = FP_ONE; // carrying food → has descent intent
+  world.colonies[PLAYER_COLONY_ID]!.workers.push(id);
+  world.colonies[PLAYER_COLONY_ID]!.workerCount += 1;
+  return id;
+}
+
+describe('pre-descent gate — #164 foreign Fighter vs. a surface queen on an entrance', () => {
+  it('does NOT descend past an enemy queen sitting on the enemy entrance tile', () => {
+    const world = createScenario(SEED);
+    world.spider = null; // isolate the queen encounter from spider combat
+    // createScenario leaves the enemy queen on (ENEMY_START_X, ENEMY_START_Y),
+    // which is also the enemy entrance — exactly the #164 opening state.
+    const enemyQueenId = world.colonies[ENEMY_COLONY_ID]!.queenEntityId;
+    expect(world.ants.zone[enemyQueenId]).toBe(Zone.Surface);
+    expect(world.ants.posX[enemyQueenId]! >> FP_SHIFT).toBe(ENEMY_START_X);
+    expect(world.ants.posY[enemyQueenId]! >> FP_SHIFT).toBe(ENEMY_START_Y);
+
+    const invaderId = spawnInvaderOnEnemyEntrance(world);
+
+    tick(world, []);
+
+    // Gate held the invader on the surface in its own grid — it did not slip
+    // underground past the queen.
+    expect(world.ants.zone[invaderId]).toBe(Zone.Surface);
+    expect(world.ants.currentGridColonyId[invaderId]).toBe(PLAYER_COLONY_ID);
+  });
+
+  it('resolves the surface encounter — the held invader damages the queen', () => {
+    const world = createScenario(SEED);
+    world.spider = null;
+    const enemyQueenId = world.colonies[ENEMY_COLONY_ID]!.queenEntityId;
+    const invaderId = spawnInvaderOnEnemyEntrance(world);
+
+    // Tick past combat windup (COMBAT_COOLDOWN_TICKS) so a strike lands.
+    for (let i = 0; i < COMBAT_COOLDOWN_TICKS + 4; i++) tick(world, []);
+
+    // The invader stayed contesting the queen tile (surface) and the queen took
+    // damage — the encounter the old ordering skipped now resolves.
+    expect(world.ants.zone[invaderId]).toBe(Zone.Surface);
+    const queenDamaged =
+      world.ants.alive[enemyQueenId] === 0 || world.ants.hp[enemyQueenId]! < COMBAT_HP_QUEEN;
+    expect(queenDamaged).toBe(true);
+  });
+
+  it('control: with the enemy queen moved off the entrance tile, the invader descends', () => {
+    const world = createScenario(SEED);
+    world.spider = null;
+    // Relocate the enemy queen off the entrance (she holds — no Queen chamber).
+    const enemyQueenId = world.colonies[ENEMY_COLONY_ID]!.queenEntityId;
+    world.ants.posX[enemyQueenId] = (ENEMY_START_X + 6) << FP_SHIFT;
+
+    const invaderId = spawnInvaderOnEnemyEntrance(world);
+
+    let descended = false;
+    for (let i = 0; i < 5; i++) {
+      tick(world, []);
+      if (world.ants.zone[invaderId] === Zone.Underground) { descended = true; break; }
+    }
+
+    expect(descended).toBe(true);
+    expect(world.ants.currentGridColonyId[invaderId]).toBe(ENEMY_COLONY_ID);
+  });
+});
+
+describe('pre-descent gate — #165 rampaging spider blockade at an entrance', () => {
+  it('does NOT descend through an entrance a rampaging spider is parked on', () => {
+    const world = createScenario(SEED);
+    world.spider = rampagingSpiderAt(PLAYER_START_X, PLAYER_START_Y, PLAYER_COLONY_ID);
+
+    const carrierId = spawnCarrierOnPlayerEntrance(world);
+
+    tick(world, []);
+
+    // Gate held the carrier on the surface entrance tile instead of letting it
+    // slip underground before spider combat could see it.
+    expect(world.ants.zone[carrierId]).toBe(Zone.Surface);
+  });
+
+  it('blockade resolves — the held carrier is caught (damaged or killed) by the spider', () => {
+    const world = createScenario(SEED);
+    world.spider = rampagingSpiderAt(PLAYER_START_X, PLAYER_START_Y, PLAYER_COLONY_ID);
+
+    const carrierId = spawnCarrierOnPlayerEntrance(world);
+    const startHp = world.ants.hp[carrierId]!;
+
+    // Tick past spider-combat windup; verify it never reaches Underground.
+    let everUnderground = false;
+    for (let i = 0; i < COMBAT_COOLDOWN_TICKS + 4; i++) {
+      tick(world, []);
+      if (world.ants.alive[carrierId] === 1 && world.ants.zone[carrierId] === Zone.Underground) {
+        everUnderground = true;
+        break;
+      }
+    }
+
+    expect(everUnderground).toBe(false);
+    const caught = world.ants.alive[carrierId] === 0 || world.ants.hp[carrierId]! < startHp;
+    expect(caught).toBe(true);
+  });
+
+  it('control: with no spider on the entrance, the carrier descends normally', () => {
+    const world = createScenario(SEED);
+    world.spider = null; // no blockade
+
+    const carrierId = spawnCarrierOnPlayerEntrance(world);
+
+    let descended = false;
+    for (let i = 0; i < 5; i++) {
+      tick(world, []);
+      if (world.ants.zone[carrierId] === Zone.Underground) { descended = true; break; }
+    }
+
+    expect(descended).toBe(true);
+  });
+});

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -557,10 +557,13 @@ export function tickSpider(world: WorldState): void {
     }
     case 'Rampaging': {
       if (rampageNearest !== null) {
-        // Park one tile above the entrance so workers in zone=Surface are caught
-        // before the entrance-tile zone transition flips them to Underground.
-        const blockadeY = rampageNearest.y > 0 ? rampageNearest.y - 1 : rampageNearest.y;
-        moveTowardTile(spider, rampageNearest.x, blockadeY);
+        // Park ON the entrance tile. The pre-descent gate (#165, ant-system.ts)
+        // holds surface ants here instead of letting them descend before combat,
+        // and spider combat scans the spider's own tile — so blockading the
+        // entrance tile itself is what actually catches entrance traffic,
+        // regardless of which direction the ant approached from. (Parking one
+        // tile above only caught ants approaching from that side.)
+        moveTowardTile(spider, rampageNearest.x, rampageNearest.y);
       }
       break;
     }


### PR DESCRIPTION
## Summary

D3 codebase review — PR 3 of 4 (pre-descent gates).

Fixes **#164** and **#165**. Both are the same root cause: descent (Surface → Underground) is a zone transition performed during **step-16 movement** (`tickAntMovement`), which runs *before* **step-17 combat** (`detectAndResolveCombat`) and **step-17.5 spider** (`tickSpider`). An ant standing on an entrance slips underground in the same tick a surface blocker should have stopped or fought it — combat never sees the encounter.

- **#164** — a foreign Fighter on an enemy entrance could descend past a queen still sitting on that same surface tile (the pre-Queen-chamber opening state, where the queen spawns on the colony start tile = the starting entrance).
- **#165** — a carrying forager could descend through an entrance a rampaging spider was blockading before spider combat checked the surface tile (the spider parked *one tile above* the entrance and combat only scans the spider's own tile).

## What changed

- **New `isDescentBlocked` gate** in `tickAntMovement`, evaluated right before the `Zone.Underground` transition. It holds the ant on the entrance's surface tile when:
  - a **rampaging spider** occupies the entrance tile (applies to any descender — the blockade catches everyone), or
  - the descender is a **foreign Fighter** and the **entrance-owner's queen** is alive on the entrance surface tile.
  - On block it `continue`s (skips descent through this entrance); with no other matching entrance the ant stays on the surface and the relevant combat pass resolves it that tick. `makeTileKey` zeroes the grid byte on the surface, so the held invader and the queen bucket together for ant-vs-ant combat; the held carrier sits on the spider's tile for spider combat.
- **Spider rampage parks ON the entrance tile** (was `entranceY - 1`). Combined with the gate, blockading the entrance tile itself is what actually catches entrance traffic regardless of approach direction; `resolveSpiderCombatOnTile` only scans the spider's own tile, so the spider must be on the tile the ant is held on.
- **New regression suite** `predescent-gate.test.ts`: both gates + control cases (queen moved off entrance → invader descends; no spider → carrier descends) proving the gate is what changed behavior.
- **Existing cross-grid / invasion / rally tests** relocate the enemy queen off the entrance tile. Those tests exercise the *underground* descent/combat path; their fresh-`createScenario` setup happened to leave the enemy queen on the entrance, which the new #164 gate (correctly) now blocks. `moveQueens` holds a queen in place when there's no completed Queen chamber, so the relocated queen stays put — modelling the developed-colony state these tests intend.

## Determinism

The gate allocates nothing, makes no RNG draws, and reads only existing `WorldState` (`world.spider`, `world.ants`, the entrance-owning colony) using integer `>> FP_SHIFT` math. No serialized scratch added. Single-world tick output for scenarios without an entrance blocker is unchanged.

## Test plan

- [x] `npm run lint` → clean
- [x] `npx tsc --noEmit` → 0 errors
- [x] `bash scripts/check-sim-boundary.sh` (FNDN-07) → clean
- [x] `bash scripts/check-asset-paths.sh` → clean
- [x] `npm test` → 2191/2191 passing (75 files, +6 new)
- [x] New `predescent-gate.test.ts` covers both gates with control cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)