### PR TITLE
fix(s3): exclude queen from spider gate-hold; add start grace

### DIFF
--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -848,6 +848,18 @@ export const SPIDER_DANGER_DEPOSIT = 1280 as const;
  */
 export const SPIDER_HUNGER_THRESHOLD_TICKS = [1800, 1200, 900] as const;
 
+/**
+ * V23 — Start-of-match grace period. The spider accrues no hunger for the first
+ * SPIDER_GRACE_TICKS ticks, so it stays dormant: it keeps Patrolling and still bites
+ * back any ant that attacks it (self-defense is NOT gated), but never *initiates* a
+ * hunt / chase / rampage until colonies have had time to raise a queen chamber. With
+ * the Normal hunger threshold (1200) the first predation then lands ~tick 2700.
+ * 1500 ticks ≈ 75 sim-seconds, measured against absolute world.tick (spider spawns at
+ * tick 0). Tuned to restore AI-colony sustainability after the queen-exclusion fix made
+ * the spider correctly aggressive; residual balance tracked in #177.
+ */
+export const SPIDER_GRACE_TICKS = 1500 as const;
+
 /** V23 — Sated meander moves only when world.tick % divisor === 0 (1 tile / 3 ticks). */
 export const SPIDER_MEANDER_TICK_DIVISOR = 3 as const;
 

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -23,6 +23,7 @@ import {
   ENEMY_START_Y,
   SPIDER_HUNGER_MAX_TICKS,
   SPIDER_HUNGER_THRESHOLD_TICKS,
+  SPIDER_GRACE_TICKS,
   SPIDER_HP_FULL,
 } from './constants.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
@@ -897,10 +898,13 @@ describe('S3 V20: spider replay determinism (Hunting → Striking → Rampaging)
       spider.state = 'Hunting';
       spider.huntTargetTileX = spider.lairTileX;
       spider.huntTargetTileY = spider.lairTileY;
-      // huntStartTick = 0 so Hunting persists for SPIDER_TELEGRAPH_TICKS ticks before
-      // transitioning to Striking, allowing statesVisited to observe 'Hunting'.
-      // (On first call world.tick=0; 0-0=0<120 → stays Hunting; at call 121 world.tick=120 → Striking.)
-      spider.huntStartTick = 0;
+      // Start past the V23 start-of-match grace window so the spider actually
+      // predates (rampages) instead of staying dormant; see SPIDER_GRACE_TICKS / #177.
+      world.tick = SPIDER_GRACE_TICKS;
+      // huntStartTick = world.tick so Hunting persists for SPIDER_TELEGRAPH_TICKS ticks
+      // before transitioning to Striking, allowing statesVisited to observe 'Hunting'.
+      // (On first call tick-huntStartTick=0<120 → stays Hunting; 120 calls later → Striking.)
+      spider.huntStartTick = SPIDER_GRACE_TICKS;
       // NORMAL_TIER_INDEX=1 → threshold 1800. After Striking exits to Patrolling
       // hunger will be ≥1800, triggering an immediate Rampaging transition.
       // Safety: createScenario places STARTING_WORKERS=3 at PLAYER_START_X/Y (24,64) and
@@ -1044,6 +1048,9 @@ describe('S3 V23 redesign: meander + feed-after-kill replay determinism', () => 
     spider.lairTileY = wy;
     spider.hp = SPIDER_HP_FULL - 25; // leave headroom so Feeding heal is observable
     spider.hungerTicks = SPIDER_HUNGER_THRESHOLD_TICKS[1]!; // hungry → predates
+    // Past the V23 start-of-match grace window so the hungry spider predates rather
+    // than staying dormant (Patrolling + self-defense only); see SPIDER_GRACE_TICKS / #177.
+    world.tick = SPIDER_GRACE_TICKS;
     return world;
   }
 

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -30,6 +30,7 @@ import {
   SPIDER_RAMPAGE_MAX_TICKS,
   SPIDER_SPEED,
   SPIDER_HUNGER_THRESHOLD_TICKS,
+  SPIDER_GRACE_TICKS,
   SPIDER_MEANDER_TICK_DIVISOR,
   SPIDER_FEED_TICKS,
   SPIDER_FEED_RETREAT_TILES,
@@ -688,6 +689,69 @@ describe('tickSpider', () => {
     });
   });
 
+  describe('start-of-match grace period (V23 #177)', () => {
+    it('does NOT accrue hunger during the grace window', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      world.spider = makeSpider({ state: 'Patrolling', hungerTicks: 10 });
+      world.tick = SPIDER_GRACE_TICKS - 1;
+      tickSpider(world);
+      expect(world.spider!.hungerTicks).toBe(10); // frozen during grace
+    });
+
+    it('resumes hunger accrual at the grace boundary', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      world.spider = makeSpider({ state: 'Patrolling', hungerTicks: 10 });
+      world.tick = SPIDER_GRACE_TICKS;
+      tickSpider(world);
+      expect(world.spider!.hungerTicks).toBe(11);
+    });
+
+    it('stays dormant — no chase — on the last grace tick even with prey in range', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      // One tick below the hungry threshold: only the grace gate stops it crossing.
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS - 1,
+      });
+      world.spider.nextHuntTick = 9999;
+      world.tick = SPIDER_GRACE_TICKS - 1;
+      placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS, sy);
+
+      tickSpider(world);
+
+      expect(world.spider!.hungerTicks).toBe(HUNGRY_TICKS - 1); // no accrual → never crosses
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+    });
+
+    it('wakes and chases once the grace window ends', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS - 1,
+      });
+      world.spider.nextHuntTick = 9999;
+      world.tick = SPIDER_GRACE_TICKS;
+      const antId = placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS, sy);
+
+      tickSpider(world);
+
+      // Accrual resumes → crosses the hungry threshold → opportunistic chase fires.
+      expect(world.spider!.state).toBe('Chasing');
+      expect(world.spider!.chaseTargetAntId).toBe(antId);
+    });
+  });
+
   describe('active self-defense (V23 #147)', () => {
     it('a sated Patrolling spider Chases the nearest attacking fighter within defense radius', () => {
       const world = makeWorld();
@@ -824,6 +888,37 @@ describe('tickSpider', () => {
       expect(world.spider!.state).toBe('Rampaging');
       expect(world.spider!.rampageTargetColonyId).toBe(PLAYER_COLONY_ID);
     });
+
+    it('still self-defends when only the enemy QUEEN sits on the camped entrance (queen does not hold the gate)', () => {
+      // The #165 gate-hold is only justified for a bite-able ant: resolveSpiderCombatOnTile
+      // skips queens, so a queen parked on the entrance is never caught by tile-coincident
+      // combat. Holding for her would let an attacker surround the spider unanswered.
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS,
+        state: 'Rampaging',
+        rampageTargetColonyId: PLAYER_COLONY_ID,
+        rampageStartTick: 0,
+      });
+      world.spider.nextHuntTick = 9999;
+      const col = createColonyRecord(PLAYER_COLONY_ID, -1);
+      col.entrances = [{ entranceId: 1, surfaceTileX: sx, surfaceTileY: sy, isOpen: true }];
+      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = col;
+      const queenId = placeWorker(world, sx, sy); // queen parked ON the entrance (unbiteable)
+      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!.queenEntityId = queenId;
+      const fighterId = placeFighter(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy); // within defense radius
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Chasing');
+      expect(world.spider!.chaseTargetAntId).toBe(fighterId);
+      expect(world.spider!.rampageTargetColonyId).toBe(-1);
+    });
   });
 
   describe('Rampaging straggler chase-divert (V23 #146)', () => {
@@ -892,6 +987,44 @@ describe('tickSpider', () => {
       expect(world.spider!.state).toBe('Rampaging');
       expect(world.spider!.rampageTargetColonyId).toBe(PLAYER_COLONY_ID);
     });
+
+    it('DOES divert to a straggler when only the enemy QUEEN sits on the camped entrance (no gate-hold for an unbiteable queen)', () => {
+      // Regression (seed2082146439 dump): the enemy queen parked on the camped entrance
+      // made holdGate=true, suppressing the chase-divert, while combat refused to bite
+      // her — a ~1200-tick deadlock camp. The queen must not hold the gate; the spider
+      // should chase the nearby bite-able straggler instead.
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      campingSpider(world, sx, sy); // entrance at (sx, sy), queenEntityId = -1
+      const queenId = placeWorker(world, sx, sy); // queen parked ON the entrance (unbiteable)
+      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!.queenEntityId = queenId;
+      const strag = placeWorker(world, sx + 1, sy); // bite-able straggler within chase radius
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Chasing');
+      expect(world.spider!.chaseTargetAntId).toBe(strag);
+      expect(world.spider!.rampageTargetColonyId).toBe(-1);
+    });
+
+    it('keeps camping when only the enemy QUEEN sits on the entrance and no straggler is in range', () => {
+      // Queen excluded from both the gate-hold and the chase-target scan → no divert,
+      // no spurious transition: the spider simply continues camping (rampage times out later).
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      campingSpider(world, sx, sy);
+      const queenId = placeWorker(world, sx, sy); // queen alone on the entrance
+      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!.queenEntityId = queenId;
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Rampaging');
+      expect(world.spider!.rampageTargetColonyId).toBe(PLAYER_COLONY_ID);
+    });
   });
 
   describe('Chasing movement + transitions (V23 #146)', () => {
@@ -957,10 +1090,12 @@ describe('tickSpider', () => {
       world.spider = makeSpider({
         state: 'Chasing',
         chaseTargetAntId: antId,
-        chaseStartTick: 0,
+        chaseStartTick: SPIDER_GRACE_TICKS, // chase began just as grace ended
         hungerTicks: 500,
       });
-      world.tick = 50;
+      // Past the grace window so hunger accrues again; chase elapsed (50) is kept
+      // under the leash (300) so the leash can't preempt the dead-target exit.
+      world.tick = SPIDER_GRACE_TICKS + 50;
 
       tickSpider(world);
 

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -594,6 +594,7 @@ describe('tickSpider', () => {
       const sy = 32;
       world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: HUNGRY_TICKS });
       world.spider.nextHuntTick = 9999;
+      world.tick = SPIDER_GRACE_TICKS; // past grace so the spider is active and hungry
       const antId = placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS, sy);
 
       tickSpider(world);
@@ -612,6 +613,7 @@ describe('tickSpider', () => {
       const sy = 32;
       world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: HUNGRY_TICKS });
       world.spider.nextHuntTick = 9999;
+      world.tick = SPIDER_GRACE_TICKS; // past grace so the spider is active and hungry
       const near = placeWorker(world, sx + 1, sy); // dist 1
       placeWorker(world, sx + 3, sy);              // dist 3 (farther)
 
@@ -661,6 +663,7 @@ describe('tickSpider', () => {
         posY: sy << FP_SHIFT,
         hungerTicks: HUNGRY_TICKS,
       });
+      world.tick = SPIDER_GRACE_TICKS; // past grace so the spider is active and hungry
       placeWorker(world, sx + 1, sy); // a chaseable ant is present → chase wins over rampage
 
       tickSpider(world);
@@ -675,6 +678,7 @@ describe('tickSpider', () => {
       const sy = 32;
       world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: HUNGRY_TICKS });
       world.spider.nextHuntTick = 9999;
+      world.tick = SPIDER_GRACE_TICKS; // past grace so the no-chase is queen-exclusion, not dormancy
       const queenId = placeWorker(world, sx + 1, sy);
       const col = createColonyRecord(PLAYER_COLONY_ID, 0);
       col.entrances = []; // caller-init contract; no open entrance → sealed
@@ -728,6 +732,29 @@ describe('tickSpider', () => {
       expect(world.spider!.hungerTicks).toBe(HUNGRY_TICKS - 1); // no accrual → never crosses
       expect(world.spider!.state).toBe('Patrolling');
       expect(world.spider!.chaseTargetAntId).toBe(-1);
+    });
+
+    it('stays dormant during grace even when hunger already exceeds the threshold (e.g. a loaded save)', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      const sx = 64;
+      const sy = 32;
+      // Hunger already over the threshold but still inside grace: grace must gate the
+      // predation transition itself, not merely freeze further accrual.
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS + 100,
+      });
+      world.spider.nextHuntTick = 0; // hunt cooldown elapsed — only grace should hold it back
+      world.tick = SPIDER_GRACE_TICKS - 1;
+      placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS, sy);
+
+      tickSpider(world);
+
+      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider!.hungerTicks).toBe(HUNGRY_TICKS + 100); // frozen during grace
     });
 
     it('wakes and chases once the grace window ends', () => {

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -27,6 +27,7 @@ import {
   SPIDER_DEFENSE_TRIGGER_RADIUS,
   SPIDER_CHASE_MAX_TICKS,
   SPIDER_HUNGER_THRESHOLD_TICKS,
+  SPIDER_GRACE_TICKS,
   SPIDER_MEANDER_TICK_DIVISOR,
   SPIDER_MEANDER_RETARGET_TICKS,
   SPIDER_FEED_RETREAT_TILES,
@@ -180,17 +181,36 @@ function findChaseTarget(world: WorldState, spider: SpiderState): number {
 }
 
 /**
- * True if any live surface ant occupies tile (tileX, tileY). Used by the Rampaging
- * straggler-divert to honor the #165 entrance blockade: while a descender sits on the
- * camped entrance tile, the tile-coincident spider bite (the gate holds the ant there)
- * resolves it this tick, so the spider must NOT divert off the gate to chase. No alloc.
+ * True if any live, bite-able surface ant occupies tile (tileX, tileY). Used by the
+ * Rampaging gate-holds to honor the #165 entrance blockade: while a descender sits on
+ * the camped entrance tile, the tile-coincident spider bite (the gate holds the ant
+ * there) resolves it this tick, so the spider must NOT divert off the gate to chase.
+ *
+ * Queens are excluded (identified by colony.queenEntityId), matching findChaseTarget
+ * and resolveSpiderCombatOnTile: the gate-hold is only justified for an ant the spider
+ * will actually bite, and combat skips queens. A queen parked on the camped entrance
+ * must NOT hold the gate — otherwise the spider deadlock-camps an unbiteable target and
+ * suppresses the chase-divert that would catch a nearby straggler. No allocation.
  */
 function isSurfaceAntOnTile(world: WorldState, tileX: number, tileY: number): boolean {
   const { ants } = world;
+
+  // Pre-scan colony queen IDs (same contract as findChaseTarget / resolveSpiderCombatOnTile).
+  let queenId0 = -1;
+  let queenId1 = -1;
+  for (const ckey in world.colonies) {
+    if (!Object.hasOwn(world.colonies, ckey)) continue;
+    const col = world.colonies[ckey as unknown as import('./colony/colony-store.js').ColonyId];
+    if (col === undefined) continue;
+    if (queenId0 < 0) queenId0 = col.queenEntityId;
+    else queenId1 = col.queenEntityId;
+  }
+
   const antCount = ants.alive.length;
   for (let i = 0; i < antCount; i++) {
     if (ants.alive[i] !== 1) continue;
     if (ants.zone[i] !== 0) continue; // surface only
+    if (i === queenId0 || i === queenId1) continue; // queens are not bite-able
     if ((ants.posX[i]! >> FP_SHIFT) === tileX && (ants.posY[i]! >> FP_SHIFT) === tileY) return true;
   }
   return false;
@@ -912,8 +932,11 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
   // 1. Normalize: 'Retreating' is unused in V23 (may load from an earlier #172 build).
   if (spider.state === 'Retreating') spider.state = 'Patrolling';
 
-  // 2. Hunger accrual: only while not Feeding.
-  if (spider.state !== 'Feeding') spider.hungerTicks += 1;
+  // 2. Hunger accrual: only while not Feeding, and only after the start-of-match grace
+  //    period (SPIDER_GRACE_TICKS). During grace the spider stays dormant — Patrolling
+  //    + self-defense (step 4a) only — so colonies can establish before it begins to
+  //    hunt. See SPIDER_GRACE_TICKS / #177.
+  if (spider.state !== 'Feeding' && world.tick >= SPIDER_GRACE_TICKS) spider.hungerTicks += 1;
 
   const tier = tierIndex(world.difficulty);
 

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -932,11 +932,17 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
   // 1. Normalize: 'Retreating' is unused in V23 (may load from an earlier #172 build).
   if (spider.state === 'Retreating') spider.state = 'Patrolling';
 
-  // 2. Hunger accrual: only while not Feeding, and only after the start-of-match grace
-  //    period (SPIDER_GRACE_TICKS). During grace the spider stays dormant — Patrolling
-  //    + self-defense (step 4a) only — so colonies can establish before it begins to
-  //    hunt. See SPIDER_GRACE_TICKS / #177.
-  if (spider.state !== 'Feeding' && world.tick >= SPIDER_GRACE_TICKS) spider.hungerTicks += 1;
+  // Start-of-match grace: for the first SPIDER_GRACE_TICKS the spider stays dormant —
+  // Patrolling + self-defense (step 4a) only — so colonies can establish before it
+  // hunts. Enforced in two places so the guarantee doesn't rely on the "hunger starts
+  // at 0" invariant alone: hunger neither accrues (below) nor gates predation (the
+  // `hungry` check in the Patrolling case). A spider that loads with hunger already
+  // past the threshold therefore still will not initiate a hunt/chase/rampage during
+  // grace. See SPIDER_GRACE_TICKS / #177.
+  const inGrace = world.tick < SPIDER_GRACE_TICKS;
+
+  // 2. Hunger accrual: only while not Feeding, and only after the grace window.
+  if (spider.state !== 'Feeding' && !inGrace) spider.hungerTicks += 1;
 
   const tier = tierIndex(world.difficulty);
 
@@ -1025,7 +1031,7 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
 
   switch (spider.state) {
     case 'Patrolling': {
-      const hungry = spider.hungerTicks >= SPIDER_HUNGER_THRESHOLD_TICKS[tier]!;
+      const hungry = !inGrace && spider.hungerTicks >= SPIDER_HUNGER_THRESHOLD_TICKS[tier]!;
       if (hungry) {
         // Precedence: (a) opportunistic chase of a lone ant; (b) telegraphed
         // density hunt (when off cooldown and a dense tile exists); (c) camp a


### PR DESCRIPTION
## Summary

- A V23 spider camping an enemy entrance **deadlock-camped** instead of pouncing on emerging/passing workers whenever the enemy **queen** sat on the entrance tile. Queens are un-bite-able (excluded from spider combat), so the entrance gate-hold in `isSurfaceAntOnTile` never released and the spider never diverted to chase. Reproduced from a live dump (`seed2082146439`, tick 2276: spider Rampaging on the queen's tile, a worker 4 tiles away ignored).
- **Fix:** `isSurfaceAntOnTile` now pre-scans and excludes colony queens, matching the existing contract of `findChaseTarget` and `resolveSpiderCombatOnTile`. The gate-hold only fires for a bite-able ant.
- **Balance follow-on:** the now-correctly-aggressive spider starts hunting foragers from ~tick 1200, which suppressed AI-colony economy and broke the REQ-C1 sustainability test. Added `SPIDER_GRACE_TICKS = 1500`: the spider accrues no hunger -- staying dormant (Patrolling + self-defense only, never *initiating* a hunt/chase/rampage) -- for the first 1500 ticks, so colonies can raise a queen chamber before predation begins (~tick 2700). Restores REQ-C1 and pre-fix multi-seed sustainability parity (6/8 seeds in an 8-seed sweep).

Residual AI-vs-spider balance is tracked in #177.

## Test plan

- [x] `npm run verify` green (lint, tsc, sim-boundary, asset-path, 2258 tests)
- [x] REQ-C1 AI-sustainability integration test (seed 42) passes
- [x] New unit tests: grace-period dormancy + boundary (4 cases); queen-on-entrance does not suppress chase-divert / self-defense (3 cases)
- [ ] UAT: observe a spider pouncing on an ant near an enemy entrance where the queen sits on the entrance tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)