### PR TITLE
fix(s3): reduce larva maturation 2400→1500 to fix colony starvation (#177)

### DIFF
--- a/src/render/ai-controller.integration.test.ts
+++ b/src/render/ai-controller.integration.test.ts
@@ -47,7 +47,7 @@ const TOTAL_TICKS = 8000;
 const TRAJECTORY_WINDOW_START = 7000;   // track workerCount from tick 7000..8000
 // S4 change: queen now lays on first eligible tick (elapsed-since-last-lay gate), not at modulo
 // boundaries. In the AI scenario, chambers complete ~tick 4000; first egg lays immediately,
-// creating ~6 larvae by tick 6000. First new worker matures at ~tick 7600 (4000+3600).
+// creating ~6 larvae by tick 6000. First new worker matures at ~tick 6700 (4000+2700).
 // Window extended from 5500..6000 → 7000..8000 so the monitoring window contains the
 // stable post-first-worker-maturation state.
 const DIAGNOSTIC_INTERVAL = 500;         // log snapshot every 500 ticks (pre-audit)

--- a/src/sim/colony/lifecycle-system.test.ts
+++ b/src/sim/colony/lifecycle-system.test.ts
@@ -756,31 +756,26 @@ describe('tickLifecycleTransitions — brood-aging gate (09 reproduction-gate me
 // ---------------------------------------------------------------------------
 
 describe('Full pipeline integration — Phase 6 SC 1', () => {
-  it('14. queen→egg→larva→worker pipeline completes within 3700 ticks', () => {
-    // Setup: queen + abundant food
-    // EGG_HATCH_TICKS=1200 + LARVA_MATURE_TICKS=2400 = 3600 ticks for first egg to
-    // become a worker. First egg laid at tick 0, matures at tick 3600.
-    // With 3700 ticks (+100 margin), colony.workerCount >= 1.
+  it('14. queen→egg→larva→worker pipeline first worker emerges after EGG_HATCH_TICKS + LARVA_MATURE_TICKS', () => {
+    // The first egg is laid on the first production tick and becomes a worker
+    // EGG_HATCH_TICKS + LARVA_MATURE_TICKS ticks later. Run past that latency
+    // (+ margin) and assert the first worker emerged exactly on schedule, with
+    // later eggs still occupying the egg and larva stages.
     const { world, colony } = setupWorldWithQueen(10_000);
     world.tick = 0;
 
-    for (let t = 0; t < 3700; t++) {
+    const pipelineLatency = EGG_HATCH_TICKS + LARVA_MATURE_TICKS;
+    let firstWorkerTick = -1;
+    for (let t = 0; t < pipelineLatency + 200; t++) {
       tickQueenEggProduction(world, colony);
       tickLifecycleTransitions(world, colony);
       world.tick += 1;
+      if (firstWorkerTick < 0 && colony.workerCount >= 1) firstWorkerTick = world.tick;
     }
 
-    // At tick 3700:
-    //   - First egg laid at tick 0: hatches at tick 1200, matures at tick 3600 → 1 worker
-    //   - Second egg laid at tick 300: hatches at tick 1500, matures at tick 3900 → still larva
-    //   - Third egg laid at tick 600: hatches at tick 1800, matures at tick 4200 → still larva
-    //   - Eggs laid at ticks 600..3600 are still in eggs or larvae buckets
-    expect(colony.workerCount).toBeGreaterThanOrEqual(1);
+    expect(firstWorkerTick).toBe(pipelineLatency);
+    // Pipeline still flowing: later eggs occupy the larva and egg stages.
     expect(colony.larvaeCount).toBeGreaterThan(0);
     expect(colony.eggCount).toBeGreaterThan(0);
-
-    // Total eggs produced: ticks 0, 300, 600, ..., 3600 = 13 eggs (0-indexed intervals)
-    // 1 should be a worker, several larvae, several eggs
-    expect(colony.workerCount).toBe(1);
   });
 });

--- a/src/sim/colony/reproduction.test.ts
+++ b/src/sim/colony/reproduction.test.ts
@@ -368,8 +368,8 @@ describe('tickLarvaMaturation — throughput cap (cap binds)', () => {
 // the sim tick when workerCount reaches 10 (one new worker from reproduction).
 //
 // Expected timing (no nurse adjacency, so no acceleration):
-//   Lean  (interval=300): first egg at t=300, larva at t=1500, worker at t=3900
-//   Rich  (interval=150): first egg at t=150, larva at t=1350, worker at t=3750
+//   Lean  (interval=300): first egg at t=300, larva at t=1500, worker at t=3000
+//   Rich  (interval=150): first egg at t=150, larva at t=1350, worker at t=2850
 //   Delta: 150 ticks ≥ MIN_TICK_DELTA (120)
 // ---------------------------------------------------------------------------
 

--- a/src/sim/colony/reproduction.test.ts
+++ b/src/sim/colony/reproduction.test.ts
@@ -2,7 +2,7 @@
 //
 // Validation targets (plan):
 //   1. Surplus thresholds: crossing 3×/5×/10× boundary changes egg interval
-//   2. Nurse acceleration: larva matures in 1200 ticks with 100% nurse coverage
+//   2. Nurse acceleration: larva matures in 750 ticks with 100% nurse coverage
 //   3. Cap — nurse-side tighter: 3 nurses, 8 larvae → 3 accelerated
 //   4. Cap — cap tighter: 10 nurses, 6 larvae, cap=4 → 4 accelerated
 //   5. V20 replay: pre-V21 simVersion leaves tickLarvaMaturation as no-op
@@ -248,7 +248,7 @@ describe('eggIntervalForColony — V21 surplus thresholds', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 2. Nurse acceleration: 100% coverage → matures in 1200 ticks
+// 2. Nurse acceleration: 100% coverage → matures in 750 ticks
 // ---------------------------------------------------------------------------
 
 describe('tickLarvaMaturation — nurse acceleration', () => {
@@ -261,10 +261,10 @@ describe('tickLarvaMaturation — nurse acceleration', () => {
 
     // The larva has a Nursery chamber (cap=12) in the colony already.
     // Each tick: tickLifecycleTransitions gives +1 (baseline), tickLarvaMaturation gives +1 (nurse).
-    // Total: +2 per tick → mature at LARVA_MATURE_TICKS / 2 = 1200 ticks.
+    // Total: +2 per tick → mature at LARVA_MATURE_TICKS / 2 = 750 ticks.
 
     // eslint-disable-next-line no-restricted-syntax -- test-only constant; LARVA_MATURE_TICKS is even
-    const halfMature = LARVA_MATURE_TICKS / 2; // 1200
+    const halfMature = LARVA_MATURE_TICKS / 2; // 750
 
     for (let t = 0; t < halfMature - 1; t++) {
       tickLifecycleTransitions(world, colony);

--- a/src/sim/constants.test.ts
+++ b/src/sim/constants.test.ts
@@ -44,8 +44,8 @@ describe('PRD §9c lifecycle tick constants', () => {
     expect(EGG_HATCH_TICKS).toBe(1200);
   });
 
-  it('LARVA_MATURE_TICKS === 2400', () => {
-    expect(LARVA_MATURE_TICKS).toBe(2400);
+  it('LARVA_MATURE_TICKS === 1500', () => {
+    expect(LARVA_MATURE_TICKS).toBe(1500);
   });
 
   it('WORKER_LIFESPAN_TICKS === 0x7FFFFFFF (INT32_MAX)', () => {

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -15,7 +15,7 @@
 export const EGG_HATCH_TICKS = 1200;
 
 /** PRD §9c — Ticks for a larva to mature into a worker. */
-export const LARVA_MATURE_TICKS = 2400;
+export const LARVA_MATURE_TICKS = 1500;
 
 /** PRD §9c — Worker lifespan: effectively immortal (INT32_MAX ticks). */
 export const WORKER_LIFESPAN_TICKS = 0x7FFFFFFF;

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -182,7 +182,7 @@ function buildWorld(seed: number): { world: WorldState; queenId: number; colonyI
   }
   // 09 reproduction-gate memo: queen egg production requires a completed
   // Queen chamber AND a completed Nursery chamber. Seed both so the lifecycle
-  // pipeline (Test 6) reaches the first worker by tick 3600.
+  // pipeline (Test 6) reaches the first worker by tick 2700.
   //
   // seed936214196-tick2401 Gate 6: tickQueenEggProduction now also requires
   // the queen to be Underground AND physically inside the Queen chamber


### PR DESCRIPTION
## Summary
- Reduce `LARVA_MATURE_TICKS` **2400 → 1500** (global — player *and* AI) so colonies stop starving out before they can field an army (#177).
- Larvae are the only food-draining brood. The 2-min (2400-tick) larva stage bled food faster than the tiny early forager base could refill it, so the queen frequently starved before workers arrived. A shorter stage brings non-eating, foraging workers online sooner, and they compound.

## Why 1500 (simulation-driven)
Queen-survival across 6 seeds × {Normal, Hard}, spider on, both colonies AI-driven:

| `LARVA_MATURE_TICKS` | survival | avg peak workers |
|---|---|---|
| 2400 (baseline) | 8/12 | ~4.5 |
| 1800 | 8/12 | ~6.6 |
| **1500** | **11/12** | **~9.3** |
| 1200 | 11/12 | ~11 |

**1500 is the knee** — the minimum cut that reaches the survival ceiling. 1800 gave *no* survival gain; 1200 gave *no further* survival gain (only a bigger army). So 1500 fixes starvation with the least change to game pacing (larva stage 120s → 75s).

Also tested but rejected: the nurse→forager flip (regressed an existing food-economy test) and halving larva food cost (fixed survival but left armies stuck at ~4.5 — it lacks the earlier-forager compounding).

## Tests
- `constants.test.ts`: drift assertion updated 2400 → 1500.
- `lifecycle-system.test.ts` #14: rewritten to assert the constant-derived pipeline latency (`EGG_HATCH_TICKS + LARVA_MATURE_TICKS`) instead of a hardcoded "1 worker at tick 3700" (which only held at the old timing).
- `reproduction.test.ts`: nurse-acceleration comments refreshed (accelerated half-time 1200 → 750; the assertion already derived from the constant).
- `npm run verify` green: lint, typecheck, sim-boundary + asset guards, 2251 tests.

## Note
Independent of PR #178 (spider gate-hold / start grace), which also targets #177 from the predation side. One Hard seed (64) still starves; residual balance stays tracked in #177.

## Test plan
- [ ] Play a match: colonies build a usable army before starving.
- [ ] Larva-stage pacing feels right at 75s (down from 120s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)