### PR TITLE
fix(d3): route invaders through bent underground tunnels via BFS (#163)

### DIFF
--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -7542,30 +7542,40 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
 });
 
 // ---------------------------------------------------------------------------
-// pickInvaderUndergroundStep — wall-aware greedy step (UAT: fighters freeze bug)
+// pickInvaderUndergroundStep — wall-aware BFS step (UAT: fighters freeze bug;
+// issue #163: route through bent tunnels)
+//
+// BFS routing requires a fully connected passable path from the invader's tile
+// to the target — including the invader's OWN tile — so each scenario carves
+// the complete corridor (the old greedy stepper only looked one tile ahead).
 // ---------------------------------------------------------------------------
 
-describe('pickInvaderUndergroundStep — wall-aware greedy invader step', () => {
-  it('returns direct cardinal step when path is clear', () => {
-    // 5x5 grid. Fighter at (1,1), target at (1,4) due south.
-    // Grid defaults to Solid; set the south tile (1,2) Open so it can be entered.
-    // DIR_DX order: N(1,0) Solid, E(2,1) Solid, S(1,2) Open dist=2<3, W(0,1) Solid.
-    // South (0,+1) is the closest passable step.
+describe('pickInvaderUndergroundStep — wall-aware BFS invader step', () => {
+  it('returns direct cardinal step when a straight open path exists', () => {
+    // 5x5 grid. Fighter at (1,1), target at (1,4) due south. Carve the full
+    // column (1,1)..(1,4) Open. BFS distances south are 3,2,1,0; the invader's
+    // lowest-distance neighbour is S (1,2)=2 < self 3, so it steps south.
     const { underground } = setupWorldWithUnderground(5, 5);
+    ugSet(underground, 1, 1, UndergroundTileState.Open);
     ugSet(underground, 1, 2, UndergroundTileState.Open);
+    ugSet(underground, 1, 3, UndergroundTileState.Open);
+    ugSet(underground, 1, 4, UndergroundTileState.Open);
     const step = pickInvaderUndergroundStep(underground, 1, 1, 1, 4);
     expect(unpackStepDx(step)).toBe(0);
     expect(unpackStepDy(step)).toBe(1);
   });
 
-  it('avoids a wall blocking the direct cardinal path and picks a passable detour', () => {
-    // 5x5 grid. Fighter at (2,1), hostile at (4,3). Current dist=4.
-    // Solid wall at (2,2) blocks the south cardinal step (would give dist=3).
-    // Set east tile (3,1) Open — it also gives dist=3<4 and is the only passable step.
-    // DIR_DX order: N(2,0) Solid, E(3,1) Open dist=3<4, S(2,2) Solid, W(1,1) Solid.
-    // East (1,0) wins.
+  it('routes around a wall blocking the direct cardinal path', () => {
+    // 5x5 grid. Fighter at (2,1), hostile at (4,3). A Solid wall at (2,2)
+    // blocks the direct south step. Carve the L path (2,1)->(3,1)->(4,1)->
+    // (4,2)->(4,3) Open. BFS routes the invader east first (toward (3,1)=3 <
+    // self 4); the blocked south neighbour is never chosen.
     const { underground } = setupWorldWithUnderground(5, 5);
+    ugSet(underground, 2, 1, UndergroundTileState.Open);
     ugSet(underground, 3, 1, UndergroundTileState.Open);
+    ugSet(underground, 4, 1, UndergroundTileState.Open);
+    ugSet(underground, 4, 2, UndergroundTileState.Open);
+    ugSet(underground, 4, 3, UndergroundTileState.Open);
     const step = pickInvaderUndergroundStep(underground, 2, 1, 4, 3);
     expect(unpackStepDx(step)).toBe(1);
     expect(unpackStepDy(step)).toBe(0);
@@ -7578,16 +7588,53 @@ describe('pickInvaderUndergroundStep — wall-aware greedy invader step', () => 
     expect(unpackStepDy(step)).toBe(0);
   });
 
-  it('returns (0,0) when all passable neighbours are farther (dead-end hold, no infinite wall-bounce)', () => {
-    // 3x3 grid. Fighter at (1,0). Target at (1,2) but row 1 is all Solid.
-    // North is out of bounds. East/West are (0,0) dist=3 and (2,0) dist=3 — farther
-    // than current dist=2. Expect hold (0,0) rather than an infinite wall-bounce.
+  it('returns (0,0) when the target is walled off (unreachable hold, no wall-bounce)', () => {
+    // 3x3 grid. Fighter at (1,0) on an Open tile; target (1,2) is isolated
+    // (row 1 all Solid, so the target tile has no passable neighbour). With no
+    // connected path the BFS never reaches the invader → it holds rather than
+    // oscillating against the wall.
     const { underground } = setupWorldWithUnderground(3, 3);
-    ugSet(underground, 0, 1, UndergroundTileState.Solid);
-    ugSet(underground, 1, 1, UndergroundTileState.Solid);
-    ugSet(underground, 2, 1, UndergroundTileState.Solid);
+    ugSet(underground, 1, 0, UndergroundTileState.Open);
     const step = pickInvaderUndergroundStep(underground, 1, 0, 1, 2);
     expect(unpackStepDx(step)).toBe(0);
     expect(unpackStepDy(step)).toBe(0);
+  });
+
+  it('routes through a one-tile-wide bent L-corridor whose first legal step increases Manhattan distance (issue #163)', () => {
+    // 5x5 grid, everything Solid except the bent corridor
+    //   (0,1) -> (0,2) -> (1,2) -> (2,2) -> (2,1)
+    // Invader at (0,1), hostile at (2,1). Straight-line Manhattan distance is 2,
+    // but the ONLY legal first step is south to (0,2), which RAISES Manhattan
+    // distance to 3. The old greedy stepper rejected any non-improving step and
+    // froze at this elbow forever; the BFS stepper takes the detour.
+    const { underground } = setupWorldWithUnderground(5, 5);
+    ugSet(underground, 0, 1, UndergroundTileState.Open);
+    ugSet(underground, 0, 2, UndergroundTileState.Open);
+    ugSet(underground, 1, 2, UndergroundTileState.Open);
+    ugSet(underground, 2, 2, UndergroundTileState.Open);
+    ugSet(underground, 2, 1, UndergroundTileState.Open);
+
+    // First step is the distance-increasing detour (south), not a hold.
+    const first = pickInvaderUndergroundStep(underground, 0, 1, 2, 1);
+    expect(unpackStepDx(first)).toBe(0);
+    expect(unpackStepDy(first)).toBe(1);
+
+    // Walking the returned steps reaches the hostile tile along the 4-step
+    // path without ever stalling.
+    let x = 0;
+    let y = 1;
+    let steps = 0;
+    while (!(x === 2 && y === 1) && steps < 16) {
+      const s = pickInvaderUndergroundStep(underground, x, y, 2, 1);
+      const sdx = unpackStepDx(s);
+      const sdy = unpackStepDy(s);
+      expect(sdx !== 0 || sdy !== 0).toBe(true); // never stalls on a connected path
+      x += sdx;
+      y += sdy;
+      steps++;
+    }
+    expect(x).toBe(2);
+    expect(y).toBe(1);
+    expect(steps).toBe(4);
   });
 });

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -3100,20 +3100,35 @@ export function pickNearestHostileUnderground(
 }
 
 // ---------------------------------------------------------------------------
-// pickInvaderUndergroundStep — wall-aware greedy step for invader fighters.
+// pickInvaderUndergroundStep — wall-aware BFS step for invader fighters.
 //
-// Replaces the previous rawDx/rawDy+pickCardinalStep path that froze fighters
-// against solid walls (the cardinal step was rejected by the passability guard
-// every tick, so the ant never moved). Scans the 4 cardinal neighbours of the
-// current tile; returns the passable step that minimises Manhattan distance to
-// the target tile. Falls back to (0,0) when no passable neighbour gets closer
-// (narrow dead-end or already adjacent to hostile). The downstream passability
-// guard remains as a safety net but will never reject a step produced here.
+// The earlier greedy version only accepted a neighbour that strictly decreased
+// Manhattan distance to the target, so it froze at any bent-tunnel elbow whose
+// first legal step temporarily increases distance (issue #163). This routes
+// with a breadth-first search instead: it floods path distances out from the
+// target through passable tiles, then steps to the neighbour that lies one step
+// closer along a shortest path — taking the necessary detour through L/bent
+// corridors. Returns (0,0) when the target is unreachable through passable
+// terrain (holds deterministically rather than oscillating against a wall).
 //
 // Uses DIR_DX/DIR_DY (N, E, S, W) — diagonals are skipped to avoid corner-cut
 // complications underground (the passability guard handles diagonals separately
-// for other movement paths).
+// for other movement paths). Deterministic: fixed N/E/S/W expansion order and
+// strict-`<` neighbour selection break every tie toward the lowest direction
+// index. No PRNG, no wall-clock, integer math only.
+//
+// Per-tick no-alloc (AGENTS.md hot-loop rule): the BFS scratch below is reused
+// across calls, grown on demand, and fully reset/consumed within one call. It
+// is transient — it holds no cross-tick or cross-world state.
 // ---------------------------------------------------------------------------
+
+// Path distance from the target tile to each cell (flat y*width+x index), or
+// -1 when unreached on the current call.
+let INV_BFS_DIST = new Int32Array(0);
+// FIFO of cell coordinates to expand. Parallel x/y arrays avoid decoding a flat
+// index (which would need division/modulo, banned in sim index arithmetic).
+let INV_BFS_QX = new Int32Array(0);
+let INV_BFS_QY = new Int32Array(0);
 
 /**
  * @param underground  The grid the invader currently occupies.
@@ -3131,23 +3146,84 @@ export function pickInvaderUndergroundStep(
   targetTileX: number,
   targetTileY: number,
 ): number {
-  const currentDist = Math.abs(targetTileX - tileX) + Math.abs(targetTileY - tileY);
-  if (currentDist === 0) return packStep(0, 0);
+  // Already on the target tile — nothing to do.
+  if (tileX === targetTileX && tileY === targetTileY) return packStep(0, 0);
 
+  const width = underground.width;
+  const height = underground.height;
+  const cells = width * height;
+
+  // A target or self outside the grid can never be connected — hold. (Callers
+  // pass in-bounds tiles; the self guard is defensive.)
+  if (targetTileX < 0 || targetTileX >= width || targetTileY < 0 || targetTileY >= height) {
+    return packStep(0, 0);
+  }
+  if (tileX < 0 || tileX >= width || tileY < 0 || tileY >= height) {
+    return packStep(0, 0);
+  }
+
+  // Grow scratch on demand (one-time as grids first appear / enlarge).
+  if (INV_BFS_DIST.length < cells) {
+    INV_BFS_DIST = new Int32Array(cells);
+    INV_BFS_QX = new Int32Array(cells);
+    INV_BFS_QY = new Int32Array(cells);
+  }
+  const dist = INV_BFS_DIST;
+  const qx = INV_BFS_QX;
+  const qy = INV_BFS_QY;
+  dist.fill(-1, 0, cells);
+
+  // BFS rooted at the target, expanding through passable tiles only in fixed
+  // N/E/S/W order. Stop as soon as the invader's own tile is dequeued: at that
+  // point every cell with a strictly smaller path distance — including the
+  // neighbour the invader must step to — has its final distance.
+  dist[targetTileY * width + targetTileX] = 0;
+  let head = 0;
+  let tail = 0;
+  qx[tail] = targetTileX;
+  qy[tail] = targetTileY;
+  tail++;
+  let reached = false;
+  while (head < tail) {
+    const cx = qx[head]!;
+    const cy = qy[head]!;
+    head++;
+    if (cx === tileX && cy === tileY) { reached = true; break; }
+    const nextDist = dist[cy * width + cx]! + 1;
+    for (let i = 0; i < DIR_DX.length; i++) {
+      const nx = cx + DIR_DX[i]!;
+      const ny = cy + DIR_DY[i]!;
+      // canEnterUndergroundTile bounds-checks and rejects Solid/Marked terrain.
+      if (!canEnterUndergroundTile(underground, nx, ny, AntTask.Fighting)) continue;
+      const ncell = ny * width + nx;
+      if (dist[ncell] !== -1) continue;
+      dist[ncell] = nextDist;
+      qx[tail] = nx;
+      qy[tail] = ny;
+      tail++;
+    }
+  }
+
+  // Target unreachable through passable terrain — hold (no wall oscillation).
+  if (!reached) return packStep(0, 0);
+
+  // Step to the passable cardinal neighbour with the smallest path distance to
+  // the target (== selfDist - 1 along a shortest path). DIR order + strict `<`
+  // break ties toward the lowest direction index (N before E before S before W).
+  const selfDist = dist[tileY * width + tileX]!;
   let bestDx = 0;
   let bestDy = 0;
-  let bestDist = currentDist;
-
+  let bestDist = selfDist;
   for (let i = 0; i < DIR_DX.length; i++) {
     const ax = DIR_DX[i]!;
     const ay = DIR_DY[i]!;
     const nx = tileX + ax;
     const ny = tileY + ay;
-    if (nx < 0 || nx >= underground.width || ny < 0 || ny >= underground.height) continue;
-    if (!canEnterUndergroundTile(underground, nx, ny, AntTask.Fighting)) continue;
-    const dist = Math.abs(targetTileX - nx) + Math.abs(targetTileY - ny);
-    if (dist < bestDist) {
-      bestDist = dist;
+    if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+    const nd = dist[ny * width + nx]!;
+    if (nd < 0) continue; // unreached this call
+    if (nd < bestDist) {
+      bestDist = nd;
       bestDx = ax;
       bestDy = ay;
     }

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -3118,8 +3118,11 @@ export function pickNearestHostileUnderground(
 // index. No PRNG, no wall-clock, integer math only.
 //
 // Per-tick no-alloc (AGENTS.md hot-loop rule): the BFS scratch below is reused
-// across calls, grown on demand, and fully reset/consumed within one call. It
-// is transient — it holds no cross-tick or cross-world state.
+// across calls and grown on demand. The dist buffer holds an all-`-1`
+// invariant between calls; each call writes only the cells it visits and then
+// clears exactly those (never a full-grid wipe), so cost scales with the BFS
+// frontier, not the grid size. It is transient — it holds no cross-tick or
+// cross-world state.
 // ---------------------------------------------------------------------------
 
 // Path distance from the target tile to each cell (flat y*width+x index), or
@@ -3162,16 +3165,19 @@ export function pickInvaderUndergroundStep(
     return packStep(0, 0);
   }
 
-  // Grow scratch on demand (one-time as grids first appear / enlarge).
+  // Grow scratch on demand (one-time as grids first appear / enlarge). A fresh
+  // dist buffer is filled with -1 so the "every cell is -1 between calls"
+  // invariant holds from the start; each call below restores it by clearing
+  // only the cells it touched (never a full-grid wipe).
   if (INV_BFS_DIST.length < cells) {
     INV_BFS_DIST = new Int32Array(cells);
+    INV_BFS_DIST.fill(-1);
     INV_BFS_QX = new Int32Array(cells);
     INV_BFS_QY = new Int32Array(cells);
   }
   const dist = INV_BFS_DIST;
   const qx = INV_BFS_QX;
   const qy = INV_BFS_QY;
-  dist.fill(-1, 0, cells);
 
   // BFS rooted at the target, expanding through passable tiles only in fixed
   // N/E/S/W order. Stop as soon as the invader's own tile is dequeued: at that
@@ -3204,29 +3210,39 @@ export function pickInvaderUndergroundStep(
     }
   }
 
-  // Target unreachable through passable terrain — hold (no wall oscillation).
-  if (!reached) return packStep(0, 0);
-
-  // Step to the passable cardinal neighbour with the smallest path distance to
-  // the target (== selfDist - 1 along a shortest path). DIR order + strict `<`
-  // break ties toward the lowest direction index (N before E before S before W).
-  const selfDist = dist[tileY * width + tileX]!;
+  // Pick the step while `dist` is still populated. When the target was
+  // unreachable, `reached` is false and we fall through holding (0,0) — no wall
+  // oscillation. Otherwise step to the passable cardinal neighbour with the
+  // smallest path distance to the target (== selfDist - 1 along a shortest
+  // path). DIR order + strict `<` break ties toward the lowest direction index
+  // (N before E before S before W).
   let bestDx = 0;
   let bestDy = 0;
-  let bestDist = selfDist;
-  for (let i = 0; i < DIR_DX.length; i++) {
-    const ax = DIR_DX[i]!;
-    const ay = DIR_DY[i]!;
-    const nx = tileX + ax;
-    const ny = tileY + ay;
-    if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
-    const nd = dist[ny * width + nx]!;
-    if (nd < 0) continue; // unreached this call
-    if (nd < bestDist) {
-      bestDist = nd;
-      bestDx = ax;
-      bestDy = ay;
+  if (reached) {
+    let bestDist = dist[tileY * width + tileX]!;
+    for (let i = 0; i < DIR_DX.length; i++) {
+      const ax = DIR_DX[i]!;
+      const ay = DIR_DY[i]!;
+      const nx = tileX + ax;
+      const ny = tileY + ay;
+      if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+      const nd = dist[ny * width + nx]!;
+      if (nd < 0) continue; // unreached this call
+      if (nd < bestDist) {
+        bestDist = nd;
+        bestDx = ax;
+        bestDy = ay;
+      }
     }
+  }
+
+  // Restore the all-`-1` invariant by clearing only the cells this BFS wrote.
+  // Every cell that received a distance was enqueued, so qx/qy[0..tail)
+  // enumerates exactly the touched cells — the reset cost is proportional to
+  // the work done, not the full grid, so dozens of invaders per tick no longer
+  // each pay an O(cells) wipe.
+  for (let i = 0; i < tail; i++) {
+    dist[qy[i]! * width + qx[i]!] = -1;
   }
 
   return packStep(bestDx, bestDy);

--- a/src/sim/invasion-routing.test.ts
+++ b/src/sim/invasion-routing.test.ts
@@ -173,7 +173,7 @@ describe('invasion-routing — Fighting ant descent-intent gate (REQ-C3)', () =>
     expect(world.ants.currentGridColonyId[playerAntId]).toBe(ENEMY_COLONY_ID);
   });
 
-  it('REQ-C3a extension: Fighting ant inside foreign grid steps TOWARD nearest hostile (Manhattan)', () => {
+  it('REQ-C3a extension: Fighting ant inside foreign grid steps TOWARD nearest hostile (BFS routing)', () => {
     // Strengthened positive test (Task 3): after descent, a Fighter inside
     // the enemy underground grid should consume pickNearestHostileUnderground
     // for target selection and its Manhattan distance to the target should
@@ -201,13 +201,12 @@ describe('invasion-routing — Fighting ant descent-intent gate (REQ-C3)', () =>
     world.ants.currentGridColonyId[hostileId] = ENEMY_COLONY_ID;
     world.colonies[ENEMY_COLONY_ID]!.workers.push(hostileId);
     world.colonies[ENEMY_COLONY_ID]!.workerCount += 1;
-    // Carve an OPEN rectangle (shaft..hostileX, 0..hostileTileY) so the
-    // invader's greedy-Manhattan stepper can reach the hostile regardless of
-    // axis-selection ties. A thin L-corridor would leave the invader stuck at
-    // the elbow when |rawDx|===|rawDy| flips preference to the blocked axis
-    // (canEnterUndergroundTile reverts the step on Solid tiles, which
-    // effectively pins the ant). A rectangular carve guarantees at least one
-    // of {east, south} is always Open for every intermediate tile.
+    // Carve an OPEN rectangle (shaft..hostileX, 0..hostileTileY) as a simple
+    // connected region for the invader to approach through. (Historically this
+    // had to be a rectangle rather than a thin L-corridor because the greedy
+    // Manhattan stepper froze at any elbow; issue #163 replaced that with BFS
+    // routing, which handles bent corridors — see the dedicated bent-L-corridor
+    // regression in ant-system.test.ts.)
     const enemyGrid = world.undergroundGrids[ENEMY_COLONY_ID]!;
     for (let y = 0; y <= hostileTileY; y++) {
       for (let x = ENEMY_START_X; x <= hostileTileX; x++) {


### PR DESCRIPTION
## Summary

Fixes #163. Active foreign-grid invaders froze at elbow tunnels because the underground stepper was strict-greedy on Manhattan distance: it rejected any cardinal move that increased distance to the target, so a path that bends *away* before reaching the target was never taken.

This replaces only the per-tick step selection with a wall-aware BFS distance field. **Targeting is unchanged** — invaders still aim at the nearest hostile via `pickNearestHostileUnderground`. The step now follows true shortest-path distance through passable tiles, so detours work.

## What changed

- `pickInvaderUndergroundStep` rewritten: target-rooted BFS floods passable tiles, early-terminates once the invader's own tile is dequeued, then steps to the neighbour with the smallest distance. Deterministic DIR-order strict-`<` tie-break. Holds in place `(0,0)` when the target is unreachable.
- Sim-discipline compliant: scratch buffers (`dist`, parallel `qx`/`qy` FIFO arrays) reused at module scope — no per-tick allocation; parallel x/y queue arrays avoid the banned division/modulo of flat-index decoding.
- New bent-L corridor regression in `ant-system.test.ts` asserting the invader takes a distance-increasing detour and reaches the target in the expected step count.
- Updated the `invasion-routing.test.ts` rectangle-carve comment (the issue flagged it as evidence of the freeze) and retitled the affected tests to reflect BFS routing.

## Test plan

- [x] `npm run verify` (lint + typecheck + sim-boundary + asset-path + 2195 tests across 76 files) — all green
- [x] New bent-L regression covers the elbow-detour case that previously froze
- [ ] UAT: confirm invaders navigate bent tunnels in-game

## Known follow-up (out of scope)

`pickNearestHostileUnderground` selects nearest-by-Manhattan ignoring walls. If the Manhattan-nearest hostile is unreachable while a farther one is reachable, the invader now holds instead of pursuing the reachable target. Worth a separate issue; not changed here to keep the fix scope-faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)