### PR TITLE
fix(s3): reflect spider feed-retreat inward at map edges

### DIFF
--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -35,6 +35,7 @@ import {
   SPIDER_FEED_RETREAT_TILES,
   SPIDER_FEED_HEAL_INTERVAL_TICKS,
   SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
   PLAYER_COLONY_ID,
   ENEMY_COLONY_ID,
 } from './constants.js';
@@ -1189,6 +1190,100 @@ describe('tickSpider', () => {
       const huntEnd = world.events.find((e) => e.type === 'spider_hunt_end');
       expect(huntEnd).toBeDefined();
       if (huntEnd?.type === 'spider_hunt_end') expect(huntEnd.payload.outcome).toBe('kill');
+    });
+
+    it('edge kill with an outward retreat direction still moves the full distance in-bounds (Codex P2)', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      // Kill near the left edge; spider sits further left (sx=0) so the
+      // deterministic direction (sx - kx < 0) points outward, off the grid.
+      const kx = 3;
+      const ky = 64;
+      world.spider = makeSpider({
+        posX: 0 << FP_SHIFT,
+        posY: ky << FP_SHIFT,
+        state: 'Striking',
+        hungerTicks: 800,
+        killedThisTick: 1,
+        lastKillTileX: kx,
+        lastKillTileY: ky,
+        killsThisStrike: 1,
+      });
+      world.tick = 10;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Feeding');
+      const fx = world.spider!.feedAwayTileX;
+      const fy = world.spider!.feedAwayTileY;
+      // In-bounds, full retreat distance, and reflected inward (away from the
+      // edge) rather than clamped onto the kill tile.
+      expect(fx).toBeGreaterThanOrEqual(0);
+      expect(fx).toBeLessThanOrEqual(SURFACE_GRID_WIDTH - 1);
+      expect(Math.abs(fx - kx) + Math.abs(fy - ky)).toBe(SPIDER_FEED_RETREAT_TILES);
+      expect(fx).toBeGreaterThan(kx);
+    });
+
+    it('edge kill on the Y axis reflects inward the full distance in-bounds (Codex P2)', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      // Kill near the bottom edge; spider sits further down so the deterministic
+      // direction (sy - ky > 0) points outward past the grid on the Y axis. This
+      // covers the SURFACE_GRID_HEIGHT call site, not just the X one.
+      const kx = 64;
+      const ky = SURFACE_GRID_HEIGHT - 4;
+      world.spider = makeSpider({
+        posX: kx << FP_SHIFT,
+        posY: (SURFACE_GRID_HEIGHT - 1) << FP_SHIFT,
+        state: 'Striking',
+        hungerTicks: 800,
+        killedThisTick: 1,
+        lastKillTileX: kx,
+        lastKillTileY: ky,
+        killsThisStrike: 1,
+      });
+      world.tick = 10;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Feeding');
+      const fx = world.spider!.feedAwayTileX;
+      const fy = world.spider!.feedAwayTileY;
+      expect(fy).toBeGreaterThanOrEqual(0);
+      expect(fy).toBeLessThanOrEqual(SURFACE_GRID_HEIGHT - 1);
+      expect(Math.abs(fx - kx) + Math.abs(fy - ky)).toBe(SPIDER_FEED_RETREAT_TILES);
+      expect(fy).toBeLessThan(ky); // reflected inward (up), away from the bottom edge
+    });
+
+    it('corner kill via the hash fallback still retreats the full distance in-bounds (Codex P2)', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      // Kill tile == spider tile at the (0,0) corner → dx==dy==0 takes the hash
+      // fallback. Whichever cardinal it picks, the endpoint must stay in-bounds
+      // and a full SPIDER_FEED_RETREAT_TILES from the kill (pre-fix, an outward
+      // pick collapsed to the edge at distance 0).
+      world.spider = makeSpider({
+        posX: 0 << FP_SHIFT,
+        posY: 0 << FP_SHIFT,
+        state: 'Striking',
+        hungerTicks: 800,
+        killedThisTick: 1,
+        lastKillTileX: 0,
+        lastKillTileY: 0,
+        killsThisStrike: 1,
+      });
+      world.tick = 10;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Feeding');
+      const fx = world.spider!.feedAwayTileX;
+      const fy = world.spider!.feedAwayTileY;
+      expect(fx).toBeGreaterThanOrEqual(0);
+      expect(fx).toBeLessThanOrEqual(SURFACE_GRID_WIDTH - 1);
+      expect(fy).toBeGreaterThanOrEqual(0);
+      expect(fy).toBeLessThanOrEqual(SURFACE_GRID_HEIGHT - 1);
+      expect(Math.abs(fx) + Math.abs(fy)).toBe(SPIDER_FEED_RETREAT_TILES);
     });
 
     it('a Rampaging kill with no fighter adjacent → Feeding emits spider_rampage_end(quota_met)', () => {

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -891,14 +891,23 @@ function computeFeedAwayTile(world: WorldState, spider: SpiderState): void {
     if (ax >= ay) signX = dx > 0 ? 1 : -1;
     else signY = dy > 0 ? 1 : -1;
   }
-  let fx = kx + signX * SPIDER_FEED_RETREAT_TILES;
-  let fy = ky + signY * SPIDER_FEED_RETREAT_TILES;
-  if (fx < 0) fx = 0;
-  if (fx > SURFACE_GRID_WIDTH - 1) fx = SURFACE_GRID_WIDTH - 1;
-  if (fy < 0) fy = 0;
-  if (fy > SURFACE_GRID_HEIGHT - 1) fy = SURFACE_GRID_HEIGHT - 1;
-  spider.feedAwayTileX = fx;
-  spider.feedAwayTileY = fy;
+  spider.feedAwayTileX = feedRetreatCoord(kx, signX, SURFACE_GRID_WIDTH);
+  spider.feedAwayTileY = feedRetreatCoord(ky, signY, SURFACE_GRID_HEIGHT);
+}
+
+// Retreat `SPIDER_FEED_RETREAT_TILES` from the kill coordinate along one axis.
+// If the preferred direction would exit the grid, reflect inward instead of
+// clamping to the edge — otherwise an edge kill collapses the endpoint onto (or
+// near) the kill tile, so the spider enters Feeding without actually moving away
+// and the post-kill chain-kill avoidance silently fails. The surface grid
+// (128) is far larger than 2× the retreat (20), so at least one direction is
+// always in-bounds; the trailing clamp only guards a hypothetically tiny grid.
+function feedRetreatCoord(k: number, sign: number, size: number): number {
+  let end = k + sign * SPIDER_FEED_RETREAT_TILES;
+  if (end < 0 || end > size - 1) end = k - sign * SPIDER_FEED_RETREAT_TILES;
+  if (end < 0) end = 0;
+  if (end > size - 1) end = size - 1;
+  return end;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses the Codex **P2** finding on PR #175 (which itself targeted the unrelated render-only health bar — the finding was on already-merged spider sim code from #172, so it's fixed here in its own PR).

`computeFeedAwayTile` picks the tile the V23 spider retreats to after a kill, `SPIDER_FEED_RETREAT_TILES` (=10) away along one axis. When the kill happens within 10 tiles of a map edge **and** the chosen direction points outward, the old code clamped the endpoint to the grid boundary — which could land it on (or right next to) the kill tile. The spider then entered `Feeding` without actually moving away, silently defeating the post-kill chain-kill avoidance behaviour.

**Fix:** a small `feedRetreatCoord` helper reflects the retreat *inward* when the preferred direction would exit the grid, so the endpoint stays in-bounds at the full retreat distance.

- **Interior kills are byte-identical** to the previous behaviour (no reflect fires when `k ± 10` is in bounds) — confirmed by the unchanged determinism suite.
- Deterministic: no RNG draws; pure integer arithmetic.

## Test plan

- [x] New regression tests in `src/sim/spider.test.ts`:
  - left X-edge kill with an outward direction → reflects inward, in-bounds, full 10-tile distance
  - bottom Y-edge kill → covers the `SURFACE_GRID_HEIGHT` call site (not just X)
  - corner kill via the `dx==dy==0` hash fallback → in-bounds, full distance regardless of the cardinal picked
- [x] `npm run typecheck`, `npm run lint`, full `spider.test.ts` (67) and `determinism.test.ts` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)