### PR TITLE
feat(s3): spider chase reflex + fighter auto-aggro (#146, #147)

### DIFF
--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -413,6 +413,12 @@ interface SerializedSpiderState {
   rampageTargetColonyId: number;
   chaseTargetAntId: number;
   chaseStartTick: number;
+  killedThisTick: number;
+  lastKillTileX: number;
+  lastKillTileY: number;
+  feedAwayTileX: number;
+  feedAwayTileY: number;
+  feedArrivedTick: number;
 }
 
 /** S2 — serialized form of AIStateRecord. operationFighterIds stored as number[]. */
@@ -869,6 +875,12 @@ function deserializeSpider(s: SerializedWorldState): SpiderState | null {
     rampageTargetColonyId: safeState === 'Rampaging' && typeof r.rampageTargetColonyId === 'number' && r.rampageTargetColonyId > 0 ? r.rampageTargetColonyId : -1,
     chaseTargetAntId: safeState === 'Chasing' ? rawChaseId : -1,
     chaseStartTick: typeof r.chaseStartTick === 'number' && Number.isInteger(r.chaseStartTick) ? r.chaseStartTick : 0,
+    killedThisTick: 0,
+    lastKillTileX: typeof r.lastKillTileX === 'number' && Number.isInteger(r.lastKillTileX) ? r.lastKillTileX : -1,
+    lastKillTileY: typeof r.lastKillTileY === 'number' && Number.isInteger(r.lastKillTileY) ? r.lastKillTileY : -1,
+    feedAwayTileX: typeof r.feedAwayTileX === 'number' && Number.isInteger(r.feedAwayTileX) ? r.feedAwayTileX : -1,
+    feedAwayTileY: typeof r.feedAwayTileY === 'number' && Number.isInteger(r.feedAwayTileY) ? r.feedAwayTileY : -1,
+    feedArrivedTick: typeof r.feedArrivedTick === 'number' && Number.isInteger(r.feedArrivedTick) ? r.feedArrivedTick : -1,
   };
 }
 

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -411,6 +411,8 @@ interface SerializedSpiderState {
   killsThisStrike: number;
   rampageKillsThisRampage: number;
   rampageTargetColonyId: number;
+  chaseTargetAntId: number;
+  chaseStartTick: number;
 }
 
 /** S2 — serialized form of AIStateRecord. operationFighterIds stored as number[]. */
@@ -821,7 +823,7 @@ function deserializeAIStateArray(s: SerializedWorldState): AIStateRecord[] {
 }
 
 function isValidSpiderBehaviorState(v: unknown): v is import('../sim/types.js').SpiderBehaviorState {
-  return v === 'Patrolling' || v === 'Hunting' || v === 'Striking' ||
+  return v === 'Patrolling' || v === 'Hunting' || v === 'Chasing' || v === 'Striking' ||
          v === 'Feeding' || v === 'Rampaging' || v === 'Retreating';
 }
 
@@ -837,9 +839,13 @@ function deserializeSpider(s: SerializedWorldState): SpiderState | null {
   // state=Hunting but target=-1 (corrupt or truncated) would route the spider to (0,0)
   // for the full telegraph duration. Fall back to Patrolling in that case.
   const huntTargetValid = rawHuntX >= 0 && rawHuntY >= 0;
-  const safeState = (rawState === 'Hunting' || rawState === 'Striking') && !huntTargetValid
+  // V23: Chasing requires a valid (non-sentinel) ant id; fall back to Patrolling otherwise.
+  const rawChaseId = typeof r.chaseTargetAntId === 'number' && Number.isInteger(r.chaseTargetAntId) ? r.chaseTargetAntId : -1;
+  const chaseTargetValid = rawChaseId >= 0;
+  let safeState = (rawState === 'Hunting' || rawState === 'Striking') && !huntTargetValid
     ? 'Patrolling'
     : rawState;
+  if (safeState === 'Chasing' && !chaseTargetValid) safeState = 'Patrolling';
   return {
     state: safeState,
     posX: typeof r.posX === 'number' && Number.isInteger(r.posX) ? r.posX : 0,
@@ -861,6 +867,8 @@ function deserializeSpider(s: SerializedWorldState): SpiderState | null {
     killsThisStrike: typeof r.killsThisStrike === 'number' && Number.isInteger(r.killsThisStrike) ? r.killsThisStrike : 0,
     rampageKillsThisRampage: typeof r.rampageKillsThisRampage === 'number' && Number.isInteger(r.rampageKillsThisRampage) ? r.rampageKillsThisRampage : 0,
     rampageTargetColonyId: safeState === 'Rampaging' && typeof r.rampageTargetColonyId === 'number' && r.rampageTargetColonyId > 0 ? r.rampageTargetColonyId : -1,
+    chaseTargetAntId: safeState === 'Chasing' ? rawChaseId : -1,
+    chaseStartTick: typeof r.chaseStartTick === 'number' && Number.isInteger(r.chaseStartTick) ? r.chaseStartTick : 0,
   };
 }
 

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -2337,6 +2337,35 @@ describe('updateFightAntTargets', () => {
     expect(world.ants.targetPosX[fighter]).not.toBe(spider.posX);
   });
 
+  it('V23: a Feeding or Retreating spider is NOT a valid aggro target (untargetable by combat gate)', () => {
+    for (const offState of ['Feeding', 'Retreating'] as const) {
+      const world = createWorldState(42, MAX_TEST_ENTITIES);
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const colA = createColonyRecord(COLONY_ID, 0);
+      colA.entrances = [];
+      colA.rallyPoint = { tileX: 50, tileY: 5 };
+      colA.digFlowFieldDirty = false;
+      world.colonies[COLONY_ID] = colA;
+
+      const fighter = allocateEntityId(world);
+      initAnt(world.ants, fighter, {
+        colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
+        task: AntTask.Fighting, subTask: 0,
+      });
+      world.ants.zone[fighter] = Zone.Surface;
+
+      const spider = placeAggroSpider(world, 11, 10); // dist 1 — close, but state is non-combat
+      spider.state = offState;
+
+      updateFightAntTargets(world);
+
+      // The combat gate does not resolve spider combat in Feeding/Retreating, so the
+      // fighter must not abandon its rally to path onto an untargetable spider.
+      expect(world.ants.targetPosX[fighter]).toBe((50 << FP_SHIFT) + (FP_ONE >> 1));
+      expect(world.ants.targetPosX[fighter]).not.toBe(spider.posX);
+    }
+  });
+
   it('V23 gate: a pre-V23 (V22) world shows no spider auto-aggro', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     world.simVersion = SIM_VERSION_V22_DIFFICULTY;

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -2236,6 +2236,12 @@ describe('updateFightAntTargets', () => {
       rampageTargetColonyId: -1,
       chaseTargetAntId: -1,
       chaseStartTick: 0,
+      killedThisTick: 0,
+      lastKillTileX: -1,
+      lastKillTileY: -1,
+      feedAwayTileX: -1,
+      feedAwayTileY: -1,
+      feedArrivedTick: -1,
     };
     world.spider = spider;
     return spider;
@@ -2337,33 +2343,31 @@ describe('updateFightAntTargets', () => {
     expect(world.ants.targetPosX[fighter]).not.toBe(spider.posX);
   });
 
-  it('V23: a Feeding or Retreating spider is NOT a valid aggro target (untargetable by combat gate)', () => {
-    for (const offState of ['Feeding', 'Retreating'] as const) {
-      const world = createWorldState(42, MAX_TEST_ENTITIES);
-      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
-      const colA = createColonyRecord(COLONY_ID, 0);
-      colA.entrances = [];
-      colA.rallyPoint = { tileX: 50, tileY: 5 };
-      colA.digFlowFieldDirty = false;
-      world.colonies[COLONY_ID] = colA;
+  it('V23 redesign: a Feeding spider IS a valid aggro target (fighters pursue to interrupt)', () => {
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    const colA = createColonyRecord(COLONY_ID, 0);
+    colA.entrances = [];
+    colA.rallyPoint = { tileX: 50, tileY: 5 };
+    colA.digFlowFieldDirty = false;
+    world.colonies[COLONY_ID] = colA;
 
-      const fighter = allocateEntityId(world);
-      initAnt(world.ants, fighter, {
-        colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
-        task: AntTask.Fighting, subTask: 0,
-      });
-      world.ants.zone[fighter] = Zone.Surface;
+    const fighter = allocateEntityId(world);
+    initAnt(world.ants, fighter, {
+      colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting, subTask: 0,
+    });
+    world.ants.zone[fighter] = Zone.Surface;
 
-      const spider = placeAggroSpider(world, 11, 10); // dist 1 — close, but state is non-combat
-      spider.state = offState;
+    const spider = placeAggroSpider(world, 11, 10); // dist 1 — close
+    spider.state = 'Feeding';
 
-      updateFightAntTargets(world);
+    updateFightAntTargets(world);
 
-      // The combat gate does not resolve spider combat in Feeding/Retreating, so the
-      // fighter must not abandon its rally to path onto an untargetable spider.
-      expect(world.ants.targetPosX[fighter]).toBe((50 << FP_SHIFT) + (FP_ONE >> 1));
-      expect(world.ants.targetPosX[fighter]).not.toBe(spider.posX);
-    }
+    // Under the redesign fighters may pursue a feeding spider to interrupt its
+    // heal, so the fighter retargets onto it rather than holding the rally.
+    expect(world.ants.targetPosX[fighter]).toBe(spider.posX);
+    expect(world.ants.targetPosY[fighter]).toBe(spider.posY);
   });
 
   it('V23 gate: a pre-V23 (V22) world shows no spider auto-aggro', () => {

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -44,6 +44,8 @@ import {
   SIM_VERSION_V10_VISIBLE_BROOD_CARRY,
   SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX,
   SIM_VERSION_V17_COMBAT_AGGRO,
+  SIM_VERSION_V22_DIFFICULTY,
+  SIM_VERSION_V23_SPIDER_AGGRO,
 } from '../types.js';
 import { createColonyRecord } from '../colony/colony-store.js';
 import { initAnt, createAntComponents, RECENT_TILES_LEN, isRecentTile } from './ant-store.js';
@@ -71,6 +73,8 @@ import {
   FIGHT_AGGRO_RADIUS,
   SEARCH_PAUSE_BASE_TICKS,
   SEARCH_PAUSE_JITTER_TICKS,
+  SPIDER_HP_FULL,
+  SPIDER_HUNT_INTERVAL_TICKS,
 } from '../constants.js';
 import { FP_SHIFT, FP_ONE } from '../fixed.js';
 import { Zone, UndergroundTileState, ugGet, ugSet, createUndergroundGrid } from '../terrain.js';
@@ -89,7 +93,7 @@ import {
   NURSING_CHAMBER_TYPES,
   NURSERY_CHAMBER_TYPES,
 } from '../chamber-flow.js';
-import type { WorldState } from '../types.js';
+import type { WorldState, SpiderState } from '../types.js';
 import type { ColonyRecord } from '../colony/colony-store.js';
 import type { FoodPile } from '../food.js';
 
@@ -2201,6 +2205,161 @@ describe('updateFightAntTargets', () => {
     // In V17, enemy within radius → target is the enemy's position (not the rally).
     expect(world.ants.targetPosX[fighter]).toBe((enemyTileX << FP_SHIFT) + (FP_ONE >> 1));
     expect(world.ants.targetPosX[fighter]).not.toBe((50 << FP_SHIFT) + (FP_ONE >> 1));
+  });
+
+  // -------------------------------------------------------------------------
+  // V23 (#147): the spider is one more candidate in the proximity aggro scan.
+  // -------------------------------------------------------------------------
+
+  /** Build a Patrolling spider parked on tile (tileX, tileY). */
+  function placeAggroSpider(world: WorldState, tileX: number, tileY: number): SpiderState {
+    const spider: SpiderState = {
+      state: 'Patrolling',
+      posX: tileX << FP_SHIFT,
+      posY: tileY << FP_SHIFT,
+      lairTileX: tileX,
+      lairTileY: tileY,
+      territoryRadiusTiles: 24,
+      hp: SPIDER_HP_FULL,
+      attackCooldown: 0,
+      hungerTicks: 0,
+      nextHuntTick: SPIDER_HUNT_INTERVAL_TICKS,
+      huntStartTick: 0,
+      strikeStartTick: 0,
+      feedingStartTick: 0,
+      retreatStartTick: 0,
+      rampageStartTick: 0,
+      huntTargetTileX: -1,
+      huntTargetTileY: -1,
+      killsThisStrike: 0,
+      rampageKillsThisRampage: 0,
+      rampageTargetColonyId: -1,
+      chaseTargetAntId: -1,
+      chaseStartTick: 0,
+    };
+    world.spider = spider;
+    return spider;
+  }
+
+  it('V23: fighter within FIGHT_AGGRO_RADIUS of the spider retargets onto it', () => {
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    const colA = createColonyRecord(COLONY_ID, 0);
+    colA.entrances = []; // rally not on any entrance → aggro scan active
+    colA.rallyPoint = { tileX: 50, tileY: 5 };
+    colA.digFlowFieldDirty = false;
+    world.colonies[COLONY_ID] = colA;
+
+    const fighter = allocateEntityId(world);
+    initAnt(world.ants, fighter, {
+      colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting, subTask: 0,
+    });
+    world.ants.zone[fighter] = Zone.Surface;
+
+    const spider = placeAggroSpider(world, 10 + 2, 10); // dist 2, within radius
+
+    updateFightAntTargets(world);
+
+    // Routed onto the spider's exact position, not the rally.
+    expect(world.ants.targetPosX[fighter]).toBe(spider.posX);
+    expect(world.ants.targetPosY[fighter]).toBe(spider.posY);
+    expect(world.ants.targetPosX[fighter]).not.toBe((50 << FP_SHIFT) + (FP_ONE >> 1));
+  });
+
+  it('V23: a closer enemy ant wins over the spider (just another candidate)', () => {
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    const COLONY_B = 2 as const;
+    const colA = createColonyRecord(COLONY_ID, 0);
+    colA.entrances = [];
+    colA.rallyPoint = { tileX: 50, tileY: 5 };
+    colA.digFlowFieldDirty = false;
+    world.colonies[COLONY_ID] = colA;
+
+    const fighter = allocateEntityId(world);
+    initAnt(world.ants, fighter, {
+      colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting, subTask: 0,
+    });
+    world.ants.zone[fighter] = Zone.Surface;
+
+    // Enemy ant at dist 1 (closer than the spider at dist 3).
+    const colB = createColonyRecord(COLONY_B, 0);
+    colB.queenEntityId = -1;
+    colB.entrances = [];
+    colB.digFlowFieldDirty = false;
+    world.colonies[COLONY_B] = colB;
+    const enemyTileX = 11;
+    const enemy = allocateEntityId(world);
+    initAnt(world.ants, enemy, {
+      colonyId: COLONY_B, posX: (enemyTileX << FP_SHIFT) + (FP_ONE >> 1), posY: 10 << FP_SHIFT,
+      task: AntTask.Idle, subTask: 0,
+    });
+    world.ants.zone[enemy] = Zone.Surface;
+    colB.workers.push(enemy);
+    colB.workerCount += 1;
+
+    const spider = placeAggroSpider(world, 13, 10); // dist 3, farther than the enemy
+
+    updateFightAntTargets(world);
+
+    // The nearer enemy ant wins; the spider is not chosen.
+    expect(world.ants.targetPosX[fighter]).toBe((enemyTileX << FP_SHIFT) + (FP_ONE >> 1));
+    expect(world.ants.targetPosX[fighter]).not.toBe(spider.posX);
+  });
+
+  it('V23: fighter rallied on an OPEN entrance is NOT diverted to a nearby spider', () => {
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    const colA = createColonyRecord(COLONY_ID, 0);
+    // Rally sits on this colony's own OPEN entrance → aggro scan suppressed so the
+    // fighter walks the exact entrance tile (descent trigger carve-out).
+    colA.entrances = [{ entranceId: 1, surfaceTileX: 20, surfaceTileY: 8, isOpen: true }];
+    colA.rallyPoint = { tileX: 20, tileY: 8 };
+    colA.digFlowFieldDirty = false;
+    world.colonies[COLONY_ID] = colA;
+
+    const fighter = allocateEntityId(world);
+    initAnt(world.ants, fighter, {
+      colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting, subTask: 0,
+    });
+    world.ants.zone[fighter] = Zone.Surface;
+
+    const spider = placeAggroSpider(world, 11, 10); // dist 1 — would aggro if not suppressed
+
+    updateFightAntTargets(world);
+
+    // Held to the entrance rally, not diverted to the spider.
+    expect(world.ants.targetPosX[fighter]).toBe((20 << FP_SHIFT) + (FP_ONE >> 1));
+    expect(world.ants.targetPosY[fighter]).toBe((8 << FP_SHIFT) + (FP_ONE >> 1));
+    expect(world.ants.targetPosX[fighter]).not.toBe(spider.posX);
+  });
+
+  it('V23 gate: a pre-V23 (V22) world shows no spider auto-aggro', () => {
+    const world = createWorldState(42, MAX_TEST_ENTITIES);
+    world.simVersion = SIM_VERSION_V22_DIFFICULTY;
+    const colA = createColonyRecord(COLONY_ID, 0);
+    colA.entrances = [];
+    colA.rallyPoint = { tileX: 50, tileY: 5 };
+    colA.digFlowFieldDirty = false;
+    world.colonies[COLONY_ID] = colA;
+
+    const fighter = allocateEntityId(world);
+    initAnt(world.ants, fighter, {
+      colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting, subTask: 0,
+    });
+    world.ants.zone[fighter] = Zone.Surface;
+
+    const spider = placeAggroSpider(world, 11, 10); // dist 1, but gate is closed pre-V23
+
+    updateFightAntTargets(world);
+
+    // No auto-aggro: fighter follows the rally, not the spider.
+    expect(world.ants.targetPosX[fighter]).toBe((50 << FP_SHIFT) + (FP_ONE >> 1));
+    expect(world.ants.targetPosX[fighter]).not.toBe(spider.posX);
   });
 });
 

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -2041,12 +2041,10 @@ export function updateFightAntTargets(world: WorldState): void {
       // (surface-only — this block is already gated to Zone.Surface). A closer enemy ant
       // wins (strict <); a closer spider wins over a farther ant. Routing the fighter onto
       // the spider's tile is enough — the widened spider-combat gate resolves the damage.
-      // Only consider the spider in states the combat gate actually resolves (see combat.ts):
-      // Feeding/Retreating are untargetable, so excluding them keeps fighters from abandoning
-      // their rally/enemy to path onto a spider they cannot damage.
+      // The spider is targetable in ANY state: fighters may pursue a Feeding spider to
+      // interrupt its heal (tickSpiderV23 forfeits the heal once a fighter is adjacent).
       let nearestIsSpider = false;
-      if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO && world.spider !== null
-          && world.spider.state !== 'Feeding' && world.spider.state !== 'Retreating') {
+      if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO && world.spider !== null) {
         const spTileX = world.spider.posX >> FP_SHIFT;
         const spTileY = world.spider.posY >> FP_SHIFT;
         const dist = Math.abs(spTileX - aggroTileX) + Math.abs(spTileY - aggroTileY);
@@ -3765,10 +3763,12 @@ function isDescentBlocked(
 ): boolean {
   const ants = world.ants;
 
-  // #165 — rampaging spider blockade. A spider parked on the entrance tile is
-  // the blockade footprint; hold every descender on the surface so step-17.5
-  // spider combat (which only scans the spider's own tile) catches it instead
-  // of letting carriers slip through the zone transition. Applies to any ant.
+  // #165 — spider blockade. A Rampaging spider parked on the entrance tile is the
+  // blockade footprint; hold every descender on the surface so step-17.5 spider
+  // combat (which only scans the spider's own tile) catches it instead of letting
+  // carriers slip through the zone transition. Applies to any ant. Only Rampaging
+  // camps an entrance (both V22 and V23); a sated V23 spider meandering over an
+  // entrance must NOT trap descenders, so the narrow state check is intentional.
   const spider = world.spider;
   if (spider !== null && spider.state === 'Rampaging') {
     const sx = spider.posX >> FP_SHIFT;

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -34,6 +34,7 @@
 
 import {
   type WorldState,
+  SIM_VERSION_V23_SPIDER_AGGRO,
 } from '../types.js';
 import {
   SurfaceMovementEffect,
@@ -2035,6 +2036,22 @@ export function updateFightAntTargets(world: WorldState): void {
           const dist = Math.abs(qTileX - aggroTileX) + Math.abs(qTileY - aggroTileY);
           if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) { nearestEnemyDist = dist; nearestEnemy = qid; }
         }
+      }
+      // V23 (#147): the spider is one more candidate in the same nearest-hostile scan
+      // (surface-only — this block is already gated to Zone.Surface). A closer enemy ant
+      // wins (strict <); a closer spider wins over a farther ant. Routing the fighter onto
+      // the spider's tile is enough — the widened spider-combat gate resolves the damage.
+      let nearestIsSpider = false;
+      if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO && world.spider !== null) {
+        const spTileX = world.spider.posX >> FP_SHIFT;
+        const spTileY = world.spider.posY >> FP_SHIFT;
+        const dist = Math.abs(spTileX - aggroTileX) + Math.abs(spTileY - aggroTileY);
+        if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) { nearestEnemyDist = dist; nearestIsSpider = true; }
+      }
+      if (nearestIsSpider) {
+        ants.targetPosX[id] = world.spider!.posX;
+        ants.targetPosY[id] = world.spider!.posY;
+        continue;
       }
       if (nearestEnemy >= 0) {
         ants.targetPosX[id] = ants.posX[nearestEnemy]!;

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -2041,8 +2041,12 @@ export function updateFightAntTargets(world: WorldState): void {
       // (surface-only — this block is already gated to Zone.Surface). A closer enemy ant
       // wins (strict <); a closer spider wins over a farther ant. Routing the fighter onto
       // the spider's tile is enough — the widened spider-combat gate resolves the damage.
+      // Only consider the spider in states the combat gate actually resolves (see combat.ts):
+      // Feeding/Retreating are untargetable, so excluding them keeps fighters from abandoning
+      // their rally/enemy to path onto a spider they cannot damage.
       let nearestIsSpider = false;
-      if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO && world.spider !== null) {
+      if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO && world.spider !== null
+          && world.spider.state !== 'Feeding' && world.spider.state !== 'Retreating') {
         const spTileX = world.spider.posX >> FP_SHIFT;
         const spTileY = world.spider.posY >> FP_SHIFT;
         const dist = Math.abs(spTileX - aggroTileX) + Math.abs(spTileY - aggroTileY);

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -635,3 +635,64 @@ describe('spider-pairing sentinel cleanup (V23 Codex P1)', () => {
     expect(world.ants.combatOpponentId[ant]).toBe(-2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// V23 (Codex P2): sated meander = self-defense only.
+// The widened gate engages spider combat in Patrolling, but the hunger-gated
+// design says a sated (Patrolling) spider ignores workers and only bites ants
+// attacking it. Predation happens in Chasing/Hunting/Striking/Rampaging, never
+// during a plain meander — so a Patrolling spider must NOT initiate a bite on a
+// worker merely sharing its tile, while predatory states still eat any ant.
+// ---------------------------------------------------------------------------
+
+describe('sated meander self-defense (V23 Codex P2)', () => {
+  it('Patrolling spider ignores a lone worker on its tile (no pairing)', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    const spider = placeSpider(world, 5, 7, 'Patrolling');
+    const worker = spawnAnt(world, cid1, 5, 7, Zone.Surface); // AntTask.Idle
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    // Sated spider does not engage a worker: no pairing, no windup, no damage.
+    expect(world.ants.combatOpponentId[worker]).toBe(-1);
+    expect(world.ants.alive[worker]).toBe(1);
+    expect(spider.attackCooldown).toBe(0);
+  });
+
+  it('Patrolling spider still bites back a fighter sharing its tile (self-defense)', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    const spider = placeSpider(world, 5, 7, 'Patrolling');
+    const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    // First contact: fighter is paired (-2) and the spider arms its windup.
+    expect(world.ants.combatOpponentId[fighter]).toBe(-2);
+    expect(spider.attackCooldown).toBe(COMBAT_COOLDOWN_TICKS);
+  });
+
+  it('Hunting spider DOES engage a lone worker on its tile (predatory)', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    placeSpider(world, 5, 7, 'Hunting');
+    const worker = spawnAnt(world, cid1, 5, 7, Zone.Surface); // AntTask.Idle
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    // Predatory state pairs even a worker (it will be eaten over the next ticks).
+    expect(world.ants.combatOpponentId[worker]).toBe(-2);
+  });
+
+  it('Rampaging spider DOES engage a lone worker on its tile (predatory)', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    placeSpider(world, 5, 7, 'Rampaging');
+    const worker = spawnAnt(world, cid1, 5, 7, Zone.Surface); // AntTask.Idle
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    expect(world.ants.combatOpponentId[worker]).toBe(-2);
+  });
+});

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -1,14 +1,24 @@
 import { describe, it, expect } from 'vitest';
 import { detectAndResolveCombat, killAnt } from './combat.js';
-import { createWorldState, allocateEntityId } from './types.js';
+import {
+  createWorldState,
+  allocateEntityId,
+  SIM_VERSION_V22_DIFFICULTY,
+  SIM_VERSION_V23_SPIDER_AGGRO,
+} from './types.js';
 import { Rng } from './rng.js';
 import { createColonyRecord } from './colony/colony-store.js';
 import { initAnt } from './ant/ant-store.js';
 import { AntTask } from './enums.js';
 import { Zone } from './terrain.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
-import { WORKER_BASE_SPEED, WORKER_LIFESPAN_TICKS } from './constants.js';
-import type { WorldState } from './types.js';
+import {
+  WORKER_BASE_SPEED,
+  WORKER_LIFESPAN_TICKS,
+  SPIDER_HP_FULL,
+  SPIDER_HUNT_INTERVAL_TICKS,
+} from './constants.js';
+import type { WorldState, SpiderState, SpiderBehaviorState } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 
 // Helper: build a minimal 2-colony world with seeded rngState.
@@ -52,6 +62,36 @@ function spawnFighter(world: WorldState, colonyId: ColonyId, tileX: number, tile
   const id = spawnAnt(world, colonyId, tileX, tileY, zone);
   world.ants.task[id] = AntTask.Fighting;
   return id;
+}
+
+// Helper: place a spider on tile (tileX, tileY) in the given behavior state.
+function placeSpider(world: WorldState, tileX: number, tileY: number, state: SpiderBehaviorState): SpiderState {
+  const spider: SpiderState = {
+    state,
+    posX: tileX << FP_SHIFT,
+    posY: tileY << FP_SHIFT,
+    lairTileX: tileX,
+    lairTileY: tileY,
+    territoryRadiusTiles: 24,
+    hp: SPIDER_HP_FULL,
+    attackCooldown: 0,
+    hungerTicks: 0,
+    nextHuntTick: SPIDER_HUNT_INTERVAL_TICKS,
+    huntStartTick: 0,
+    strikeStartTick: 0,
+    feedingStartTick: 0,
+    retreatStartTick: 0,
+    rampageStartTick: 0,
+    huntTargetTileX: -1,
+    huntTargetTileY: -1,
+    killsThisStrike: 0,
+    rampageKillsThisRampage: 0,
+    rampageTargetColonyId: -1,
+    chaseTargetAntId: -1,
+    chaseStartTick: 0,
+  };
+  world.spider = spider;
+  return spider;
 }
 
 describe('detectAndResolveCombat (V15 coin-flip path)', () => {
@@ -455,5 +495,69 @@ describe('non-fighter and queen combat stats (V17)', () => {
       task: AntTask.Idle, hp: COMBAT_HP_QUEEN,
     });
     expect(world.ants.hp[queenSlot]).toBe(COMBAT_HP_QUEEN);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V23 (#146/#147): widened spider-combat gate.
+// Pre-V23 the spider only engages in Striking/Rampaging; V23 also engages in the
+// other surface states (Patrolling/Hunting/Chasing) so auto-aggro fighters can
+// damage it and the spider defends itself.
+// ---------------------------------------------------------------------------
+
+describe('spider combat gate (V23 #146/#147)', () => {
+  // Pair a fighter with the spider and arm it to strike on the next resolve tick.
+  function armFighterAgainstSpider(world: WorldState, fighterId: number): void {
+    world.ants.combatOpponentId[fighterId] = -2; // already paired (skip windup)
+    world.ants.attackCooldown[fighterId] = 1;     // decrements to 0 → strikes this tick
+  }
+
+  it('Patrolling spider takes fighter damage under V23', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const spider = placeSpider(world, 5, 7, 'Patrolling');
+    armFighterAgainstSpider(world, fighter);
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    expect(spider.hp).toBe(SPIDER_HP_FULL - COMBAT_DAMAGE_BASE);
+  });
+
+  it('Chasing spider takes fighter damage under V23', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const spider = placeSpider(world, 5, 7, 'Chasing');
+    spider.chaseTargetAntId = fighter;
+    armFighterAgainstSpider(world, fighter);
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    expect(spider.hp).toBe(SPIDER_HP_FULL - COMBAT_DAMAGE_BASE);
+  });
+
+  it('Patrolling spider takes NO damage under a pre-V23 (V22) world — old-replay guard', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V22_DIFFICULTY;
+    const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const spider = placeSpider(world, 5, 7, 'Patrolling');
+    armFighterAgainstSpider(world, fighter);
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    expect(spider.hp).toBe(SPIDER_HP_FULL); // gate closed pre-V23
+  });
+
+  it('Striking spider still engages even under a pre-V23 world (unchanged behavior)', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V22_DIFFICULTY;
+    const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    const spider = placeSpider(world, 5, 7, 'Striking');
+    armFighterAgainstSpider(world, fighter);
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    expect(spider.hp).toBe(SPIDER_HP_FULL - COMBAT_DAMAGE_BASE);
   });
 });

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -89,6 +89,12 @@ function placeSpider(world: WorldState, tileX: number, tileY: number, state: Spi
     rampageTargetColonyId: -1,
     chaseTargetAntId: -1,
     chaseStartTick: 0,
+    killedThisTick: 0,
+    lastKillTileX: -1,
+    lastKillTileY: -1,
+    feedAwayTileX: -1,
+    feedAwayTileY: -1,
+    feedArrivedTick: -1,
   };
   world.spider = spider;
   return spider;

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -567,3 +567,71 @@ describe('spider combat gate (V23 #146/#147)', () => {
     expect(spider.hp).toBe(SPIDER_HP_FULL - COMBAT_DAMAGE_BASE);
   });
 });
+
+// ---------------------------------------------------------------------------
+// V23 (Codex P1): off-tile spider-pairing sentinel cleanup.
+// Under V23 the gate engages in unbounded surface states (Patrolling/Hunting/
+// Chasing), where no state transition is guaranteed — so an ant that brushed the
+// spider (combatOpponentId === -2) and then walked off its tile must have the
+// sentinel cleared every tick by detectAndResolveCombat, not just by a spider
+// state-exit. Otherwise the stale -2 would skip the next encounter's windup and
+// bypass normal stale-opponent cleanup.
+// ---------------------------------------------------------------------------
+
+describe('spider-pairing sentinel cleanup (V23 Codex P1)', () => {
+  it('clears -2 on an ant that disengaged from a Patrolling spider (off-tile)', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    placeSpider(world, 5, 7, 'Patrolling');
+    // Ant was paired last tick (-2) and has since moved off the spider's tile.
+    const ant = spawnFighter(world, cid1, 9, 9, Zone.Surface);
+    world.ants.combatOpponentId[ant] = -2;
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    expect(world.ants.combatOpponentId[ant]).toBe(-1);
+  });
+
+  it('preserves -2 on an ant still on the spider tile (ongoing windup)', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    placeSpider(world, 5, 7, 'Patrolling');
+    const ant = spawnFighter(world, cid1, 5, 7, Zone.Surface);
+    world.ants.combatOpponentId[ant] = -2;
+    world.ants.attackCooldown[ant] = 5; // mid-windup
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    // Still engaged on the tile → sentinel kept so resolveSpiderCombatOnTile
+    // continues the cooldown rather than restarting the windup.
+    expect(world.ants.combatOpponentId[ant]).toBe(-2);
+  });
+
+  it('clears -2 when the ant descends underground (off the surface tile)', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+    placeSpider(world, 5, 7, 'Patrolling');
+    // Same tile coords but underground — the spider is surface-only, so this is
+    // a disengage.
+    const ant = spawnFighter(world, cid1, 5, 7, Zone.Underground);
+    world.ants.combatOpponentId[ant] = -2;
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    expect(world.ants.combatOpponentId[ant]).toBe(-1);
+  });
+
+  it('does NOT clear off-tile -2 under a pre-V23 (V22) world — old-replay guard', () => {
+    const { world, cid1 } = makeWorldWith2Colonies();
+    world.simVersion = SIM_VERSION_V22_DIFFICULTY;
+    placeSpider(world, 5, 7, 'Striking');
+    const ant = spawnFighter(world, cid1, 9, 9, Zone.Surface);
+    world.ants.combatOpponentId[ant] = -2;
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    // V22 clears -2 only via clearSpiderPairingSentinels on episode exit, never
+    // in this pass — byte-identical guard.
+    expect(world.ants.combatOpponentId[ant]).toBe(-2);
+  });
+});

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -116,10 +116,34 @@ export function detectAndResolveCombat(world: WorldState, _rng: Rng): void {
       for (let q = runStart; q < p; q++) COMBAT_CONTESTED[liveIdx[q]!] = 1;
     }
   }
+  // Spider-pairing sentinel (-2) handling differs by version:
+  //   Pre-V23: the spider only engages combat in the bounded Striking/Rampaging
+  //     episodes, which always end by calling clearSpiderPairingSentinels — so a
+  //     -2 ant is guaranteed cleared on disengage. Skip -2 here to preserve windup.
+  //   V23: the gate widened to the unbounded surface states (Patrolling/Hunting/
+  //     Chasing), where no state transition is guaranteed. An ant that brushes a
+  //     patrolling spider and walks off would otherwise keep -2 forever (skipping
+  //     the next encounter's windup and bypassing this stale cleanup). So clear -2
+  //     for any ant NOT on the spider's tile this tick (= disengaged), while
+  //     preserving it for ants still on the tile so resolveSpiderCombatOnTile can
+  //     continue their windup. (Codex P1.)
+  const spider = world.spider;
+  const v23Spider = spider !== null && world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO;
+  const spiderTileX = v23Spider ? spider!.posX >> FP_SHIFT : -1;
+  const spiderTileY = v23Spider ? spider!.posY >> FP_SHIFT : -1;
   for (let i = 0; i < count; i++) {
-    // -2 is the spider-pairing sentinel; skip it here so resolveSpiderCombatOnTile
-    // can preserve windup state. The sentinel is cleared by clearSpiderPairingSentinels.
-    if (ants.alive[i] === 1 && COMBAT_CONTESTED[i] === 0 && ants.combatOpponentId[i] !== -2) {
+    if (ants.alive[i] !== 1) continue;
+    if (ants.combatOpponentId[i] === -2) {
+      if (v23Spider) {
+        const onSpiderTile =
+          ants.zone[i] === 0 &&
+          (ants.posX[i]! >> FP_SHIFT) === spiderTileX &&
+          (ants.posY[i]! >> FP_SHIFT) === spiderTileY;
+        if (!onSpiderTile) ants.combatOpponentId[i] = -1;
+      }
+      continue;
+    }
+    if (COMBAT_CONTESTED[i] === 0) {
       ants.combatOpponentId[i] = -1;
     }
   }

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -533,11 +533,29 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
 
   // Prefer AntTask.Fighting ants for the active pair; fall back to any ant.
   let activeAntIdx = onTile[0]!;
+  let hasFighter = false;
   for (const idx of onTile) {
     if (ants.task[idx] === AntTask.Fighting) {
       activeAntIdx = idx;
+      hasFighter = true;
       break;
     }
+  }
+
+  // Sated meander = self-defense only (Codex P2). Under V23 the combat gate opens
+  // for every non-Feeding surface state, including a sated `Patrolling` spider. But
+  // the hunger-gated design says a sated spider ignores workers and only bites ants
+  // attacking it — predation happens in the Chasing/Hunting/Striking/Rampaging
+  // episodes, never during a plain meander. So a Patrolling spider engages only when
+  // a Fighting ant is on its tile (self-defense); it never initiates a bite on a
+  // worker merely sharing the tile. Pre-V23 never reaches here in Patrolling (gate is
+  // Striking/Rampaging only), so this is V23-only by construction.
+  if (
+    world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO &&
+    spider.state === 'Patrolling' &&
+    !hasFighter
+  ) {
+    return;
   }
 
   // Swarm bonus: priority set AND enough fighters from the priority colony on tile.

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -137,15 +137,16 @@ export function detectAndResolveCombat(world: WorldState, _rng: Rng): void {
 
   // S3 — spider combat: resolve spider vs ants on the spider's tile.
   // Pre-V23: only the combat-active states (Striking, Rampaging) engage.
-  // V23 (#146/#147): all *surface* states engage (Patrolling, Hunting, Chasing too) so
-  // fighters that auto-aggro onto a patrolling/chasing spider can actually damage it, and
-  // the spider defends itself. Feeding/Retreating are off-surface (at lair) and never engage.
+  // V23 (#146/#147): every surface state engages so the spider always bites back
+  // any ant attacking it (always-on self-defense). Only Feeding sits off the gate
+  // — interruption is handled in tickSpiderV23 the tick a fighter reaches it.
+  // Retreating is unused in V23 (normalized to Patrolling on the first tick).
   if (world.spider !== null) {
     const ss = world.spider.state;
     const spiderCombatActive =
       ss === 'Striking' || ss === 'Rampaging' ||
       (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO &&
-        (ss === 'Patrolling' || ss === 'Hunting' || ss === 'Chasing'));
+        ss !== 'Feeding' && ss !== 'Retreating');
     if (spiderCombatActive) {
       resolveSpiderCombatOnTile(world);
     }
@@ -606,6 +607,11 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
     if (antDies) {
       if (spider.state === 'Striking') spider.killsThisStrike += 1;
       if (spider.state === 'Rampaging') spider.rampageKillsThisRampage += 1;
+      if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO) {
+        spider.killedThisTick = 1;
+        spider.lastKillTileX = spiderTileX;
+        spider.lastKillTileY = spiderTileY;
+      }
       killAnt(world, swarmRetaliationTarget, null, null, 'Spider');
     }
     return;
@@ -663,6 +669,11 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
   if (antDies2) {
     if (spider.state === 'Striking') spider.killsThisStrike += 1;
     if (spider.state === 'Rampaging') spider.rampageKillsThisRampage += 1;
+    if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO) {
+      spider.killedThisTick = 1;
+      spider.lastKillTileX = spiderTileX;
+      spider.lastKillTileY = spiderTileY;
+    }
     killAnt(world, activeAntIdx, null, null, 'Spider');
   }
 }

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -17,6 +17,7 @@ import { Rng } from './rng.js';
 import { AntTask } from './enums.js';
 import { makeTileKey } from './tile-key.js';
 import type { WorldState, KillerKind, QueenDeathContext } from './types.js';
+import { SIM_VERSION_V23_SPIDER_AGGRO } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 import type { Zone } from './terrain.js';
 import { FP_SHIFT } from './fixed.js';
@@ -135,11 +136,19 @@ export function detectAndResolveCombat(world: WorldState, _rng: Rng): void {
   }
 
   // S3 — spider combat: resolve spider vs ants on the spider's tile.
-  // Only during combat-active states (Striking, Rampaging). Spider in Patrolling,
-  // Hunting, Feeding, or Retreating does not engage in direct HP combat.
-  if (world.spider !== null &&
-      (world.spider.state === 'Striking' || world.spider.state === 'Rampaging')) {
-    resolveSpiderCombatOnTile(world);
+  // Pre-V23: only the combat-active states (Striking, Rampaging) engage.
+  // V23 (#146/#147): all *surface* states engage (Patrolling, Hunting, Chasing too) so
+  // fighters that auto-aggro onto a patrolling/chasing spider can actually damage it, and
+  // the spider defends itself. Feeding/Retreating are off-surface (at lair) and never engage.
+  if (world.spider !== null) {
+    const ss = world.spider.state;
+    const spiderCombatActive =
+      ss === 'Striking' || ss === 'Rampaging' ||
+      (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO &&
+        (ss === 'Patrolling' || ss === 'Hunting' || ss === 'Chasing'));
+    if (spiderCombatActive) {
+      resolveSpiderCombatOnTile(world);
+    }
   }
 
   // Clear pendingQueenDeathContexts for ants that survived (i.e., where the queen kill

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -836,3 +836,33 @@ export const SPIDER_SPEED = 256 as const;
  */
 export const SPIDER_DANGER_DEPOSIT = 1280 as const;
 
+// ---------------------------------------------------------------------------
+// V23 — Hunger-gated meandering predator redesign (gated on simVersion >= V23)
+// ---------------------------------------------------------------------------
+
+/**
+ * V23 — Ticks since the last meal before the spider becomes "Hungry" and starts
+ * actively seeking prey. Tier triplet [Easy, Normal, Hard]; Normal = 1200 (the
+ * former hunt cadence). Preserves the D-33 Axis-B difficulty-pressure knob.
+ * Read via tierIndex(world.difficulty). Resets to 0 (hungerTicks) on any kill.
+ */
+export const SPIDER_HUNGER_THRESHOLD_TICKS = [1800, 1200, 900] as const;
+
+/** V23 — Sated meander moves only when world.tick % divisor === 0 (1 tile / 3 ticks). */
+export const SPIDER_MEANDER_TICK_DIVISOR = 3 as const;
+
+/** V23 — Re-roll the deterministic wander target every N ticks. */
+export const SPIDER_MEANDER_RETARGET_TICKS = 128 as const;
+
+/** V23 — Tiles the spider steps away from a kill before feeding (avoid chain-killing). */
+export const SPIDER_FEED_RETREAT_TILES = 10 as const;
+
+/** V23 — Manhattan radius at which a Fighting ant counts as "adjacent" (blocks/interrupts feed). */
+export const SPIDER_FEED_DANGER_RADIUS = 1 as const;
+
+/** V23 — Feed/heal window, measured from arrival at the feed tile. 300 ticks = 15 sim-seconds. */
+export const SPIDER_FEED_TICKS = 300 as const;
+
+/** V23 — While feeding at the feed tile, regen +1 HP every N ticks (~30 HP over SPIDER_FEED_TICKS). */
+export const SPIDER_FEED_HEAL_INTERVAL_TICKS = 10 as const;
+

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -866,3 +866,12 @@ export const SPIDER_FEED_TICKS = 300 as const;
 /** V23 — While feeding at the feed tile, regen +1 HP every N ticks (~30 HP over SPIDER_FEED_TICKS). */
 export const SPIDER_FEED_HEAL_INTERVAL_TICKS = 10 as const;
 
+/**
+ * V23 (#146/#147) — Manhattan tile radius within which a Fighting ant attacking the
+ * spider triggers active self-defense: the spider stops meandering/camping and Chases
+ * the nearest attacker so it actually engages instead of drifting away. Slightly wider
+ * than SPIDER_CHASE_TRIGGER_RADIUS so the spider reacts to an approaching swarm before
+ * it is surrounded. The spider moves at 2× ant speed, so a Chase reliably closes.
+ */
+export const SPIDER_DEFENSE_TRIGGER_RADIUS = 6 as const;
+

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -792,6 +792,20 @@ export const SPIDER_HUNT_MIN_TARGET_WORKERS = 2 as const;
 /** S3 — Manhattan scatter radius around hunt target tile. Workers within this scatter. */
 export const SPIDER_SCATTER_RADIUS_TILES = 1 as const;
 
+/**
+ * V23 (#146) — Manhattan tile radius within which a Patrolling spider opportunistically
+ * chases the nearest live surface ant. Mirrors FIGHT_AGGRO_RADIUS so prey and predator
+ * react at the same range.
+ */
+export const SPIDER_CHASE_TRIGGER_RADIUS = 4 as const;
+
+/**
+ * V23 (#146) — Safety leash: maximum ticks the spider will pursue a single chase target
+ * before abandoning and returning to Patrolling. Prevents a "relentless" chase from
+ * stranding the spider far from its lair indefinitely. 300 ticks = 15 sim-seconds.
+ */
+export const SPIDER_CHASE_MAX_TICKS = 300 as const;
+
 /** S3 — Patrolling territory radius (tiles) around lair. */
 export const SPIDER_TERRITORY_RADIUS_TILES = 24 as const;
 

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -22,6 +22,7 @@ import {
   ENEMY_START_X,
   ENEMY_START_Y,
   SPIDER_HUNGER_MAX_TICKS,
+  SPIDER_HUNGER_THRESHOLD_TICKS,
   SPIDER_HP_FULL,
 } from './constants.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
@@ -964,13 +965,15 @@ describe('S3 V23: spider chase + fighter aggro replay determinism', () => {
       const wy = world.ants.posY[prey]! >> FP_SHIFT;
 
       // Park the spider 2 tiles from the worker cluster so findChaseTarget fires
-      // on the first tick (within SPIDER_CHASE_TRIGGER_RADIUS=4). No hunger → no rampage.
+      // on the first tick (within SPIDER_CHASE_TRIGGER_RADIUS=4). Under the V23
+      // redesign a sated spider ignores workers, so saturate hunger past the
+      // threshold — a hungry spider opportunistically Chases a lone ant in radius.
       spider.state = 'Patrolling';
       spider.posX = (wx + 2) << FP_SHIFT;
       spider.posY = wy << FP_SHIFT;
       spider.lairTileX = wx + 2;
       spider.lairTileY = wy;
-      spider.hungerTicks = 0;
+      spider.hungerTicks = SPIDER_HUNGER_THRESHOLD_TICKS[1]!;
       spider.hp = SPIDER_HP_FULL;
       spider.chaseTargetAntId = -1;
       spider.chaseStartTick = 0;
@@ -1001,5 +1004,96 @@ describe('S3 V23: spider chase + fighter aggro replay determinism', () => {
     // Byte-identical parity including the new V23 spider fields.
     expect(serializeWorldState(worldA)).toBe(serializeWorldState(worldB));
   }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// S3 V23 redesign — hunger-gated meander + feed-after-kill replay determinism
+//
+// Exercises the redesign-specific deterministic surfaces that the chase test
+// above does not reach:
+//   - the meander hash (Patrolling wander target derived from terrainSeed ^ tick)
+//   - the feed-after-kill path: killedThisTick → hunger reset → computeFeedAwayTile
+//     (feed-direction hash) → Feeding heal window
+//   - the rampage pick (pickRampageTarget) when no chase/hunt target is available
+// None of these draw world.rngState, so two independent runs must serialize
+// byte-identically AND leave rngState in lockstep.
+// ---------------------------------------------------------------------------
+
+describe('S3 V23 redesign: meander + feed-after-kill replay determinism', () => {
+  // Build a hungry spider sitting on top of a lone player worker with no
+  // fighters anywhere, so the predation→kill→feed loop fires: combat resolves
+  // on the shared tile (kill), the spider resets hunger and — finding no
+  // adjacent fighter — retreats ~10 tiles and Feeds. Running long enough also
+  // lets hunger re-accrue past the threshold and drive a second predation beat.
+  function buildFeedWorld(): WorldState {
+    const world = createScenario(7777);
+    expect(world.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V23_SPIDER_AGGRO);
+    const spider = world.spider!;
+    const player = world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!;
+    expect(player.workers.length).toBeGreaterThanOrEqual(1);
+
+    // Anchor the spider directly on the first worker's surface tile so the
+    // first combat pass already has a victim on the tile.
+    const prey = player.workers[0]!;
+    const wx = world.ants.posX[prey]! >> FP_SHIFT;
+    const wy = world.ants.posY[prey]! >> FP_SHIFT;
+    spider.state = 'Patrolling';
+    spider.posX = wx << FP_SHIFT;
+    spider.posY = wy << FP_SHIFT;
+    spider.lairTileX = wx;
+    spider.lairTileY = wy;
+    spider.hp = SPIDER_HP_FULL - 25; // leave headroom so Feeding heal is observable
+    spider.hungerTicks = SPIDER_HUNGER_THRESHOLD_TICKS[1]!; // hungry → predates
+    return world;
+  }
+
+  it('two redesign worlds from seed 7777 run byte-identical over 400 ticks through Feeding', () => {
+    const TICKS = 400;
+    const worldA = buildFeedWorld();
+    const worldB = buildFeedWorld();
+    const statesVisited = new Set<string>();
+    for (let t = 0; t < TICKS; t++) {
+      tick(worldA, []);
+      if (worldA.spider !== null) statesVisited.add(worldA.spider.state);
+    }
+    for (let t = 0; t < TICKS; t++) tick(worldB, []);
+
+    // Guard: the feed-after-kill path must actually have been exercised.
+    expect(statesVisited.has('Feeding')).toBe(true);
+
+    // Byte-identical parity AND rngState lockstep (spider logic draws no RNG).
+    expect(serializeWorldState(worldA)).toBe(serializeWorldState(worldB));
+    expect(worldA.rngState).toBe(worldB.rngState);
+  }, 30_000);
+
+  it('save round-trip mid-Feeding deep-equals the spider, with killedThisTick forced to 0 on load', async () => {
+    const { serializeWorldState: saveWorld, deserializeWorldState: loadWorld } =
+      await import('../platform/save.js');
+
+    const world = buildFeedWorld();
+    // Advance until the spider is mid-Feeding (kill → feed transition).
+    let reachedFeeding = false;
+    for (let t = 0; t < 400; t++) {
+      tick(world, []);
+      if (world.spider !== null && world.spider.state === 'Feeding') {
+        reachedFeeding = true;
+        break;
+      }
+    }
+    expect(reachedFeeding).toBe(true);
+
+    // killedThisTick is a transient combat→spider flag; force it set so we can
+    // prove deserialize hard-defaults it back to 0 (it must never persist as 1).
+    world.spider!.killedThisTick = 1;
+    const before = { ...world.spider! };
+
+    const restored = loadWorld(saveWorld(world));
+    expect(restored.spider).not.toBeNull();
+    const after = restored.spider!;
+
+    // Every field round-trips except killedThisTick, which is hard-defaulted 0.
+    expect(after.killedThisTick).toBe(0);
+    expect({ ...after, killedThisTick: before.killedThisTick }).toEqual(before);
+  });
 });
 

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { tick } from './tick.js';
-import { createWorldState, allocateEntityId, SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V20_SPIDER } from './types.js';
+import { createWorldState, allocateEntityId, SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V20_SPIDER, SIM_VERSION_V23_SPIDER_AGGRO } from './types.js';
 import { initAnt } from './ant/ant-store.js';
 import { createColonyRecord } from './colony/colony-store.js';
 import { createPheromoneGrid, phGet, pheromoneGridKey } from './pheromone/pheromone-store.js';
@@ -22,6 +22,7 @@ import {
   ENEMY_START_X,
   ENEMY_START_Y,
   SPIDER_HUNGER_MAX_TICKS,
+  SPIDER_HP_FULL,
 } from './constants.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
 import { Zone, UndergroundTileState, ugSet } from './terrain.js';
@@ -930,6 +931,74 @@ describe('S3 V20: spider replay determinism (Hunting → Striking → Rampaging)
     expect(statesVisited.has('Rampaging')).toBe(true);
 
     // Byte-identical parity including V20 fields.
+    expect(serializeWorldState(worldA)).toBe(serializeWorldState(worldB));
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// S3 V23 — spider chase (#146) + fighter auto-aggro (#147) replay determinism
+//
+// Exercises the V23-gated paths: findChaseTarget / Chasing transitions+movement
+// (spider.ts), the widened spider-combat gate (combat.ts), and the spider
+// candidate in the fighter proximity scan (ant-system.ts). The serializer spreads
+// the whole spider object, so the new chaseTargetAntId/chaseStartTick fields are
+// covered — any RNG or non-deterministic branch surfaces as a JSON divergence.
+// ---------------------------------------------------------------------------
+
+describe('S3 V23: spider chase + fighter aggro replay determinism', () => {
+  it('two V23 worlds from seed 7777 run byte-identical over 200 ticks through Chasing', () => {
+    const SEED = 7777;
+    const TICKS = 200;
+
+    function buildChaseWorld(): WorldState {
+      const world = createScenario(SEED);
+      // V23 behavior must be active for chase + fighter aggro to fire.
+      expect(world.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V23_SPIDER_AGGRO);
+      const spider = world.spider!;
+      const player = world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!;
+      expect(player.workers.length).toBeGreaterThanOrEqual(2);
+
+      // Anchor on the first starting worker's surface tile.
+      const prey = player.workers[0]!;
+      const wx = world.ants.posX[prey]! >> FP_SHIFT;
+      const wy = world.ants.posY[prey]! >> FP_SHIFT;
+
+      // Park the spider 2 tiles from the worker cluster so findChaseTarget fires
+      // on the first tick (within SPIDER_CHASE_TRIGGER_RADIUS=4). No hunger → no rampage.
+      spider.state = 'Patrolling';
+      spider.posX = (wx + 2) << FP_SHIFT;
+      spider.posY = wy << FP_SHIFT;
+      spider.lairTileX = wx + 2;
+      spider.lairTileY = wy;
+      spider.hungerTicks = 0;
+      spider.hp = SPIDER_HP_FULL;
+      spider.chaseTargetAntId = -1;
+      spider.chaseStartTick = 0;
+
+      // Convert a second worker into a fighter adjacent to the spider and rally it
+      // on its own (non-entrance) tile so the proximity-aggro scan runs and folds
+      // the spider in as a candidate.
+      const fighter = player.workers[1]!;
+      world.ants.task[fighter] = AntTask.Fighting;
+      world.ants.posX[fighter] = ((wx + 1) << FP_SHIFT) + (FP_ONE >> 1);
+      world.ants.posY[fighter] = (wy << FP_SHIFT) + (FP_ONE >> 1);
+      player.rallyPoint = { tileX: wx + 1, tileY: wy };
+      return world;
+    }
+
+    const worldA = buildChaseWorld();
+    const worldB = buildChaseWorld();
+    const statesVisited = new Set<string>();
+    for (let t = 0; t < TICKS; t++) {
+      tick(worldA, []);
+      if (worldA.spider !== null) statesVisited.add(worldA.spider.state);
+    }
+    for (let t = 0; t < TICKS; t++) tick(worldB, []);
+
+    // Guard: the chase path must actually have been exercised.
+    expect(statesVisited.has('Chasing')).toBe(true);
+
+    // Byte-identical parity including the new V23 spider fields.
     expect(serializeWorldState(worldA)).toBe(serializeWorldState(worldB));
   }, 30_000);
 });

--- a/src/sim/predescent-gate.test.ts
+++ b/src/sim/predescent-gate.test.ts
@@ -67,6 +67,8 @@ function rampagingSpiderAt(tileX: number, tileY: number, targetColonyId: number)
     killsThisStrike: 0,
     rampageKillsThisRampage: 0,
     rampageTargetColonyId: targetColonyId,
+    chaseTargetAntId: -1,
+    chaseStartTick: 0,
   };
 }
 

--- a/src/sim/predescent-gate.test.ts
+++ b/src/sim/predescent-gate.test.ts
@@ -69,6 +69,12 @@ function rampagingSpiderAt(tileX: number, tileY: number, targetColonyId: number)
     rampageTargetColonyId: targetColonyId,
     chaseTargetAntId: -1,
     chaseStartTick: 0,
+    killedThisTick: 0,
+    lastKillTileX: -1,
+    lastKillTileY: -1,
+    feedAwayTileX: -1,
+    feedAwayTileY: -1,
+    feedArrivedTick: -1,
   };
 }
 

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -298,6 +298,12 @@ function _placeSpider(world: WorldState): SpiderState {
     rampageTargetColonyId: -1,
     chaseTargetAntId: -1,
     chaseStartTick: 0,
+    killedThisTick: 0,
+    lastKillTileX: -1,
+    lastKillTileY: -1,
+    feedAwayTileX: -1,
+    feedAwayTileY: -1,
+    feedArrivedTick: -1,
   };
 }
 

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -296,6 +296,8 @@ function _placeSpider(world: WorldState): SpiderState {
     killsThisStrike: 0,
     rampageKillsThisRampage: 0,
     rampageTargetColonyId: -1,
+    chaseTargetAntId: -1,
+    chaseStartTick: 0,
   };
 }
 

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -736,6 +736,10 @@ describe('tickSpider', () => {
       expect(world.spider!.hungerTicks).toBe(0);
       const evt = world.events.find((e) => e.type === 'spider_feed_start');
       expect(evt).toBeDefined();
+      // The chase episode is closed before Feeding so start/end pairs aren't dangling.
+      const chaseEnd = world.events.find((e) => e.type === 'spider_chase_end');
+      expect(chaseEnd).toBeDefined();
+      if (chaseEnd?.type === 'spider_chase_end') expect(chaseEnd.payload.outcome).toBe('kill');
     });
 
     it('a stale dead target (no kill signal) returns to Patrolling without resetting hunger', () => {
@@ -974,6 +978,40 @@ describe('tickSpider', () => {
       const fy = world.spider!.feedAwayTileY;
       const dist = Math.abs(fx - sx) + Math.abs(fy - sy);
       expect(dist).toBe(SPIDER_FEED_RETREAT_TILES);
+      // The hunt/strike episode is closed before Feeding (no dangling start/end pair).
+      const huntEnd = world.events.find((e) => e.type === 'spider_hunt_end');
+      expect(huntEnd).toBeDefined();
+      if (huntEnd?.type === 'spider_hunt_end') expect(huntEnd.payload.outcome).toBe('kill');
+    });
+
+    it('a Rampaging kill with no fighter adjacent → Feeding emits spider_rampage_end(quota_met)', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        state: 'Rampaging',
+        rampageStartTick: 0,
+        rampageTargetColonyId: PLAYER_COLONY_ID,
+        hungerTicks: 800,
+        killedThisTick: 1,
+        lastKillTileX: sx,
+        lastKillTileY: sy,
+        rampageKillsThisRampage: 1,
+      });
+      world.tick = 10;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Feeding');
+      const rampageEnd = world.events.find((e) => e.type === 'spider_rampage_end');
+      expect(rampageEnd).toBeDefined();
+      if (rampageEnd?.type === 'spider_rampage_end') {
+        expect(rampageEnd.payload.outcome).toBe('quota_met');
+        expect(rampageEnd.payload.broodKilled).toBe(1);
+      }
     });
 
     it('heals ~+1 HP per interval while parked at the feed tile, then resumes Patrolling', () => {

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -24,6 +24,7 @@ import {
   SPIDER_HUNGER_MAX_TICKS,
   SPIDER_RAMPAGE_KILL_QUOTA,
   SPIDER_CHASE_TRIGGER_RADIUS,
+  SPIDER_DEFENSE_TRIGGER_RADIUS,
   SPIDER_CHASE_MAX_TICKS,
   SPIDER_RAMPAGE_RETREAT_HP,
   SPIDER_RAMPAGE_MAX_TICKS,
@@ -684,6 +685,212 @@ describe('tickSpider', () => {
       // Only the queen is in range and queens are excluded → no chase.
       expect(world.spider!.state).not.toBe('Chasing');
       expect(world.spider!.chaseTargetAntId).toBe(-1);
+    });
+  });
+
+  describe('active self-defense (V23 #147)', () => {
+    it('a sated Patrolling spider Chases the nearest attacking fighter within defense radius', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: 0 });
+      world.spider.nextHuntTick = 9999;
+      // Distance 5: inside defense radius (6), outside chase radius (4) — only the
+      // self-defense path can pick this up, proving sated bite-back works.
+      expect(SPIDER_DEFENSE_TRIGGER_RADIUS).toBeGreaterThan(SPIDER_CHASE_TRIGGER_RADIUS);
+      const fighterId = placeFighter(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy);
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Chasing');
+      expect(world.spider!.chaseTargetAntId).toBe(fighterId);
+      expect(world.spider!.chaseStartTick).toBe(world.tick);
+    });
+
+    it('picks the nearest attacking fighter when several are in range', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: 0 });
+      world.spider.nextHuntTick = 9999;
+      placeFighter(world, sx + 6, sy);            // dist 6 (farther)
+      const near = placeFighter(world, sx, sy + 5); // dist 5 (nearer)
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Chasing');
+      expect(world.spider!.chaseTargetAntId).toBe(near);
+    });
+
+    it('ignores a non-fighter worker within defense radius (only bites back attackers)', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: 0 });
+      world.spider.nextHuntTick = 9999;
+      placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy); // dist 5, but Foraging
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+    });
+
+    it('does NOT self-defend an attacker outside the defense radius', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: 0 });
+      world.spider.nextHuntTick = 9999;
+      placeFighter(world, sx + SPIDER_DEFENSE_TRIGGER_RADIUS + 1, sy); // out of defense range
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+    });
+
+    it('does NOT self-defend under a pre-V23 (V22) world — old-replay guard', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V22_DIFFICULTY;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
+      world.spider.nextHuntTick = 9999;
+      placeFighter(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy);
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+    });
+
+    it('a Rampaging spider under attack abandons the camp and Chases the attacker', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS,
+        state: 'Rampaging',
+        rampageTargetColonyId: PLAYER_COLONY_ID,
+        rampageStartTick: 0,
+      });
+      world.spider.nextHuntTick = 9999;
+      const fighterId = placeFighter(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy);
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Chasing');
+      expect(world.spider!.chaseTargetAntId).toBe(fighterId);
+      expect(world.spider!.rampageTargetColonyId).toBe(-1);
+      const evt = world.events.find((e) => e.type === 'spider_rampage_end');
+      expect(evt).toBeDefined();
+      if (evt?.type === 'spider_rampage_end') {
+        expect(evt.payload.outcome).toBe('retreated');
+      }
+    });
+
+    it('a Rampaging spider pinning a descender on its entrance HOLDS even under attack (#165)', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS,
+        state: 'Rampaging',
+        rampageTargetColonyId: PLAYER_COLONY_ID,
+        rampageStartTick: 0,
+      });
+      world.spider.nextHuntTick = 9999;
+      const col = createColonyRecord(PLAYER_COLONY_ID, -1);
+      col.entrances = [{ entranceId: 1, surfaceTileX: sx, surfaceTileY: sy, isOpen: true }];
+      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = col;
+      placeWorker(world, sx, sy);                              // descender pinned on the entrance
+      placeFighter(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy); // attacker within defense radius
+
+      tickSpider(world);
+
+      // Holds the gate: combat catches the pinned descender this tick; the spider does
+      // not chase the attacker off the entrance (which would let the descender escape).
+      expect(world.spider!.state).toBe('Rampaging');
+      expect(world.spider!.rampageTargetColonyId).toBe(PLAYER_COLONY_ID);
+    });
+  });
+
+  describe('Rampaging straggler chase-divert (V23 #146)', () => {
+    function campingSpider(world: WorldState, sx: number, sy: number): void {
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS,
+        state: 'Rampaging',
+        rampageTargetColonyId: PLAYER_COLONY_ID,
+        rampageStartTick: world.tick,
+      });
+      world.spider.nextHuntTick = 9999;
+      // queenEntityId = -1 so the first placed ant (id 0) is not mistaken for the queen.
+      const col = createColonyRecord(PLAYER_COLONY_ID, -1);
+      col.entrances = [{ entranceId: 1, surfaceTileX: sx, surfaceTileY: sy, isOpen: true }];
+      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = col;
+    }
+
+    it('diverts to Chasing a straggler that emerges within chase radius', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      campingSpider(world, sx, sy);
+      const strag = placeWorker(world, sx + 1, sy);
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Chasing');
+      expect(world.spider!.chaseTargetAntId).toBe(strag);
+      expect(world.spider!.rampageTargetColonyId).toBe(-1);
+      const evt = world.events.find((e) => e.type === 'spider_rampage_end');
+      expect(evt).toBeDefined();
+      if (evt?.type === 'spider_rampage_end') {
+        expect(evt.payload.outcome).toBe('retreated');
+      }
+    });
+
+    it('keeps camping (stays Rampaging) when no ant is within chase radius', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      campingSpider(world, sx, sy);
+      placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy); // out of chase range
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Rampaging');
+      expect(world.spider!.rampageTargetColonyId).toBe(PLAYER_COLONY_ID);
+    });
+
+    it('does NOT divert off an ant sitting ON the camped entrance tile (#165 blockade hold)', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      campingSpider(world, sx, sy); // entrance at (sx, sy)
+      placeWorker(world, sx, sy);   // descender sitting ON the entrance → must be held, not chased
+
+      tickSpider(world);
+
+      // The spider holds the gate so tile-coincident combat can catch the descender,
+      // rather than chasing it off the entrance (which would let it slip underground).
+      expect(world.spider!.state).toBe('Rampaging');
+      expect(world.spider!.rampageTargetColonyId).toBe(PLAYER_COLONY_ID);
     });
   });
 

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -26,7 +26,13 @@ import {
   SPIDER_CHASE_TRIGGER_RADIUS,
   SPIDER_CHASE_MAX_TICKS,
   SPIDER_RAMPAGE_RETREAT_HP,
+  SPIDER_RAMPAGE_MAX_TICKS,
   SPIDER_SPEED,
+  SPIDER_HUNGER_THRESHOLD_TICKS,
+  SPIDER_MEANDER_TICK_DIVISOR,
+  SPIDER_FEED_TICKS,
+  SPIDER_FEED_RETREAT_TILES,
+  SPIDER_FEED_HEAL_INTERVAL_TICKS,
   SURFACE_GRID_WIDTH,
   PLAYER_COLONY_ID,
   ENEMY_COLONY_ID,
@@ -62,6 +68,12 @@ function makeSpider(overrides: Partial<SpiderState> = {}): SpiderState {
     rampageTargetColonyId: -1,
     chaseTargetAntId: -1,
     chaseStartTick: 0,
+    killedThisTick: 0,
+    lastKillTileX: -1,
+    lastKillTileY: -1,
+    feedAwayTileX: -1,
+    feedAwayTileY: -1,
+    feedArrivedTick: -1,
     ...overrides,
   };
 }
@@ -88,6 +100,20 @@ function placeWorker(world: WorldState, tx: number, ty: number, colonyId = PLAYE
   });
   return id;
 }
+
+function placeFighter(world: WorldState, tx: number, ty: number, colonyId = PLAYER_COLONY_ID): number {
+  const id = world.nextEntityId++;
+  initAnt(world.ants, id, {
+    colonyId,
+    posX: tx << FP_SHIFT,
+    posY: ty << FP_SHIFT,
+    task: AntTask.Fighting,
+  });
+  return id;
+}
+
+// Hunger value (Normal tier) that puts a V23 spider over the hungry threshold.
+const HUNGRY_TICKS = SPIDER_HUNGER_THRESHOLD_TICKS[1]!;
 
 // ---------------------------------------------------------------------------
 // State transition tests
@@ -543,14 +569,29 @@ describe('tickSpider', () => {
   // V23 (#146): Chasing — opportunistic chase of a nearby ant
   // ---------------------------------------------------------------------------
 
-  describe('Patrolling → Chasing trigger (V23 #146)', () => {
-    it('enters Chasing for the nearest surface ant within trigger radius', () => {
+  describe('hunger gate (V23 redesign #146/#147)', () => {
+    it('a sated spider does NOT chase a lone ant in radius', () => {
       const world = makeWorld();
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       const sx = 64;
       const sy = 32;
-      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
-      world.spider.nextHuntTick = 9999; // scheduled hunt must not fire — chase takes precedence
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: 0 });
+      world.spider.nextHuntTick = 9999;
+      placeWorker(world, sx + 1, sy);
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+    });
+
+    it('a hungry spider enters Chasing for the nearest surface ant within trigger radius', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: HUNGRY_TICKS });
+      world.spider.nextHuntTick = 9999;
       const antId = placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS, sy);
 
       tickSpider(world);
@@ -562,12 +603,12 @@ describe('tickSpider', () => {
       expect(evt).toBeDefined();
     });
 
-    it('picks the nearest ant (lower id wins on tie)', () => {
+    it('picks the nearest ant (lower id wins on tie) when hungry', () => {
       const world = makeWorld();
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       const sx = 64;
       const sy = 32;
-      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: HUNGRY_TICKS });
       world.spider.nextHuntTick = 9999;
       const near = placeWorker(world, sx + 1, sy); // dist 1
       placeWorker(world, sx + 3, sy);              // dist 3 (farther)
@@ -578,18 +619,18 @@ describe('tickSpider', () => {
       expect(world.spider!.chaseTargetAntId).toBe(near);
     });
 
-    it('does NOT chase an ant just outside the trigger radius', () => {
+    it('does NOT chase an ant just outside the trigger radius (camps an entrance instead)', () => {
       const world = makeWorld();
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       const sx = 64;
       const sy = 32;
-      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: HUNGRY_TICKS });
       world.spider.nextHuntTick = 9999;
       placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy); // out of range
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.state).not.toBe('Chasing');
       expect(world.spider!.chaseTargetAntId).toBe(-1);
     });
 
@@ -608,7 +649,7 @@ describe('tickSpider', () => {
       expect(world.spider!.chaseTargetAntId).toBe(-1);
     });
 
-    it('rampage preempts chase when hunger is maxed', () => {
+    it('chase takes precedence over entrance-camping when hungry', () => {
       const world = makeWorld();
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       const sx = 64;
@@ -616,13 +657,13 @@ describe('tickSpider', () => {
       world.spider = makeSpider({
         posX: sx << FP_SHIFT,
         posY: sy << FP_SHIFT,
-        hungerTicks: SPIDER_HUNGER_MAX_TICKS[1] - 1, // +1 this tick reaches max
+        hungerTicks: HUNGRY_TICKS,
       });
-      placeWorker(world, sx + 1, sy); // a chaseable ant is present, but hunger wins
+      placeWorker(world, sx + 1, sy); // a chaseable ant is present → chase wins over rampage
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Rampaging');
+      expect(world.spider!.state).toBe('Chasing');
     });
 
     it('excludes the queen from chase targets', () => {
@@ -630,16 +671,18 @@ describe('tickSpider', () => {
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       const sx = 64;
       const sy = 32;
-      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: HUNGRY_TICKS });
       world.spider.nextHuntTick = 9999;
       const queenId = placeWorker(world, sx + 1, sy);
-      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = createColonyRecord(PLAYER_COLONY_ID, 0);
+      const col = createColonyRecord(PLAYER_COLONY_ID, 0);
+      col.entrances = []; // caller-init contract; no open entrance → sealed
+      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = col;
       world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!.queenEntityId = queenId;
 
       tickSpider(world);
 
       // Only the queen is in range and queens are excluded → no chase.
-      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.state).not.toBe('Chasing');
       expect(world.spider!.chaseTargetAntId).toBe(-1);
     });
   });
@@ -666,11 +709,40 @@ describe('tickSpider', () => {
       expect(world.spider!.posX).toBe((sx << FP_SHIFT) + SPIDER_SPEED); // moved +X toward target
     });
 
-    it('successful catch (target dead) resets hunger and returns to Patrolling', () => {
+    it('a chase catch (killedThisTick) with no fighter adjacent → Feeding, hunger reset', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 66;
+      const sy = 32;
+      const antId = placeWorker(world, sx, sy);
+      world.ants.alive[antId] = 0; // combat killed it this tick
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        state: 'Chasing',
+        chaseTargetAntId: antId,
+        chaseStartTick: 0,
+        hungerTicks: 500,
+        killedThisTick: 1,
+        lastKillTileX: sx,
+        lastKillTileY: sy,
+      });
+      world.tick = 50;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Feeding');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider!.hungerTicks).toBe(0);
+      const evt = world.events.find((e) => e.type === 'spider_feed_start');
+      expect(evt).toBeDefined();
+    });
+
+    it('a stale dead target (no kill signal) returns to Patrolling without resetting hunger', () => {
       const world = makeWorld();
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       const antId = placeWorker(world, 66, 32);
-      world.ants.alive[antId] = 0; // combat killed it this tick
+      world.ants.alive[antId] = 0; // died to some other cause, no killedThisTick
       world.spider = makeSpider({
         state: 'Chasing',
         chaseTargetAntId: antId,
@@ -683,11 +755,7 @@ describe('tickSpider', () => {
 
       expect(world.spider!.state).toBe('Patrolling');
       expect(world.spider!.chaseTargetAntId).toBe(-1);
-      expect(world.spider!.hungerTicks).toBe(0);
-      expect(world.spider!.nextHuntTick).toBe(50 + SPIDER_HUNT_INTERVAL_TICKS);
-      const evt = world.events.find((e) => e.type === 'spider_chase_end');
-      expect(evt).toBeDefined();
-      if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('kill');
+      expect(world.spider!.hungerTicks).toBe(501); // accrued +1, not reset
     });
 
     it('abandons the chase when the target reaches safety underground', () => {
@@ -729,7 +797,7 @@ describe('tickSpider', () => {
       if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('leash');
     });
 
-    it('retreats (and emits retreat) when damaged below threshold mid-chase', () => {
+    it('does NOT retreat when damaged below the old threshold mid-chase — fights on', () => {
       const world = makeWorld();
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       const antId = placeWorker(world, 66, 32);
@@ -743,10 +811,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Retreating');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
-      const evt = world.events.find((e) => e.type === 'spider_chase_end');
-      if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('retreat');
+      expect(world.spider!.state).not.toBe('Retreating');
+      expect(world.spider!.state).toBe('Chasing'); // still pursuing its live target
     });
 
     it('emits spider_chase_end(killed) when the spider dies mid-chase', () => {
@@ -765,6 +831,214 @@ describe('tickSpider', () => {
       const evt = world.events.find((e) => e.type === 'spider_chase_end');
       expect(evt).toBeDefined();
       if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('killed');
+    });
+  });
+
+  describe('meander (V23 redesign)', () => {
+    it('a sated spider moves only on tick % SPIDER_MEANDER_TICK_DIVISOR === 0', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      world.spider = makeSpider({ posX: 64 << FP_SHIFT, posY: 32 << FP_SHIFT, hungerTicks: 0 });
+
+      // Pick a tick that is NOT divisible by the divisor → no movement.
+      // divisor+1 is never ≡ 0 (mod divisor) for divisor > 1.
+      world.tick = SPIDER_MEANDER_TICK_DIVISOR + 1;
+      const beforeX = world.spider.posX;
+      const beforeY = world.spider.posY;
+      tickSpider(world);
+      expect(world.spider!.posX).toBe(beforeX);
+      expect(world.spider!.posY).toBe(beforeY);
+      expect(world.spider!.state).toBe('Patrolling');
+    });
+
+    it('writes no scatter reticle while meandering', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      world.spider = makeSpider({ posX: 64 << FP_SHIFT, posY: 32 << FP_SHIFT, hungerTicks: 0 });
+      world.tick = 3;
+      tickSpider(world);
+      expect(world.scatterReticleTile).toBeNull();
+    });
+
+    it('does NOT orbit a fixed lair point (meanders away over time)', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const lairX = 64;
+      const lairY = 32;
+      world.spider = makeSpider({
+        posX: lairX << FP_SHIFT,
+        posY: lairY << FP_SHIFT,
+        lairTileX: lairX,
+        lairTileY: lairY,
+        territoryRadiusTiles: 24,
+        hungerTicks: 0,
+      });
+      let maxDist = 0;
+      for (let t = 0; t < 2000; t++) {
+        world.tick = t;
+        tickSpider(world);
+        const tx = world.spider!.posX >> FP_SHIFT;
+        const ty = world.spider!.posY >> FP_SHIFT;
+        const d = Math.abs(tx - lairX) + Math.abs(ty - lairY);
+        if (d > maxDist) maxDist = d;
+      }
+      // Old lair orbit was bounded by territoryRadiusTiles (24); the meander should
+      // wander well beyond half-radius and is not pinned to the lair.
+      expect(maxDist).toBeGreaterThan(24);
+    });
+  });
+
+  describe('feed-after-kill + heal (V23 redesign)', () => {
+    it('kill with adjacent fighter resets hunger but does NOT feed', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        state: 'Striking',
+        hungerTicks: 800,
+        killedThisTick: 1,
+        lastKillTileX: sx,
+        lastKillTileY: sy,
+        killsThisStrike: 1,
+      });
+      placeFighter(world, sx, sy); // fighter on the spider's tile (adjacent)
+      world.tick = 10;
+
+      tickSpider(world);
+
+      expect(world.spider!.hungerTicks).toBe(0);
+      expect(world.spider!.state).not.toBe('Feeding');
+    });
+
+    it('kill with no fighter adjacent → Feeding, feedAwayTile ~10 tiles from kill, hunger reset', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        state: 'Striking',
+        hungerTicks: 800,
+        killedThisTick: 1,
+        lastKillTileX: sx,
+        lastKillTileY: sy,
+        killsThisStrike: 1,
+      });
+      world.tick = 10;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Feeding');
+      expect(world.spider!.hungerTicks).toBe(0);
+      const fx = world.spider!.feedAwayTileX;
+      const fy = world.spider!.feedAwayTileY;
+      const dist = Math.abs(fx - sx) + Math.abs(fy - sy);
+      expect(dist).toBe(SPIDER_FEED_RETREAT_TILES);
+    });
+
+    it('heals ~+1 HP per interval while parked at the feed tile, then resumes Patrolling', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const fx = 70;
+      const fy = 32;
+      const arrived = 100;
+      world.spider = makeSpider({
+        posX: fx << FP_SHIFT,
+        posY: fy << FP_SHIFT,
+        state: 'Feeding',
+        feedAwayTileX: fx,
+        feedAwayTileY: fy,
+        feedArrivedTick: arrived,
+        hp: 40,
+      });
+
+      // Advance through the heal window. No fighters anywhere → never interrupted.
+      const startHp = world.spider.hp;
+      for (let t = arrived + 1; t <= arrived + SPIDER_FEED_TICKS; t++) {
+        world.tick = t;
+        tickSpider(world);
+        if (world.spider === null || world.spider.state !== 'Feeding') break;
+      }
+      // Healed by roughly SPIDER_FEED_TICKS / interval HP (within 2 of target).
+      // eslint-disable-next-line no-restricted-syntax -- test-only expected-count math; both operands are constants, result is floored
+      const expectedHeal = Math.floor(SPIDER_FEED_TICKS / SPIDER_FEED_HEAL_INTERVAL_TICKS);
+      expect(world.spider!.hp).toBeGreaterThanOrEqual(startHp + expectedHeal - 2);
+      expect(world.spider!.state).toBe('Patrolling');
+    });
+
+    it('a fighter reaching the feeding spider interrupts the heal → Patrolling', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const fx = 70;
+      const fy = 32;
+      world.spider = makeSpider({
+        posX: fx << FP_SHIFT,
+        posY: fy << FP_SHIFT,
+        state: 'Feeding',
+        feedAwayTileX: fx,
+        feedAwayTileY: fy,
+        feedArrivedTick: 100,
+        hp: 40,
+      });
+      placeFighter(world, fx, fy); // fighter adjacent → interrupt
+      world.tick = 150;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      const evt = world.events.find((e) => e.type === 'spider_feed_end');
+      if (evt?.type === 'spider_feed_end') expect(evt.payload.outcome).toBe('interrupted');
+    });
+  });
+
+  describe('rampage no-quota + retreating normalization (V23 redesign)', () => {
+    it('a sealed colony (no open entrance) leashes Rampaging back to Patrolling', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      // No colonies with open entrances exist in makeWorld → findNearestEntrance null.
+      world.spider = makeSpider({
+        state: 'Rampaging',
+        rampageStartTick: 0,
+        rampageTargetColonyId: PLAYER_COLONY_ID,
+        hungerTicks: HUNGRY_TICKS,
+      });
+      world.tick = 10;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.rampageTargetColonyId).toBe(-1);
+    });
+
+    it('Rampaging leashes back to Patrolling after SPIDER_RAMPAGE_MAX_TICKS', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      world.spider = makeSpider({
+        state: 'Rampaging',
+        rampageStartTick: 0,
+        rampageTargetColonyId: PLAYER_COLONY_ID,
+        hungerTicks: HUNGRY_TICKS,
+      });
+      world.tick = SPIDER_RAMPAGE_MAX_TICKS;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+    });
+
+    it('normalizes a loaded Retreating state to Patrolling on the first V23 tick', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      world.spider = makeSpider({ state: 'Retreating', retreatStartTick: 0, hungerTicks: 0 });
+      world.tick = 5;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
     });
   });
 });

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -2,7 +2,13 @@
 
 import { describe, it, expect } from 'vitest';
 import type { WorldState, SpiderState } from './types.js';
-import { createWorldState, SIM_VERSION_V19_AI_STATE, SIM_VERSION_V20_SPIDER } from './types.js';
+import {
+  createWorldState,
+  SIM_VERSION_V19_AI_STATE,
+  SIM_VERSION_V20_SPIDER,
+  SIM_VERSION_V22_DIFFICULTY,
+  SIM_VERSION_V23_SPIDER_AGGRO,
+} from './types.js';
 import { tickSpider } from './spider.js';
 import { initAnt } from './ant/ant-store.js';
 import { AntTask, PheromoneType } from './enums.js';
@@ -17,11 +23,16 @@ import {
   SPIDER_HUNT_INTERVAL_TICKS,
   SPIDER_HUNGER_MAX_TICKS,
   SPIDER_RAMPAGE_KILL_QUOTA,
+  SPIDER_CHASE_TRIGGER_RADIUS,
+  SPIDER_CHASE_MAX_TICKS,
+  SPIDER_RAMPAGE_RETREAT_HP,
+  SPIDER_SPEED,
   SURFACE_GRID_WIDTH,
   PLAYER_COLONY_ID,
   ENEMY_COLONY_ID,
 } from './constants.js';
 import { FP_SHIFT } from './fixed.js';
+import { Zone } from './terrain.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -49,6 +60,8 @@ function makeSpider(overrides: Partial<SpiderState> = {}): SpiderState {
     killsThisStrike: 0,
     rampageKillsThisRampage: 0,
     rampageTargetColonyId: -1,
+    chaseTargetAntId: -1,
+    chaseStartTick: 0,
     ...overrides,
   };
 }
@@ -523,6 +536,235 @@ describe('tickSpider', () => {
       tickSpider(world);
       expect(world.spider!.state).toBe('Feeding');
       expect(world.spider!.hungerTicks).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // V23 (#146): Chasing — opportunistic chase of a nearby ant
+  // ---------------------------------------------------------------------------
+
+  describe('Patrolling → Chasing trigger (V23 #146)', () => {
+    it('enters Chasing for the nearest surface ant within trigger radius', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
+      world.spider.nextHuntTick = 9999; // scheduled hunt must not fire — chase takes precedence
+      const antId = placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS, sy);
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Chasing');
+      expect(world.spider!.chaseTargetAntId).toBe(antId);
+      expect(world.spider!.chaseStartTick).toBe(world.tick);
+      const evt = world.events.find((e) => e.type === 'spider_chase_start');
+      expect(evt).toBeDefined();
+    });
+
+    it('picks the nearest ant (lower id wins on tie)', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
+      world.spider.nextHuntTick = 9999;
+      const near = placeWorker(world, sx + 1, sy); // dist 1
+      placeWorker(world, sx + 3, sy);              // dist 3 (farther)
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Chasing');
+      expect(world.spider!.chaseTargetAntId).toBe(near);
+    });
+
+    it('does NOT chase an ant just outside the trigger radius', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
+      world.spider.nextHuntTick = 9999;
+      placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy); // out of range
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+    });
+
+    it('does NOT chase under a pre-V23 (V22) world — old-replay guard', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V22_DIFFICULTY;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
+      world.spider.nextHuntTick = 9999;
+      placeWorker(world, sx + 1, sy);
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+    });
+
+    it('rampage preempts chase when hunger is maxed', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: SPIDER_HUNGER_MAX_TICKS[1] - 1, // +1 this tick reaches max
+      });
+      placeWorker(world, sx + 1, sy); // a chaseable ant is present, but hunger wins
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Rampaging');
+    });
+
+    it('excludes the queen from chase targets', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
+      world.spider.nextHuntTick = 9999;
+      const queenId = placeWorker(world, sx + 1, sy);
+      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = createColonyRecord(PLAYER_COLONY_ID, 0);
+      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!.queenEntityId = queenId;
+
+      tickSpider(world);
+
+      // Only the queen is in range and queens are excluded → no chase.
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+    });
+  });
+
+  describe('Chasing movement + transitions (V23 #146)', () => {
+    it('moves one step toward the target ant while chasing', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      const antId = placeWorker(world, sx + 4, sy);
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        state: 'Chasing',
+        chaseTargetAntId: antId,
+        chaseStartTick: 0,
+      });
+      world.tick = 1;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Chasing');
+      expect(world.spider!.posX).toBe((sx << FP_SHIFT) + SPIDER_SPEED); // moved +X toward target
+    });
+
+    it('successful catch (target dead) resets hunger and returns to Patrolling', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const antId = placeWorker(world, 66, 32);
+      world.ants.alive[antId] = 0; // combat killed it this tick
+      world.spider = makeSpider({
+        state: 'Chasing',
+        chaseTargetAntId: antId,
+        chaseStartTick: 0,
+        hungerTicks: 500,
+      });
+      world.tick = 50;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider!.hungerTicks).toBe(0);
+      expect(world.spider!.nextHuntTick).toBe(50 + SPIDER_HUNT_INTERVAL_TICKS);
+      const evt = world.events.find((e) => e.type === 'spider_chase_end');
+      expect(evt).toBeDefined();
+      if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('kill');
+    });
+
+    it('abandons the chase when the target reaches safety underground', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const antId = placeWorker(world, 66, 32);
+      world.ants.zone[antId] = Zone.Underground;
+      world.spider = makeSpider({
+        state: 'Chasing',
+        chaseTargetAntId: antId,
+        chaseStartTick: 0,
+      });
+      world.tick = 50;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      const evt = world.events.find((e) => e.type === 'spider_chase_end');
+      if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('escape');
+    });
+
+    it('abandons the chase when the safety leash expires', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const antId = placeWorker(world, 66, 32);
+      world.spider = makeSpider({
+        state: 'Chasing',
+        chaseTargetAntId: antId,
+        chaseStartTick: 0,
+      });
+      world.tick = SPIDER_CHASE_MAX_TICKS; // leash window elapsed
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      const evt = world.events.find((e) => e.type === 'spider_chase_end');
+      if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('leash');
+    });
+
+    it('retreats (and emits retreat) when damaged below threshold mid-chase', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const antId = placeWorker(world, 66, 32);
+      world.spider = makeSpider({
+        state: 'Chasing',
+        chaseTargetAntId: antId,
+        chaseStartTick: 0,
+        hp: SPIDER_RAMPAGE_RETREAT_HP - 1,
+      });
+      world.tick = 10;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Retreating');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      const evt = world.events.find((e) => e.type === 'spider_chase_end');
+      if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('retreat');
+    });
+
+    it('emits spider_chase_end(killed) when the spider dies mid-chase', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const antId = placeWorker(world, 66, 32);
+      world.spider = makeSpider({
+        state: 'Chasing',
+        chaseTargetAntId: antId,
+        hp: 0, // combat killed the spider this tick
+      });
+
+      tickSpider(world);
+
+      expect(world.spider).toBeNull();
+      const evt = world.events.find((e) => e.type === 'spider_chase_end');
+      expect(evt).toBeDefined();
+      if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('killed');
     });
   });
 });

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -756,6 +756,42 @@ describe('tickSpider', () => {
       expect(world.spider!.state).toBe('Patrolling');
       expect(world.spider!.chaseTargetAntId).toBe(-1);
       expect(world.spider!.hungerTicks).toBe(501); // accrued +1, not reset
+      // Target died from another source (no killedThisTick) → 'lost', not 'kill',
+      // so chase-success telemetry isn't credited a phantom spider kill.
+      const evt = world.events.find((e) => e.type === 'spider_chase_end');
+      expect(evt).toBeDefined();
+      if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('lost');
+    });
+
+    it('reports a chase kill (killed signal) when caught with a fighter adjacent', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 66;
+      const sy = 32;
+      const target = placeWorker(world, sx, sy);
+      world.ants.alive[target] = 0; // spider killed it this tick
+      // A fighter sharing the tile keeps the spider out of Feeding (still Chasing).
+      placeFighter(world, sx, sy);
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        state: 'Chasing',
+        chaseTargetAntId: target,
+        chaseStartTick: 0,
+        hungerTicks: 500,
+        killedThisTick: 1,
+        lastKillTileX: sx,
+        lastKillTileY: sy,
+      });
+      world.tick = 50;
+
+      tickSpider(world);
+
+      // Out of Feeding (fighter adjacent) but a real spider kill → 'kill'.
+      expect(world.spider!.state).toBe('Patrolling');
+      const evt = world.events.find((e) => e.type === 'spider_chase_end');
+      expect(evt).toBeDefined();
+      if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('kill');
     });
 
     it('abandons the chase when the target reaches safety underground', () => {

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -851,6 +851,21 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
   if (spider.killedThisTick === 1) {
     spider.hungerTicks = 0;
     if (!isFighterAdjacent(world, spider) && spider.state !== 'Feeding') {
+      // Close the open encounter episode before switching to Feeding so telemetry
+      // consumers that pair spider_*_start with spider_*_end don't see a dangling
+      // encounter on the common no-fighter kill path. A self-defense kill while
+      // Patrolling has no open episode, so it emits no end event. (Codex P2.)
+      const priorState = spider.state;
+      if (priorState === 'Chasing') {
+        emitSpiderChaseEnd(world, 'kill');
+      } else if (priorState === 'Hunting' || priorState === 'Striking') {
+        // killsThisStrike is only incremented during Striking; a self-defense kill
+        // in the Hunting telegraph phase leaves it 0, so floor deaths at 1 to avoid
+        // reporting outcome:'kill' with deaths:0. (Codex P3.)
+        emitSpiderHuntEnd(world, 'kill', spider.killsThisStrike > 0 ? spider.killsThisStrike : 1);
+      } else if (priorState === 'Rampaging') {
+        emitSpiderRampageEnd(world, 'quota_met', spider.rampageKillsThisRampage, false);
+      }
       // Out of danger: retreat ~10 tiles from the kill, then eat there to heal.
       computeFeedAwayTile(world, spider);
       spider.feedArrivedTick = -1;

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -25,6 +25,13 @@ import {
   SPIDER_DANGER_DEPOSIT,
   SPIDER_CHASE_TRIGGER_RADIUS,
   SPIDER_CHASE_MAX_TICKS,
+  SPIDER_HUNGER_THRESHOLD_TICKS,
+  SPIDER_MEANDER_TICK_DIVISOR,
+  SPIDER_MEANDER_RETARGET_TICKS,
+  SPIDER_FEED_RETREAT_TILES,
+  SPIDER_FEED_DANGER_RADIUS,
+  SPIDER_FEED_TICKS,
+  SPIDER_FEED_HEAL_INTERVAL_TICKS,
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
   PHEROMONE_CAP,
@@ -36,6 +43,12 @@ import { FP_SHIFT } from './fixed.js';
 // Requires SURFACE_GRID_WIDTH === 2^HUNT_KEY_SHIFT. Compile-time assertion below.
 const HUNT_KEY_SHIFT = 7; // SURFACE_GRID_WIDTH = 128 = 2^7
 const _huntKeyShiftCheck: 128 = SURFACE_GRID_WIDTH; // fails to compile if SURFACE_GRID_WIDTH !== 128
+
+// Meander tick-bucket: `tick >> SHIFT` is integer division by the retarget
+// window (avoids the float-division lint). Requires the window to stay a power
+// of two; the compile-time assertion below fails if the constant drifts.
+const SPIDER_MEANDER_RETARGET_SHIFT = 7; // SPIDER_MEANDER_RETARGET_TICKS = 128 = 2^7
+const _meanderRetargetCheck: 128 = SPIDER_MEANDER_RETARGET_TICKS; // fails to compile if != 128
 
 // ---------------------------------------------------------------------------
 // Module-level scratch for findHuntTarget — avoids per-call Map allocation.
@@ -228,6 +241,18 @@ function findNearestEntrance(
  * using a deterministic hash of (terrainSeed ^ rampageStartTick) so the
  * result looks organic but is fully replay-safe. No world.rngState draws.
  */
+/**
+ * Murmur3 32-bit finalizer over a single integer seed. Good avalanche,
+ * deterministic, no rngState draw. Shared by pickRampageTarget, the V23 meander
+ * target, and the V23 feed-away direction. Returns an unsigned 32-bit int.
+ */
+function hash32(x: number): number {
+  let h = Math.imul(x | 0, 2654435761) >>> 0;
+  h = Math.imul(h ^ (h >>> 16), 0x85ebca6b) >>> 0;
+  h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35) >>> 0;
+  return (h ^ (h >>> 16)) >>> 0;
+}
+
 function pickRampageTarget(world: WorldState, spider: SpiderState): number {
   const candidates: Array<{ colonyId: number; score: number }> = [];
   for (const key in world.colonies) {
@@ -244,10 +269,7 @@ function pickRampageTarget(world: WorldState, spider: SpiderState): number {
   candidates.sort((a, b) => b.score - a.score || a.colonyId - b.colonyId);
   // Murmur3 finalizer seeded by terrainSeed ^ rampageStartTick — good avalanche,
   // deterministic, no rngState draw.
-  let h = Math.imul(world.terrainSeed ^ spider.rampageStartTick, 2654435761) >>> 0;
-  h = Math.imul(h ^ (h >>> 16), 0x85ebca6b) >>> 0;
-  h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35) >>> 0;
-  h = (h ^ (h >>> 16)) >>> 0;
+  const h = hash32(world.terrainSeed ^ spider.rampageStartTick);
   // 60% → richer colony (index 0), 40% → poorer (index 1).
   return (h % 100) < 60 ? candidates[0]!.colonyId : candidates[1]!.colonyId;
 }
@@ -434,6 +456,21 @@ export function tickSpider(world: WorldState): void {
     return;
   }
 
+  // Version dispatch: V23+ uses the hunger-gated meandering predator; V22 and
+  // earlier use the frozen lair-orbit/scheduled-rampage behavior (byte-identical).
+  if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO) {
+    tickSpiderV23(world, spider);
+    return;
+  }
+  tickSpiderV22(world, spider);
+}
+
+// ---------------------------------------------------------------------------
+// tickSpiderV22 — frozen pre-V23 behavior (lair orbit + scheduled rampage).
+// Verbatim move of the original tickSpider body. Do NOT modify: V22-and-earlier
+// replays must stay byte-identical.
+// ---------------------------------------------------------------------------
+function tickSpiderV22(world: WorldState, spider: SpiderState): void {
   // HP regeneration: 1 HP per 20 ticks while Retreating or Feeding.
   if ((spider.state === 'Retreating' || spider.state === 'Feeding') &&
       (world.tick % 20 === 0) &&
@@ -728,4 +765,374 @@ export function tickSpider(world: WorldState): void {
   } else {
     world.scatterReticleTile = null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// V23 helpers — fighter adjacency + feed-away destination
+// ---------------------------------------------------------------------------
+
+/**
+ * V23: true if any live surface Fighting ant is within SPIDER_FEED_DANGER_RADIUS
+ * (Manhattan) of the spider's tile. Boolean scan, no allocation.
+ */
+function isFighterAdjacent(world: WorldState, spider: SpiderState): boolean {
+  const sx = spider.posX >> FP_SHIFT;
+  const sy = spider.posY >> FP_SHIFT;
+  const r = SPIDER_FEED_DANGER_RADIUS;
+  const { ants } = world;
+  const len = ants.alive.length;
+  for (let i = 0; i < len; i++) {
+    if (ants.alive[i] !== 1) continue;
+    if (ants.zone[i] !== 0) continue; // surface only
+    if (ants.task[i] !== AntTask.Fighting) continue;
+    const ax = ants.posX[i]! >> FP_SHIFT;
+    const ay = ants.posY[i]! >> FP_SHIFT;
+    const dist = (ax > sx ? ax - sx : sx - ax) + (ay > sy ? ay - sy : sy - ay);
+    if (dist <= r) return true;
+  }
+  return false;
+}
+
+/**
+ * V23: compute the ~10-tile feed destination away from the kill tile and store
+ * it in feedAwayTile{X,Y}. The spider is normally on the kill tile (dx=dy=0); in
+ * that case a deterministic hash picks one of ±X/±Y. Otherwise step along the
+ * dominant away-axis (no diagonals). Clamped to grid bounds. No allocation.
+ */
+function computeFeedAwayTile(world: WorldState, spider: SpiderState): void {
+  const sx = spider.posX >> FP_SHIFT;
+  const sy = spider.posY >> FP_SHIFT;
+  const kx = spider.lastKillTileX >= 0 ? spider.lastKillTileX : sx;
+  const ky = spider.lastKillTileY >= 0 ? spider.lastKillTileY : sy;
+  let signX = 0;
+  let signY = 0;
+  const dx = sx - kx;
+  const dy = sy - ky;
+  if (dx === 0 && dy === 0) {
+    const h = hash32(world.tick ^ world.terrainSeed) & 3;
+    if (h === 0) signX = 1;
+    else if (h === 1) signX = -1;
+    else if (h === 2) signY = 1;
+    else signY = -1;
+  } else {
+    const ax = dx < 0 ? -dx : dx;
+    const ay = dy < 0 ? -dy : dy;
+    if (ax >= ay) signX = dx > 0 ? 1 : -1;
+    else signY = dy > 0 ? 1 : -1;
+  }
+  let fx = kx + signX * SPIDER_FEED_RETREAT_TILES;
+  let fy = ky + signY * SPIDER_FEED_RETREAT_TILES;
+  if (fx < 0) fx = 0;
+  if (fx > SURFACE_GRID_WIDTH - 1) fx = SURFACE_GRID_WIDTH - 1;
+  if (fy < 0) fy = 0;
+  if (fy > SURFACE_GRID_HEIGHT - 1) fy = SURFACE_GRID_HEIGHT - 1;
+  spider.feedAwayTileX = fx;
+  spider.feedAwayTileY = fy;
+}
+
+// ---------------------------------------------------------------------------
+// tickSpiderV23 — hunger-gated meandering surface predator (#146/#147 redesign).
+// No lair orbit; slow meander while sated, fast lunge while hunting/chasing.
+// Always bites back any ant attacking it; fights to the death (no retreat/flee).
+// A kill resets hunger; if out of danger it retreats ~10 tiles and heals while
+// feeding (interruptible). Deterministic: no world.rngState draws.
+// ---------------------------------------------------------------------------
+function tickSpiderV23(world: WorldState, spider: SpiderState): void {
+  // 1. Normalize: 'Retreating' is unused in V23 (may load from an earlier #172 build).
+  if (spider.state === 'Retreating') spider.state = 'Patrolling';
+
+  // 2. Hunger accrual: only while not Feeding.
+  if (spider.state !== 'Feeding') spider.hungerTicks += 1;
+
+  const tier = tierIndex(world.difficulty);
+
+  // 3. Post-kill feed signal (highest priority). Combat (step 17) set this flag
+  //    earlier this tick. Any meal — predation OR self-defense — resets hunger.
+  if (spider.killedThisTick === 1) {
+    spider.hungerTicks = 0;
+    if (!isFighterAdjacent(world, spider) && spider.state !== 'Feeding') {
+      // Out of danger: retreat ~10 tiles from the kill, then eat there to heal.
+      computeFeedAwayTile(world, spider);
+      spider.feedArrivedTick = -1;
+      clearSpiderPairingSentinels(world);
+      spider.state = 'Feeding';
+      spider.huntTargetTileX = -1;
+      spider.huntTargetTileY = -1;
+      spider.chaseTargetAntId = -1;
+      spider.rampageTargetColonyId = -1;
+      world.spiderPriorityColonyId = null;
+      emitEvent(world, {
+        tick: world.tick,
+        type: 'spider_feed_start',
+        payload: { killTile: { x: spider.lastKillTileX, y: spider.lastKillTileY } },
+      });
+    }
+    // Fighter adjacent: hunger reset only — stay in current state and keep fighting.
+  }
+
+  // 4. State machine transitions.
+  switch (spider.state) {
+    case 'Patrolling': {
+      const hungry = spider.hungerTicks >= SPIDER_HUNGER_THRESHOLD_TICKS[tier]!;
+      if (hungry) {
+        // Precedence: (a) opportunistic chase of a lone ant; (b) telegraphed
+        // density hunt (when off cooldown and a dense tile exists); (c) camp a
+        // colony entrance via the balance-tuned rampage target picker.
+        const chaseId = findChaseTarget(world, spider);
+        if (chaseId >= 0) {
+          spider.state = 'Chasing';
+          spider.chaseTargetAntId = chaseId;
+          spider.chaseStartTick = world.tick;
+          emitEvent(world, {
+            tick: world.tick,
+            type: 'spider_chase_start',
+            payload: {
+              targetAntId: chaseId,
+              targetTile: {
+                x: world.ants.posX[chaseId]! >> FP_SHIFT,
+                y: world.ants.posY[chaseId]! >> FP_SHIFT,
+              },
+            },
+          });
+        } else {
+          let entered = false;
+          if (world.tick >= spider.nextHuntTick) {
+            const target = findHuntTarget(world, spider);
+            if (target !== null) {
+              spider.state = 'Hunting';
+              spider.huntTargetTileX = target.x;
+              spider.huntTargetTileY = target.y;
+              spider.huntStartTick = world.tick;
+              entered = true;
+              emitEvent(world, {
+                tick: world.tick,
+                type: 'spider_hunt_start',
+                payload: {
+                  reticleTile: { x: target.x, y: target.y, grid: 'surface' },
+                  targetWorkers: target.workerCount,
+                },
+              });
+            } else {
+              // No dense tile — postpone the hunt scan by one interval.
+              spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+            }
+          }
+          if (!entered) {
+            // Camp a colony entrance and eat the first ant there.
+            spider.state = 'Rampaging';
+            spider.rampageStartTick = world.tick;
+            spider.rampageKillsThisRampage = 0;
+            spider.rampageTargetColonyId = pickRampageTarget(world, spider);
+            emitEvent(world, {
+              tick: world.tick,
+              type: 'spider_rampage_start',
+              payload: {
+                lairTile: { x: spider.lairTileX, y: spider.lairTileY },
+                hungerTicks: spider.hungerTicks,
+              },
+            });
+          }
+        }
+      }
+      // Sated: no predation — slow meander handled in the movement switch.
+      break;
+    }
+
+    case 'Hunting': {
+      if (world.tick - spider.huntStartTick >= SPIDER_TELEGRAPH_TICKS) {
+        spider.state = 'Striking';
+        spider.strikeStartTick = world.tick;
+        spider.killsThisStrike = 0;
+      }
+      break;
+    }
+
+    case 'Striking': {
+      if (world.tick - spider.strikeStartTick >= SPIDER_STRIKE_TICKS) {
+        // Kills route through step 3 (killedThisTick → Feeding). Reaching here
+        // means no feed this strike (no kill, or a fighter-adjacent kill); scatter.
+        emitSpiderHuntEnd(world, spider.killsThisStrike > 0 ? 'kill' : 'scatter', spider.killsThisStrike);
+        clearSpiderPairingSentinels(world);
+        spider.state = 'Patrolling';
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        spider.huntTargetTileX = -1;
+        spider.huntTargetTileY = -1;
+        world.spiderPriorityColonyId = null;
+      }
+      break;
+    }
+
+    case 'Chasing': {
+      // A catch routes through step 3 (→ Feeding when out of danger). Reaching
+      // here means the target is alive, escaped underground, leashed out, or the
+      // catch happened with a fighter adjacent (dead target, no feed).
+      const tid = spider.chaseTargetAntId;
+      const targetAlive = tid >= 0 && world.ants.alive[tid] === 1;
+      if (!targetAlive) {
+        emitSpiderChaseEnd(world, 'kill');
+        clearSpiderPairingSentinels(world);
+        spider.state = 'Patrolling';
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        spider.chaseTargetAntId = -1;
+      } else if (world.ants.zone[tid] !== 0) {
+        emitSpiderChaseEnd(world, 'escape');
+        clearSpiderPairingSentinels(world);
+        spider.state = 'Patrolling';
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        spider.chaseTargetAntId = -1;
+      } else if (world.tick - spider.chaseStartTick >= SPIDER_CHASE_MAX_TICKS) {
+        emitSpiderChaseEnd(world, 'leash');
+        clearSpiderPairingSentinels(world);
+        spider.state = 'Patrolling';
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        spider.chaseTargetAntId = -1;
+      }
+      break;
+    }
+
+    case 'Rampaging': {
+      // Camp the entrance and eat the first ant there. No quota — a kill routes
+      // through step 3 (→ Feeding). Do NOT chase-divert: a camping spider must
+      // hold its entrance (the #165 blockade) rather than chase a passing ant.
+      if (world.tick - spider.rampageStartTick >= SPIDER_RAMPAGE_MAX_TICKS) {
+        // Leash: no ant surfaced at the entrance in time.
+        emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
+        clearSpiderPairingSentinels(world);
+        spider.state = 'Patrolling';
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        spider.rampageTargetColonyId = -1;
+        world.spiderPriorityColonyId = null;
+      } else {
+        if (spider.rampageTargetColonyId < 0) spider.rampageTargetColonyId = pickRampageTarget(world, spider);
+        if (findNearestEntrance(world, spider, spider.rampageTargetColonyId) === null) {
+          // Sealed colony — no open entrance to camp. Resume patrolling.
+          emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
+          clearSpiderPairingSentinels(world);
+          spider.state = 'Patrolling';
+          spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+          spider.rampageTargetColonyId = -1;
+          world.spiderPriorityColonyId = null;
+        }
+      }
+      break;
+    }
+
+    case 'Feeding': {
+      if (isFighterAdjacent(world, spider)) {
+        // Interrupted: forfeit the remaining heal and resume defending.
+        emitEvent(world, {
+          tick: world.tick,
+          type: 'spider_feed_end',
+          payload: { outcome: 'interrupted' },
+        });
+        spider.state = 'Patrolling';
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        spider.feedArrivedTick = -1;
+      } else {
+        const sx = spider.posX >> FP_SHIFT;
+        const sy = spider.posY >> FP_SHIFT;
+        if (spider.feedArrivedTick < 0 && sx === spider.feedAwayTileX && sy === spider.feedAwayTileY) {
+          spider.feedArrivedTick = world.tick;
+        }
+        if (spider.feedArrivedTick >= 0) {
+          if ((world.tick - spider.feedArrivedTick) % SPIDER_FEED_HEAL_INTERVAL_TICKS === 0 &&
+              spider.hp < SPIDER_HP_FULL) {
+            spider.hp += 1;
+            if (spider.hp > SPIDER_HP_FULL) spider.hp = SPIDER_HP_FULL;
+          }
+          if (world.tick - spider.feedArrivedTick >= SPIDER_FEED_TICKS) {
+            emitEvent(world, {
+              tick: world.tick,
+              type: 'spider_feed_end',
+              payload: { outcome: 'healed' },
+            });
+            spider.state = 'Patrolling';
+            spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+            spider.feedArrivedTick = -1;
+          }
+        }
+      }
+      break;
+    }
+  }
+
+  // 6. Movement.
+  const rampageNearest = spider.state === 'Rampaging'
+    ? findNearestEntrance(world, spider, spider.rampageTargetColonyId)
+    : null;
+  switch (spider.state) {
+    case 'Patrolling': {
+      // Slow meander across the whole map: step only every Nth tick toward a
+      // wander target re-rolled every SPIDER_MEANDER_RETARGET_TICKS ticks. The
+      // target derives from a hash of (tick-bucket ^ terrainSeed) — no lair orbit,
+      // no rng draw.
+      if (world.tick % SPIDER_MEANDER_TICK_DIVISOR === 0) {
+        // SPIDER_MEANDER_RETARGET_TICKS is 128 = 2^7, so `tick >> 7` is the
+        // integer tick-bucket (same idiom as entrance-flow's row decode); avoids
+        // the float-division lint and keeps the bucket deterministic.
+        const bucket = world.tick >> SPIDER_MEANDER_RETARGET_SHIFT;
+        const seed = bucket ^ world.terrainSeed;
+        const tx = hash32(seed) % SURFACE_GRID_WIDTH;
+        const ty = hash32(seed ^ 0x9e3779b9) % SURFACE_GRID_HEIGHT;
+        moveTowardTile(spider, tx, ty);
+      }
+      break;
+    }
+    case 'Hunting':
+    case 'Striking': {
+      moveTowardTile(spider, spider.huntTargetTileX, spider.huntTargetTileY);
+      break;
+    }
+    case 'Chasing': {
+      const tid = spider.chaseTargetAntId;
+      if (tid >= 0 && world.ants.alive[tid] === 1) {
+        moveTowardTile(spider, world.ants.posX[tid]! >> FP_SHIFT, world.ants.posY[tid]! >> FP_SHIFT);
+      }
+      break;
+    }
+    case 'Feeding': {
+      // Travel to the feed tile, then idle there while healing.
+      moveTowardTile(spider, spider.feedAwayTileX, spider.feedAwayTileY);
+      break;
+    }
+    case 'Rampaging': {
+      if (rampageNearest !== null) {
+        moveTowardTile(spider, rampageNearest.x, rampageNearest.y);
+      }
+      break;
+    }
+  }
+
+  // 7. Danger pheromone — all surface states (everything except Feeding).
+  if (spider.state !== 'Feeding') {
+    seedDangerPheromone(world, spider);
+  }
+
+  // scatterReticleTile shadow field: Hunting/Striking scatter around the hunt
+  // tile; Chasing scatters around the pursued ant; everything else clears it.
+  const chaseTid = spider.chaseTargetAntId;
+  const chaseReticleValid =
+    spider.state === 'Chasing' && chaseTid >= 0 && world.ants.alive[chaseTid] === 1;
+  if (spider.state === 'Hunting' || spider.state === 'Striking') {
+    if (world.scatterReticleTile === null) {
+      world.scatterReticleTile = { x: spider.huntTargetTileX, y: spider.huntTargetTileY };
+    } else {
+      world.scatterReticleTile.x = spider.huntTargetTileX;
+      world.scatterReticleTile.y = spider.huntTargetTileY;
+    }
+  } else if (chaseReticleValid) {
+    const rx = world.ants.posX[chaseTid]! >> FP_SHIFT;
+    const ry = world.ants.posY[chaseTid]! >> FP_SHIFT;
+    if (world.scatterReticleTile === null) {
+      world.scatterReticleTile = { x: rx, y: ry };
+    } else {
+      world.scatterReticleTile.x = rx;
+      world.scatterReticleTile.y = ry;
+    }
+  } else {
+    world.scatterReticleTile = null;
+  }
+
+  // 8. Clear the per-tick kill flag — must never leak into the next tick.
+  spider.killedThisTick = 0;
 }

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -24,6 +24,7 @@ import {
   SPIDER_SPEED,
   SPIDER_DANGER_DEPOSIT,
   SPIDER_CHASE_TRIGGER_RADIUS,
+  SPIDER_DEFENSE_TRIGGER_RADIUS,
   SPIDER_CHASE_MAX_TICKS,
   SPIDER_HUNGER_THRESHOLD_TICKS,
   SPIDER_MEANDER_TICK_DIVISOR,
@@ -168,6 +169,54 @@ function findChaseTarget(world: WorldState, spider: SpiderState): number {
     if (ants.alive[i] !== 1) continue;
     if (ants.zone[i] !== 0) continue; // surface only
     if (i === chaseQueenId0 || i === chaseQueenId1) continue; // queens are not prey
+    const ax = ants.posX[i]! >> FP_SHIFT;
+    const ay = ants.posY[i]! >> FP_SHIFT;
+    const dist = (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +
+                 (ay > spiderTileY ? ay - spiderTileY : spiderTileY - ay);
+    if (dist > r) continue;
+    if (dist < bestDist) { bestDist = dist; bestId = i; } // strict < ⇒ lower id wins on tie
+  }
+  return bestId;
+}
+
+/**
+ * True if any live surface ant occupies tile (tileX, tileY). Used by the Rampaging
+ * straggler-divert to honor the #165 entrance blockade: while a descender sits on the
+ * camped entrance tile, the tile-coincident spider bite (the gate holds the ant there)
+ * resolves it this tick, so the spider must NOT divert off the gate to chase. No alloc.
+ */
+function isSurfaceAntOnTile(world: WorldState, tileX: number, tileY: number): boolean {
+  const { ants } = world;
+  const antCount = ants.alive.length;
+  for (let i = 0; i < antCount; i++) {
+    if (ants.alive[i] !== 1) continue;
+    if (ants.zone[i] !== 0) continue; // surface only
+    if ((ants.posX[i]! >> FP_SHIFT) === tileX && (ants.posY[i]! >> FP_SHIFT) === tileY) return true;
+  }
+  return false;
+}
+
+/**
+ * V23 self-defense (#147): nearest live surface AntTask.Fighting ant within
+ * SPIDER_DEFENSE_TRIGGER_RADIUS of the spider. Returns the ant entity id, or -1.
+ * Used to make an attacked spider stop meandering/camping and actively engage its
+ * attackers (a Chasing spider moves at 2× ant speed, so it reliably closes). Same
+ * deterministic Manhattan + ascending-id-tiebreak contract as findChaseTarget; no
+ * allocation. Queens are never AntTask.Fighting, so no queen exclusion is needed.
+ */
+function findNearestAttackingFighter(world: WorldState, spider: SpiderState): number {
+  const spiderTileX = spider.posX >> FP_SHIFT;
+  const spiderTileY = spider.posY >> FP_SHIFT;
+  const r = SPIDER_DEFENSE_TRIGGER_RADIUS;
+
+  const { ants } = world;
+  const antCount = ants.alive.length;
+  let bestId = -1;
+  let bestDist = r + 1;
+  for (let i = 0; i < antCount; i++) {
+    if (ants.alive[i] !== 1) continue;
+    if (ants.zone[i] !== 0) continue; // surface only
+    if (ants.task[i] !== AntTask.Fighting) continue;
     const ax = ants.posX[i]! >> FP_SHIFT;
     const ay = ants.posY[i]! >> FP_SHIFT;
     const dist = (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +
@@ -402,6 +451,28 @@ function emitSpiderChaseEnd(
     tick: world.tick,
     type: 'spider_chase_end',
     payload: { outcome },
+  });
+}
+
+/**
+ * Enter the Chasing state targeting ant `targetId` and emit spider_chase_start.
+ * Shared by the three V23 entry points: opportunistic Patrolling chase, active
+ * self-defense (engage an attacker), and the Rampaging straggler chase-divert.
+ */
+function enterChasing(world: WorldState, spider: SpiderState, targetId: number): void {
+  spider.state = 'Chasing';
+  spider.chaseTargetAntId = targetId;
+  spider.chaseStartTick = world.tick;
+  emitEvent(world, {
+    tick: world.tick,
+    type: 'spider_chase_start',
+    payload: {
+      targetAntId: targetId,
+      targetTile: {
+        x: world.ants.posX[targetId]! >> FP_SHIFT,
+        y: world.ants.posY[targetId]! >> FP_SHIFT,
+      },
+    },
   });
 }
 
@@ -886,6 +957,49 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
   }
 
   // 4. State machine transitions.
+  //
+  // 4a. Active self-defense (#147): if a Fighting ant is attacking from within
+  //     SPIDER_DEFENSE_TRIGGER_RADIUS, abandon the current non-committed activity
+  //     (sated meander / hunt telegraph / entrance camp) and Chase the nearest
+  //     attacker. Without this the spider just meanders away from its attackers —
+  //     the meander (1 tile / 3 ticks ≈ 0.33/tick) is slower than a fighter
+  //     (0.5/tick), so a pursuing swarm surrounds and kills it while it never
+  //     engages. A Chasing spider moves at 1 tile/tick and reliably closes. Striking
+  //     is a committed one-shot; Chasing already engages; Feeding interrupts on
+  //     adjacency in its own case — so those three states are excluded here.
+  //     EXCEPTION (#165): a Rampaging spider pinning a descender on its camped
+  //     entrance must HOLD even under attack — vacating the gate to chase an attacker
+  //     would let the pinned ant slip underground next tick (movement reads the
+  //     spider's state before the spider ticks). Holding is not passive: the spider
+  //     still bites back any ant that steps onto its tile via tile-coincident combat.
+  if (
+    spider.state === 'Patrolling' ||
+    spider.state === 'Hunting' ||
+    spider.state === 'Rampaging'
+  ) {
+    let holdGate = false;
+    if (spider.state === 'Rampaging' && spider.rampageTargetColonyId >= 0) {
+      const camped = findNearestEntrance(world, spider, spider.rampageTargetColonyId);
+      holdGate = camped !== null && isSurfaceAntOnTile(world, camped.x, camped.y);
+    }
+    const attackerId = holdGate ? -1 : findNearestAttackingFighter(world, spider);
+    if (attackerId >= 0) {
+      if (spider.state === 'Hunting') {
+        emitSpiderHuntEnd(world, 'scatter', spider.killsThisStrike);
+        spider.huntTargetTileX = -1;
+        spider.huntTargetTileY = -1;
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        world.spiderPriorityColonyId = null;
+      } else if (spider.state === 'Rampaging') {
+        emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
+        spider.rampageTargetColonyId = -1;
+        world.spiderPriorityColonyId = null;
+      }
+      clearSpiderPairingSentinels(world);
+      enterChasing(world, spider, attackerId);
+    }
+  }
+
   switch (spider.state) {
     case 'Patrolling': {
       const hungry = spider.hungerTicks >= SPIDER_HUNGER_THRESHOLD_TICKS[tier]!;
@@ -895,20 +1009,7 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
         // colony entrance via the balance-tuned rampage target picker.
         const chaseId = findChaseTarget(world, spider);
         if (chaseId >= 0) {
-          spider.state = 'Chasing';
-          spider.chaseTargetAntId = chaseId;
-          spider.chaseStartTick = world.tick;
-          emitEvent(world, {
-            tick: world.tick,
-            type: 'spider_chase_start',
-            payload: {
-              targetAntId: chaseId,
-              targetTile: {
-                x: world.ants.posX[chaseId]! >> FP_SHIFT,
-                y: world.ants.posY[chaseId]! >> FP_SHIFT,
-              },
-            },
-          });
+          enterChasing(world, spider, chaseId);
         } else {
           let entered = false;
           if (world.tick >= spider.nextHuntTick) {
@@ -1013,8 +1114,7 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
 
     case 'Rampaging': {
       // Camp the entrance and eat the first ant there. No quota — a kill routes
-      // through step 3 (→ Feeding). Do NOT chase-divert: a camping spider must
-      // hold its entrance (the #165 blockade) rather than chase a passing ant.
+      // through step 3 (→ Feeding).
       if (world.tick - spider.rampageStartTick >= SPIDER_RAMPAGE_MAX_TICKS) {
         // Leash: no ant surfaced at the entrance in time.
         emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
@@ -1023,16 +1123,40 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
         spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
         spider.rampageTargetColonyId = -1;
         world.spiderPriorityColonyId = null;
-      } else {
+      } else if (spider.rampageTargetColonyId < 0 ||
+                 findNearestEntrance(world, spider, spider.rampageTargetColonyId) === null) {
+        // No target yet, or the camped colony sealed its only open entrance.
+        // (Re-pick first; if still no open entrance, resume patrolling.)
         if (spider.rampageTargetColonyId < 0) spider.rampageTargetColonyId = pickRampageTarget(world, spider);
         if (findNearestEntrance(world, spider, spider.rampageTargetColonyId) === null) {
-          // Sealed colony — no open entrance to camp. Resume patrolling.
           emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
           clearSpiderPairingSentinels(world);
           spider.state = 'Patrolling';
           spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
           spider.rampageTargetColonyId = -1;
           world.spiderPriorityColonyId = null;
+        }
+      } else {
+        // Camping-straggler lunge (#146): an ant emerging from the entrance moves off
+        // the spider's tile before the combat step samples it (movement runs before
+        // combat), so a stationary camper rarely lands the tile-coincident bite. If a
+        // live ant is within SPIDER_CHASE_TRIGGER_RADIUS, divert to Chasing it — the
+        // spider is 2× ant speed so it closes and eats, then Feeds or resumes camping.
+        //
+        // BUT honor the #165 blockade first: while an ant occupies the camped entrance
+        // tile, hold — the gate pins that descender on the entrance and the tile-coincident
+        // spider bite resolves it THIS tick. Diverting would vacate the gate and let the
+        // pinned ant slip underground. Only chase once the entrance tile is clear.
+        // Attacking fighters were already handled by the step-4a self-defense check.
+        const camped = findNearestEntrance(world, spider, spider.rampageTargetColonyId);
+        const holdGate = camped !== null && isSurfaceAntOnTile(world, camped.x, camped.y);
+        const stragglerId = holdGate ? -1 : findChaseTarget(world, spider);
+        if (stragglerId >= 0) {
+          emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
+          clearSpiderPairingSentinels(world);
+          spider.rampageTargetColonyId = -1;
+          world.spiderPriorityColonyId = null;
+          enterChasing(world, spider, stragglerId);
         }
       }
       break;

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -23,10 +23,13 @@ import {
   SPIDER_HUNT_MIN_TARGET_WORKERS,
   SPIDER_SPEED,
   SPIDER_DANGER_DEPOSIT,
+  SPIDER_CHASE_TRIGGER_RADIUS,
+  SPIDER_CHASE_MAX_TICKS,
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
   PHEROMONE_CAP,
 } from './constants.js';
+import { SIM_VERSION_V23_SPIDER_AGGRO } from './types.js';
 import { FP_SHIFT } from './fixed.js';
 
 // HUNT_KEY_SHIFT: number of bits to shift Y to form a tile key (Y << SHIFT + X).
@@ -116,6 +119,50 @@ function findHuntTarget(
   }
   if (bestKey === -1) return null;
   return { x: bestX, y: bestY, workerCount: bestCount };
+}
+
+// ---------------------------------------------------------------------------
+// Chase target selection (V23 / #146) — deterministic (no rng draws)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the nearest live surface ant (any caste; queens excluded) within
+ * SPIDER_CHASE_TRIGGER_RADIUS of the spider. Returns the ant entity id, or -1 if
+ * none qualify. Manhattan distance; ties broken by ascending ant id (lower id wins),
+ * matching the deterministic SoA iteration order. No allocation.
+ */
+function findChaseTarget(world: WorldState, spider: SpiderState): number {
+  const spiderTileX = spider.posX >> FP_SHIFT;
+  const spiderTileY = spider.posY >> FP_SHIFT;
+  const r = SPIDER_CHASE_TRIGGER_RADIUS;
+
+  // Exclude queens (identified by colony.queenEntityId) — they are not chase prey.
+  let chaseQueenId0 = -1;
+  let chaseQueenId1 = -1;
+  for (const ckey in world.colonies) {
+    if (!Object.hasOwn(world.colonies, ckey)) continue;
+    const col = world.colonies[ckey as unknown as import('./colony/colony-store.js').ColonyId];
+    if (col === undefined) continue;
+    if (chaseQueenId0 < 0) chaseQueenId0 = col.queenEntityId;
+    else chaseQueenId1 = col.queenEntityId;
+  }
+
+  const { ants } = world;
+  const antCount = ants.alive.length;
+  let bestId = -1;
+  let bestDist = r + 1; // must be <= r to qualify
+  for (let i = 0; i < antCount; i++) {
+    if (ants.alive[i] !== 1) continue;
+    if (ants.zone[i] !== 0) continue; // surface only
+    if (i === chaseQueenId0 || i === chaseQueenId1) continue; // queens are not prey
+    const ax = ants.posX[i]! >> FP_SHIFT;
+    const ay = ants.posY[i]! >> FP_SHIFT;
+    const dist = (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +
+                 (ay > spiderTileY ? ay - spiderTileY : spiderTileY - ay);
+    if (dist > r) continue;
+    if (dist < bestDist) { bestDist = dist; bestId = i; } // strict < ⇒ lower id wins on tie
+  }
+  return bestId;
 }
 
 // ---------------------------------------------------------------------------
@@ -325,6 +372,17 @@ function emitSpiderRampageEnd(
   });
 }
 
+function emitSpiderChaseEnd(
+  world: WorldState,
+  outcome: 'kill' | 'escape' | 'leash' | 'retreat' | 'killed',
+): void {
+  emitEvent(world, {
+    tick: world.tick,
+    type: 'spider_chase_end',
+    payload: { outcome },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Utility: clear stale spider-pairing sentinels from live ants
 // ---------------------------------------------------------------------------
@@ -364,6 +422,8 @@ export function tickSpider(world: WorldState): void {
     // Spider died from combat this tick. Emit end events, then clear.
     if (spider.state === 'Striking') {
       emitSpiderHuntEnd(world, 'swarm_retreat', spider.killsThisStrike);
+    } else if (spider.state === 'Chasing') {
+      emitSpiderChaseEnd(world, 'killed');
     } else if (spider.state === 'Rampaging') {
       emitSpiderRampageEnd(world, 'killed_in_nest', spider.rampageKillsThisRampage, false);
     }
@@ -387,13 +447,15 @@ export function tickSpider(world: WorldState): void {
     spider.hungerTicks += 1;
   }
 
-  // --- Priority retreating-threshold check (applies to Striking and Rampaging) ---
+  // --- Priority retreating-threshold check (applies to Striking, Chasing, Rampaging) ---
   // This runs before state-specific logic so a combat-damaged spider retreats
   // immediately, even on the same tick its duration would have expired.
-  if ((spider.state === 'Striking' || spider.state === 'Rampaging') &&
+  if ((spider.state === 'Striking' || spider.state === 'Chasing' || spider.state === 'Rampaging') &&
       spider.hp < SPIDER_RAMPAGE_RETREAT_HP) {
     if (spider.state === 'Striking') {
       emitSpiderHuntEnd(world, 'swarm_retreat', spider.killsThisStrike);
+    } else if (spider.state === 'Chasing') {
+      emitSpiderChaseEnd(world, 'retreat');
     } else {
       emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
     }
@@ -402,6 +464,7 @@ export function tickSpider(world: WorldState): void {
     spider.retreatStartTick = world.tick;
     spider.huntTargetTileX = -1;
     spider.huntTargetTileY = -1;
+    spider.chaseTargetAntId = -1;
     spider.hungerTicks = 0; // prevent immediate re-rampaging on return to Patrolling
     spider.rampageTargetColonyId = -1;
     world.spiderPriorityColonyId = null;
@@ -425,25 +488,47 @@ export function tickSpider(world: WorldState): void {
             hungerTicks: spider.hungerTicks,
           },
         });
-      } else if (world.tick >= spider.nextHuntTick) {
-        const target = findHuntTarget(world, spider);
-        if (target !== null) {
-          spider.state = 'Hunting';
-          spider.huntTargetTileX = target.x;
-          spider.huntTargetTileY = target.y;
-          spider.huntStartTick = world.tick;
+      } else {
+        // V23 (#146): opportunistic chase — a lone ant within trigger radius takes
+        // precedence over the scheduled tile-density hunt (but not over rampaging).
+        const chaseId = world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO
+          ? findChaseTarget(world, spider)
+          : -1;
+        if (chaseId >= 0) {
+          spider.state = 'Chasing';
+          spider.chaseTargetAntId = chaseId;
+          spider.chaseStartTick = world.tick;
           emitEvent(world, {
             tick: world.tick,
-            type: 'spider_hunt_start',
+            type: 'spider_chase_start',
             payload: {
-              reticleTile: { x: target.x, y: target.y, grid: 'surface' },
-              targetWorkers: target.workerCount,
+              targetAntId: chaseId,
+              targetTile: {
+                x: world.ants.posX[chaseId]! >> FP_SHIFT,
+                y: world.ants.posY[chaseId]! >> FP_SHIFT,
+              },
             },
           });
-        } else {
-          // No qualifying workers in range — postpone hunt by one interval to preserve
-          // the 1200-tick cadence rather than re-scanning every tick.
-          spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        } else if (world.tick >= spider.nextHuntTick) {
+          const target = findHuntTarget(world, spider);
+          if (target !== null) {
+            spider.state = 'Hunting';
+            spider.huntTargetTileX = target.x;
+            spider.huntTargetTileY = target.y;
+            spider.huntStartTick = world.tick;
+            emitEvent(world, {
+              tick: world.tick,
+              type: 'spider_hunt_start',
+              payload: {
+                reticleTile: { x: target.x, y: target.y, grid: 'surface' },
+                targetWorkers: target.workerCount,
+              },
+            });
+          } else {
+            // No qualifying workers in range — postpone hunt by one interval to preserve
+            // the 1200-tick cadence rather than re-scanning every tick.
+            spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+          }
         }
       }
       break;
@@ -454,6 +539,38 @@ export function tickSpider(world: WorldState): void {
         spider.state = 'Striking';
         spider.strikeStartTick = world.tick;
         spider.killsThisStrike = 0;
+      }
+      break;
+    }
+
+    case 'Chasing': {
+      // Combat ran at step 17 (this tick) before tickSpider, so a catch shows up as a
+      // dead target here. Exit on catch / escape underground / leash-timeout; otherwise
+      // keep pursuing (movement happens in the movement switch below).
+      const tid = spider.chaseTargetAntId;
+      const targetAlive = tid >= 0 && world.ants.alive[tid] === 1;
+      if (!targetAlive) {
+        // Target died — treat as a successful catch (hunger satisfied).
+        emitSpiderChaseEnd(world, 'kill');
+        clearSpiderPairingSentinels(world);
+        spider.state = 'Patrolling';
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        spider.chaseTargetAntId = -1;
+        spider.hungerTicks = 0;
+      } else if (world.ants.zone[tid] !== 0) {
+        // Target reached safety underground — abandon.
+        emitSpiderChaseEnd(world, 'escape');
+        clearSpiderPairingSentinels(world);
+        spider.state = 'Patrolling';
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        spider.chaseTargetAntId = -1;
+      } else if (world.tick - spider.chaseStartTick >= SPIDER_CHASE_MAX_TICKS) {
+        // Safety leash expired — give up and return to patrol.
+        emitSpiderChaseEnd(world, 'leash');
+        clearSpiderPairingSentinels(world);
+        spider.state = 'Patrolling';
+        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
+        spider.chaseTargetAntId = -1;
       }
       break;
     }
@@ -550,6 +667,15 @@ export function tickSpider(world: WorldState): void {
       moveTowardTile(spider, spider.huntTargetTileX, spider.huntTargetTileY);
       break;
     }
+    case 'Chasing': {
+      // Pursue the target ant's current tile each tick (transition logic above already
+      // handled dead/underground/leash-expired targets, so the id is live here).
+      const tid = spider.chaseTargetAntId;
+      if (tid >= 0 && world.ants.alive[tid] === 1) {
+        moveTowardTile(spider, world.ants.posX[tid]! >> FP_SHIFT, world.ants.posY[tid]! >> FP_SHIFT);
+      }
+      break;
+    }
     case 'Feeding':
     case 'Retreating': {
       moveTowardTile(spider, spider.lairTileX, spider.lairTileY);
@@ -570,7 +696,7 @@ export function tickSpider(world: WorldState): void {
   }
 
   // --- Danger pheromone seeding ---
-  // Surface states: Patrolling, Hunting, Striking, Rampaging (while on surface)
+  // Surface states: Patrolling, Hunting, Chasing, Striking, Rampaging (while on surface)
   const isOnSurface = spider.state !== 'Feeding' && spider.state !== 'Retreating';
   if (isOnSurface) {
     seedDangerPheromone(world, spider);
@@ -578,12 +704,26 @@ export function tickSpider(world: WorldState): void {
 
 
   // --- scatterReticleTile shadow field: written at end for next tick's step 13e ---
+  // Hunting/Striking scatter around the hunt target tile; Chasing (V23) scatters around
+  // the pursued ant's current tile so nearby non-fighters flee the chase.
+  const chaseTid = spider.chaseTargetAntId;
+  const chaseReticleValid =
+    spider.state === 'Chasing' && chaseTid >= 0 && world.ants.alive[chaseTid] === 1;
   if (spider.state === 'Hunting' || spider.state === 'Striking') {
     if (world.scatterReticleTile === null) {
       world.scatterReticleTile = { x: spider.huntTargetTileX, y: spider.huntTargetTileY };
     } else {
       world.scatterReticleTile.x = spider.huntTargetTileX;
       world.scatterReticleTile.y = spider.huntTargetTileY;
+    }
+  } else if (chaseReticleValid) {
+    const rx = world.ants.posX[chaseTid]! >> FP_SHIFT;
+    const ry = world.ants.posY[chaseTid]! >> FP_SHIFT;
+    if (world.scatterReticleTile === null) {
+      world.scatterReticleTile = { x: rx, y: ry };
+    } else {
+      world.scatterReticleTile.x = rx;
+      world.scatterReticleTile.y = ry;
     }
   } else {
     world.scatterReticleTile = null;

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -396,7 +396,7 @@ function emitSpiderRampageEnd(
 
 function emitSpiderChaseEnd(
   world: WorldState,
-  outcome: 'kill' | 'escape' | 'leash' | 'retreat' | 'killed',
+  outcome: 'kill' | 'escape' | 'leash' | 'retreat' | 'killed' | 'lost',
 ): void {
   emitEvent(world, {
     tick: world.tick,
@@ -969,7 +969,13 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
       const tid = spider.chaseTargetAntId;
       const targetAlive = tid >= 0 && world.ants.alive[tid] === 1;
       if (!targetAlive) {
-        emitSpiderChaseEnd(world, 'kill');
+        // Target is gone. Report a spider 'kill' only when the spider actually
+        // killed this tick (combat resolver set killedThisTick); a genuine catch
+        // with a fighter adjacent stays Chasing and lands here. Otherwise the
+        // target died from another source (e.g. ant-vs-ant combat earlier this
+        // tick) — emit 'lost', not 'kill', so chase-success telemetry isn't
+        // credited a spider kill with no matching combat_kill. (Codex P2.)
+        emitSpiderChaseEnd(world, spider.killedThisTick === 1 ? 'kill' : 'lost');
         clearSpiderPairingSentinels(world);
         spider.state = 'Patrolling';
         spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;

--- a/src/sim/telemetry.ts
+++ b/src/sim/telemetry.ts
@@ -113,6 +113,16 @@ export type SimEvent =
     }
   | {
       tick: number;
+      type: 'spider_feed_start';
+      payload: { killTile: { x: number; y: number } };
+    }
+  | {
+      tick: number;
+      type: 'spider_feed_end';
+      payload: { outcome: 'healed' | 'interrupted' };
+    }
+  | {
+      tick: number;
       type: 'queen_death';
       payload: {
         // cause is null in V15 traces (S0b proof-of-concept). S1/S2 will fill

--- a/src/sim/telemetry.ts
+++ b/src/sim/telemetry.ts
@@ -84,6 +84,16 @@ export type SimEvent =
     }
   | {
       tick: number;
+      type: 'spider_chase_start';
+      payload: { targetAntId: number; targetTile: { x: number; y: number } };
+    }
+  | {
+      tick: number;
+      type: 'spider_chase_end';
+      payload: { outcome: 'kill' | 'escape' | 'leash' | 'retreat' | 'killed' };
+    }
+  | {
+      tick: number;
       type: 'spider_rampage_start';
       payload: { lairTile: { x: number; y: number }; hungerTicks: number };
     }

--- a/src/sim/telemetry.ts
+++ b/src/sim/telemetry.ts
@@ -90,7 +90,7 @@ export type SimEvent =
   | {
       tick: number;
       type: 'spider_chase_end';
-      payload: { outcome: 'kill' | 'escape' | 'leash' | 'retreat' | 'killed' };
+      payload: { outcome: 'kill' | 'escape' | 'leash' | 'retreat' | 'killed' | 'lost' };
     }
   | {
       tick: number;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -275,7 +275,21 @@ export const SIM_VERSION_V21_REPRODUCTION = 21 as const;
  * behaviour for byte-identical replay of pre-V22 recordings.
  */
 export const SIM_VERSION_V22_DIFFICULTY = 22 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V22_DIFFICULTY;
+/**
+ * V23 (S3 follow-up) — Spider surface-aggro loop (#146, #147).
+ * - Spider gains an opportunistic Chasing state: while Patrolling it darts at the nearest
+ *   live surface ant within SPIDER_CHASE_TRIGGER_RADIUS, engaging via the normal combat
+ *   resolver, then returns to Patrolling on catch/escape/leash-timeout.
+ * - Fighter ants autonomously target the spider when it is the nearest hostile within
+ *   FIGHT_AGGRO_RADIUS (folded into the existing proximity-aggression scan).
+ * - resolveSpiderCombatOnTile now runs in all surface states (not only Striking/Rampaging)
+ *   so fighters can damage a Patrolling/Hunting/Chasing spider.
+ * Adds SpiderState.chaseTargetAntId and SpiderState.chaseStartTick.
+ * Pre-V23 saves load with chaseTargetAntId=-1, chaseStartTick=0 and replay with none of the
+ * above behaviour (all three paths gate on simVersion >= V23) for byte-identical replay.
+ */
+export const SIM_VERSION_V23_SPIDER_AGGRO = 23 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V23_SPIDER_AGGRO;
 
 
 /**
@@ -296,6 +310,7 @@ export type AIState =
 export type SpiderBehaviorState =
   | 'Patrolling'
   | 'Hunting'
+  | 'Chasing'
   | 'Striking'
   | 'Feeding'
   | 'Rampaging'
@@ -323,6 +338,8 @@ export interface SpiderState {
   killsThisStrike: number;
   rampageKillsThisRampage: number;
   rampageTargetColonyId: number;  // colony targeted for current rampage; -1 when not rampaging
+  chaseTargetAntId: number;       // V23: ant id being chased; -1 when not Chasing
+  chaseStartTick: number;         // V23: tick the current chase began (leash-timeout reference)
 }
 
 export interface AIStateRecord {
@@ -677,6 +694,8 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
     ds.killsThisStrike = ss.killsThisStrike;
     ds.rampageKillsThisRampage = ss.rampageKillsThisRampage;
     ds.rampageTargetColonyId = ss.rampageTargetColonyId;
+    ds.chaseTargetAntId = ss.chaseTargetAntId;
+    ds.chaseStartTick = ss.chaseStartTick;
   }
   dst.spiderPriorityColonyId = src.spiderPriorityColonyId;
   // scatterReticleTile

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -340,6 +340,12 @@ export interface SpiderState {
   rampageTargetColonyId: number;  // colony targeted for current rampage; -1 when not rampaging
   chaseTargetAntId: number;       // V23: ant id being chased; -1 when not Chasing
   chaseStartTick: number;         // V23: tick the current chase began (leash-timeout reference)
+  killedThisTick: number;         // V23: 0/1 flag set by combat (step 17), consumed by tickSpider (17.5); never persists as 1
+  lastKillTileX: number;          // V23: tile of the most recent kill (= spider tile); -1 default
+  lastKillTileY: number;
+  feedAwayTileX: number;          // V23: ~10-tile feed destination after a kill; -1 default
+  feedAwayTileY: number;
+  feedArrivedTick: number;        // V23: tick the spider reached feedAwayTile (heal-window clock); -1 while traveling
 }
 
 export interface AIStateRecord {
@@ -696,6 +702,12 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
     ds.rampageTargetColonyId = ss.rampageTargetColonyId;
     ds.chaseTargetAntId = ss.chaseTargetAntId;
     ds.chaseStartTick = ss.chaseStartTick;
+    ds.killedThisTick = ss.killedThisTick;
+    ds.lastKillTileX = ss.lastKillTileX;
+    ds.lastKillTileY = ss.lastKillTileY;
+    ds.feedAwayTileX = ss.feedAwayTileX;
+    ds.feedAwayTileY = ss.feedAwayTileY;
+    ds.feedArrivedTick = ss.feedArrivedTick;
   }
   dst.spiderPriorityColonyId = src.spiderPriorityColonyId;
   // scatterReticleTile


### PR DESCRIPTION
## Summary

Closes #146 and #147 behind one new sim-behavior version (`SIM_VERSION_V23_SPIDER_AGGRO = 23`). After UAT on the first cut, the spider was **redesigned** from a lair-orbiting, schedule-driven foe into a **hunger-gated meandering surface predator with always-on self-defense** — a more dynamic creature that wanders a patrol area, eats ants it runs across, defends itself whenever attacked, and recovers HP by feeding on a kill. The redesign stays inside the same unmerged V23 version (no new sim-version); the V22 path is a verbatim move so older replays remain byte-identical.

### Behavior

- **Meander, no lair.** The invisible lair orbit is gone. A sated spider slow-meanders across the whole map (moves every `SPIDER_MEANDER_TICK_DIVISOR` ticks toward a hash-derived wander target re-rolled every `SPIDER_MEANDER_RETARGET_TICKS`); chasing/hunting/striking lunge every tick. The lair tile remains only as a vestigial spawn point.
- **Hunger gate.** A single `hungerTicks` meter (+1/tick except while feeding, reset to 0 on **any** kill) gates predation. Hungry at `SPIDER_HUNGER_THRESHOLD_TICKS[tier]` (Normal = 1200, difficulty-scaled). Sated → ignore workers; hungry → seek one meal, precedence **chase (#146) → telegraphed density-hunt → camp a colony entrance** (the balance-tuned `pickRampageTarget` / `findNearestEntrance` are preserved). No brood quota — satisfied on the first kill.
- **Always-on self-defense (#147).** The combat gate engages in **every state except Feeding**, so the spider always bites back. Fighters fold the spider into their proximity scan **in any state** (a closer enemy ant still wins; the open-entrance rally carve-out is preserved) — including pursuing a **feeding** spider to interrupt it.
- **No retreat — fights to the death.** The `Retreating` state and the `hp < threshold → Retreating` transition are removed from the V23 path; a loaded `Retreating` save is normalized to `Patrolling` on the first V23 tick.
- **Feed-after-kill.** On any kill, hunger resets. If **no fighter is adjacent**, the spider retreats ~`SPIDER_FEED_RETREAT_TILES` from the kill and feeds, healing +1 HP per `SPIDER_FEED_HEAL_INTERVAL_TICKS` over a `SPIDER_FEED_TICKS` window; **interruptible** when a fighter reaches it (heal forfeited). If a fighter **is** adjacent, hunger resets but it keeps fighting (no feed).
- **Pre-descent gate** keeps blockading an entrance **only on `Rampaging`** (both V22 and V23), so a sated meander passing over an entrance does not trap descenders.

## Determinism / compatibility

- No `world.rngState` draws — the meander target and feed-away direction derive from a Murmur32 finalizer (`hash32`) over `tick`/`terrainSeed`. No `Math.random`, no wall-clock, no per-tick allocation; integer-only fixed-point math (meander tick-bucket uses a power-of-two shift with a compile-time guard).
- `LATEST_SIM_VERSION = V23`; `MIN_ACCEPTED_SIM_VERSION` stays V22. V22 saves load and replay at V22 **byte-identically** (`tickSpiderV22` is the unchanged original body; the combat kill-signal is gated `>= V23` at both kill sites).
- Six additive `SpiderState` fields (`killedThisTick`, `lastKillTile{X,Y}`, `feedAwayTile{X,Y}`, `feedArrivedTick`) round-trip through serialize/deserialize/copy/scenario with tolerant defaults — `killedThisTick` is **hard-defaulted to 0** on load (a transient flag must never persist as 1), the rest to `-1`. No `SAVE_FORMAT_VERSION` bump.
- New telemetry: `spider_feed_start` / `spider_feed_end` (`healed | interrupted`), alongside the existing `spider_chase_*` events.

## UAT round 2 — engagement fixes (#146, #147)

Follow-up UAT found the spider disengaging in two situations; both are now fixed:

- **Camping spider let ants walk past (#146).** A Rampaging spider parked on an entrance
  rarely landed its tile-coincident bite because emerging ants step off the tile during
  movement (which runs before combat). It now **diverts to Chasing** a straggler within
  `SPIDER_CHASE_TRIGGER_RADIUS`, closing at 2× ant speed.
- **Attacked spider meandered away instead of fighting (#147).** A spider under attack kept
  drifting (meander ≈ 1 tile/3 ticks is slower than a fighter), so a swarm surrounded and
  killed it without it engaging. A Patrolling/Hunting/Rampaging spider whose attacker
  (`AntTask.Fighting`) is within the new `SPIDER_DEFENSE_TRIGGER_RADIUS` now abandons its
  activity and **Chases the nearest attacker** — fights to the death, no flee.
- **#165 blockade preserved.** Both divert paths (straggler-divert and self-defense) **hold**
  the gate while a surface ant occupies the camped entrance tile: the gate pins the descender
  there and tile-coincident combat resolves it that tick, so the spider does not vacate the
  entrance and let the pinned ant slip underground. New regression tests cover hold-on-entrance
  and hold-under-attack; `predescent-gate.test.ts` stays green.

All round-2 logic is V23-gated; the V22 path is unchanged and replays byte-identically.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 2231 tests pass (76 files)
- [x] `npm run test:coverage` — 88.01% stmts / 81.9% branches / 93.96% funcs / 90.57% lines (80% gate passes)
- [x] Unit tests: hunger gate + precedence, meander (moves only on the divisor tick, no lair orbit, no reticle), feed/no-feed split, heal + interrupt, no-retreat, rampage no-quota, Retreating normalization (spider.test.ts); widened combat gate + kill-signal + V22 guard (combat.test.ts); fighter auto-aggro targets any state incl. Feeding + closer-ant-wins + entrance carve-out + V22 guard (ant-system.test.ts); Rampaging-only pre-descent blockade (predescent-gate.test.ts)
- [x] Determinism: V23 chase **and** the meander/feed/rampage redesign replay byte-identically over 200–400 ticks with `rngState` in lockstep; save round-trip mid-Feeding deep-equals the spider with `killedThisTick` forced to 0 on load; V22 byte-identical replay (determinism.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

