### PR TITLE
chore: adopt Prettier and normalize formatting repo-wide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Report something that is broken, crashes, or behaves unexpectedly.
-title: "[Bug]: "
-labels: ["bug"]
+title: '[Bug]: '
+labels: ['bug']
 body:
   - type: markdown
     attributes:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,19 @@
+# Dependencies & build output
+node_modules/
+dist/
+dist-lib/
+build/
+*.tsbuildinfo
+
+# Test artifacts
+coverage/
+test-results/
+playwright-report/
+
+# Assets — sprites, audio, fonts and any generated/binary-adjacent files.
+# Prettier has no business reformatting these (and may corrupt non-text formats).
+assets/
+public/
+
+# Lockfiles are generated; leave them as the tool writes them.
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ Use strong language deliberately — these are non-negotiable invariants of the 
 ### Fixed timestep
 
 - Simulation advances exactly 50 ms per tick (20 Hz). Code under `src/sim/` must not accept or branch on a `dt` / `deltaTime` / `elapsed` parameter. Variable timestep is a blocker.
-- Interpolation for rendering is the responsibility of `src/render/` and reads the *previous* and *current* tick snapshots — flag any render code that mutates sim state to "smooth" a frame.
+- Interpolation for rendering is the responsibility of `src/render/` and reads the _previous_ and _current_ tick snapshots — flag any render code that mutates sim state to "smooth" a frame.
 
 ### ECS conventions
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,11 +23,13 @@ src/
 ```
 
 **What counts as a violation:**
+
 - Any `import` in `src/sim/` that references `phaser`, `src/render`, `src/input`, `src/platform`, or any browser global
 - Any direct DOM access (`document`, `window`, `navigator`, `localStorage`)
 - Any canvas or WebGL API usage
 
 **What is allowed in `src/sim/`:**
+
 - Standard TypeScript/JavaScript built-ins (`Array`, `Map`, `Set`, `Math` floor/abs/min/max — but not `Math.random`)
 - Imports from other files within `src/sim/`
 - Typed arrays (`Int32Array`, `Uint8Array`, etc.)
@@ -63,6 +65,7 @@ function update(dtMs: number): void {
 ```
 
 **What counts as a violation:**
+
 - Passing a variable `dt` into any simulation function
 - Using `requestAnimationFrame` timing directly in simulation logic
 - Any simulation behavior that changes based on how fast the game runs
@@ -84,13 +87,13 @@ export type EntityId = number;
 
 /** Fixed-point position: 1 unit = 1/256 of a tile */
 export interface PositionStore {
-  x: Int32Array;   // indexed by EntityId
-  y: Int32Array;   // indexed by EntityId
+  x: Int32Array; // indexed by EntityId
+  y: Int32Array; // indexed by EntityId
 }
 
 export interface HungerStore {
-  current: Int32Array;  // indexed by EntityId, fixed-point
-  max: Int32Array;      // indexed by EntityId, fixed-point
+  current: Int32Array; // indexed by EntityId, fixed-point
+  max: Int32Array; // indexed by EntityId, fixed-point
 }
 
 export function createPositionStore(capacity: number): PositionStore {
@@ -118,11 +121,13 @@ export function tickHunger(
 ```
 
 **What counts as a violation:**
+
 - `class Ant { ... }` or any class representing a simulation entity
 - Inheritance hierarchies for game objects (`class Soldier extends Ant`)
 - Entity behavior encoded as methods on objects rather than systems operating on data
 
 **What is allowed:**
+
 - Classes for non-entity infrastructure (e.g., a `World` container that holds all the stores, or the PRNG)
 - TypeScript interfaces and type aliases (these are just compile-time shapes)
 - Plain objects and maps where typed arrays would be overkill (cold data, small collections)
@@ -152,7 +157,7 @@ export class Rng {
     let t = (this.state += 0x6d2b79f5);
     t = Math.imul(t ^ (t >>> 15), t | 1);
     t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0);
+    return (t ^ (t >>> 14)) >>> 0;
   }
 
   /** Returns an integer in [0, max) */
@@ -168,11 +173,13 @@ export class Rng {
 ```
 
 **What counts as a violation:**
+
 - `Math.random()` anywhere in `src/sim/`
 - Creating a second `Rng` instance inside the simulation
 - Any randomness source other than the single world-level `Rng`
 
 **What is allowed:**
+
 - `Math.random()` in `src/render/` for visual-only effects (particle jitter, etc.)
 - The rendering layer does not affect simulation state, so non-deterministic visuals are fine
 
@@ -185,6 +192,7 @@ export class Rng {
 **Why:** Wall-clock time breaks determinism. If the simulation behaves differently depending on when it runs, replay and multiplayer break. The simulation must produce identical output whether it runs in real-time, fast-forward, or instant batch replay.
 
 **What counts as a violation:**
+
 - Any reference to `Date`, `performance`, `setTimeout`, or `setInterval` in `src/sim/`
 - Computing durations from anything other than tick counts
 
@@ -222,11 +230,13 @@ export function fpMul(a: number, b: number): number {
 ```
 
 **What counts as a violation:**
+
 - Any arithmetic in `src/sim/` that produces or depends on fractional `number` values
 - Division without truncation (use `Math.trunc(a / b)` or `(a / b) | 0`)
 - `Math.sqrt`, `Math.sin`, `Math.cos` in `src/sim/` (use lookup tables or integer approximations)
 
 **What is allowed:**
+
 - `toFloat()` conversions in `src/render/` for drawing positions
 - Floating-point interpolation in the rendering layer
 - Integer-safe `Math` functions: `Math.abs`, `Math.min`, `Math.max`, `Math.trunc`
@@ -246,8 +256,8 @@ interface SaveFile {
   version: number;
   seed: number;
   tickCount: number;
-  world: WorldState;       // full snapshot
-  inputLog: InputEntry[];  // every command with its tick number
+  world: WorldState; // full snapshot
+  inputLog: InputEntry[]; // every command with its tick number
 }
 
 interface InputEntry {

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,19 +10,19 @@ We pledge to act and interact in ways that contribute to an open, welcoming, div
 
 Examples of behavior that contributes to a positive environment for our community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall community
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,12 @@ npm run verify     # lint + typecheck + sim-boundary check + tests
 ```
 
 Requirements:
+
 - Node.js 22 LTS or newer
 - A Chromium-based browser for Playwright E2E tests (`npx playwright install` on first run)
 
 Useful scripts:
+
 - `npm test` — Vitest unit/integration suite
 - `npm run test:watch` — Vitest in watch mode
 - `npm run test:e2e` — Playwright browser tests
@@ -38,7 +40,7 @@ Useful scripts:
 1. **[ROADMAP.md](ROADMAP.md)** — high-level direction and upcoming phases. Work that's on the roadmap is pre-approved in principle; scope details still need alignment.
 2. **GitHub Issues** — filter for `good first issue` or `help wanted`.
 3. **Small fixes welcome unannounced** — typos, doc improvements, failing-test reproductions, boundary-rule enforcement.
-4. **For anything larger or off-roadmap, talk first.** The project lead is opinionated about how the game should feel and play — that's not a bug, it's the thesis of the project. If you have a significant gameplay, systems, or design change in mind that isn't already on the roadmap, open a discussion or issue *before* you start coding. Either convince us it fits, or save us both the awkward "this doesn't match the vision" PR review.
+4. **For anything larger or off-roadmap, talk first.** The project lead is opinionated about how the game should feel and play — that's not a bug, it's the thesis of the project. If you have a significant gameplay, systems, or design change in mind that isn't already on the roadmap, open a discussion or issue _before_ you start coding. Either convince us it fits, or save us both the awkward "this doesn't match the vision" PR review.
 
 If you're unsure whether an idea fits, open a discussion or draft issue — we'd rather talk early than reject a finished PR.
 
@@ -47,6 +49,7 @@ If you're unsure whether an idea fits, open a discussion or draft issue — we'd
 Subterrans is partly an experiment in AI-driven software development. **Contributions should be written primarily by AI coding assistants** (Claude Code, Codex, Cursor, Aider, etc.) with human guidance, review, and judgment. Human-written code is welcome as a last resort — for example, when an AI is stuck, when fine-grained control matters, or when you're fixing something trivial and writing it yourself is faster than prompting.
 
 What we actually care about:
+
 - The code is correct, tested, and follows the architectural rules.
 - You understand and take responsibility for what you submit — reviewers will ask questions, and "the AI wrote it" is not an answer.
 - You disclose AI involvement honestly in the PR description if it's the bulk of the work. We're not gatekeeping; we're curious about what works.
@@ -55,12 +58,13 @@ This norm is a preference, not a hard rule. Good human-written contributions won
 
 ## Architectural Rules (Read Before Coding)
 
-Subterrans has strict architectural boundaries that a reviewer *will* block on. Skim these first:
+Subterrans has strict architectural boundaries that a reviewer _will_ block on. Skim these first:
 
 - **[AGENTS.md](AGENTS.md)** — the contributor quick-reference (directory layout, banned APIs, testing expectations).
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — full explanations with examples.
 
 Highlights:
+
 - `src/sim/` is a pure, deterministic, integer-math simulation. **No Phaser, no DOM, no `Math.random`, no `Date`, no floats** — ever.
 - Render and input layers read simulation state; they never mutate it.
 - Fixed 20 Hz tick. No variable timestep.
@@ -71,12 +75,15 @@ Highlights:
 1. **Fork & branch.** Branch off `main` with a short descriptive name: `fix/rally-oscillation`, `feat/scent-trails`.
 2. **Write tests first where practical.** Simulation bugs almost always have a minimal reproducer — prefer a failing test in `src/sim/` over a console log.
 3. **Keep commits small and focused.** One logical change per commit. Commit message style:
+
    ```
    feat(sim): rally hold radius prevents fighter stutter
 
    Explain *why* in the body when the diff doesn't make it obvious.
    ```
+
    Prefixes we use: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`.
+
 4. **Run `npm run verify` before pushing.** Same command CI runs.
 5. **Open a PR** against `main`. Fill out the PR template (summary + test plan).
 
@@ -94,6 +101,7 @@ Owner may override an AI block if it's a false positive; if you disagree with a 
 ## Reporting Bugs
 
 Open an issue with:
+
 - What you did (steps, seed if relevant)
 - What you expected
 - What actually happened

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,7 +8,7 @@ Subterrans exists thanks to the people listed below. See [CONTRIBUTING.md](CONTR
 
 ## Contributors
 
-*(alphabetical by first name)*
+_(alphabetical by first name)_
 
 <!-- Add your name in the same PR as your first substantive contribution. Format: `- Your Name — one-line note on area of contribution (optional)` -->
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Subterrans
 
-A modern ant colony simulation game, built for the web. A spiritual successor to Maxis's *SimAnt* (1991) — same core idea (you are the colony, not an individual ant; you influence behavior through allocation and pheromones rather than direct control), with contemporary design, determinism, and moddability baked in from the start.
+A modern ant colony simulation game, built for the web. A spiritual successor to Maxis's _SimAnt_ (1991) — same core idea (you are the colony, not an individual ant; you influence behavior through allocation and pheromones rather than direct control), with contemporary design, determinism, and moddability baked in from the start.
 
 > **Status:** early development. The simulation is working end-to-end and playable at a rough level; art, audio, and polish are ongoing. Expect things to change. See the [roadmap](https://subterrans.com/roadmap) for the current phase structure and what's next.
 
@@ -34,20 +34,21 @@ npm run dev       # launches Vite dev server, opens in browser
 ```
 
 Requirements:
+
 - **Node.js 22 LTS or newer**
 - A Chromium-based browser for the Playwright E2E suite (`npx playwright install` on first run).
 
 Useful scripts:
 
-| Command | What it does |
-| --- | --- |
-| `npm run dev` | Vite dev server with hot reload |
-| `npm run build` | Production build |
-| `npm test` | Vitest unit/integration tests |
-| `npm run test:e2e` | Playwright browser tests |
-| `npm run typecheck` | TypeScript in `--noEmit` mode |
-| `npm run lint` | ESLint |
-| `npm run verify` | Lint + typecheck + sim-boundary check + tests (what CI runs) |
+| Command             | What it does                                                 |
+| ------------------- | ------------------------------------------------------------ |
+| `npm run dev`       | Vite dev server with hot reload                              |
+| `npm run build`     | Production build                                             |
+| `npm test`          | Vitest unit/integration tests                                |
+| `npm run test:e2e`  | Playwright browser tests                                     |
+| `npm run typecheck` | TypeScript in `--noEmit` mode                                |
+| `npm run lint`      | ESLint                                                       |
+| `npm run verify`    | Lint + typecheck + sim-boundary check + tests (what CI runs) |
 
 ---
 
@@ -69,9 +70,10 @@ Full detail in [ARCHITECTURE.md](ARCHITECTURE.md). A condensed contributor refer
 We welcome contributions, and the project is partly an experiment in AI-driven development — so contributions written with AI coding assistants are the norm, not the exception. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community expectations.
 
 Quick pointers:
+
 - Small fixes: open a PR.
 - Anything on the roadmap: open an issue to claim it, then PR.
-- Anything *off* the roadmap: talk to us first — open an issue or discussion before starting work.
+- Anything _off_ the roadmap: talk to us first — open an issue or discussion before starting work.
 
 Past and present contributors are listed in [CONTRIBUTORS.md](CONTRIBUTORS.md).
 
@@ -87,5 +89,5 @@ In plain English: you can use, modify, and redistribute Subterrans freely, but a
 
 ## Acknowledgements
 
-- Maxis and the original *SimAnt* (1991) team, for making the game that made this one necessary.
+- Maxis and the original _SimAnt_ (1991) team, for making the game that made this one necessary.
 - The Phaser, Vite, Vitest, and Playwright communities for the tools this project stands on.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,11 +36,13 @@ Subterrans is a small, early-stage project — responses may be slower than a co
 ## Scope
 
 **In scope:**
+
 - Code in this repository (game client, simulation, save/load, any server components if added later).
 - Save-file parsing (e.g. crafted save files causing RCE or denial-of-service in the client).
 - Dependency vulnerabilities with a working impact path into this codebase.
 
 **Out of scope:**
+
 - The surrounding website infrastructure, marketing site, and account/login systems — those are separate projects and have their own reporting channels.
 - Vulnerabilities in upstream dependencies without a demonstrated impact on Subterrans; please report those to the upstream project first.
 - Social engineering, physical attacks, or anything requiring prior compromise of a user's device.

--- a/bench/pheromone-decay.bench.ts
+++ b/bench/pheromone-decay.bench.ts
@@ -9,8 +9,8 @@ describe('pheromone decay wall-clock benchmark (PHER-07 / Phase 6 SC 10)', () =>
   it('decay time with 10000 deposits < 3x decay time with 100 deposits on identical grid size', () => {
     const WIDTH = 128;
     const HEIGHT = 128;
-    const ITERATIONS = 200;       // amortize per-run noise
-    const WARMUP_RUNS = 20;       // JIT warmup
+    const ITERATIONS = 200; // amortize per-run noise
+    const WARMUP_RUNS = 20; // JIT warmup
 
     function buildGrid(depositCount: number): ReturnType<typeof createPheromoneGrid> {
       const grid = createPheromoneGrid(WIDTH, HEIGHT);

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -12,27 +12,30 @@
 // Nested writes (world.ants.alive[id] = 0) are NOT caught here; they are caught by
 // scripts/check-sim-boundary.sh (the grep backstop). See RESEARCH.md Pattern 1c for details.
 
-import tseslint from "@typescript-eslint/eslint-plugin";
-import tsParser from "@typescript-eslint/parser";
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
 
 /** Rules applied to ALL TypeScript source files */
 const baseConfig = {
-  files: ["src/**/*.ts", "bench/**/*.ts"],
+  files: ['src/**/*.ts', 'bench/**/*.ts'],
   languageOptions: {
     parser: tsParser,
     ecmaVersion: 2022,
-    sourceType: "module",
+    sourceType: 'module',
   },
-  plugins: { "@typescript-eslint": tseslint },
+  plugins: { '@typescript-eslint': tseslint },
   rules: {
     // Baseline TS rules (non-type-checked — no project overhead)
     ...tseslint.configs.recommended.rules,
     // Allow _-prefixed identifiers to signal intentionally unused args/vars.
-    "@typescript-eslint/no-unused-vars": ["error", {
-      argsIgnorePattern: "^_",
-      varsIgnorePattern: "^_",
-      caughtErrorsIgnorePattern: "^_",
-    }],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
   },
 };
 
@@ -40,71 +43,95 @@ const baseConfig = {
  *  Applied ONLY to src/sim/**\/*.ts.
  */
 const simSafetyConfig = {
-  files: ["src/sim/**/*.ts"],
+  files: ['src/sim/**/*.ts'],
   rules: {
     // FNDN-04 (PRD Rule Set 1) — Phaser + cross-layer import bans
     // patterns (glob form) required — string `paths` form only matches exact strings (RESEARCH.md Pitfall 2).
-    "no-restricted-imports": ["error", {
-      patterns: [
-        { group: ["phaser", "phaser/*"],
-          message: "Phaser is banned in src/sim/. The sim layer must be pure TypeScript." },
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['phaser', 'phaser/*'],
+            message: 'Phaser is banned in src/sim/. The sim layer must be pure TypeScript.',
+          },
 
-        // Relative paths — any-depth globbing (src/sim/systems/ai/foo.ts → ../../../render/...)
-        { group: ["**/render", "**/render/**"],
-          message: "src/sim/ cannot import from render/ at any path depth." },
-        { group: ["**/input", "**/input/**"],
-          message: "src/sim/ cannot import from input/ at any path depth." },
-        { group: ["**/platform", "**/platform/**"],
-          message: "src/sim/ cannot import from platform/ at any path depth." },
+          // Relative paths — any-depth globbing (src/sim/systems/ai/foo.ts → ../../../render/...)
+          {
+            group: ['**/render', '**/render/**'],
+            message: 'src/sim/ cannot import from render/ at any path depth.',
+          },
+          {
+            group: ['**/input', '**/input/**'],
+            message: 'src/sim/ cannot import from input/ at any path depth.',
+          },
+          {
+            group: ['**/platform', '**/platform/**'],
+            message: 'src/sim/ cannot import from platform/ at any path depth.',
+          },
 
-        // Alias paths (@/ prefix configured in tsconfig.json)
-        { group: ["@/render", "@/render/**"],
-          message: "src/sim/ cannot import from src/render/ (even via alias)." },
-        { group: ["@/input", "@/input/**"],
-          message: "src/sim/ cannot import from src/input/ (even via alias)." },
-        { group: ["@/platform", "@/platform/**"],
-          message: "src/sim/ cannot import from src/platform/ (even via alias)." },
-      ],
-    }],
+          // Alias paths (@/ prefix configured in tsconfig.json)
+          {
+            group: ['@/render', '@/render/**'],
+            message: 'src/sim/ cannot import from src/render/ (even via alias).',
+          },
+          {
+            group: ['@/input', '@/input/**'],
+            message: 'src/sim/ cannot import from src/input/ (even via alias).',
+          },
+          {
+            group: ['@/platform', '@/platform/**'],
+            message: 'src/sim/ cannot import from src/platform/ (even via alias).',
+          },
+        ],
+      },
+    ],
 
     // FNDN-05 (PRD Rule Set 2) — wall-clock, async, browser globals, network bans
-    "no-restricted-properties": ["error",
-      { object: "Math", property: "random", message: "Use the seeded Rng instance." },
-      { object: "Math", property: "sqrt",   message: "Use integer approximations or lookup tables." },
-      { object: "Math", property: "sin",    message: "Use a fixed-point lookup table." },
-      { object: "Math", property: "cos",    message: "Use a fixed-point lookup table." },
+    'no-restricted-properties': [
+      'error',
+      { object: 'Math', property: 'random', message: 'Use the seeded Rng instance.' },
+      { object: 'Math', property: 'sqrt', message: 'Use integer approximations or lookup tables.' },
+      { object: 'Math', property: 'sin', message: 'Use a fixed-point lookup table.' },
+      { object: 'Math', property: 'cos', message: 'Use a fixed-point lookup table.' },
     ],
-    "no-restricted-globals": ["error",
-      { name: "Date",                    message: "Wall-clock time is banned in src/sim/. Time = tickCount * MS_PER_TICK." },
-      { name: "performance",             message: "Wall-clock time is banned in src/sim/." },
-      { name: "setTimeout",              message: "Async scheduling is banned in src/sim/." },
-      { name: "setInterval",             message: "Async scheduling is banned in src/sim/." },
-      { name: "window",                  message: "Browser globals are banned in src/sim/." },
-      { name: "document",                message: "Browser globals are banned in src/sim/." },
-      { name: "navigator",               message: "Browser globals are banned in src/sim/." },
-      { name: "localStorage",            message: "Browser storage is banned in src/sim/." },
-      { name: "requestAnimationFrame",   message: "Frame scheduling is banned in src/sim/." },
-      { name: "cancelAnimationFrame",    message: "Frame scheduling is banned in src/sim/." },
-      { name: "fetch",                   message: "Network access is banned in src/sim/." },
-      { name: "XMLHttpRequest",          message: "Network access is banned in src/sim/." },
+    'no-restricted-globals': [
+      'error',
+      {
+        name: 'Date',
+        message: 'Wall-clock time is banned in src/sim/. Time = tickCount * MS_PER_TICK.',
+      },
+      { name: 'performance', message: 'Wall-clock time is banned in src/sim/.' },
+      { name: 'setTimeout', message: 'Async scheduling is banned in src/sim/.' },
+      { name: 'setInterval', message: 'Async scheduling is banned in src/sim/.' },
+      { name: 'window', message: 'Browser globals are banned in src/sim/.' },
+      { name: 'document', message: 'Browser globals are banned in src/sim/.' },
+      { name: 'navigator', message: 'Browser globals are banned in src/sim/.' },
+      { name: 'localStorage', message: 'Browser storage is banned in src/sim/.' },
+      { name: 'requestAnimationFrame', message: 'Frame scheduling is banned in src/sim/.' },
+      { name: 'cancelAnimationFrame', message: 'Frame scheduling is banned in src/sim/.' },
+      { name: 'fetch', message: 'Network access is banned in src/sim/.' },
+      { name: 'XMLHttpRequest', message: 'Network access is banned in src/sim/.' },
     ],
 
     // FNDN-02 — ban float literals and division (both return IEEE 754 doubles)
-    "no-restricted-syntax": ["error",
+    'no-restricted-syntax': [
+      'error',
       {
         // Matches any numeric literal whose source text signals floating-point intent:
         //   - decimal point anywhere after leading digits: 3.14, 1.5, 0.5, 1.0, .5, 1.e5
         //   - scientific notation: 1e3, 1e-3, 2E10, 1.5e2
         // The ^\d* anchor spares string literals (raw starts with ") and hex/binary/octal
         // literals (raw starts with 0x, 0b, 0o — the non-digit char after 0 breaks the match).
-        selector: "Literal[raw=/^\\d*(\\.|\\d[eE])/]",
-        message: "Float literal (decimal or scientific notation) in src/sim/ — convert to fixed-point integer (multiply by FP_ONE).",
+        selector: 'Literal[raw=/^\\d*(\\.|\\d[eE])/]',
+        message:
+          'Float literal (decimal or scientific notation) in src/sim/ — convert to fixed-point integer (multiply by FP_ONE).',
       },
       {
         // JS integer division still returns IEEE 754 double.
         // fpDiv() in src/sim/fixed.ts needs one `// eslint-disable-next-line` on its own line.
         selector: "BinaryExpression[operator='/']",
-        message: "Division in src/sim/ returns a float — use fpDiv() instead.",
+        message: 'Division in src/sim/ returns a float — use fpDiv() instead.',
       },
     ],
   },
@@ -132,22 +159,23 @@ const simSafetyConfig = {
  *  are the CORRECT write pattern from non-sim layers and MUST pass.
  */
 const nonSimMutationGuard = {
-  files: [
-    "src/render/**/*.ts",
-    "src/input/**/*.ts",
-    "src/platform/**/*.ts",
-  ],
+  files: ['src/render/**/*.ts', 'src/input/**/*.ts', 'src/platform/**/*.ts'],
   rules: {
-    "no-restricted-syntax": ["error",
+    'no-restricted-syntax': [
+      'error',
       {
         // Tripwire: catches `world.tick = ...`, `world.rngState = ...`, whole-field replacement.
-        selector: "AssignmentExpression[left.type='MemberExpression'][left.property.name=/^(tick|rngState|nextEntityId|ants|colonies|pheromoneGrids|surface|undergroundGrids|pendingChambers)$/]",
-        message: "FNDN-07 tripwire: direct write to WorldState sim-state field from non-sim layer. Push a SimCommand onto world.commandQueue instead (PRD §5). [Nested writes like world.colonies[id].x are not caught by lint — see grep guard.]",
+        selector:
+          "AssignmentExpression[left.type='MemberExpression'][left.property.name=/^(tick|rngState|nextEntityId|ants|colonies|pheromoneGrids|surface|undergroundGrids|pendingChambers)$/]",
+        message:
+          'FNDN-07 tripwire: direct write to WorldState sim-state field from non-sim layer. Push a SimCommand onto world.commandQueue instead (PRD §5). [Nested writes like world.colonies[id].x are not caught by lint — see grep guard.]',
       },
       {
         // Tripwire: catches `world.tick++`, `--world.nextEntityId`, etc.
-        selector: "UpdateExpression[argument.type='MemberExpression'][argument.property.name=/^(tick|rngState|nextEntityId|ants|colonies|pheromoneGrids|surface|undergroundGrids|pendingChambers)$/]",
-        message: "FNDN-07 tripwire: UpdateExpression on WorldState sim-state field from non-sim layer. Mutations happen inside tick(); use a SimCommand.",
+        selector:
+          "UpdateExpression[argument.type='MemberExpression'][argument.property.name=/^(tick|rngState|nextEntityId|ants|colonies|pheromoneGrids|surface|undergroundGrids|pendingChambers)$/]",
+        message:
+          'FNDN-07 tripwire: UpdateExpression on WorldState sim-state field from non-sim layer. Mutations happen inside tick(); use a SimCommand.',
       },
     ],
   },

--- a/index.html
+++ b/index.html
@@ -5,8 +5,18 @@
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Subterrans</title>
     <style>
-      body { margin: 0; background: #000; display: flex; align-items: center; justify-content: center; min-height: 100vh; }
-      #game { width: 800px; height: 592px; }
+      body {
+        margin: 0;
+        background: #000;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+      }
+      #game {
+        width: 800px;
+        height: 592px;
+      }
     </style>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint": "^10.2.0",
         "jiti": "^2.6.1",
         "jsdom": "^29.0.2",
+        "prettier": "3.8.3",
         "typescript": "~5.9.3",
         "vite": "^8.0.8",
         "vitest": "^4.1.4"
@@ -2642,6 +2643,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check .",
+    "format:check": "prettier --check src/",
     "verify": "npm run format:check && npm run lint && npm run typecheck && bash scripts/check-sim-boundary.sh && bash scripts/check-asset-paths.sh && npm run test"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "verify": "npm run lint && npm run typecheck && bash scripts/check-sim-boundary.sh && bash scripts/check-asset-paths.sh && npm run test"
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "verify": "npm run format:check && npm run lint && npm run typecheck && bash scripts/check-sim-boundary.sh && bash scripts/check-asset-paths.sh && npm run test"
   },
   "dependencies": {
     "phaser": "^3.90.0"
@@ -37,12 +39,13 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
-    "@vitest/coverage-v8": "^4.1.6",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
+    "@vitest/coverage-v8": "^4.1.6",
     "eslint": "^10.2.0",
     "jiti": "^2.6.1",
     "jsdom": "^29.0.2",
+    "prettier": "3.8.3",
     "typescript": "~5.9.3",
     "vite": "^8.0.8",
     "vitest": "^4.1.4"

--- a/scripts/analyze-snapshot.ts
+++ b/scripts/analyze-snapshot.ts
@@ -27,7 +27,8 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 register(
-  'data:text/javascript,' + encodeURIComponent(`
+  'data:text/javascript,' +
+    encodeURIComponent(`
     export async function resolve(specifier, context, nextResolve) {
       if (specifier.endsWith('.js')) {
         const tsSpec = specifier.slice(0, -3) + '.ts';
@@ -36,26 +37,26 @@ register(
       return nextResolve(specifier, context);
     }
   `),
-  pathToFileURL('./')
+  pathToFileURL('./'),
 );
 
-const { createScenario }                       = await import('../src/sim/scenario.js');
-const { tick }                                 = await import('../src/sim/tick.js');
-const { Zone, UndergroundTileState, ugGet }    = await import('../src/sim/terrain.js');
-const { FP_SHIFT }                             = await import('../src/sim/fixed.js');
-const { AntTask, ForagingSubState }            = await import('../src/sim/enums.js');
+const { createScenario } = await import('../src/sim/scenario.js');
+const { tick } = await import('../src/sim/tick.js');
+const { Zone, UndergroundTileState, ugGet } = await import('../src/sim/terrain.js');
+const { FP_SHIFT } = await import('../src/sim/fixed.js');
+const { AntTask, ForagingSubState } = await import('../src/sim/enums.js');
 const { serializeWorldState, deserializeWorldState } = await import('../src/platform/save.js');
 
 const ANT_TASK_NAME: Record<number, string> = {
-  [AntTask.Idle]:     'Idle',
+  [AntTask.Idle]: 'Idle',
   [AntTask.Foraging]: 'Foraging',
-  [AntTask.Digging]:  'Digging',
+  [AntTask.Digging]: 'Digging',
   [AntTask.Fighting]: 'Fighting',
-  [AntTask.Nursing]:  'Nursing',
+  [AntTask.Nursing]: 'Nursing',
 };
 const FORAGING_SUB_NAME: Record<number, string> = {
-  [ForagingSubState.SearchingFood]:   'SearchingFood',
-  [ForagingSubState.CarryingFood]:    'CarryingFood',
+  [ForagingSubState.SearchingFood]: 'SearchingFood',
+  [ForagingSubState.CarryingFood]: 'CarryingFood',
   [ForagingSubState.ReturningToNest]: 'ReturningToNest',
 };
 function describeTask(task: number, subTask: number): string {
@@ -70,17 +71,19 @@ function describeTask(task: number, subTask: number): string {
 const CLUSTER_THRESHOLD = 5;
 
 // Motion-history sampling — 20 ticks = 1 sim second; 30 samples = 30 sim sec.
-const SAMPLE_INTERVAL_TICKS    = 20;
-const ANALYSIS_WINDOW_SAMPLES  = 30;
+const SAMPLE_INTERVAL_TICKS = 20;
+const ANALYSIS_WINDOW_SAMPLES = 30;
 // Stationary classification: ≥90% of samples on the same tile.
-const STATIONARY_FRACTION      = 0.9;
+const STATIONARY_FRACTION = 0.9;
 // Oscillation classification: ant visits ≤3 unique tiles across the window
 // AND fails the stationary test (i.e., genuinely cycles between a few tiles).
-const OSCILLATION_MAX_UNIQUE   = 3;
+const OSCILLATION_MAX_UNIQUE = 3;
 
 const argPath = process.argv[2];
 if (!argPath) {
-  console.error('Usage: node --experimental-transform-types scripts/analyze-snapshot.ts <snapshot.json>');
+  console.error(
+    'Usage: node --experimental-transform-types scripts/analyze-snapshot.ts <snapshot.json>',
+  );
   process.exit(2);
 }
 
@@ -89,7 +92,10 @@ const snapPath = resolve(process.cwd(), argPath);
 // Minimal envelope validation — surface a clear error on a missing file,
 // malformed JSON, or wrong-shape envelope instead of a cryptic stack trace
 // mid-replay.
-function bail(msg: string): never { console.error(`Invalid snapshot: ${msg}`); process.exit(3); }
+function bail(msg: string): never {
+  console.error(`Invalid snapshot: ${msg}`);
+  process.exit(3);
+}
 let rawJson: string;
 try {
   rawJson = readFileSync(snapPath, 'utf-8');
@@ -112,13 +118,16 @@ const debug = parsed as {
 // Number.isInteger rejects NaN, ±Infinity, and fractional values — important
 // because tick=Infinity would loop forever and seed=NaN is silently coerced
 // to 0 by createScenario (via `seed >>> 0`).
-if (!Number.isInteger(debug.seed))               bail(`"seed" must be an integer (got ${String(debug.seed)})`);
-if (!Number.isInteger(debug.tick) || debug.tick < 0) bail(`"tick" must be a non-negative integer (got ${String(debug.tick)})`);
-if (!Array.isArray(debug.inputLog))              bail('missing or non-array "inputLog"');
+if (!Number.isInteger(debug.seed)) bail(`"seed" must be an integer (got ${String(debug.seed)})`);
+if (!Number.isInteger(debug.tick) || debug.tick < 0)
+  bail(`"tick" must be a non-negative integer (got ${String(debug.tick)})`);
+if (!Array.isArray(debug.inputLog)) bail('missing or non-array "inputLog"');
 if (!debug.snapshot || typeof debug.snapshot !== 'object') bail('missing "snapshot"');
 
 console.log(`Snapshot: ${snapPath}`);
-console.log(`  seed=${debug.seed}  tick=${debug.tick}  inputLog=${debug.inputLog.length} cmds  version=${debug.version}`);
+console.log(
+  `  seed=${debug.seed}  tick=${debug.tick}  inputLog=${debug.inputLog.length} cmds  version=${debug.version}`,
+);
 console.log('');
 
 // --- 1. Replay-from-seed byte-equality check (SCEN-06) -----------------------
@@ -134,13 +143,19 @@ const replay = createScenario(debug.seed, replayDifficulty);
 // match the original session. createScenario always starts at LATEST_SIM_VERSION; without this
 // a pre-V22 snapshot replayed on V22 code would have V22 paths active, causing divergence.
 const snapshotSimVersion = (debug.snapshot as { simVersion?: unknown }).simVersion;
-if (typeof snapshotSimVersion === 'number' && Number.isInteger(snapshotSimVersion) && snapshotSimVersion > 0) {
+if (
+  typeof snapshotSimVersion === 'number' &&
+  Number.isInteger(snapshotSimVersion) &&
+  snapshotSimVersion > 0
+) {
   replay.simVersion = snapshotSimVersion;
 } else {
-  console.warn(`[analyze-snapshot] Could not restore simVersion from snapshot (got ${String(snapshotSimVersion)}); replay runs at LATEST_SIM_VERSION — byte-equality may fail for pre-V22 captures.`);
+  console.warn(
+    `[analyze-snapshot] Could not restore simVersion from snapshot (got ${String(snapshotSimVersion)}); replay runs at LATEST_SIM_VERSION — byte-equality may fail for pre-V22 captures.`,
+  );
 }
 
-const byTick: typeof debug.inputLog[] = [];
+const byTick: (typeof debug.inputLog)[] = [];
 for (let i = 0; i < debug.inputLog.length; i++) {
   const cmd = debug.inputLog[i];
   if (!cmd || typeof cmd !== 'object') bail(`inputLog[${i}] is not an object`);
@@ -171,7 +186,10 @@ function sampleAnts(): void {
   for (let id = 0; id < replay.nextEntityId; id++) {
     if (a.alive[id] !== 1) continue;
     let arr = history.get(id);
-    if (!arr) { arr = []; history.set(id, arr); }
+    if (!arr) {
+      arr = [];
+      history.set(id, arr);
+    }
     arr.push({
       zone: a.zone[id]!,
       tileX: a.posX[id]! >> FP_SHIFT,
@@ -207,18 +225,26 @@ function stripCommandQueue(s: typeof debug.snapshot): unknown {
   return rest;
 }
 const replaySerialized = serializeWorldState(replay);
-const replayJson   = JSON.stringify(stripCommandQueue(replaySerialized as unknown as typeof debug.snapshot));
+const replayJson = JSON.stringify(
+  stripCommandQueue(replaySerialized as unknown as typeof debug.snapshot),
+);
 const capturedJson = JSON.stringify(stripCommandQueue(debug.snapshot));
 const replayMatches = replayJson === capturedJson;
-const capturedQueuedCount = Array.isArray((debug.snapshot as unknown as { commandQueue?: unknown[] }).commandQueue)
-  ? ((debug.snapshot as unknown as { commandQueue: unknown[] }).commandQueue.length)
+const capturedQueuedCount = Array.isArray(
+  (debug.snapshot as unknown as { commandQueue?: unknown[] }).commandQueue,
+)
+  ? (debug.snapshot as unknown as { commandQueue: unknown[] }).commandQueue.length
   : 0;
 
 console.log(`  replayed ${debug.tick} ticks in ${(replayElapsedMs / 1000).toFixed(1)}s`);
-console.log(`  replay vs captured byte-equality: ${replayMatches ? 'PASS' : 'FAIL'} (commandQueue excluded; captured had ${capturedQueuedCount} pending command${capturedQueuedCount === 1 ? '' : 's'})`);
+console.log(
+  `  replay vs captured byte-equality: ${replayMatches ? 'PASS' : 'FAIL'} (commandQueue excluded; captured had ${capturedQueuedCount} pending command${capturedQueuedCount === 1 ? '' : 's'})`,
+);
 if (!replayMatches) {
   console.log(`  WARNING: SCEN-06 determinism regression — replayed state differs from captured.`);
-  console.log(`  (or a benign serializer key-order change between snapshot capture and this build)`);
+  console.log(
+    `  (or a benign serializer key-order change between snapshot capture and this build)`,
+  );
   console.log(`  Cluster / stuck-in-dirt reports below use the CAPTURED snapshot (trustworthy).`);
   console.log(`  Motion-history reports use the REPLAYED trajectory and may not reflect the`);
   console.log(`  captured ants' real motion when replay has diverged — treat with caution.`);
@@ -228,7 +254,7 @@ console.log('');
 // --- 2. Analysis is run against the CAPTURED snapshot ------------------------
 
 const world = deserializeWorldState(debug.snapshot);
-const ants  = world.ants;
+const ants = world.ants;
 
 let liveCount = 0;
 for (let id = 0; id < world.nextEntityId; id++) {
@@ -251,9 +277,12 @@ const cells = new Map<string, ClusterCell>();
 for (let id = 0; id < world.nextEntityId; id++) {
   if (ants.alive[id] !== 1) continue;
   const zone = ants.zone[id]!;
-  const colonyId = zone === Zone.Underground
-    ? (ants.currentGridColonyId[id]! >= 0 ? ants.currentGridColonyId[id]! : ants.colonyId[id]!)
-    : ants.colonyId[id]!;
+  const colonyId =
+    zone === Zone.Underground
+      ? ants.currentGridColonyId[id]! >= 0
+        ? ants.currentGridColonyId[id]!
+        : ants.colonyId[id]!
+      : ants.colonyId[id]!;
   const tileX = ants.posX[id]! >> FP_SHIFT;
   const tileY = ants.posY[id]! >> FP_SHIFT;
   const key = `${zone}:${colonyId}:${tileX},${tileY}`;
@@ -274,7 +303,9 @@ for (const c of clusters) {
   const zoneLabel = c.zone === Zone.Underground ? 'underground' : 'surface    ';
   const sample = c.ids.slice(0, 6).join(', ');
   const more = c.ids.length > 6 ? ` …+${c.ids.length - 6}` : '';
-  console.log(`  ${zoneLabel}  colony ${c.colonyId}  (${c.tileX.toString().padStart(3)}, ${c.tileY.toString().padStart(3)})  ${c.ids.length} ants  [${sample}${more}]`);
+  console.log(
+    `  ${zoneLabel}  colony ${c.colonyId}  (${c.tileX.toString().padStart(3)}, ${c.tileY.toString().padStart(3)})  ${c.ids.length} ants  [${sample}${more}]`,
+  );
 }
 console.log('');
 
@@ -290,19 +321,18 @@ interface StuckInDirt {
 }
 
 const stuckLabel: Record<number, string> = {
-  [UndergroundTileState.Solid]:    'solid',
-  [UndergroundTileState.Marked]:   'marked-for-dig',
+  [UndergroundTileState.Solid]: 'solid',
+  [UndergroundTileState.Marked]: 'marked-for-dig',
   [UndergroundTileState.BeingDug]: 'being-dug',
-  [UndergroundTileState.Open]:     'open',
+  [UndergroundTileState.Open]: 'open',
 };
 
 const stuck: StuckInDirt[] = [];
 for (let id = 0; id < world.nextEntityId; id++) {
   if (ants.alive[id] !== 1) continue;
   if (ants.zone[id] !== Zone.Underground) continue;
-  const gridColonyId = ants.currentGridColonyId[id]! >= 0
-    ? ants.currentGridColonyId[id]!
-    : ants.colonyId[id]!;
+  const gridColonyId =
+    ants.currentGridColonyId[id]! >= 0 ? ants.currentGridColonyId[id]! : ants.colonyId[id]!;
   const grid = world.undergroundGrids[gridColonyId];
   if (!grid) continue;
   const tileX = ants.posX[id]! >> FP_SHIFT;
@@ -424,13 +454,13 @@ const WINDOW_TICKS = ANALYSIS_WINDOW_SAMPLES * SAMPLE_INTERVAL_TICKS;
 const WINDOW_START = Math.max(0, debug.tick - WINDOW_TICKS);
 console.log(
   `Motion-history analysis (sampled every ${SAMPLE_INTERVAL_TICKS} ticks, ` +
-  `window = ${ANALYSIS_WINDOW_SAMPLES} samples = ${WINDOW_TICKS} ticks; ` +
-  `covers ticks ${WINDOW_START}-${debug.tick}):`,
+    `window = ${ANALYSIS_WINDOW_SAMPLES} samples = ${WINDOW_TICKS} ticks; ` +
+    `covers ticks ${WINDOW_START}-${debug.tick}):`,
 );
 if (!replayMatches) {
   console.log(
     `  (replay diverged — motion below reflects the replayed trajectory, ` +
-    `which may differ from the captured ants' real motion)`,
+      `which may differ from the captured ants' real motion)`,
   );
 }
 
@@ -452,7 +482,14 @@ for (const c of stationary) {
   const k = `${t.zone}:${c.colonyId}:${t.tileX},${t.tileY}`;
   let g = stationaryGroups.get(k);
   if (!g) {
-    g = { zone: t.zone, tileX: t.tileX, tileY: t.tileY, colonyId: c.colonyId, ids: [], taskCounts: new Map() };
+    g = {
+      zone: t.zone,
+      tileX: t.tileX,
+      tileY: t.tileY,
+      colonyId: c.colonyId,
+      ids: [],
+      taskCounts: new Map(),
+    };
     stationaryGroups.set(k, g);
   }
   g.ids.push(c.antId);
@@ -475,7 +512,9 @@ for (const g of stationarySorted.slice(0, 15)) {
   const zoneLabel = g.zone === Zone.Underground ? 'underground' : 'surface    ';
   const sample = g.ids.slice(0, 6).join(', ');
   const more = g.ids.length > 6 ? ` …+${g.ids.length - 6}` : '';
-  console.log(`    ${zoneLabel}  colony ${g.colonyId}  (${g.tileX.toString().padStart(3)}, ${g.tileY.toString().padStart(3)})  ${g.ids.length} ants  ${dominantTask(g.taskCounts)}  [${sample}${more}]`);
+  console.log(
+    `    ${zoneLabel}  colony ${g.colonyId}  (${g.tileX.toString().padStart(3)}, ${g.tileY.toString().padStart(3)})  ${g.ids.length} ants  ${dominantTask(g.taskCounts)}  [${sample}${more}]`,
+  );
 }
 if (stationarySorted.length > 15) console.log(`    …+${stationarySorted.length - 15} more tiles`);
 
@@ -493,7 +532,7 @@ const oscGroups = new Map<string, OscGroup>();
 for (const c of oscillating) {
   const t0 = c.tiles[0]!;
   // Canonical key: sort tiles by (tileX, tileY) so A↔B and B↔A collapse.
-  const sortedTiles = [...c.tiles].sort((a, b) => (a.tileX - b.tileX) || (a.tileY - b.tileY));
+  const sortedTiles = [...c.tiles].sort((a, b) => a.tileX - b.tileX || a.tileY - b.tileY);
   const tileSetKey = sortedTiles.map((tt) => `${tt.tileX},${tt.tileY}`).join('|');
   const k = `${t0.zone}:${c.colonyId}:${tileSetKey}`;
   let g = oscGroups.get(k);
@@ -520,7 +559,9 @@ for (const g of oscSorted.slice(0, 15)) {
   const cycle = g.tiles.map((tt) => `(${tt.tileX},${tt.tileY})`).join(' ↔ ');
   const sample = g.ids.slice(0, 6).join(', ');
   const more = g.ids.length > 6 ? ` …+${g.ids.length - 6}` : '';
-  console.log(`    ${zoneLabel}  colony ${g.colonyId}  ${cycle}  length-${g.tiles.length}  ${g.ids.length} ants  ${dominantTask(g.taskCounts)}  [${sample}${more}]`);
+  console.log(
+    `    ${zoneLabel}  colony ${g.colonyId}  ${cycle}  length-${g.tiles.length}  ${g.ids.length} ants  ${dominantTask(g.taskCounts)}  [${sample}${more}]`,
+  );
 }
 if (oscSorted.length > 15) console.log(`    …+${oscSorted.length - 15} more eddies`);
 

--- a/scripts/check-foraging-survival.ts
+++ b/scripts/check-foraging-survival.ts
@@ -24,7 +24,8 @@ import { register } from 'node:module';
 import { pathToFileURL } from 'node:url';
 
 register(
-  'data:text/javascript,' + encodeURIComponent(`
+  'data:text/javascript,' +
+    encodeURIComponent(`
     export async function resolve(specifier, context, nextResolve) {
       if (specifier.endsWith('.js')) {
         const tsSpec = specifier.slice(0, -3) + '.ts';
@@ -37,9 +38,9 @@ register(
 );
 
 const { createScenario } = await import('../src/sim/scenario.js');
-const { tick }           = await import('../src/sim/tick.js');
+const { tick } = await import('../src/sim/tick.js');
 const { PLAYER_COLONY_ID, ENEMY_COLONY_ID } = await import('../src/sim/constants.js');
-const { isAlive }        = await import('../src/sim/ant/ant-store.js');
+const { isAlive } = await import('../src/sim/ant/ant-store.js');
 
 function parseArg(name: string, fallback: number): number {
   const prefix = `--${name}=`;
@@ -58,19 +59,19 @@ const TICKS = parseArg('ticks', 2000);
 interface SeedResult {
   seed: number;
   playerAlive: boolean;
-  enemyAlive:  boolean;
+  enemyAlive: boolean;
   playerFirstDeposit: number | null;
-  enemyFirstDeposit:  number | null;
+  enemyFirstDeposit: number | null;
   playerFoodStored: number;
-  enemyFoodStored:  number;
+  enemyFoodStored: number;
 }
 
 function runSeed(seed: number): SeedResult {
   const world = createScenario(seed);
   let playerFirst: number | null = null;
-  let enemyFirst:  number | null = null;
+  let enemyFirst: number | null = null;
   let prevPlayer = world.colonies[PLAYER_COLONY_ID]!.foodStored;
-  let prevEnemy  = world.colonies[ENEMY_COLONY_ID]!.foodStored;
+  let prevEnemy = world.colonies[ENEMY_COLONY_ID]!.foodStored;
 
   for (let t = 0; t < TICKS; t++) {
     const cmds = world.commandQueue.splice(0);
@@ -78,21 +79,21 @@ function runSeed(seed: number): SeedResult {
     const pf = world.colonies[PLAYER_COLONY_ID]!.foodStored;
     const ef = world.colonies[ENEMY_COLONY_ID]!.foodStored;
     if (playerFirst === null && pf > prevPlayer) playerFirst = t;
-    if (enemyFirst  === null && ef > prevEnemy ) enemyFirst  = t;
+    if (enemyFirst === null && ef > prevEnemy) enemyFirst = t;
     prevPlayer = pf;
-    prevEnemy  = ef;
+    prevEnemy = ef;
   }
 
   const playerColony = world.colonies[PLAYER_COLONY_ID]!;
-  const enemyColony  = world.colonies[ENEMY_COLONY_ID]!;
+  const enemyColony = world.colonies[ENEMY_COLONY_ID]!;
   return {
     seed,
     playerAlive: isAlive(world.ants, playerColony.queenEntityId),
-    enemyAlive:  isAlive(world.ants, enemyColony.queenEntityId),
+    enemyAlive: isAlive(world.ants, enemyColony.queenEntityId),
     playerFirstDeposit: playerFirst,
-    enemyFirstDeposit:  enemyFirst,
+    enemyFirstDeposit: enemyFirst,
     playerFoodStored: playerColony.foodStored,
-    enemyFoodStored:  enemyColony.foodStored,
+    enemyFoodStored: enemyColony.foodStored,
   };
 }
 
@@ -120,34 +121,36 @@ for (let s = 0; s < SEEDS; s++) {
 }
 const elapsed = ((Date.now() - start) / 1000).toFixed(1);
 
-const playerAlive = results.filter(r => r.playerAlive).length;
-const enemyAlive  = results.filter(r => r.enemyAlive).length;
-const playerNoDeposit = results.filter(r => r.playerFirstDeposit === null).length;
-const enemyNoDeposit  = results.filter(r => r.enemyFirstDeposit  === null).length;
+const playerAlive = results.filter((r) => r.playerAlive).length;
+const enemyAlive = results.filter((r) => r.enemyAlive).length;
+const playerNoDeposit = results.filter((r) => r.playerFirstDeposit === null).length;
+const enemyNoDeposit = results.filter((r) => r.enemyFirstDeposit === null).length;
 
 const playerFirsts = results
-  .map(r => r.playerFirstDeposit)
+  .map((r) => r.playerFirstDeposit)
   .filter((x): x is number => x !== null)
   .sort((a, b) => a - b);
 const enemyFirsts = results
-  .map(r => r.enemyFirstDeposit)
+  .map((r) => r.enemyFirstDeposit)
   .filter((x): x is number => x !== null)
   .sort((a, b) => a - b);
 
 const playerMedian = median(playerFirsts);
-const playerP90    = percentile(playerFirsts, 90);
-const playerP95    = percentile(playerFirsts, 95);
-const enemyMedian  = median(enemyFirsts);
-const enemyP90     = percentile(enemyFirsts, 90);
-const enemyP95     = percentile(enemyFirsts, 95);
+const playerP90 = percentile(playerFirsts, 90);
+const playerP95 = percentile(playerFirsts, 95);
+const enemyMedian = median(enemyFirsts);
+const enemyP90 = percentile(enemyFirsts, 90);
+const enemyP95 = percentile(enemyFirsts, 95);
 
 console.log('');
 console.log(`== 09 excursion-foraging memo QC gate ==`);
 console.log(`Seeds: ${SEEDS}  Ticks: ${TICKS}  Elapsed: ${elapsed}s`);
 console.log('');
 console.log('Queen survival @ tick ' + TICKS + ':');
-console.log(`  Player: ${playerAlive}/${SEEDS} alive (${((playerAlive / SEEDS) * 100).toFixed(1)}%)`);
-console.log(`  Enemy:  ${enemyAlive}/${SEEDS} alive (${((enemyAlive  / SEEDS) * 100).toFixed(1)}%)`);
+console.log(
+  `  Player: ${playerAlive}/${SEEDS} alive (${((playerAlive / SEEDS) * 100).toFixed(1)}%)`,
+);
+console.log(`  Enemy:  ${enemyAlive}/${SEEDS} alive (${((enemyAlive / SEEDS) * 100).toFixed(1)}%)`);
 console.log('');
 console.log('No-deposit seeds (never picked up food):');
 console.log(`  Player: ${playerNoDeposit}/${SEEDS}`);

--- a/scripts/run-sim.ts
+++ b/scripts/run-sim.ts
@@ -15,7 +15,8 @@ import { pathToFileURL } from 'node:url';
 
 // Register a resolve hook that remaps .js -> .ts for Node strip-types.
 register(
-  'data:text/javascript,' + encodeURIComponent(`
+  'data:text/javascript,' +
+    encodeURIComponent(`
     export async function resolve(specifier, context, nextResolve) {
       if (specifier.endsWith('.js')) {
         const tsSpec = specifier.slice(0, -3) + '.ts';
@@ -24,7 +25,7 @@ register(
       return nextResolve(specifier, context);
     }
   `),
-  pathToFileURL('./')
+  pathToFileURL('./'),
 );
 
 // Dynamic imports run after hook registration — .js paths resolve correctly.

--- a/src/input/camera-input.test.ts
+++ b/src/input/camera-input.test.ts
@@ -69,16 +69,18 @@ function makeViewState(
 }
 
 /** Build a minimal mock PanInputs with all keys up. */
-function makePanInputs(overrides: Partial<{
-  leftDown: boolean;
-  rightDown: boolean;
-  upDown: boolean;
-  downDown: boolean;
-  wasdA: boolean;
-  wasdD: boolean;
-  wasdW: boolean;
-  wasdS: boolean;
-}> = {}): PanInputs {
+function makePanInputs(
+  overrides: Partial<{
+    leftDown: boolean;
+    rightDown: boolean;
+    upDown: boolean;
+    downDown: boolean;
+    wasdA: boolean;
+    wasdD: boolean;
+    wasdW: boolean;
+    wasdS: boolean;
+  }> = {},
+): PanInputs {
   const opts = {
     leftDown: false,
     rightDown: false,
@@ -96,10 +98,10 @@ function makePanInputs(overrides: Partial<{
   }
 
   const cursors = {
-    left:  key(opts.leftDown),
+    left: key(opts.leftDown),
     right: key(opts.rightDown),
-    up:    key(opts.upDown),
-    down:  key(opts.downDown),
+    up: key(opts.upDown),
+    down: key(opts.downDown),
   } as unknown as import('phaser').Types.Input.Keyboard.CursorKeys;
 
   const wasd = {
@@ -145,10 +147,9 @@ describe('isPointerOverHUD', () => {
       expect(isPointerOverHUD(HUD.STATS.x, HUD.STATS.y + HUD.STATS.h)).toBe(false);
     });
     it('returns true for point at (right-1, bottom-1) inside STATS', () => {
-      expect(isPointerOverHUD(
-        HUD.STATS.x + HUD.STATS.w - 1,
-        HUD.STATS.y + HUD.STATS.h - 1,
-      )).toBe(true);
+      expect(isPointerOverHUD(HUD.STATS.x + HUD.STATS.w - 1, HUD.STATS.y + HUD.STATS.h - 1)).toBe(
+        true,
+      );
     });
   });
 
@@ -190,7 +191,10 @@ describe('isPointerOverHUD', () => {
     }
 
     it('masks the colony-toggle zone ONLY when activeView === underground', () => {
-      const inside = [HUD.UNDERGROUND_COLONY_TOGGLE.x + 5, HUD.UNDERGROUND_COLONY_TOGGLE.y + 5] as const;
+      const inside = [
+        HUD.UNDERGROUND_COLONY_TOGGLE.x + 5,
+        HUD.UNDERGROUND_COLONY_TOGGLE.y + 5,
+      ] as const;
       // Underground view → the toggle is rendered → click zone is masked.
       expect(isPointerOverHUD(inside[0], inside[1], vs('underground'))).toBe(true);
       // Surface view → the toggle is invisible → masking it would create a
@@ -201,11 +205,13 @@ describe('isPointerOverHUD', () => {
     });
 
     it('returns false for a point above the colony-toggle button', () => {
-      expect(isPointerOverHUD(
-        HUD.UNDERGROUND_COLONY_TOGGLE.x + 5,
-        HUD.UNDERGROUND_COLONY_TOGGLE.y - 1,
-        vs('underground'),
-      )).toBe(false);
+      expect(
+        isPointerOverHUD(
+          HUD.UNDERGROUND_COLONY_TOGGLE.x + 5,
+          HUD.UNDERGROUND_COLONY_TOGGLE.y - 1,
+          vs('underground'),
+        ),
+      ).toBe(false);
     });
   });
 
@@ -243,10 +249,7 @@ describe('isPointerOverHUD', () => {
       expect(antActivityPanelState.visible).toBe(false);
       // Panel rect is safely outside every other HUD zone, so this is a
       // clean conditional-mask test.
-      expect(isPointerOverHUD(
-        ANT_ACTIVITY_PANEL.x + 5,
-        ANT_ACTIVITY_PANEL.y + 5,
-      )).toBe(false);
+      expect(isPointerOverHUD(ANT_ACTIVITY_PANEL.x + 5, ANT_ACTIVITY_PANEL.y + 5)).toBe(false);
     });
 
     it('masks the panel rect when panel is visible', async () => {
@@ -255,10 +258,7 @@ describe('isPointerOverHUD', () => {
       const { ANT_ACTIVITY_PANEL } = await import('../render/ant-activity.js');
       showAntActivityPanel();
       try {
-        expect(isPointerOverHUD(
-          ANT_ACTIVITY_PANEL.x + 5,
-          ANT_ACTIVITY_PANEL.y + 5,
-        )).toBe(true);
+        expect(isPointerOverHUD(ANT_ACTIVITY_PANEL.x + 5, ANT_ACTIVITY_PANEL.y + 5)).toBe(true);
       } finally {
         hideAntActivityPanel();
       }
@@ -274,11 +274,8 @@ describe('isPointerOverHUD', () => {
       // produces both a world action AND a dismissal. Masking on `visible`
       // alone forces the world handler to drop the click regardless of
       // listener order.
-      const {
-        showAntActivityPanel,
-        hideAntActivityPanel,
-        antActivityPanelState,
-      } = await import('../render/ant-activity-panel-state.js');
+      const { showAntActivityPanel, hideAntActivityPanel, antActivityPanelState } =
+        await import('../render/ant-activity-panel-state.js');
       showAntActivityPanel();
       try {
         expect(antActivityPanelState.visible).toBe(true);
@@ -313,10 +310,7 @@ describe('isPointerOverHUD', () => {
         expect(antActivityPanelState.visible).toBe(true);
         expect(antActivityPanelState.pendingHide).toBe(true);
         // Panel rect itself — masked.
-        expect(isPointerOverHUD(
-          ANT_ACTIVITY_PANEL.x + 5,
-          ANT_ACTIVITY_PANEL.y + 5,
-        )).toBe(true);
+        expect(isPointerOverHUD(ANT_ACTIVITY_PANEL.x + 5, ANT_ACTIVITY_PANEL.y + 5)).toBe(true);
         // Deep middle of the world map — must ALSO be masked.
         expect(isPointerOverHUD(400, 300)).toBe(true);
         // A point near a map edge — also masked.

--- a/src/input/camera-input.ts
+++ b/src/input/camera-input.ts
@@ -26,10 +26,7 @@
 // imported with `import type` only so this file can be tested without Phaser.
 
 import type * as Phaser from 'phaser';
-import {
-  HUD,
-  TILE_SIZE_PX,
-} from '../render/sprites.js';
+import { HUD, TILE_SIZE_PX } from '../render/sprites.js';
 import { antActivityPanelState } from '../render/ant-activity-panel-state.js';
 import {
   type ViewState,
@@ -165,12 +162,7 @@ export function isPointerOverHUD(px: number, py: number, viewState?: ViewState):
     zones.push(HUD.UNDERGROUND_COLONY_TOGGLE);
   }
   for (const zone of zones) {
-    if (
-      px >= zone.x &&
-      px < zone.x + zone.w &&
-      py >= zone.y &&
-      py < zone.y + zone.h
-    ) {
+    if (px >= zone.x && px < zone.x + zone.w && py >= zone.y && py < zone.y + zone.h) {
       return true;
     }
   }
@@ -222,9 +214,7 @@ function worldDimensions(viewState: ViewState): [number, number] {
 
 /** Return the active camera for the current view. */
 function activeCamera(viewState: ViewState): CameraState {
-  return viewState.activeView === 'surface'
-    ? viewState.surfaceCamera
-    : viewState.undergroundCamera;
+  return viewState.activeView === 'surface' ? viewState.surfaceCamera : viewState.undergroundCamera;
 }
 
 // ---------------------------------------------------------------------------
@@ -325,7 +315,11 @@ export interface DragState {
  * HUD-zone pointerdown and HUD-zone pointermove are ignored so a drag
  * starting inside a HUD widget never pans the camera.
  */
-export function registerDragPan(scene: Phaser.Scene, viewState: ViewState, isBlocked?: () => boolean): DragState {
+export function registerDragPan(
+  scene: Phaser.Scene,
+  viewState: ViewState,
+  isBlocked?: () => boolean,
+): DragState {
   const dragState: DragState = {
     isDragging: false,
     lastX: 0,
@@ -372,7 +366,10 @@ export function registerDragPan(scene: Phaser.Scene, viewState: ViewState, isBlo
   });
 
   scene.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
-    if (isBlocked?.()) { releaseDrag(); return; }
+    if (isBlocked?.()) {
+      releaseDrag();
+      return;
+    }
     if (!dragState.active) return;
     // Continue pan only while the originating trigger is still held.
     if (!isPanTriggerDown(pointer)) return;

--- a/src/input/surface-input.test.ts
+++ b/src/input/surface-input.test.ts
@@ -52,8 +52,18 @@ function makeViewState(
 ): ViewState {
   return {
     activeView: view,
-    surfaceCamera: { x: camX, y: camY, viewportWidth: VIEWPORT_WIDTH_TILES, viewportHeight: VIEWPORT_HEIGHT_TILES },
-    undergroundCamera: { x: camX, y: camY, viewportWidth: VIEWPORT_WIDTH_TILES, viewportHeight: VIEWPORT_HEIGHT_TILES },
+    surfaceCamera: {
+      x: camX,
+      y: camY,
+      viewportWidth: VIEWPORT_WIDTH_TILES,
+      viewportHeight: VIEWPORT_HEIGHT_TILES,
+    },
+    undergroundCamera: {
+      x: camX,
+      y: camY,
+      viewportWidth: VIEWPORT_WIDTH_TILES,
+      viewportHeight: VIEWPORT_HEIGHT_TILES,
+    },
     undergroundVisited: false,
     activeUndergroundColonyId: PLAYER_COLONY_ID,
     showPheromoneOverlay: true,
@@ -67,7 +77,12 @@ function makeViewState(
  * fractional camera here caused a 1-tile drift whenever the half-viewport was
  * fractional (e.g. VIEWPORT_HEIGHT_TILES=37 → vh/2 = 18.5).
  */
-function tileToScreen(tileX: number, tileY: number, camX: number, camY: number): { x: number; y: number } {
+function tileToScreen(
+  tileX: number,
+  tileY: number,
+  camX: number,
+  camY: number,
+): { x: number; y: number } {
   const left = Math.floor(camX - VIEWPORT_WIDTH_TILES / 2);
   const top = Math.floor(camY - VIEWPORT_HEIGHT_TILES / 2);
   const px = (tileX - left) * TILE_SIZE_PX;
@@ -76,15 +91,17 @@ function tileToScreen(tileX: number, tileY: number, camX: number, camY: number):
 }
 
 /** Build a minimal WorldState stub with given foodPiles, colonies, and commandQueue. */
-function makeWorld(overrides: {
-  tick?: number;
-  foodPiles?: WorldState['foodPiles'];
-  colonies?: WorldState['colonies'];
-  surfaceWidth?: number;
-  surfaceHeight?: number;
-  spider?: WorldState['spider'];
-  spiderPriorityColonyId?: WorldState['spiderPriorityColonyId'];
-} = {}): WorldState {
+function makeWorld(
+  overrides: {
+    tick?: number;
+    foodPiles?: WorldState['foodPiles'];
+    colonies?: WorldState['colonies'];
+    surfaceWidth?: number;
+    surfaceHeight?: number;
+    spider?: WorldState['spider'];
+    spiderPriorityColonyId?: WorldState['spiderPriorityColonyId'];
+  } = {},
+): WorldState {
   const sw = overrides.surfaceWidth ?? 128;
   const sh = overrides.surfaceHeight ?? 4;
   return {
@@ -92,7 +109,25 @@ function makeWorld(overrides: {
     rngState: 0,
     nextEntityId: 0,
     commandQueue: [] as SimCommand[],
-    ants: { posX: new Int32Array(0), posY: new Int32Array(0), colonyId: new Int32Array(0), task: new Int32Array(0), subTask: new Int32Array(0), speed: new Int32Array(0), foodCarrying: new Int32Array(0), starvationTimer: new Int32Array(0), age: new Int32Array(0), alive: new Int32Array(0), lifespan: new Int32Array(0), zone: new Int32Array(0), digTileX: new Int32Array(0), digTileY: new Int32Array(0), digTicksRemaining: new Int32Array(0), targetPosX: new Int32Array(0), targetPosY: new Int32Array(0) },
+    ants: {
+      posX: new Int32Array(0),
+      posY: new Int32Array(0),
+      colonyId: new Int32Array(0),
+      task: new Int32Array(0),
+      subTask: new Int32Array(0),
+      speed: new Int32Array(0),
+      foodCarrying: new Int32Array(0),
+      starvationTimer: new Int32Array(0),
+      age: new Int32Array(0),
+      alive: new Int32Array(0),
+      lifespan: new Int32Array(0),
+      zone: new Int32Array(0),
+      digTileX: new Int32Array(0),
+      digTileY: new Int32Array(0),
+      digTicksRemaining: new Int32Array(0),
+      targetPosX: new Int32Array(0),
+      targetPosY: new Int32Array(0),
+    },
     colonies: overrides.colonies ?? {},
     pheromoneGrids: {},
     surface: { data: new Uint8Array(sw * sh), width: sw, height: sh },
@@ -105,11 +140,13 @@ function makeWorld(overrides: {
 }
 
 /** Build a minimal colony record stub with an optional rally point and entrances. */
-function makeColony(overrides: {
-  colonyId?: ColonyId;
-  rallyPoint?: { tileX: number; tileY: number } | null;
-  entrances?: Array<{ surfaceTileX: number; surfaceTileY: number }>;
-} = {}) {
+function makeColony(
+  overrides: {
+    colonyId?: ColonyId;
+    rallyPoint?: { tileX: number; tileY: number } | null;
+    entrances?: Array<{ surfaceTileX: number; surfaceTileY: number }>;
+  } = {},
+) {
   return {
     colonyId: overrides.colonyId ?? (PLAYER_COLONY_ID as ColonyId),
     queenEntityId: 0,
@@ -141,7 +178,10 @@ function makeColony(overrides: {
 }
 
 /** A SurfaceInputState equivalent (the exported interface in surface-input.ts). */
-function makeState(pendingEntranceTileX: number | null = null, pendingEntranceTileY: number | null = null) {
+function makeState(
+  pendingEntranceTileX: number | null = null,
+  pendingEntranceTileY: number | null = null,
+) {
   return { pendingEntranceTileX, pendingEntranceTileY };
 }
 
@@ -153,17 +193,25 @@ describe('findFoodPileAt', () => {
   it('returns the pile at the exact tile coordinate', () => {
     const world = makeWorld({
       foodPiles: [
-        { foodPileId: 1, tileX: 10, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50},
-        { foodPileId: 2, tileX: 30, tileY: 40 , pickupsRemaining: 50, pickupsInitial: 50},
-        { foodPileId: 3, tileX: 50, tileY: 60 , pickupsRemaining: 50, pickupsInitial: 50},
+        { foodPileId: 1, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
+        { foodPileId: 2, tileX: 30, tileY: 40, pickupsRemaining: 50, pickupsInitial: 50 },
+        { foodPileId: 3, tileX: 50, tileY: 60, pickupsRemaining: 50, pickupsInitial: 50 },
       ],
     });
-    expect(findFoodPileAt(world, 30, 40)).toEqual({ foodPileId: 2, tileX: 30, tileY: 40 , pickupsRemaining: 50, pickupsInitial: 50});
+    expect(findFoodPileAt(world, 30, 40)).toEqual({
+      foodPileId: 2,
+      tileX: 30,
+      tileY: 40,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
   });
 
   it('returns null when no pile is at the given tile', () => {
     const world = makeWorld({
-      foodPiles: [{ foodPileId: 1, tileX: 10, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50}],
+      foodPiles: [
+        { foodPileId: 1, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
     });
     expect(findFoodPileAt(world, 11, 20)).toBeNull();
   });
@@ -176,8 +224,8 @@ describe('findFoodPileAt', () => {
   it('returns first match when multiple piles share coords (edge case)', () => {
     const world = makeWorld({
       foodPiles: [
-        { foodPileId: 1, tileX: 5, tileY: 5 , pickupsRemaining: 50, pickupsInitial: 50},
-        { foodPileId: 2, tileX: 5, tileY: 5 , pickupsRemaining: 50, pickupsInitial: 50},
+        { foodPileId: 1, tileX: 5, tileY: 5, pickupsRemaining: 50, pickupsInitial: 50 },
+        { foodPileId: 2, tileX: 5, tileY: 5, pickupsRemaining: 50, pickupsInitial: 50 },
       ],
     });
     const result = findFoodPileAt(world, 5, 5);
@@ -193,14 +241,22 @@ describe('handleSurfaceLeftClick — food pile mark', () => {
   it('pushes MarkFoodPileCommand for a pile at the clicked tile', () => {
     const world = makeWorld({
       tick: 5,
-      foodPiles: [{ foodPileId: 7, tileX: 10, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50}],
+      foodPiles: [
+        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
     });
     const vs = makeViewState('surface', 64, 64);
     const state = makeState();
     const { x, y } = tileToScreen(10, 20, 64, 64);
     handleSurfaceLeftClick(world, vs, x, y, state);
     expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; colonyId: number; tileX: number; tileY: number; issuedAtTick: number };
+    const cmd = world.commandQueue[0] as {
+      type: string;
+      colonyId: number;
+      tileX: number;
+      tileY: number;
+      issuedAtTick: number;
+    };
     expect(cmd.type).toBe('MarkFoodPile');
     expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
     expect(cmd.tileX).toBe(10);
@@ -209,7 +265,9 @@ describe('handleSurfaceLeftClick — food pile mark', () => {
   });
 
   it('pushes no command when no food pile exists at the clicked tile', () => {
-    const world = makeWorld({ foodPiles: [{ foodPileId: 1, tileX: 5, tileY: 5 , pickupsRemaining: 50, pickupsInitial: 50}] });
+    const world = makeWorld({
+      foodPiles: [{ foodPileId: 1, tileX: 5, tileY: 5, pickupsRemaining: 50, pickupsInitial: 50 }],
+    });
     const vs = makeViewState('surface', 64, 64);
     const state = makeState();
     const { x, y } = tileToScreen(6, 5, 64, 64);
@@ -218,7 +276,11 @@ describe('handleSurfaceLeftClick — food pile mark', () => {
   });
 
   it('is a no-op when activeView is underground', () => {
-    const world = makeWorld({ foodPiles: [{ foodPileId: 1, tileX: 10, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50}] });
+    const world = makeWorld({
+      foodPiles: [
+        { foodPileId: 1, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
+    });
     const vs = makeViewState('underground', 64, 64);
     const state = makeState();
     const { x, y } = tileToScreen(10, 20, 64, 64);
@@ -227,7 +289,11 @@ describe('handleSurfaceLeftClick — food pile mark', () => {
   });
 
   it('is a no-op when pointer is over HUD TRIANGLE zone', () => {
-    const world = makeWorld({ foodPiles: [{ foodPileId: 1, tileX: 10, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50}] });
+    const world = makeWorld({
+      foodPiles: [
+        { foodPileId: 1, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
+    });
     const vs = makeViewState('surface', 64, 64);
     const state = makeState();
     // HUD.TRIANGLE zone — use a point guaranteed inside it.
@@ -239,7 +305,9 @@ describe('handleSurfaceLeftClick — food pile mark', () => {
 
   it('is a no-op while panInputState.spaceHeld is true (Space+left-drag is pan, not world action)', () => {
     const world = makeWorld({
-      foodPiles: [{ foodPileId: 7, tileX: 10, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50}],
+      foodPiles: [
+        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
     });
     const vs = makeViewState('surface', 64, 64);
     const state = makeState();
@@ -251,7 +319,9 @@ describe('handleSurfaceLeftClick — food pile mark', () => {
 
   it('is a no-op while panInputState.isPanning is true (mid-pan left-click is pan continuation)', () => {
     const world = makeWorld({
-      foodPiles: [{ foodPileId: 7, tileX: 10, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50}],
+      foodPiles: [
+        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
     });
     const vs = makeViewState('surface', 64, 64);
     const state = makeState();
@@ -295,7 +365,9 @@ describe('handleSurfaceLeftClick — ant-activity popup dismissal must not fall 
       await import('../render/ant-activity-panel-state.js');
     const world = makeWorld({
       tick: 5,
-      foodPiles: [{ foodPileId: 7, tileX: 10, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50}],
+      foodPiles: [
+        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
     });
     const vs = makeViewState('surface', 64, 64);
     const state = makeState();
@@ -364,7 +436,9 @@ describe('handleSurfaceLeftClick — ant-activity popup dismissal must not fall 
       await import('../render/ant-activity-panel-state.js');
     const world = makeWorld({
       tick: 5,
-      foodPiles: [{ foodPileId: 7, tileX: 10, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50}],
+      foodPiles: [
+        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
     });
     const vs = makeViewState('surface', 64, 64);
     const state = makeState();
@@ -445,7 +519,9 @@ describe('handleSurfaceLeftClick — ant-activity popup dismissal must not fall 
       await import('../render/ant-activity-panel-state.js');
     const world = makeWorld({
       tick: 5,
-      foodPiles: [{ foodPileId: 7, tileX: 10, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50}],
+      foodPiles: [
+        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
     });
     const vs = makeViewState('surface', 64, 64);
     const state = makeState();
@@ -477,7 +553,13 @@ describe('handleSurfaceLeftClick — entrance designation confirmation', () => {
     const { x, y } = tileToScreen(15, 30, 64, 64);
     handleSurfaceLeftClick(world, vs, x, y, state);
     expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; colonyId: number; surfaceTileX: number; surfaceTileY: number; issuedAtTick: number };
+    const cmd = world.commandQueue[0] as {
+      type: string;
+      colonyId: number;
+      surfaceTileX: number;
+      surfaceTileY: number;
+      issuedAtTick: number;
+    };
     expect(cmd.type).toBe('DesignateEntrance');
     expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
     expect(cmd.surfaceTileX).toBe(15);
@@ -515,7 +597,9 @@ describe('handleSurfaceLeftClick — entrance designation confirmation', () => {
 
   it('falls through to food-pile check when tileX does not match pending', () => {
     const world = makeWorld({
-      foodPiles: [{ foodPileId: 99, tileX: 20, tileY: 30 , pickupsRemaining: 50, pickupsInitial: 50}],
+      foodPiles: [
+        { foodPileId: 99, tileX: 20, tileY: 30, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
     });
     const vs = makeViewState('surface', 64, 64);
     const state = makeState(15, 30); // pending entrance at (15, 30)
@@ -588,7 +672,9 @@ describe('handleSurfaceRightClick', () => {
     const world = makeWorld({
       surfaceWidth: 128,
       surfaceHeight: 128,
-      foodPiles: [{ foodPileId: 1, tileX: 40, tileY: 50 , pickupsRemaining: 50, pickupsInitial: 50}],
+      foodPiles: [
+        { foodPileId: 1, tileX: 40, tileY: 50, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
     });
     const vs = makeViewState('surface', 64, 64);
     const state = makeState();
@@ -617,7 +703,9 @@ describe('handleSurfaceRightClick', () => {
     const world = makeWorld({
       surfaceWidth: 128,
       surfaceHeight: 128,
-      foodPiles: [{ foodPileId: 1, tileX: 40, tileY: 50 , pickupsRemaining: 50, pickupsInitial: 50}],
+      foodPiles: [
+        { foodPileId: 1, tileX: 40, tileY: 50, pickupsRemaining: 50, pickupsInitial: 50 },
+      ],
     });
     const vs = makeViewState('surface', 64, 64);
     const state = makeState(10, 20); // prior valid preview
@@ -641,8 +729,9 @@ describe('isEmptySurfaceTile', () => {
 
   it('returns false when tile has a food pile', () => {
     const world = makeWorld({
-      surfaceWidth: 128, surfaceHeight: 4,
-      foodPiles: [{ foodPileId: 1, tileX: 10, tileY: 1 , pickupsRemaining: 50, pickupsInitial: 50}],
+      surfaceWidth: 128,
+      surfaceHeight: 4,
+      foodPiles: [{ foodPileId: 1, tileX: 10, tileY: 1, pickupsRemaining: 50, pickupsInitial: 50 }],
     });
     expect(isEmptySurfaceTile(world, 10, 1)).toBe(false);
   });
@@ -650,7 +739,8 @@ describe('isEmptySurfaceTile', () => {
   it('returns false when tile is a colony entrance (plain-object colonies check)', () => {
     const colony = makeColony({ entrances: [{ surfaceTileX: 20, surfaceTileY: 0 }] });
     const world = makeWorld({
-      surfaceWidth: 128, surfaceHeight: 4,
+      surfaceWidth: 128,
+      surfaceHeight: 4,
       colonies: { [PLAYER_COLONY_ID]: colony } as unknown as WorldState['colonies'],
     });
     expect(isEmptySurfaceTile(world, 20, 0)).toBe(false);
@@ -680,7 +770,13 @@ describe('surface-input rally-point fall-through (SURF-04)', () => {
     const { x, y } = tileToScreen(10, 1, 64, 2);
     handleSurfaceLeftClick(world, vs, x, y, state);
     expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; colonyId: number; tileX: number; tileY: number; issuedAtTick: number };
+    const cmd = world.commandQueue[0] as {
+      type: string;
+      colonyId: number;
+      tileX: number;
+      tileY: number;
+      issuedAtTick: number;
+    };
     expect(cmd.type).toBe('SetRallyPoint');
     expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
     expect(cmd.tileX).toBe(10);
@@ -701,8 +797,9 @@ describe('surface-input rally-point fall-through (SURF-04)', () => {
   it('does NOT push SetRallyPoint when tile has a food pile', () => {
     const world = makeWorld({
       tick: 0,
-      surfaceWidth: 128, surfaceHeight: 4,
-      foodPiles: [{ foodPileId: 1, tileX: 10, tileY: 1 , pickupsRemaining: 50, pickupsInitial: 50}],
+      surfaceWidth: 128,
+      surfaceHeight: 4,
+      foodPiles: [{ foodPileId: 1, tileX: 10, tileY: 1, pickupsRemaining: 50, pickupsInitial: 50 }],
     });
     const vs = makeViewState('surface', 64, 2);
     const state = makeState();
@@ -718,7 +815,8 @@ describe('surface-input rally-point fall-through (SURF-04)', () => {
     const colony = makeColony({ entrances: [{ surfaceTileX: 10, surfaceTileY: 0 }] });
     const world = makeWorld({
       tick: 0,
-      surfaceWidth: 128, surfaceHeight: 4,
+      surfaceWidth: 128,
+      surfaceHeight: 4,
       colonies: { [PLAYER_COLONY_ID]: colony } as unknown as WorldState['colonies'],
     });
     const vs = makeViewState('surface', 64, 2);
@@ -732,7 +830,8 @@ describe('surface-input rally-point fall-through (SURF-04)', () => {
     const colony = makeColony({ rallyPoint: { tileX: 15, tileY: 1 } });
     const world = makeWorld({
       tick: 7,
-      surfaceWidth: 128, surfaceHeight: 4,
+      surfaceWidth: 128,
+      surfaceHeight: 4,
       colonies: { [PLAYER_COLONY_ID]: colony } as unknown as WorldState['colonies'],
     });
     const vs = makeViewState('surface', 64, 2);
@@ -749,7 +848,8 @@ describe('surface-input rally-point fall-through (SURF-04)', () => {
   it('right-click elsewhere does NOT clear rally (sets entrance preview instead)', () => {
     const colony = makeColony({ rallyPoint: { tileX: 15, tileY: 1 } });
     const world = makeWorld({
-      surfaceWidth: 128, surfaceHeight: 4,
+      surfaceWidth: 128,
+      surfaceHeight: 4,
       colonies: { [PLAYER_COLONY_ID]: colony } as unknown as WorldState['colonies'],
     });
     const vs = makeViewState('surface', 64, 2);
@@ -778,7 +878,13 @@ describe('surface-input rally-point fall-through (SURF-04)', () => {
     const world = makeWorld({ tick: 3 });
     handleSetRallyPoint(world, 7, 2, PLAYER_COLONY_ID as ColonyId);
     expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; colonyId: number; tileX: number; tileY: number; issuedAtTick: number };
+    const cmd = world.commandQueue[0] as {
+      type: string;
+      colonyId: number;
+      tileX: number;
+      tileY: number;
+      issuedAtTick: number;
+    };
     expect(cmd.type).toBe('SetRallyPoint');
     expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
     expect(cmd.tileX).toBe(7);
@@ -798,7 +904,8 @@ describe('isForeignColonyEntrance', () => {
       entrances: [{ surfaceTileX: 100, surfaceTileY: 0 }],
     });
     const world = makeWorld({
-      surfaceWidth: 128, surfaceHeight: 4,
+      surfaceWidth: 128,
+      surfaceHeight: 4,
       colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
     });
     expect(isForeignColonyEntrance(world, 100, 0, PLAYER_COLONY_ID as ColonyId)).toBe(true);
@@ -807,7 +914,8 @@ describe('isForeignColonyEntrance', () => {
   it('returns false for the own-colony entrance tile (preserves designation flow)', () => {
     const own = makeColony({ entrances: [{ surfaceTileX: 20, surfaceTileY: 0 }] });
     const world = makeWorld({
-      surfaceWidth: 128, surfaceHeight: 4,
+      surfaceWidth: 128,
+      surfaceHeight: 4,
       colonies: { [PLAYER_COLONY_ID]: own } as unknown as WorldState['colonies'],
     });
     expect(isForeignColonyEntrance(world, 20, 0, PLAYER_COLONY_ID as ColonyId)).toBe(false);
@@ -819,7 +927,8 @@ describe('isForeignColonyEntrance', () => {
       entrances: [{ surfaceTileX: 100, surfaceTileY: 0 }],
     });
     const world = makeWorld({
-      surfaceWidth: 128, surfaceHeight: 4,
+      surfaceWidth: 128,
+      surfaceHeight: 4,
       colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
     });
     expect(isForeignColonyEntrance(world, 50, 1, PLAYER_COLONY_ID as ColonyId)).toBe(false);
@@ -831,7 +940,8 @@ describe('isForeignColonyEntrance', () => {
       entrances: [{ surfaceTileX: 100, surfaceTileY: 0 }],
     });
     const world = makeWorld({
-      surfaceWidth: 128, surfaceHeight: 4,
+      surfaceWidth: 128,
+      surfaceHeight: 4,
       colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
     });
     expect(isForeignColonyEntrance(world, -1, 0, PLAYER_COLONY_ID as ColonyId)).toBe(false);
@@ -847,7 +957,8 @@ describe('handleSurfaceLeftClick — rally on enemy entrance (issue #14)', () =>
     });
     const world = makeWorld({
       tick: 7,
-      surfaceWidth: 128, surfaceHeight: 4,
+      surfaceWidth: 128,
+      surfaceHeight: 4,
       colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
     });
     const vs = makeViewState('surface', 64, 2);
@@ -855,7 +966,13 @@ describe('handleSurfaceLeftClick — rally on enemy entrance (issue #14)', () =>
     const { x, y } = tileToScreen(100, 0, 64, 2);
     handleSurfaceLeftClick(world, vs, x, y, state);
     expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; colonyId: number; tileX: number; tileY: number; issuedAtTick: number };
+    const cmd = world.commandQueue[0] as {
+      type: string;
+      colonyId: number;
+      tileX: number;
+      tileY: number;
+      issuedAtTick: number;
+    };
     expect(cmd.type).toBe('SetRallyPoint');
     expect(cmd.colonyId).toBe(PLAYER_COLONY_ID); // rally is the PLAYER's, not the enemy's
     expect(cmd.tileX).toBe(100);
@@ -866,7 +983,8 @@ describe('handleSurfaceLeftClick — rally on enemy entrance (issue #14)', () =>
   it('left-click on own entrance is still a no-op (entrance designation right-click flow undisturbed)', () => {
     const own = makeColony({ entrances: [{ surfaceTileX: 20, surfaceTileY: 0 }] });
     const world = makeWorld({
-      surfaceWidth: 128, surfaceHeight: 4,
+      surfaceWidth: 128,
+      surfaceHeight: 4,
       colonies: { [PLAYER_COLONY_ID]: own } as unknown as WorldState['colonies'],
     });
     const vs = makeViewState('surface', 64, 2);
@@ -932,12 +1050,12 @@ describe('handleSurfaceRightClick — spider priority toggle (S7/D1)', () => {
   const FP_ONE_VAL = 256;
   const SPIDER_TILE_X = 10;
   const SPIDER_TILE_Y = 10;
-  const CAMERA_LEFT = Math.floor(CAM_X - VIEWPORT_WIDTH_TILES  / 2); // 39
-  const CAMERA_TOP  = Math.floor(CAM_Y - VIEWPORT_HEIGHT_TILES / 2); // 13
+  const CAMERA_LEFT = Math.floor(CAM_X - VIEWPORT_WIDTH_TILES / 2); // 39
+  const CAMERA_TOP = Math.floor(CAM_Y - VIEWPORT_HEIGHT_TILES / 2); // 13
   const SPIDER_SCR_X = (SPIDER_TILE_X - CAMERA_LEFT) * TILE_SIZE_PX; // -464
-  const SPIDER_SCR_Y = (SPIDER_TILE_Y - CAMERA_TOP)  * TILE_SIZE_PX; // -48
+  const SPIDER_SCR_Y = (SPIDER_TILE_Y - CAMERA_TOP) * TILE_SIZE_PX; // -48
   // Sprite half: hit box for stationary spider (prevWorld=null)
-  const HIT_HALF_W = SPIDER_SPRITE_WIDTH  / 2; // 24
+  const HIT_HALF_W = SPIDER_SPRITE_WIDTH / 2; // 24
   const HIT_HALF_H = SPIDER_SPRITE_HEIGHT / 2; // 24
 
   function makeSpider() {
@@ -1090,7 +1208,10 @@ describe('handleSurfaceRightClick — spider priority toggle (S7/D1)', () => {
     const prevWorld = makeWorld({
       surfaceWidth: 128,
       surfaceHeight: 64,
-      spider: { posX: (SPIDER_TILE_X - 1) * FP_ONE_VAL, posY: SPIDER_TILE_Y * FP_ONE_VAL } as WorldState['spider'],
+      spider: {
+        posX: (SPIDER_TILE_X - 1) * FP_ONE_VAL,
+        posY: SPIDER_TILE_Y * FP_ONE_VAL,
+      } as WorldState['spider'],
     });
     const vs = makeViewState('surface', CAM_X, CAM_Y);
     const state = makeState();
@@ -1110,7 +1231,10 @@ describe('handleSurfaceRightClick — spider priority toggle (S7/D1)', () => {
     const prevWorld = makeWorld({
       surfaceWidth: 128,
       surfaceHeight: 64,
-      spider: { posX: (SPIDER_TILE_X - 1) * FP_ONE_VAL, posY: SPIDER_TILE_Y * FP_ONE_VAL } as WorldState['spider'],
+      spider: {
+        posX: (SPIDER_TILE_X - 1) * FP_ONE_VAL,
+        posY: SPIDER_TILE_Y * FP_ONE_VAL,
+      } as WorldState['spider'],
     });
     const vs = makeViewState('surface', CAM_X, CAM_Y);
     const state = makeState();
@@ -1127,7 +1251,9 @@ describe('handleSurfaceRightClick — spider priority toggle (S7/D1)', () => {
       spider: makeSpider(),
       spiderPriorityColonyId: null,
       colonies: {
-        [PLAYER_COLONY_ID]: makeColony({ rallyPoint: { tileX: SPIDER_TILE_X, tileY: SPIDER_TILE_Y } }),
+        [PLAYER_COLONY_ID]: makeColony({
+          rallyPoint: { tileX: SPIDER_TILE_X, tileY: SPIDER_TILE_Y },
+        }),
       } as unknown as WorldState['colonies'],
     });
     const vs = makeViewState('surface', CAM_X, CAM_Y);

--- a/src/input/surface-input.ts
+++ b/src/input/surface-input.ts
@@ -332,23 +332,29 @@ export function handleSurfaceRightClick(
   // registers. When prevWorld is null (stationary or unavailable) the box is exactly the
   // 48×48px sprite; when the spider moved it expands by one tile in the movement direction.
   if (world.spider !== null) {
-    const camLeft = Math.floor(viewState.surfaceCamera.x - viewState.surfaceCamera.viewportWidth  / 2);
-    const camTop  = Math.floor(viewState.surfaceCamera.y - viewState.surfaceCamera.viewportHeight / 2);
+    const camLeft = Math.floor(
+      viewState.surfaceCamera.x - viewState.surfaceCamera.viewportWidth / 2,
+    );
+    const camTop = Math.floor(
+      viewState.surfaceCamera.y - viewState.surfaceCamera.viewportHeight / 2,
+    );
     const currScrX = (world.spider.posX >> FP_SHIFT) * TILE_SIZE_PX - camLeft * TILE_SIZE_PX;
-    const currScrY = (world.spider.posY >> FP_SHIFT) * TILE_SIZE_PX - camTop  * TILE_SIZE_PX;
-    const prevScrX = (prevWorld?.spider != null)
-      ? (prevWorld.spider.posX >> FP_SHIFT) * TILE_SIZE_PX - camLeft * TILE_SIZE_PX
-      : currScrX;
-    const prevScrY = (prevWorld?.spider != null)
-      ? (prevWorld.spider.posY >> FP_SHIFT) * TILE_SIZE_PX - camTop  * TILE_SIZE_PX
-      : currScrY;
-    const halfW = SPIDER_SPRITE_WIDTH  / 2;
+    const currScrY = (world.spider.posY >> FP_SHIFT) * TILE_SIZE_PX - camTop * TILE_SIZE_PX;
+    const prevScrX =
+      prevWorld?.spider != null
+        ? (prevWorld.spider.posX >> FP_SHIFT) * TILE_SIZE_PX - camLeft * TILE_SIZE_PX
+        : currScrX;
+    const prevScrY =
+      prevWorld?.spider != null
+        ? (prevWorld.spider.posY >> FP_SHIFT) * TILE_SIZE_PX - camTop * TILE_SIZE_PX
+        : currScrY;
+    const halfW = SPIDER_SPRITE_WIDTH / 2;
     const halfH = SPIDER_SPRITE_HEIGHT / 2;
     if (
       screenX >= Math.min(currScrX, prevScrX) - halfW &&
-      screenX <  Math.max(currScrX, prevScrX) + halfW &&
+      screenX < Math.max(currScrX, prevScrX) + halfW &&
       screenY >= Math.min(currScrY, prevScrY) - halfH &&
-      screenY <  Math.max(currScrY, prevScrY) + halfH
+      screenY < Math.max(currScrY, prevScrY) + halfH
     ) {
       state.pendingEntranceTileX = null;
       state.pendingEntranceTileY = null;
@@ -364,7 +370,7 @@ export function handleSurfaceRightClick(
   }
 
   // Rally-point clear: right-click on the current rally point tile (SURF-04)
-  const playerColony = world.colonies[playerColonyId];  // plain-object bracket access (ADR-0006)
+  const playerColony = world.colonies[playerColonyId]; // plain-object bracket access (ADR-0006)
   if (playerColony !== undefined && playerColony.rallyPoint !== null) {
     if (playerColony.rallyPoint.tileX === tileX && playerColony.rallyPoint.tileY === tileY) {
       const cmd: ClearRallyPointCommand = {
@@ -426,7 +432,15 @@ export function registerSurfaceInput(
       handleSurfaceLeftClick(world, viewState, pointer.x, pointer.y, state);
     } else if (pointer.rightButtonDown()) {
       const prevWorld = getPrevWorld?.() ?? null;
-      handleSurfaceRightClick(world, viewState, pointer.x, pointer.y, state, PLAYER_COLONY_ID, prevWorld);
+      handleSurfaceRightClick(
+        world,
+        viewState,
+        pointer.x,
+        pointer.y,
+        state,
+        PLAYER_COLONY_ID,
+        prevWorld,
+      );
     }
   });
   return state;

--- a/src/input/underground-input.test.ts
+++ b/src/input/underground-input.test.ts
@@ -31,10 +31,7 @@ import {
 import { panInputState, resetPanInputStateForTests } from './camera-input.js';
 import { UndergroundTileState, ugSet, createUndergroundGrid } from '../sim/terrain.js';
 import type { WorldState } from '../sim/types.js';
-import {
-  LEGACY_SIM_VERSION,
-  SIM_VERSION_V5_CHAMBER_ON_MARKED,
-} from '../sim/types.js';
+import { LEGACY_SIM_VERSION, SIM_VERSION_V5_CHAMBER_ON_MARKED } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
 import { VIEWPORT_WIDTH_TILES, VIEWPORT_HEIGHT_TILES } from '../render/camera.js';
 import { HUD, TILE_SIZE_PX } from '../render/sprites.js';
@@ -53,8 +50,18 @@ function makeViewState(
 ): ViewState {
   return {
     activeView: view,
-    surfaceCamera: { x: camX, y: camY, viewportWidth: VIEWPORT_WIDTH_TILES, viewportHeight: VIEWPORT_HEIGHT_TILES },
-    undergroundCamera: { x: camX, y: camY, viewportWidth: VIEWPORT_WIDTH_TILES, viewportHeight: VIEWPORT_HEIGHT_TILES },
+    surfaceCamera: {
+      x: camX,
+      y: camY,
+      viewportWidth: VIEWPORT_WIDTH_TILES,
+      viewportHeight: VIEWPORT_HEIGHT_TILES,
+    },
+    undergroundCamera: {
+      x: camX,
+      y: camY,
+      viewportWidth: VIEWPORT_WIDTH_TILES,
+      viewportHeight: VIEWPORT_HEIGHT_TILES,
+    },
     undergroundVisited: true,
     activeUndergroundColonyId: PLAYER_COLONY_ID,
     showPheromoneOverlay: true,
@@ -66,7 +73,12 @@ function makeViewState(
  * Mirrors the renderer's integer-tile snap so tests hit the pixel the player
  * sees the tile at.
  */
-function tileToScreen(tileX: number, tileY: number, camX: number, camY: number): { x: number; y: number } {
+function tileToScreen(
+  tileX: number,
+  tileY: number,
+  camX: number,
+  camY: number,
+): { x: number; y: number } {
   const left = Math.floor(camX - VIEWPORT_WIDTH_TILES / 2);
   const top = Math.floor(camY - VIEWPORT_HEIGHT_TILES / 2);
   const px = (tileX - left) * TILE_SIZE_PX;
@@ -78,11 +90,13 @@ function tileToScreen(tileX: number, tileY: number, camX: number, camY: number):
  * Build a WorldState stub with a single underground grid for PLAYER_COLONY_ID.
  * gridWidth/gridHeight default to 20x20 for test convenience.
  */
-function makeWorld(overrides: {
-  tick?: number;
-  gridWidth?: number;
-  gridHeight?: number;
-} = {}): WorldState {
+function makeWorld(
+  overrides: {
+    tick?: number;
+    gridWidth?: number;
+    gridHeight?: number;
+  } = {},
+): WorldState {
   const w = overrides.gridWidth ?? 20;
   const h = overrides.gridHeight ?? 20;
   const grid = createUndergroundGrid(w, h);
@@ -94,7 +108,25 @@ function makeWorld(overrides: {
     rngState: 0,
     nextEntityId: 0,
     commandQueue: [] as SimCommand[],
-    ants: { posX: new Int32Array(0), posY: new Int32Array(0), colonyId: new Int32Array(0), task: new Int32Array(0), subTask: new Int32Array(0), speed: new Int32Array(0), foodCarrying: new Int32Array(0), starvationTimer: new Int32Array(0), age: new Int32Array(0), alive: new Int32Array(0), lifespan: new Int32Array(0), zone: new Int32Array(0), digTileX: new Int32Array(0), digTileY: new Int32Array(0), digTicksRemaining: new Int32Array(0), targetPosX: new Int32Array(0), targetPosY: new Int32Array(0) },
+    ants: {
+      posX: new Int32Array(0),
+      posY: new Int32Array(0),
+      colonyId: new Int32Array(0),
+      task: new Int32Array(0),
+      subTask: new Int32Array(0),
+      speed: new Int32Array(0),
+      foodCarrying: new Int32Array(0),
+      starvationTimer: new Int32Array(0),
+      age: new Int32Array(0),
+      alive: new Int32Array(0),
+      lifespan: new Int32Array(0),
+      zone: new Int32Array(0),
+      digTileX: new Int32Array(0),
+      digTileY: new Int32Array(0),
+      digTicksRemaining: new Int32Array(0),
+      targetPosX: new Int32Array(0),
+      targetPosY: new Int32Array(0),
+    },
     colonies: {},
     pheromoneGrids: {},
     surface: { data: new Uint8Array(0), width: 0, height: 0 },
@@ -208,7 +240,13 @@ describe('handleUndergroundLeftClick', () => {
     const { x, y } = tileToScreen(5, 10, 64, 32);
     handleUndergroundLeftClick(world, vs, x, y, state);
     expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; colonyId: number; tileX: number; tileY: number; issuedAtTick: number };
+    const cmd = world.commandQueue[0] as {
+      type: string;
+      colonyId: number;
+      tileX: number;
+      tileY: number;
+      issuedAtTick: number;
+    };
     expect(cmd.type).toBe('MarkDigTile');
     expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
     expect(cmd.tileX).toBe(5);
@@ -749,7 +787,13 @@ describe('handleUndergroundRightClick', () => {
     const { x, y } = tileToScreen(5, 10, 64, 32);
     handleUndergroundRightClick(world, vs, x, y);
     expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; colonyId: number; tileX: number; tileY: number; issuedAtTick: number };
+    const cmd = world.commandQueue[0] as {
+      type: string;
+      colonyId: number;
+      tileX: number;
+      tileY: number;
+      issuedAtTick: number;
+    };
     expect(cmd.type).toBe('CancelDigMark');
     expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
     expect(cmd.tileX).toBe(5);
@@ -956,7 +1000,6 @@ describe('handleUndergroundRightClick', () => {
     expect(contextMenuState.pendingShow).toBe(false);
     expect(world.commandQueue).toHaveLength(0);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -1000,7 +1043,11 @@ describe('resetUndergroundInputState', () => {
 
   it('restart simulation: a post-reset drag does not inherit the old debounce', () => {
     // Starting state after restart — no prior drag, no prior tile mark.
-    const state: UndergroundInputState = { isDragging: true, lastMarkedTileX: 5, lastMarkedTileY: 5 };
+    const state: UndergroundInputState = {
+      isDragging: true,
+      lastMarkedTileX: 5,
+      lastMarkedTileY: 5,
+    };
     resetUndergroundInputState(state);
     // After reset: a pointerdown on tile (5,5) in the new session must mark
     // it, because lastMarkedTile was cleared. handleUndergroundLeftClick
@@ -1028,8 +1075,18 @@ describe('underground-input read-only when activeUndergroundColonyId !== PLAYER_
   function makeEnemyView(): ViewState {
     return {
       activeView: 'underground',
-      surfaceCamera: { x: 64, y: 32, viewportWidth: VIEWPORT_WIDTH_TILES, viewportHeight: VIEWPORT_HEIGHT_TILES },
-      undergroundCamera: { x: 64, y: 32, viewportWidth: VIEWPORT_WIDTH_TILES, viewportHeight: VIEWPORT_HEIGHT_TILES },
+      surfaceCamera: {
+        x: 64,
+        y: 32,
+        viewportWidth: VIEWPORT_WIDTH_TILES,
+        viewportHeight: VIEWPORT_HEIGHT_TILES,
+      },
+      undergroundCamera: {
+        x: 64,
+        y: 32,
+        viewportWidth: VIEWPORT_WIDTH_TILES,
+        viewportHeight: VIEWPORT_HEIGHT_TILES,
+      },
       undergroundVisited: true,
       activeUndergroundColonyId: ENEMY_COLONY_ID,
       showPheromoneOverlay: true,

--- a/src/input/underground-input.ts
+++ b/src/input/underground-input.ts
@@ -81,15 +81,20 @@ export function resetUndergroundInputState(state: UndergroundInputState): void {
  *
  * Returns false if the undergroundGrid for colonyId does not exist.
  */
-export function isTunnelEnd(world: WorldState, tileX: number, tileY: number, colonyId: number): boolean {
+export function isTunnelEnd(
+  world: WorldState,
+  tileX: number,
+  tileY: number,
+  colonyId: number,
+): boolean {
   const grid = world.undergroundGrids[colonyId];
   if (!grid) return false;
   if (ugGet(grid, tileX, tileY) !== UndergroundTileState.Open) return false;
   const neighbors: Array<[number, number]> = [
-    [tileX, tileY - 1],  // N
-    [tileX + 1, tileY],  // E
-    [tileX, tileY + 1],  // S
-    [tileX - 1, tileY],  // W
+    [tileX, tileY - 1], // N
+    [tileX + 1, tileY], // E
+    [tileX, tileY + 1], // S
+    [tileX - 1, tileY], // W
   ];
   for (const [nx, ny] of neighbors) {
     if (nx < 0 || ny < 0 || nx >= grid.width || ny >= grid.height) continue;
@@ -234,7 +239,10 @@ export function handleUndergroundDrag(
   state: UndergroundInputState,
 ): void {
   if (!state.isDragging) return;
-  if (viewState.activeView !== 'underground') { state.isDragging = false; return; }
+  if (viewState.activeView !== 'underground') {
+    state.isDragging = false;
+    return;
+  }
   // Issue #14: same read-only guard as handleUndergroundLeftClick. If the
   // player flipped to the enemy view mid-drag (X keybind), abort the stroke
   // so it can't write through to the player's grid silently.
@@ -246,7 +254,10 @@ export function handleUndergroundDrag(
   // Pan-mode guard: if the player pressed Space mid-drag, treat it as a
   // clean cancel of the excavation drag so further pointer movement goes
   // through the pan handler exclusively.
-  if (panInputState.spaceHeld || panInputState.isPanning) { state.isDragging = false; return; }
+  if (panInputState.spaceHeld || panInputState.isPanning) {
+    state.isDragging = false;
+    return;
+  }
   const { tileX, tileY } = screenToTile(screenX, screenY, viewState.undergroundCamera);
   // Debounce: same tile as last emission → no work.
   if (tileX === state.lastMarkedTileX && tileY === state.lastMarkedTileY) return;
@@ -274,7 +285,10 @@ export function handleUndergroundDrag(
       return;
     }
     const tileStateSingle = ugGet(grid, x1, y1);
-    if (tileStateSingle === UndergroundTileState.Solid || tileStateSingle === UndergroundTileState.Open) {
+    if (
+      tileStateSingle === UndergroundTileState.Solid ||
+      tileStateSingle === UndergroundTileState.Open
+    ) {
       const cmd: MarkDigTileCommand = {
         type: 'MarkDigTile',
         colonyId: PLAYER_COLONY_ID,

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,9 +101,9 @@ export function mount(target: HTMLElement, options?: MountOptions): MountedGame 
   // assetsBase normalization so both env-var-derived options share the same
   // empty-string convention.
   const playtraceEndpointRaw =
-    options?.playtraceEndpoint
-    ?? (import.meta.env.VITE_PLAYTRACE_ENDPOINT as string | undefined)
-    ?? '';
+    options?.playtraceEndpoint ??
+    (import.meta.env.VITE_PLAYTRACE_ENDPOINT as string | undefined) ??
+    '';
   const playtraceEndpoint = playtraceEndpointRaw.trim();
 
   const config: Phaser.Types.Core.GameConfig = {

--- a/src/platform/debug-snapshot.test.ts
+++ b/src/platform/debug-snapshot.test.ts
@@ -20,17 +20,18 @@ import { createWorldState, allocateEntityId } from '../sim/types.js';
 import { createColonyRecord } from '../sim/colony/colony-store.js';
 import { initAnt } from '../sim/ant/ant-store.js';
 import {
-  AntTask, ChamberType, DiggingSubState, FightingSubState,
-  ForagingSubState, NursingSubState, PheromoneType,
+  AntTask,
+  ChamberType,
+  DiggingSubState,
+  FightingSubState,
+  ForagingSubState,
+  NursingSubState,
+  PheromoneType,
 } from '../sim/enums.js';
 import { Zone } from '../sim/terrain.js';
 import { FP_SHIFT } from '../sim/fixed.js';
-import {
-  createPheromoneGrid, phSet, pheromoneGridKey,
-} from '../sim/pheromone/pheromone-store.js';
-import {
-  SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT, FOOD_TRAIL_DEPOSIT,
-} from '../sim/constants.js';
+import { createPheromoneGrid, phSet, pheromoneGridKey } from '../sim/pheromone/pheromone-store.js';
+import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT, FOOD_TRAIL_DEPOSIT } from '../sim/constants.js';
 
 const COLONY_ID = 1;
 const OTHER_COLONY_ID = 2;
@@ -46,12 +47,14 @@ function setupSurfaceGrid(world: ReturnType<typeof createWorldState>, colonyId: 
 function setupWorldWithColony(colonyId: number) {
   const world = createWorldState(42, MAX_TEST_ENTITIES);
   const colony = createColonyRecord(colonyId, allocateEntityId(world));
-  colony.entrances = [{
-    entranceId: allocateEntityId(world),
-    surfaceTileX: 0,
-    surfaceTileY: 0,
-    isOpen: true,
-  }];
+  colony.entrances = [
+    {
+      entranceId: allocateEntityId(world),
+      surfaceTileX: 0,
+      surfaceTileY: 0,
+      isOpen: true,
+    },
+  ];
   colony.rallyPoint = null;
   colony.digFlowFieldDirty = false;
   world.colonies[colonyId] = colony;
@@ -87,7 +90,7 @@ describe('buildAntTrace — currentGridColonyId (Phase 09.1-05)', () => {
     // expose BOTH so a reader can see at-a-glance which ants are inside a
     // foreign grid.
     const PLAYER = 0;
-    const ENEMY  = 1;
+    const ENEMY = 1;
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     for (const cid of [PLAYER, ENEMY]) {
       const c = createColonyRecord(cid, -1);
@@ -314,7 +317,13 @@ describe('buildAntTrace — movement source inference', () => {
   it('SearchingFood + food pile within scent radius → "scent"', () => {
     const { world, antId } = makeAnt(ForagingSubState.SearchingFood);
     // Pile 5 tiles away (well within DEBUG_SCENT_RADIUS = 15).
-    world.foodPiles.push({ foodPileId: 1, tileX: 25, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 25,
+      tileY: 20,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     expect(buildAntTrace(world, antId).movementSource).toBe('scent');
   });
 
@@ -334,7 +343,13 @@ describe('buildAntTrace — movement source inference', () => {
     const { world, antId } = makeAnt(ForagingSubState.SearchingFood);
     world.ants.targetPosX[antId] = 30 << FP_SHIFT;
     world.ants.targetPosY[antId] = 30 << FP_SHIFT;
-    world.foodPiles.push({ foodPileId: 1, tileX: 25, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 25,
+      tileY: 20,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     const key = pheromoneGridKey(COLONY_ID, PheromoneType.FoodTrail, 'surface');
     phSet(world.pheromoneGrids[key]!, 21, 20, FOOD_TRAIL_DEPOSIT);
     expect(buildAntTrace(world, antId).movementSource).toBe('priority');
@@ -342,7 +357,13 @@ describe('buildAntTrace — movement source inference', () => {
 
   it('scent overrides pheromone (decision order preserved)', () => {
     const { world, antId } = makeAnt(ForagingSubState.SearchingFood);
-    world.foodPiles.push({ foodPileId: 1, tileX: 25, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 25,
+      tileY: 20,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     const key = pheromoneGridKey(COLONY_ID, PheromoneType.FoodTrail, 'surface');
     phSet(world.pheromoneGrids[key]!, 21, 20, FOOD_TRAIL_DEPOSIT);
     expect(buildAntTrace(world, antId).movementSource).toBe('scent');
@@ -354,7 +375,13 @@ describe('buildAntTrace — movement source inference', () => {
     const { world, antId } = makeAnt(ForagingSubState.SearchingFood, Zone.Underground);
     // Populate the surface grid with a nearby pile + pheromone — if the
     // classifier incorrectly ran the surface cascade, one of these would win.
-    world.foodPiles.push({ foodPileId: 1, tileX: 25, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 25,
+      tileY: 20,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     const key = pheromoneGridKey(COLONY_ID, PheromoneType.FoodTrail, 'surface');
     phSet(world.pheromoneGrids[key]!, 21, 20, FOOD_TRAIL_DEPOSIT);
     expect(buildAntTrace(world, antId).movementSource).toBe('underground-exit');
@@ -411,7 +438,12 @@ describe('buildDebugSnapshot — envelope + filtering', () => {
     setupSurfaceGrid(world, COLONY_ID);
     initAnt(world.ants, queenId, { colonyId: COLONY_ID, posX: 0, posY: 0, task: AntTask.Idle });
     const workerId = allocateEntityId(world);
-    initAnt(world.ants, workerId, { colonyId: COLONY_ID, posX: 0, posY: 0, task: AntTask.Foraging });
+    initAnt(world.ants, workerId, {
+      colonyId: COLONY_ID,
+      posX: 0,
+      posY: 0,
+      task: AntTask.Foraging,
+    });
 
     const snap = buildDebugSnapshot(world, 1, []);
     const ids = snap.antTrace.map((r) => r.antId);
@@ -430,9 +462,19 @@ describe('buildDebugSnapshot — envelope + filtering', () => {
       setupSurfaceGrid(world, cid);
     }
     const playerAnt = allocateEntityId(world);
-    initAnt(world.ants, playerAnt, { colonyId: COLONY_ID, posX: 0, posY: 0, task: AntTask.Foraging });
+    initAnt(world.ants, playerAnt, {
+      colonyId: COLONY_ID,
+      posX: 0,
+      posY: 0,
+      task: AntTask.Foraging,
+    });
     const enemyAnt = allocateEntityId(world);
-    initAnt(world.ants, enemyAnt, { colonyId: OTHER_COLONY_ID, posX: 0, posY: 0, task: AntTask.Foraging });
+    initAnt(world.ants, enemyAnt, {
+      colonyId: OTHER_COLONY_ID,
+      posX: 0,
+      posY: 0,
+      task: AntTask.Foraging,
+    });
 
     const filtered = buildDebugSnapshot(world, 1, [], [COLONY_ID]);
     const ids = filtered.antTrace.map((r) => r.antId);
@@ -499,7 +541,14 @@ describe('buildDebugSnapshot — BuildDebugSnapshotOptions (issue #122)', () => 
 
   it('default options include both antTrace and inputLog (F9 path is unchanged)', () => {
     const world = makeWorldWithAnts();
-    const log = [{ type: 'SetBehaviorRatio', colonyId: COLONY_ID, ratio: { forage: 50, fight: 50 }, issuedAtTick: 0 }] as never;
+    const log = [
+      {
+        type: 'SetBehaviorRatio',
+        colonyId: COLONY_ID,
+        ratio: { forage: 50, fight: 50 },
+        issuedAtTick: 0,
+      },
+    ] as never;
     const snap = buildDebugSnapshot(world, 1, log);
     expect(snap.antTrace.length).toBeGreaterThan(0);
     expect(snap.inputLog.length).toBe(1);
@@ -507,7 +556,14 @@ describe('buildDebugSnapshot — BuildDebugSnapshotOptions (issue #122)', () => 
 
   it('includeAntTrace=false emits an empty trace array (downgrade stage 1)', () => {
     const world = makeWorldWithAnts();
-    const log = [{ type: 'SetBehaviorRatio', colonyId: COLONY_ID, ratio: { forage: 50, fight: 50 }, issuedAtTick: 0 }] as never;
+    const log = [
+      {
+        type: 'SetBehaviorRatio',
+        colonyId: COLONY_ID,
+        ratio: { forage: 50, fight: 50 },
+        issuedAtTick: 0,
+      },
+    ] as never;
     const snap = buildDebugSnapshot(world, 1, log, { includeAntTrace: false });
     expect(snap.antTrace).toEqual([]);
     // inputLog must still be present at this stage.
@@ -516,8 +572,18 @@ describe('buildDebugSnapshot — BuildDebugSnapshotOptions (issue #122)', () => 
 
   it('includeInputLog=false drops the input log (downgrade stage 2)', () => {
     const world = makeWorldWithAnts();
-    const log = [{ type: 'SetBehaviorRatio', colonyId: COLONY_ID, ratio: { forage: 50, fight: 50 }, issuedAtTick: 0 }] as never;
-    const snap = buildDebugSnapshot(world, 1, log, { includeAntTrace: false, includeInputLog: false });
+    const log = [
+      {
+        type: 'SetBehaviorRatio',
+        colonyId: COLONY_ID,
+        ratio: { forage: 50, fight: 50 },
+        issuedAtTick: 0,
+      },
+    ] as never;
+    const snap = buildDebugSnapshot(world, 1, log, {
+      includeAntTrace: false,
+      includeInputLog: false,
+    });
     expect(snap.antTrace).toEqual([]);
     expect(snap.inputLog).toEqual([]);
   });
@@ -525,7 +591,7 @@ describe('buildDebugSnapshot — BuildDebugSnapshotOptions (issue #122)', () => 
   it('legacy colonyFilter array signature still works', () => {
     const world = makeWorldWithAnts();
     const snap = buildDebugSnapshot(world, 1, [], [COLONY_ID]);
-    expect(snap.antTrace.every(r => r.colonyId === COLONY_ID)).toBe(true);
+    expect(snap.antTrace.every((r) => r.colonyId === COLONY_ID)).toBe(true);
   });
 
   it('options.colonyFilter narrows the trace to the listed colonies', () => {
@@ -579,7 +645,10 @@ describe('buildDebugGuide — self-describing legend (issue #179)', () => {
     // ForagingSubState CarryingFood).
     expect(guide.enums['task']).toMatchObject({ '0': 'Idle', '1': 'Foraging', '4': 'Nursing' });
     expect(guide.enums['subTask if task=Foraging']).toMatchObject({ '1': 'CarryingFood' });
-    expect(guide.enums['subTask if task=Nursing']).toMatchObject({ '1': 'Feeding', '2': 'Attending' });
+    expect(guide.enums['subTask if task=Nursing']).toMatchObject({
+      '1': 'Feeding',
+      '2': 'Attending',
+    });
     expect(guide.enums['subTask if task=Digging']).toMatchObject({ '1': 'Excavating' });
     expect(guide.enums['zone']).toMatchObject({ '0': 'Surface', '1': 'Underground' });
     expect(guide.enums['chamberType']).toMatchObject({ '2': 'FoodStorage' });
@@ -608,7 +677,9 @@ describe('buildDebugGuide — self-describing legend (issue #179)', () => {
     // Diamond prose names the row-major index formula and the LIVE radius.
     const side = 2 * DEBUG_TRACE_PHEROMONE_RADIUS + 1;
     expect(guide.nearbyPheromone).toContain(`(dy+r)*${side}`);
-    expect(guide.nearbyPheromone).toContain(`r=nearbyPheromoneRadius=${DEBUG_TRACE_PHEROMONE_RADIUS}`);
+    expect(guide.nearbyPheromone).toContain(
+      `r=nearbyPheromoneRadius=${DEBUG_TRACE_PHEROMONE_RADIUS}`,
+    );
   });
 
   it('is embedded in the full snapshot payload and survives JSON round-trip', () => {

--- a/src/platform/debug-snapshot.ts
+++ b/src/platform/debug-snapshot.ts
@@ -14,16 +14,18 @@
 import type { WorldState } from '../sim/types.js';
 import type { SimCommand } from '../sim/commands.js';
 import {
-  AntTask, ChamberType, DiggingSubState, FightingSubState,
-  ForagingSubState, NursingSubState, PheromoneType,
+  AntTask,
+  ChamberType,
+  DiggingSubState,
+  FightingSubState,
+  ForagingSubState,
+  NursingSubState,
+  PheromoneType,
 } from '../sim/enums.js';
 import { Zone } from '../sim/terrain.js';
 import { FP_SHIFT, FP_ONE } from '../sim/fixed.js';
 import { pheromoneGridKey, phGet } from '../sim/pheromone/pheromone-store.js';
-import {
-  serializeWorldState,
-  type SerializedWorldState,
-} from './save.js';
+import { serializeWorldState, type SerializedWorldState } from './save.js';
 
 export const DEBUG_SNAPSHOT_VERSION = 2 as const;
 
@@ -45,15 +47,21 @@ const DEBUG_SCENT_RADIUS = 15;
  *  `guide` re-exports this object verbatim, so the legend can never drift from
  *  the code. Explanations mirror the precedence chain in inferMovementSource. */
 export const MOVEMENT_SOURCES = {
-  priority: 'Surface SearchingFood with targetPosX/Y set → chase that priority pile (beats scent/pheromone/wander).',
+  priority:
+    'Surface SearchingFood with targetPosX/Y set → chase that priority pile (beats scent/pheromone/wander).',
   scent: `Surface SearchingFood, no priority, with a food pile within ${DEBUG_SCENT_RADIUS} tiles (Manhattan) → head toward scent.`,
   pheromone: `Surface SearchingFood, no priority/scent, with FoodTrail pheromone within ${DEBUG_TRACE_PHEROMONE_RADIUS} tiles → follow the trail.`,
-  wander: 'Surface SearchingFood with no priority/scent/pheromone signal → chooseExcursionDirection (random walk).',
-  entrance: 'CarryingFood/ReturningToNest heading to a surface entrance (also the fallback when no FoodStorage chamber exists).',
-  'food-storage': 'Underground CarryingFood routing to a FoodStorage chamber via the chamber flow-field.',
-  'underground-exit': 'Underground SearchingFood routing back to the surface via the entrance flow-field (surface scent/pheromone probes do not apply underground).',
+  wander:
+    'Surface SearchingFood with no priority/scent/pheromone signal → chooseExcursionDirection (random walk).',
+  entrance:
+    'CarryingFood/ReturningToNest heading to a surface entrance (also the fallback when no FoodStorage chamber exists).',
+  'food-storage':
+    'Underground CarryingFood routing to a FoodStorage chamber via the chamber flow-field.',
+  'underground-exit':
+    'Underground SearchingFood routing back to the surface via the entrance flow-field (surface scent/pheromone probes do not apply underground).',
   'nursing-chamber': 'Nursing ant routing to the Queen/Nursery chamber via the chamber flow-field.',
-  rally: 'Fighting ant moving to colony.rallyPoint (surface) or, underground, to an entrance as transit toward the rally.',
+  rally:
+    'Fighting ant moving to colony.rallyPoint (surface) or, underground, to an entrance as transit toward the rally.',
   task: 'Non-forager fallback (Digging/Idle), or a Nursing ant whose colony has no Queen/Nursery chamber.',
   dead: 'Slot is not alive (ants.alive !== 1).',
 } as const;
@@ -76,19 +84,19 @@ export interface AntTraceRow {
   zone: number;
   tileX: number;
   tileY: number;
-  posX: number;   // fixed-point (FP_ONE = 256)
+  posX: number; // fixed-point (FP_ONE = 256)
   posY: number;
   foodCarrying: number;
   searchWave: number;
   searchHeadingX: number;
   searchHeadingY: number;
   searchHeadingTicks: number;
-  searchPrevTileX: number;  // -1 sentinel when no prev tile
+  searchPrevTileX: number; // -1 sentinel when no prev tile
   searchPrevTileY: number;
-  targetPosX: number;       // -1 sentinel when no priority target
+  targetPosX: number; // -1 sentinel when no priority target
   targetPosY: number;
-  nearestEntranceDist: number;    // Manhattan tiles; -1 if colony has none
-  nearbyPheromoneRadius: number;  // echoes DEBUG_TRACE_PHEROMONE_RADIUS
+  nearestEntranceDist: number; // Manhattan tiles; -1 if colony has none
+  nearbyPheromoneRadius: number; // echoes DEBUG_TRACE_PHEROMONE_RADIUS
   /** Flat row-major diamond (length = (2r+1)^2). Cells outside the Manhattan
    *  diamond are emitted as 0 so the array is a simple square for consumers
    *  to pretty-print. Centre cell (the ant's tile) is the middle entry. */
@@ -324,20 +332,21 @@ export function buildAntTrace(world: WorldState, antId: number): AntTraceRow {
     tileY,
     posX,
     posY,
-    foodCarrying:       a.foodCarrying[antId]!,
-    searchWave:         a.searchWave[antId]!,
-    searchHeadingX:     a.searchHeadingX[antId]!,
-    searchHeadingY:     a.searchHeadingY[antId]!,
+    foodCarrying: a.foodCarrying[antId]!,
+    searchWave: a.searchWave[antId]!,
+    searchHeadingX: a.searchHeadingX[antId]!,
+    searchHeadingY: a.searchHeadingY[antId]!,
     searchHeadingTicks: a.searchHeadingTicks[antId]!,
-    searchPrevTileX:    a.searchPrevTileX[antId]!,
-    searchPrevTileY:    a.searchPrevTileY[antId]!,
-    targetPosX:         a.targetPosX[antId]!,
-    targetPosY:         a.targetPosY[antId]!,
-    nearestEntranceDist:   nearestEntranceDist(world, colonyId, tileX, tileY),
+    searchPrevTileX: a.searchPrevTileX[antId]!,
+    searchPrevTileY: a.searchPrevTileY[antId]!,
+    targetPosX: a.targetPosX[antId]!,
+    targetPosY: a.targetPosY[antId]!,
+    nearestEntranceDist: nearestEntranceDist(world, colonyId, tileX, tileY),
     nearbyPheromoneRadius: DEBUG_TRACE_PHEROMONE_RADIUS,
-    nearbyPheromone:       a.zone[antId] === Zone.Surface
-      ? samplePheromoneDiamond(world, colonyId, tileX, tileY, DEBUG_TRACE_PHEROMONE_RADIUS)
-      : new Array<number>((2 * DEBUG_TRACE_PHEROMONE_RADIUS + 1) ** 2).fill(0),
+    nearbyPheromone:
+      a.zone[antId] === Zone.Surface
+        ? samplePheromoneDiamond(world, colonyId, tileX, tileY, DEBUG_TRACE_PHEROMONE_RADIUS)
+        : new Array<number>((2 * DEBUG_TRACE_PHEROMONE_RADIUS + 1) ** 2).fill(0),
     movementSource: inferMovementSource(world, antId),
   };
 }

--- a/src/platform/game-loop.test.ts
+++ b/src/platform/game-loop.test.ts
@@ -7,14 +7,17 @@ import type { SimCommand } from '../sim/commands.js';
 
 // Helper: create a spy tick function that records calls without advancing rngState etc.
 function makeSpyTick(): {
-  fn: (world: ReturnType<typeof createWorldState>, cmds: readonly SimCommand[]) => typeof GameOutcome[keyof typeof GameOutcome];
+  fn: (
+    world: ReturnType<typeof createWorldState>,
+    cmds: readonly SimCommand[],
+  ) => (typeof GameOutcome)[keyof typeof GameOutcome];
   calls: Array<{ cmdCount: number }>;
 } {
   const calls: Array<{ cmdCount: number }> = [];
   const fn = (
     _world: ReturnType<typeof createWorldState>,
     cmds: readonly SimCommand[],
-  ): typeof GameOutcome[keyof typeof GameOutcome] => {
+  ): (typeof GameOutcome)[keyof typeof GameOutcome] => {
     calls.push({ cmdCount: cmds.length });
     return GameOutcome.None;
   };
@@ -142,10 +145,10 @@ describe('createGameLoop — Phase 8 opts', () => {
     const spy = vi.fn();
     const loop = createGameLoop(fn, world, { onBeforeTick: spy });
 
-    loop.update(50);   // 1 tick
+    loop.update(50); // 1 tick
     expect(spy).toHaveBeenCalledTimes(1);
 
-    loop.update(150);  // 3 more ticks
+    loop.update(150); // 3 more ticks
     expect(spy).toHaveBeenCalledTimes(4);
   });
 
@@ -164,8 +167,8 @@ describe('createGameLoop — Phase 8 opts', () => {
     });
 
     loop.update(50); // 1 tick
-    expect(receivedWorld[0]).toBe(world);          // same object reference
-    expect(queueLengthAtHook[0]).toBe(1);          // command still present when hook fires
+    expect(receivedWorld[0]).toBe(world); // same object reference
+    expect(queueLengthAtHook[0]).toBe(1); // command still present when hook fires
   });
 
   it('onBeforeTick is NOT called when no tick fires', () => {
@@ -195,14 +198,14 @@ describe('createGameLoop — Phase 8 opts', () => {
     let mpt = 50;
     const loop = createGameLoop(fn, world, { getMsPerTick: () => mpt });
 
-    loop.update(50);   // mpt=50 → 1 tick
+    loop.update(50); // mpt=50 → 1 tick
     expect(calls.length).toBe(1);
 
     mpt = 100;
-    loop.update(100);  // mpt=100, acc=0+100 → 1 tick; 0ms residual
+    loop.update(100); // mpt=100, acc=0+100 → 1 tick; 0ms residual
     expect(calls.length).toBe(2);
 
-    loop.update(50);   // mpt=100, acc=0+50 → 0 ticks (50 < 100)
+    loop.update(50); // mpt=100, acc=0+50 → 0 ticks (50 < 100)
     expect(calls.length).toBe(2);
   });
 
@@ -238,7 +241,7 @@ describe('createGameLoop — Phase 8 opts', () => {
     expect(calls.length).toBe(0);
 
     paused = false;
-    loop.update(100);  // acc=0+100 → 2 ticks (100/50)
+    loop.update(100); // acc=0+100 → 2 ticks (100/50)
     expect(calls.length).toBe(2);
   });
 
@@ -261,7 +264,9 @@ describe('GameLoopOpts Phase 9 seams', () => {
     world.commandQueue.push(makeNoOp(1), makeNoOp(2));
     const drainedArrays: (readonly SimCommand[])[] = [];
     const loop = createGameLoop(makeSpyTick().fn, world, {
-      onAfterDrain: (cmds) => { drainedArrays.push(cmds); },
+      onAfterDrain: (cmds) => {
+        drainedArrays.push(cmds);
+      },
     });
     loop.update(MS_PER_TICK);
     expect(drainedArrays.length).toBe(1);
@@ -283,7 +288,7 @@ describe('GameLoopOpts Phase 9 seams', () => {
   it('onTickOutcome fires exactly once and breaks accumulator loop when tickFn returns Victory', () => {
     const world = createWorldState(42);
     let callCount = 0;
-    const tickFn = (): typeof GameOutcome[keyof typeof GameOutcome] => {
+    const tickFn = (): (typeof GameOutcome)[keyof typeof GameOutcome] => {
       callCount += 1;
       return callCount >= 2 ? GameOutcome.Victory : GameOutcome.None;
     };
@@ -302,7 +307,7 @@ describe('GameLoopOpts Phase 9 seams', () => {
     for (const outcome of [GameOutcome.Defeat, GameOutcome.MutualDestruction]) {
       const world = createWorldState(42);
       let callCount = 0;
-      const tickFn = (): typeof GameOutcome[keyof typeof GameOutcome] => {
+      const tickFn = (): (typeof GameOutcome)[keyof typeof GameOutcome] => {
         callCount += 1;
         return callCount >= 2 ? outcome : GameOutcome.None;
       };
@@ -339,7 +344,7 @@ describe('GameLoop pause()/resume() (Phase 9 Plan 06 Task 1)', () => {
     const world = createWorldState(1);
     const loop = createGameLoop(tickSpy, world);
     loop.pause();
-    loop.update(MS_PER_TICK * 5);  // would fire 5 ticks if running
+    loop.update(MS_PER_TICK * 5); // would fire 5 ticks if running
     expect(tickSpy).toHaveBeenCalledTimes(0);
     expect(loop.isPaused()).toBe(true);
   });
@@ -361,13 +366,13 @@ describe('GameLoop pause()/resume() (Phase 9 Plan 06 Task 1)', () => {
     const world = createWorldState(1);
     const loop = createGameLoop(tickSpy, world);
     // Run once to advance accumulator near a tick boundary
-    loop.update(MS_PER_TICK - 1);     // accumulator = MS_PER_TICK - 1, 0 ticks
+    loop.update(MS_PER_TICK - 1); // accumulator = MS_PER_TICK - 1, 0 ticks
     loop.pause();
-    loop.update(MS_PER_TICK * 100);   // paused — no-op; accumulator preserved internally BUT ignored on resume
-    loop.resume();                    // resume resets accumulator to 0
-    loop.update(MS_PER_TICK - 1);     // 0 ticks (accumulator rebuilds from zero)
+    loop.update(MS_PER_TICK * 100); // paused — no-op; accumulator preserved internally BUT ignored on resume
+    loop.resume(); // resume resets accumulator to 0
+    loop.update(MS_PER_TICK - 1); // 0 ticks (accumulator rebuilds from zero)
     expect(tickSpy).toHaveBeenCalledTimes(0);
-    loop.update(1);                   // crosses boundary → exactly 1 tick
+    loop.update(1); // crosses boundary → exactly 1 tick
     expect(tickSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -392,7 +397,7 @@ describe('GameLoop pause()/resume() (Phase 9 Plan 06 Task 1)', () => {
     let externallyPaused = true;
     const loop = createGameLoop(tickSpy, world, { getIsPaused: () => externallyPaused });
     loop.update(MS_PER_TICK);
-    expect(tickSpy).toHaveBeenCalledTimes(0);  // gated by getIsPaused
+    expect(tickSpy).toHaveBeenCalledTimes(0); // gated by getIsPaused
     externallyPaused = false;
     loop.update(MS_PER_TICK);
     expect(tickSpy).toHaveBeenCalledTimes(1);
@@ -418,7 +423,11 @@ describe('determinism — accumulator + tick composition', () => {
     }
 
     // Sim-state fields must be bit-identical.
-    expect({ tick: worldA.tick, rngState: worldA.rngState, nextEntityId: worldA.nextEntityId }).toEqual({
+    expect({
+      tick: worldA.tick,
+      rngState: worldA.rngState,
+      nextEntityId: worldA.nextEntityId,
+    }).toEqual({
       tick: worldB.tick,
       rngState: worldB.rngState,
       nextEntityId: worldB.nextEntityId,

--- a/src/platform/game-loop.ts
+++ b/src/platform/game-loop.ts
@@ -48,19 +48,15 @@ export interface GameLoopOpts {
 
 type TickFn = (world: WorldState, commands: readonly SimCommand[]) => GameOutcome;
 
-export function createGameLoop(
-  tickFn: TickFn,
-  world: WorldState,
-  opts?: GameLoopOpts,
-): GameLoop {
-  const getMsPerTick  = opts?.getMsPerTick ?? (() => MS_PER_TICK);
-  const getIsPaused   = opts?.getIsPaused;
-  const onBeforeTick  = opts?.onBeforeTick;
-  const onAfterDrain  = opts?.onAfterDrain;
+export function createGameLoop(tickFn: TickFn, world: WorldState, opts?: GameLoopOpts): GameLoop {
+  const getMsPerTick = opts?.getMsPerTick ?? (() => MS_PER_TICK);
+  const getIsPaused = opts?.getIsPaused;
+  const onBeforeTick = opts?.onBeforeTick;
+  const onAfterDrain = opts?.onAfterDrain;
   const onTickOutcome = opts?.onTickOutcome;
 
   let accumulatorMs = 0;
-  let paused = false;  // Phase 9 Plan 06 — imperative pause flag
+  let paused = false; // Phase 9 Plan 06 — imperative pause flag
 
   return {
     update(dtMs: number): void {
@@ -68,15 +64,15 @@ export function createGameLoop(
       if (paused) return;
       // Backward-compat predicate gate (honor existing getIsPaused opt).
       if (getIsPaused?.() === true) return;
-      const msPerTick = getMsPerTick();                 // queried once per frame
+      const msPerTick = getMsPerTick(); // queried once per frame
       accumulatorMs += dtMs;
       // PRD §3 spiral-of-death guard: dynamic clamp honors variable speed.
       const maxAcc = msPerTick * MAX_CATCHUP_TICKS;
       if (accumulatorMs > maxAcc) accumulatorMs = maxAcc;
       while (accumulatorMs >= msPerTick) {
-        onBeforeTick?.(world);                          // Phase 8: copyWorldState seam
+        onBeforeTick?.(world); // Phase 8: copyWorldState seam
         const cmds = world.commandQueue.splice(0);
-        onAfterDrain?.(cmds);                           // Phase 9: inputLog seam
+        onAfterDrain?.(cmds); // Phase 9: inputLog seam
         const outcome = tickFn(world, cmds);
         accumulatorMs -= msPerTick;
         if (outcome !== GameOutcome.None && onTickOutcome !== undefined) {

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -1,10 +1,18 @@
 /* @vitest-environment jsdom */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
-  SAVE_FORMAT_VERSION, SAVE_KEY, AUTOSAVE_INTERVAL_MS,
-  serializeWorldState, deserializeWorldState,
-  hasSave, loadSave, deleteSave, tickAutosave,
-  manualSave, hasIncompatibleSave, getSaveInfo,
+  SAVE_FORMAT_VERSION,
+  SAVE_KEY,
+  AUTOSAVE_INTERVAL_MS,
+  serializeWorldState,
+  deserializeWorldState,
+  hasSave,
+  loadSave,
+  deleteSave,
+  tickAutosave,
+  manualSave,
+  hasIncompatibleSave,
+  getSaveInfo,
   parseSaveFile,
   FutureSimVersionError,
   OldSimVersionError,
@@ -20,7 +28,9 @@ import { ChamberType } from '../sim/enums.js';
 
 describe('save.ts (SCEN-04 + SCEN-06)', () => {
   // Use window.localStorage to ensure jsdom's implementation (not Node 25 native localStorage)
-  beforeEach(() => { window.localStorage.clear(); });
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
 
   describe('serializeWorldState — envelope coverage', () => {
     it('includes every WorldState field (tick, rngState, nextEntityId, commandQueue, ants, colonies, pheromoneGrids, surface, undergroundGrids, foodPiles, pendingChambers)', () => {
@@ -38,9 +48,26 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     it('serializes all 18 Int32Array ant fields as number[] (NOT "{}")', () => {
       const w = createScenario(42);
       const s = serializeWorldState(w);
-      const fields = ['posX','posY','colonyId','task','subTask','speed','foodCarrying','starvationTimer',
-                      'age','alive','lifespan','zone','digTileX','digTileY','digTicksRemaining',
-                      'targetPosX','targetPosY','searchWave'] as const;
+      const fields = [
+        'posX',
+        'posY',
+        'colonyId',
+        'task',
+        'subTask',
+        'speed',
+        'foodCarrying',
+        'starvationTimer',
+        'age',
+        'alive',
+        'lifespan',
+        'zone',
+        'digTileX',
+        'digTileY',
+        'digTicksRemaining',
+        'targetPosX',
+        'targetPosY',
+        'searchWave',
+      ] as const;
       for (const f of fields) {
         expect(Array.isArray(s.ants[f])).toBe(true);
         expect(s.ants[f]!.length).toBeGreaterThan(0);
@@ -56,7 +83,13 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     });
     it('includes commandQueue (Pitfall 7 — autosave fires on wall clock, not tick boundary)', () => {
       const w = createScenario(42);
-      w.commandQueue.push({ type: 'MarkDigTile', colonyId: PLAYER_COLONY_ID as ColonyId, tileX: 3, tileY: 4, issuedAtTick: 0 });
+      w.commandQueue.push({
+        type: 'MarkDigTile',
+        colonyId: PLAYER_COLONY_ID as ColonyId,
+        tileX: 3,
+        tileY: 4,
+        issuedAtTick: 0,
+      });
       const s = serializeWorldState(w);
       expect(s.commandQueue.length).toBe(1);
       expect(s.commandQueue[0]).toMatchObject({ type: 'MarkDigTile', tileX: 3, tileY: 4 });
@@ -104,7 +137,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   describe('deserializeWorldState — round-trip', () => {
     it('round-trip: serialize → deserialize → re-serialize produces identical JSON (byte-for-byte)', () => {
       const w = createScenario(42);
-      for (let t = 0; t < 50; t++) tick(w, []);   // some non-trivial state
+      for (let t = 0; t < 50; t++) tick(w, []); // some non-trivial state
       const s1 = JSON.stringify(serializeWorldState(w));
       const w2 = deserializeWorldState(JSON.parse(s1));
       const s2 = JSON.stringify(serializeWorldState(w2));
@@ -121,7 +154,13 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     });
     it('preserves queued commands through serialize → deserialize', () => {
       const w = createScenario(42);
-      w.commandQueue.push({ type: 'MarkDigTile', colonyId: PLAYER_COLONY_ID as ColonyId, tileX: 1, tileY: 2, issuedAtTick: 0 });
+      w.commandQueue.push({
+        type: 'MarkDigTile',
+        colonyId: PLAYER_COLONY_ID as ColonyId,
+        tileX: 1,
+        tileY: 2,
+        issuedAtTick: 0,
+      });
       const w2 = deserializeWorldState(serializeWorldState(w));
       expect(w2.commandQueue.length).toBe(1);
       expect(w2.commandQueue[0]).toMatchObject({ type: 'MarkDigTile', tileX: 1, tileY: 2 });
@@ -161,17 +200,27 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // Canonical FoodStorage dims: 4×3 (CHAMBER_DIMENSIONS[FoodStorage]).
       // Issue #101 boundary validator now enforces these.
       colony.chambers.push({
-        chamberId: 999, chamberType: ChamberType.FoodStorage, foodStored: 1234,
-        posX: 10 << 8, posY: 5 << 8, width: 4, height: 3,
+        chamberId: 999,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 1234,
+        posX: 10 << 8,
+        posY: 5 << 8,
+        width: 4,
+        height: 3,
       });
       colony.chambers.push({
-        chamberId: 998, chamberType: ChamberType.FoodStorage, foodStored: 4321,
-        posX: 16 << 8, posY: 5 << 8, width: 4, height: 3,
+        chamberId: 998,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 4321,
+        posX: 16 << 8,
+        posY: 5 << 8,
+        width: 4,
+        height: 3,
       });
       const w2 = deserializeWorldState(serializeWorldState(w));
       const c2 = w2.colonies[PLAYER_COLONY_ID]!;
-      const ch1 = c2.chambers.find(c => c.chamberId === 999)!;
-      const ch2 = c2.chambers.find(c => c.chamberId === 998)!;
+      const ch1 = c2.chambers.find((c) => c.chamberId === 999)!;
+      const ch2 = c2.chambers.find((c) => c.chamberId === 998)!;
       expect(ch1.foodStored).toBe(1234);
       expect(ch2.foodStored).toBe(4321);
     });
@@ -221,7 +270,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // sets currentGridColonyId === colonyId. Confirm the precondition by
       // picking two alive ants from the scenario.
       const playerQueen = w.colonies[PLAYER_COLONY_ID]!.queenEntityId;
-      const enemyQueen  = w.colonies[ENEMY_COLONY_ID]!.queenEntityId;
+      const enemyQueen = w.colonies[ENEMY_COLONY_ID]!.queenEntityId;
       expect(w.ants.alive[playerQueen]).toBe(1);
       expect(w.ants.alive[enemyQueen]).toBe(1);
       expect(w.ants.colonyId[playerQueen]).toBe(PLAYER_COLONY_ID);
@@ -245,7 +294,8 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(w2.ants.currentGridColonyId[playerInvader]).toBe(ENEMY_COLONY_ID);
     });
     it('round-trips simVersion (LATEST: v10 visible brood carry)', async () => {
-      const { LATEST_SIM_VERSION, SIM_VERSION_V7_SURFACE_PASSABILITY } = await import('../sim/types.js');
+      const { LATEST_SIM_VERSION, SIM_VERSION_V7_SURFACE_PASSABILITY } =
+        await import('../sim/types.js');
       // New worlds default to LATEST_SIM_VERSION. Save/load must preserve
       // it so any LATEST replay continues to apply the gated behaviour
       // (currently surface passability, soft cost, leash hysteresis,
@@ -259,9 +309,6 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       const w2 = deserializeWorldState(JSON.parse(JSON.stringify(s)));
       expect(w2.simVersion).toBe(LATEST_SIM_VERSION);
     });
-
-
-
 
     it('round-trips world.terrainSeed (issue #44)', () => {
       const w = createScenario(42);
@@ -307,7 +354,6 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(w2.spiderPriorityColonyId).toBe(PLAYER_COLONY_ID);
       expect(w2.scatterReticleTile).toEqual({ x: 10, y: 20 });
     });
-
 
     it('V20: null spider (spider killed mid-game) round-trips through serialize → deserialize', () => {
       const w = createScenario(42);
@@ -366,8 +412,6 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         expect(w2.terrainSeed).toBe(0);
       }
     });
-
-
   });
 
   describe('SaveFile envelope (PRD §8a: version + seed + inputLog + snapshot)', () => {
@@ -376,9 +420,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     });
     it('hasSave returns true when valid envelope present', () => {
       const w = createScenario(42);
-      localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: SAVE_FORMAT_VERSION, seed: 42, inputLog: [], snapshot: serializeWorldState(w),
-      } satisfies SaveFile));
+      localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: SAVE_FORMAT_VERSION,
+          seed: 42,
+          inputLog: [],
+          snapshot: serializeWorldState(w),
+        } satisfies SaveFile),
+      );
       expect(hasSave()).toBe(true);
     });
     it('hasSave returns false on malformed JSON', () => {
@@ -387,9 +437,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     });
     it('hasSave returns false on mismatched version', () => {
       const w = createScenario(42);
-      localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: 999, seed: 42, inputLog: [], snapshot: serializeWorldState(w),
-      }));
+      localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: 999,
+          seed: 42,
+          inputLog: [],
+          snapshot: serializeWorldState(w),
+        }),
+      );
       expect(hasSave()).toBe(false);
     });
     it('rejects v1 saves (issue #15 — chamber-authoritative food storage)', () => {
@@ -400,20 +456,38 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // forces the loader to reject the save and boot a fresh scenario,
       // which is the documented behaviour for breaking format changes.
       const w = createScenario(42);
-      localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: 1, seed: 42, inputLog: [], snapshot: serializeWorldState(w),
-      }));
+      localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: 1,
+          seed: 42,
+          inputLog: [],
+          snapshot: serializeWorldState(w),
+        }),
+      );
       expect(hasSave()).toBe(false);
       expect(loadSave()).toBeNull();
     });
     it('loadSave returns a SaveFile with seed + inputLog + snapshot fields', () => {
       const w = createScenario(42);
       const inputLog: SimCommand[] = [
-        { type: 'MarkDigTile', colonyId: PLAYER_COLONY_ID as ColonyId, tileX: 5, tileY: 5, issuedAtTick: 10 },
+        {
+          type: 'MarkDigTile',
+          colonyId: PLAYER_COLONY_ID as ColonyId,
+          tileX: 5,
+          tileY: 5,
+          issuedAtTick: 10,
+        },
       ];
-      localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: SAVE_FORMAT_VERSION, seed: 42, inputLog, snapshot: serializeWorldState(w),
-      } satisfies SaveFile));
+      localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: SAVE_FORMAT_VERSION,
+          seed: 42,
+          inputLog,
+          snapshot: serializeWorldState(w),
+        } satisfies SaveFile),
+      );
       const loaded = loadSave();
       expect(loaded).not.toBeNull();
       expect(loaded!.seed).toBe(42);
@@ -425,7 +499,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(loadSave()).toBeNull();
     });
     it('deleteSave removes the key and does not throw on missing', () => {
-      localStorage.setItem(SAVE_KEY, JSON.stringify({ version: SAVE_FORMAT_VERSION, seed: 1, inputLog: [], snapshot: serializeWorldState(createScenario(1)) }));
+      localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: SAVE_FORMAT_VERSION,
+          seed: 1,
+          inputLog: [],
+          snapshot: serializeWorldState(createScenario(1)),
+        }),
+      );
       deleteSave();
       expect(localStorage.getItem(SAVE_KEY)).toBeNull();
       expect(() => deleteSave()).not.toThrow();
@@ -454,7 +536,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     it('returns nowMs on setItem throw — honors cooldown to prevent retry storm (#80)', () => {
       const w = createScenario(42);
       // Spy on the actual localStorage instance (InMemoryStorage replaces Storage.prototype on Node 25)
-      const spy = vi.spyOn(localStorage, 'setItem').mockImplementation(() => { throw new Error('quota'); });
+      const spy = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+        throw new Error('quota');
+      });
       try {
         const now = AUTOSAVE_INTERVAL_MS + 1;
         const result = tickAutosave(42, [], w, 0, now);
@@ -468,15 +552,17 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     });
     it('after setItem throw, the next call within the interval is a no-op (cooldown observed)', () => {
       const w = createScenario(42);
-      const spy = vi.spyOn(localStorage, 'setItem').mockImplementation(() => { throw new Error('quota'); });
+      const spy = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+        throw new Error('quota');
+      });
       try {
         const t1 = AUTOSAVE_INTERVAL_MS + 1;
         const lastSaveMs = tickAutosave(42, [], w, 0, t1);
         expect(spy).toHaveBeenCalledTimes(1);
         // Half an interval later — cooldown should suppress the retry.
-        const t2 = t1 + (AUTOSAVE_INTERVAL_MS / 2);
+        const t2 = t1 + AUTOSAVE_INTERVAL_MS / 2;
         const result = tickAutosave(42, [], w, lastSaveMs, t2);
-        expect(spy).toHaveBeenCalledTimes(1);  // no second attempt
+        expect(spy).toHaveBeenCalledTimes(1); // no second attempt
         expect(result).toBe(lastSaveMs);
       } finally {
         spy.mockRestore();
@@ -493,8 +579,20 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     it('(b) inputLog round-trips', () => {
       const w = createScenario(42);
       const log: SimCommand[] = [
-        { type: 'MarkDigTile', colonyId: PLAYER_COLONY_ID as ColonyId, tileX: 2, tileY: 2, issuedAtTick: 1 },
-        { type: 'MarkDigTile', colonyId: PLAYER_COLONY_ID as ColonyId, tileX: 3, tileY: 3, issuedAtTick: 5 },
+        {
+          type: 'MarkDigTile',
+          colonyId: PLAYER_COLONY_ID as ColonyId,
+          tileX: 2,
+          tileY: 2,
+          issuedAtTick: 1,
+        },
+        {
+          type: 'MarkDigTile',
+          colonyId: PLAYER_COLONY_ID as ColonyId,
+          tileX: 3,
+          tileY: 3,
+          issuedAtTick: 5,
+        },
       ];
       tickAutosave(42, log, w, 0, AUTOSAVE_INTERVAL_MS + 1);
       const loaded = loadSave()!;
@@ -503,7 +601,13 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     });
     it('(c) queued unprocessed commands round-trip via snapshot.commandQueue', () => {
       const w = createScenario(42);
-      w.commandQueue.push({ type: 'MarkDigTile', colonyId: PLAYER_COLONY_ID as ColonyId, tileX: 9, tileY: 9, issuedAtTick: 0 });
+      w.commandQueue.push({
+        type: 'MarkDigTile',
+        colonyId: PLAYER_COLONY_ID as ColonyId,
+        tileX: 9,
+        tileY: 9,
+        issuedAtTick: 0,
+      });
       tickAutosave(42, [], w, 0, AUTOSAVE_INTERVAL_MS + 1);
       const loaded = loadSave()!;
       expect(loaded.snapshot.commandQueue.length).toBe(1);
@@ -515,14 +619,23 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       tickAutosave(42, [], w, 0, AUTOSAVE_INTERVAL_MS + 1);
       const loaded = loadSave()!;
       const rebuilt = deserializeWorldState(loaded.snapshot);
-      expect(JSON.stringify(serializeWorldState(rebuilt)))
-        .toBe(JSON.stringify(serializeWorldState(w)));
+      expect(JSON.stringify(serializeWorldState(rebuilt))).toBe(
+        JSON.stringify(serializeWorldState(w)),
+      );
     });
     it('(e) inputLog replay: createScenario(seed) + tick(cmds[t]) for each tick reproduces snapshot', () => {
       // Build a reference world with a deterministic schedule
       const seed = 42;
       const schedule: SimCommand[][] = [];
-      schedule[10] = [{ type: 'MarkDigTile', colonyId: PLAYER_COLONY_ID as ColonyId, tileX: 7, tileY: 3, issuedAtTick: 10 }];
+      schedule[10] = [
+        {
+          type: 'MarkDigTile',
+          colonyId: PLAYER_COLONY_ID as ColonyId,
+          tileX: 7,
+          tileY: 3,
+          issuedAtTick: 10,
+        },
+      ];
 
       // Play 50 ticks while appending each tick's commands to inputLog (render-layer pattern)
       const original = createScenario(seed);
@@ -547,12 +660,11 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       }
       for (let t = 0; t < 50; t++) tick(replay, byTick[t] ?? []);
 
-      expect(JSON.stringify(serializeWorldState(replay)))
-        .toBe(JSON.stringify(serializeWorldState(original)));
+      expect(JSON.stringify(serializeWorldState(replay))).toBe(
+        JSON.stringify(serializeWorldState(original)),
+      );
     });
   });
-
-
 
   // ---------------------------------------------------------------------------
   // Phase 10 / WR-09 — inputLog SetBehaviorRatio migration on load
@@ -576,13 +688,16 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   // each queued command at deserialize time too.
   // ---------------------------------------------------------------------------
   describe('Issue #82 — commandQueue migration on deserialize', () => {
-
     it('non-SetBehaviorRatio commandQueue entries pass through unchanged', () => {
       const w = createScenario(42);
       const s = serializeWorldState(w);
-      (s.commandQueue as unknown as Array<unknown>).push(
-        { type: 'MarkDigTile', colonyId: PLAYER_COLONY_ID, tileX: 7, tileY: 3, issuedAtTick: 0 },
-      );
+      (s.commandQueue as unknown as Array<unknown>).push({
+        type: 'MarkDigTile',
+        colonyId: PLAYER_COLONY_ID,
+        tileX: 7,
+        tileY: 3,
+        issuedAtTick: 0,
+      });
       const world = deserializeWorldState(s);
       expect(world.commandQueue[0]).toMatchObject({ type: 'MarkDigTile', tileX: 7, tileY: 3 });
     });
@@ -602,11 +717,14 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   });
 
   describe('Phase 10 / WR-09 — inputLog migration on load', () => {
-    function writeSave(file: { version: number; seed: number; inputLog: unknown[]; snapshot: unknown }): void {
+    function writeSave(file: {
+      version: number;
+      seed: number;
+      inputLog: unknown[];
+      snapshot: unknown;
+    }): void {
       localStorage.setItem(SAVE_KEY, JSON.stringify(file));
     }
-
-
 
     it('post-Phase-10 entry without dig field passes through unchanged (including idle {0,0})', () => {
       const w = createScenario(42);
@@ -617,15 +735,14 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         issuedAtTick: 7,
       };
       writeSave({
-        version: SAVE_FORMAT_VERSION, seed: 42,
+        version: SAVE_FORMAT_VERSION,
+        seed: 42,
         inputLog: [modernIdle],
         snapshot: serializeWorldState(w),
       });
       const loaded = loadSave()!;
       expect((loaded.inputLog[0] as { ratio: unknown }).ratio).toEqual({ forage: 0, fight: 0 });
     });
-
-
   });
 
   // ---------------------------------------------------------------------------
@@ -635,7 +752,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   // a memory-DoS vector on save load.
   // ---------------------------------------------------------------------------
   describe('Issue #65 — ants.count boundary validation', () => {
-    function makeSavedSnapshot(mut: (s: ReturnType<typeof serializeWorldState>) => void): ReturnType<typeof serializeWorldState> {
+    function makeSavedSnapshot(
+      mut: (s: ReturnType<typeof serializeWorldState>) => void,
+    ): ReturnType<typeof serializeWorldState> {
       const w = createScenario(42);
       const s = serializeWorldState(w);
       mut(s);
@@ -643,42 +762,60 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     }
 
     it('accepts count = 0 (legacy fallback to MAX_ENTITIES)', () => {
-      const snapshot = makeSavedSnapshot((s) => { s.ants.count = 0; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.ants.count = 0;
+      });
       const w = deserializeWorldState(snapshot);
       // Capacity falls back to MAX_ENTITIES, which is the alive array length.
       expect(w.ants.alive.length).toBe(8192);
     });
     it('accepts a small positive integer count', () => {
-      const snapshot = makeSavedSnapshot((s) => { s.ants.count = 8; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.ants.count = 8;
+      });
       expect(() => deserializeWorldState(snapshot)).not.toThrow();
     });
     it('rejects count > MAX_ENTITIES (memory-DoS guard)', () => {
-      const snapshot = makeSavedSnapshot((s) => { s.ants.count = 1_000_000_000; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.ants.count = 1_000_000_000;
+      });
       expect(() => deserializeWorldState(snapshot)).toThrow(/Invalid ants\.count/);
     });
     it('exact boundary: count = MAX_ENTITIES is accepted', () => {
-      const snapshot = makeSavedSnapshot((s) => { s.ants.count = 8192; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.ants.count = 8192;
+      });
       const w = deserializeWorldState(snapshot);
       expect(w.ants.alive.length).toBe(8192);
     });
     it('exact boundary: count = MAX_ENTITIES + 1 is rejected', () => {
-      const snapshot = makeSavedSnapshot((s) => { s.ants.count = 8193; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.ants.count = 8193;
+      });
       expect(() => deserializeWorldState(snapshot)).toThrow(/Invalid ants\.count/);
     });
     it('rejects negative count', () => {
-      const snapshot = makeSavedSnapshot((s) => { s.ants.count = -1; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.ants.count = -1;
+      });
       expect(() => deserializeWorldState(snapshot)).toThrow(/Invalid ants\.count/);
     });
     it('rejects non-integer count', () => {
-      const snapshot = makeSavedSnapshot((s) => { s.ants.count = 1.5; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.ants.count = 1.5;
+      });
       expect(() => deserializeWorldState(snapshot)).toThrow(/Invalid ants\.count/);
     });
     it('rejects NaN count', () => {
-      const snapshot = makeSavedSnapshot((s) => { s.ants.count = NaN; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.ants.count = NaN;
+      });
       expect(() => deserializeWorldState(snapshot)).toThrow(/Invalid ants\.count/);
     });
     it('rejects Infinity count', () => {
-      const snapshot = makeSavedSnapshot((s) => { s.ants.count = Infinity; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.ants.count = Infinity;
+      });
       expect(() => deserializeWorldState(snapshot)).toThrow(/Invalid ants\.count/);
     });
     it('rejects non-number count (string)', () => {
@@ -742,15 +879,14 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   });
 
   describe('Issue #66 — simVersion boundary validation', () => {
-    function makeSavedSnapshot(mut: (s: ReturnType<typeof serializeWorldState>) => void): ReturnType<typeof serializeWorldState> {
+    function makeSavedSnapshot(
+      mut: (s: ReturnType<typeof serializeWorldState>) => void,
+    ): ReturnType<typeof serializeWorldState> {
       const w = createScenario(42);
       const s = serializeWorldState(w);
       mut(s);
       return s;
     }
-
-
-
 
     it('accepts simVersion = LATEST', () => {
       // LATEST_SIM_VERSION is 10 today; the value is whatever serializeWorldState
@@ -762,7 +898,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(out.simVersion).toBe(latest);
     });
     it('rejects simVersion above LATEST with FutureSimVersionError (recoverable signal)', () => {
-      const snapshot = makeSavedSnapshot((s) => { s.simVersion = 99999; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.simVersion = 99999;
+      });
       expect(() => deserializeWorldState(snapshot)).toThrow(FutureSimVersionError);
     });
     it('future simVersion takes precedence over count check (a future build can legitimately bump MAX_ENTITIES)', () => {
@@ -772,9 +910,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // preserves bytes), not as tampering (plain Error → deleteSave).
       const snapshot = makeSavedSnapshot((s) => {
         s.simVersion = 99999;
-        s.ants.count = 1_000_000;  // would be tampering at current LATEST, but
-                                   // simVersion=99999 means we don't know our
-                                   // own MAX_ENTITIES governs this save.
+        s.ants.count = 1_000_000; // would be tampering at current LATEST, but
+        // simVersion=99999 means we don't know our
+        // own MAX_ENTITIES governs this save.
       });
       expect(() => deserializeWorldState(snapshot)).toThrow(FutureSimVersionError);
     });
@@ -794,7 +932,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(() => deserializeWorldState(snapshot)).toThrow(FutureSimVersionError);
     });
     it('rejects negative simVersion (all-gates-off guard)', () => {
-      const snapshot = makeSavedSnapshot((s) => { s.simVersion = -1; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.simVersion = -1;
+      });
       expect(() => deserializeWorldState(snapshot)).toThrow(OldSimVersionError);
     });
     it('exact boundary: simVersion = LATEST + 1 throws FutureSimVersionError (recoverable)', () => {
@@ -802,16 +942,19 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // scenario; the value is captured here to keep the test version-agnostic.
       const w = createScenario(42);
       const latest = serializeWorldState(w).simVersion!;
-      const snapshot = makeSavedSnapshot((s) => { s.simVersion = latest + 1; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.simVersion = latest + 1;
+      });
       expect(() => deserializeWorldState(snapshot)).toThrow(FutureSimVersionError);
     });
     it('exact boundary: simVersion = MIN_ACCEPTED - 1 throws OldSimVersionError', () => {
       // Any simVersion below MIN_ACCEPTED_SIM_VERSION (22) is rejected with
       // OldSimVersionError so bootFromSave can handle it appropriately.
-      const snapshot = makeSavedSnapshot((s) => { s.simVersion = 1; });
+      const snapshot = makeSavedSnapshot((s) => {
+        s.simVersion = 1;
+      });
       expect(() => deserializeWorldState(snapshot)).toThrow(OldSimVersionError);
     });
-
   });
 
   // ---------------------------------------------------------------------------
@@ -822,15 +965,23 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   // to total save loss (the whole envelope returned null → bootFresh).
   // ---------------------------------------------------------------------------
   describe('Issue #78 — malformed BehaviorRatio resilience on load', () => {
-    function writeSave(file: { version: number; seed: number; inputLog: unknown[]; snapshot: unknown }): void {
+    function writeSave(file: {
+      version: number;
+      seed: number;
+      inputLog: unknown[];
+      snapshot: unknown;
+    }): void {
       localStorage.setItem(SAVE_KEY, JSON.stringify(file));
     }
 
     it('null ratio in inputLog: save still loads (command preserved verbatim)', () => {
       const w = createScenario(42);
       writeSave({
-        version: SAVE_FORMAT_VERSION, seed: 42,
-        inputLog: [{ type: 'SetBehaviorRatio', colonyId: PLAYER_COLONY_ID, ratio: null, issuedAtTick: 0 }],
+        version: SAVE_FORMAT_VERSION,
+        seed: 42,
+        inputLog: [
+          { type: 'SetBehaviorRatio', colonyId: PLAYER_COLONY_ID, ratio: null, issuedAtTick: 0 },
+        ],
         snapshot: serializeWorldState(w),
       });
       const loaded = loadSave();
@@ -841,8 +992,11 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     it('numeric ratio in inputLog: save still loads', () => {
       const w = createScenario(42);
       writeSave({
-        version: SAVE_FORMAT_VERSION, seed: 42,
-        inputLog: [{ type: 'SetBehaviorRatio', colonyId: PLAYER_COLONY_ID, ratio: 5, issuedAtTick: 0 }],
+        version: SAVE_FORMAT_VERSION,
+        seed: 42,
+        inputLog: [
+          { type: 'SetBehaviorRatio', colonyId: PLAYER_COLONY_ID, ratio: 5, issuedAtTick: 0 },
+        ],
         snapshot: serializeWorldState(w),
       });
       expect(loadSave()).not.toBeNull();
@@ -850,16 +1004,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     it('string ratio in inputLog: save still loads', () => {
       const w = createScenario(42);
       writeSave({
-        version: SAVE_FORMAT_VERSION, seed: 42,
-        inputLog: [{ type: 'SetBehaviorRatio', colonyId: PLAYER_COLONY_ID, ratio: 'bogus', issuedAtTick: 0 }],
+        version: SAVE_FORMAT_VERSION,
+        seed: 42,
+        inputLog: [
+          { type: 'SetBehaviorRatio', colonyId: PLAYER_COLONY_ID, ratio: 'bogus', issuedAtTick: 0 },
+        ],
         snapshot: serializeWorldState(w),
       });
       expect(loadSave()).not.toBeNull();
     });
-
-
-
-
   });
 
   // -------------------------------------------------------------------------
@@ -869,7 +1022,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   // -------------------------------------------------------------------------
 
   describe('boundary hardening — issues #99 / #101 / #102 / #103 / #104 / #105 / #109 / #110', () => {
-    function writeSave(file: { version: number; seed: unknown; inputLog: unknown; snapshot: unknown }): void {
+    function writeSave(file: {
+      version: number;
+      seed: unknown;
+      inputLog: unknown;
+      snapshot: unknown;
+    }): void {
       localStorage.setItem(SAVE_KEY, JSON.stringify(file));
     }
 
@@ -878,12 +1036,22 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     // -----------------------------------------------------------------------
     it('#110 rejects envelope seed: string', () => {
       const w = createScenario(42);
-      writeSave({ version: SAVE_FORMAT_VERSION, seed: 'abc' as unknown as number, inputLog: [], snapshot: serializeWorldState(w) });
+      writeSave({
+        version: SAVE_FORMAT_VERSION,
+        seed: 'abc' as unknown as number,
+        inputLog: [],
+        snapshot: serializeWorldState(w),
+      });
       expect(loadSave()).toBeNull();
     });
     it('#110 rejects envelope seed: null', () => {
       const w = createScenario(42);
-      writeSave({ version: SAVE_FORMAT_VERSION, seed: null, inputLog: [], snapshot: serializeWorldState(w) });
+      writeSave({
+        version: SAVE_FORMAT_VERSION,
+        seed: null,
+        inputLog: [],
+        snapshot: serializeWorldState(w),
+      });
       expect(loadSave()).toBeNull();
     });
     it('#110 rejects envelope seed: missing', () => {
@@ -894,19 +1062,39 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     });
     it('#110 rejects envelope seed: non-integer', () => {
       const w = createScenario(42);
-      writeSave({ version: SAVE_FORMAT_VERSION, seed: 1.5, inputLog: [], snapshot: serializeWorldState(w) });
+      writeSave({
+        version: SAVE_FORMAT_VERSION,
+        seed: 1.5,
+        inputLog: [],
+        snapshot: serializeWorldState(w),
+      });
       expect(loadSave()).toBeNull();
     });
     it('#110 rejects envelope seed: out of int32 range', () => {
       const w = createScenario(42);
-      writeSave({ version: SAVE_FORMAT_VERSION, seed: 0x80000000, inputLog: [], snapshot: serializeWorldState(w) });
+      writeSave({
+        version: SAVE_FORMAT_VERSION,
+        seed: 0x80000000,
+        inputLog: [],
+        snapshot: serializeWorldState(w),
+      });
       expect(loadSave()).toBeNull();
     });
     it('#110 accepts envelope seed: int32 boundary values', () => {
       const w = createScenario(42);
-      writeSave({ version: SAVE_FORMAT_VERSION, seed: 0x7fffffff, inputLog: [], snapshot: serializeWorldState(w) });
+      writeSave({
+        version: SAVE_FORMAT_VERSION,
+        seed: 0x7fffffff,
+        inputLog: [],
+        snapshot: serializeWorldState(w),
+      });
       expect(loadSave()).not.toBeNull();
-      writeSave({ version: SAVE_FORMAT_VERSION, seed: -0x80000000, inputLog: [], snapshot: serializeWorldState(w) });
+      writeSave({
+        version: SAVE_FORMAT_VERSION,
+        seed: -0x80000000,
+        inputLog: [],
+        snapshot: serializeWorldState(w),
+      });
       expect(loadSave()).not.toBeNull();
     });
 
@@ -923,14 +1111,24 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     });
     it('#103 normalizes null inputLog to empty array', () => {
       const w = createScenario(42);
-      writeSave({ version: SAVE_FORMAT_VERSION, seed: 42, inputLog: null, snapshot: serializeWorldState(w) });
+      writeSave({
+        version: SAVE_FORMAT_VERSION,
+        seed: 42,
+        inputLog: null,
+        snapshot: serializeWorldState(w),
+      });
       const loaded = loadSave();
       expect(loaded).not.toBeNull();
       expect(loaded!.inputLog).toEqual([]);
     });
     it('#103 normalizes string inputLog to empty array', () => {
       const w = createScenario(42);
-      writeSave({ version: SAVE_FORMAT_VERSION, seed: 42, inputLog: 'abc', snapshot: serializeWorldState(w) });
+      writeSave({
+        version: SAVE_FORMAT_VERSION,
+        seed: 42,
+        inputLog: 'abc',
+        snapshot: serializeWorldState(w),
+      });
       const loaded = loadSave();
       expect(loaded).not.toBeNull();
       expect(loaded!.inputLog).toEqual([]);
@@ -942,7 +1140,8 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     it('#105 null inputLog entry passes through migrateInputLogCommand without throwing', () => {
       const w = createScenario(42);
       writeSave({
-        version: SAVE_FORMAT_VERSION, seed: 42,
+        version: SAVE_FORMAT_VERSION,
+        seed: 42,
         inputLog: [null] as unknown as SimCommand[],
         snapshot: serializeWorldState(w),
       });
@@ -1002,8 +1201,13 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     function scenarioWithChamber() {
       const w = createScenario(42);
       w.colonies[PLAYER_COLONY_ID]!.chambers.push({
-        chamberId: 100, chamberType: ChamberType.Queen, foodStored: 0,
-        posX: 10 << 8, posY: 5 << 8, width: 5, height: 3,
+        chamberId: 100,
+        chamberType: ChamberType.Queen,
+        foodStored: 0,
+        posX: 10 << 8,
+        posY: 5 << 8,
+        width: 5,
+        height: 3,
       });
       return w;
     }
@@ -1031,11 +1235,11 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       (c0 as { foodStored: number }).foodStored = 99_999_999;
       expect(() => deserializeWorldState(s)).toThrow();
     });
-    it('#101 rejects chamber dims: don\'t match canonical CHAMBER_DIMENSIONS', () => {
+    it("#101 rejects chamber dims: don't match canonical CHAMBER_DIMENSIONS", () => {
       const s = serializeWorldState(scenarioWithChamber());
       const c0 = s.colonies[String(PLAYER_COLONY_ID)]!.chambers[0]!;
-      (c0 as { width: number }).width = 5;     // canonical for Queen
-      (c0 as { height: number }).height = 4;   // BAD: Queen height is 3
+      (c0 as { width: number }).width = 5; // canonical for Queen
+      (c0 as { height: number }).height = 4; // BAD: Queen height is 3
       expect(() => deserializeWorldState(s)).toThrow();
     });
 
@@ -1046,9 +1250,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       const w = createScenario(42);
       const s = serializeWorldState(w);
       (s.pendingChambers as Record<string, unknown>)['0:5:5'] = {
-        colonyId: 1, chamberType: 1,
-        anchorTileX: 0, anchorTileY: 1,
-        width: 1_000_000_000, height: 1_000_000_000,
+        colonyId: 1,
+        chamberType: 1,
+        anchorTileX: 0,
+        anchorTileY: 1,
+        width: 1_000_000_000,
+        height: 1_000_000_000,
       };
       expect(() => deserializeWorldState(s)).toThrow();
     });
@@ -1056,19 +1263,25 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       const w = createScenario(42);
       const s = serializeWorldState(w);
       (s.pendingChambers as Record<string, unknown>)['0:5:5'] = {
-        colonyId: 1, chamberType: 1,
-        anchorTileX: 1_000_000, anchorTileY: 1,
-        width: 4, height: 3,
+        colonyId: 1,
+        chamberType: 1,
+        anchorTileX: 1_000_000,
+        anchorTileY: 1,
+        width: 4,
+        height: 3,
       };
       expect(() => deserializeWorldState(s)).toThrow();
     });
-    it('#102 rejects pendingChamber: dims don\'t match canonical CHAMBER_DIMENSIONS', () => {
+    it("#102 rejects pendingChamber: dims don't match canonical CHAMBER_DIMENSIONS", () => {
       const w = createScenario(42);
       const s = serializeWorldState(w);
       (s.pendingChambers as Record<string, unknown>)['0:5:5'] = {
-        colonyId: 1, chamberType: 0, // Queen wants 5×3
-        anchorTileX: 0, anchorTileY: 1,
-        width: 4, height: 3, // wrong dims for type 0
+        colonyId: 1,
+        chamberType: 0, // Queen wants 5×3
+        anchorTileX: 0,
+        anchorTileY: 1,
+        width: 4,
+        height: 3, // wrong dims for type 0
       };
       expect(() => deserializeWorldState(s)).toThrow();
     });
@@ -1087,7 +1300,13 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       const s = serializeWorldState(w);
       const oversized = [];
       for (let i = 0; i < 1000; i++) {
-        oversized.push({ foodPileId: i, tileX: i % 128, tileY: 0 , pickupsRemaining: 50, pickupsInitial: 50});
+        oversized.push({
+          foodPileId: i,
+          tileX: i % 128,
+          tileY: 0,
+          pickupsRemaining: 50,
+          pickupsInitial: 50,
+        });
       }
       s.foodPiles = oversized;
       expect(() => deserializeWorldState(s)).toThrow();
@@ -1095,15 +1314,17 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     it('#109 rejects foodPile.tileX: out-of-grid', () => {
       const w = createScenario(42);
       const s = serializeWorldState(w);
-      s.foodPiles = [{ foodPileId: 1, tileX: 1_000_000, tileY: 0 , pickupsRemaining: 50, pickupsInitial: 50}];
+      s.foodPiles = [
+        { foodPileId: 1, tileX: 1_000_000, tileY: 0, pickupsRemaining: 50, pickupsInitial: 50 },
+      ];
       expect(() => deserializeWorldState(s)).toThrow();
     });
     it('#109 rejects foodPiles: duplicate foodPileId', () => {
       const w = createScenario(42);
       const s = serializeWorldState(w);
       s.foodPiles = [
-        { foodPileId: 5, tileX: 10, tileY: 10 , pickupsRemaining: 50, pickupsInitial: 50},
-        { foodPileId: 5, tileX: 20, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50},
+        { foodPileId: 5, tileX: 10, tileY: 10, pickupsRemaining: 50, pickupsInitial: 50 },
+        { foodPileId: 5, tileX: 20, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
       ];
       expect(() => deserializeWorldState(s)).toThrow();
     });
@@ -1111,8 +1332,8 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       const w = createScenario(42);
       const s = serializeWorldState(w);
       s.foodPiles = [
-        { foodPileId: 5, tileX: 10, tileY: 10 , pickupsRemaining: 50, pickupsInitial: 50},
-        { foodPileId: 6, tileX: 10, tileY: 10 , pickupsRemaining: 50, pickupsInitial: 50},
+        { foodPileId: 5, tileX: 10, tileY: 10, pickupsRemaining: 50, pickupsInitial: 50 },
+        { foodPileId: 6, tileX: 10, tileY: 10, pickupsRemaining: 50, pickupsInitial: 50 },
       ];
       expect(() => deserializeWorldState(s)).toThrow();
     });
@@ -1155,7 +1376,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       const s = serializeWorldState(w);
       for (let i = 0; i < 300; i++) {
         (s.pendingChambers as Record<string, unknown>)[`0:${i}:1`] = {
-          colonyId: 1, chamberType: 1, anchorTileX: i % 100, anchorTileY: 1, width: 4, height: 3,
+          colonyId: 1,
+          chamberType: 1,
+          anchorTileX: i % 100,
+          anchorTileY: 1,
+          width: 4,
+          height: 3,
         };
       }
       expect(() => deserializeWorldState(s)).toThrow();
@@ -1177,7 +1403,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // bare assignment of '__proto__' would mutate the prototype instead.
       Object.defineProperty(s.pendingChambers as object, '__shady', {
         value: {
-          colonyId: 1, chamberType: 1, anchorTileX: 0, anchorTileY: 1, width: 4, height: 3,
+          colonyId: 1,
+          chamberType: 1,
+          anchorTileX: 0,
+          anchorTileY: 1,
+          width: 4,
+          height: 3,
         },
         enumerable: true,
         configurable: true,
@@ -1349,7 +1580,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     it('preserves the inputLog the caller supplies', () => {
       const world = createScenario(42);
       const log: SimCommand[] = [
-        { type: 'SetBehaviorRatio', colonyId: PLAYER_COLONY_ID, ratio: { forage: 5, fight: 5 }, issuedAtTick: 0 },
+        {
+          type: 'SetBehaviorRatio',
+          colonyId: PLAYER_COLONY_ID,
+          ratio: { forage: 5, fight: 5 },
+          issuedAtTick: 0,
+        },
       ];
       manualSave(42, log, world);
       const loaded = loadSave();
@@ -1360,7 +1596,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     it('returns false (does not throw) when localStorage.setItem rejects', () => {
       const world = createScenario(42);
       const orig = window.localStorage.setItem;
-      window.localStorage.setItem = vi.fn(() => { throw new Error('QuotaExceededError'); });
+      window.localStorage.setItem = vi.fn(() => {
+        throw new Error('QuotaExceededError');
+      });
       try {
         const ok = manualSave(42, [], world);
         expect(ok).toBe(false);
@@ -1404,12 +1642,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // → hasIncompatibleSave returns true; hasSave returns false. The pair
       // lets the dialog distinguish "no save" from "save present, this build
       // can't read it" instead of silently booting fresh.
-      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: 2,
-        seed: 1,
-        inputLog: [],
-        snapshot: {},
-      }));
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: 2,
+          seed: 1,
+          inputLog: [],
+          snapshot: {},
+        }),
+      );
       expect(hasIncompatibleSave()).toBe(true);
       expect(hasSave()).toBe(false);
     });
@@ -1481,22 +1722,28 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // parseSaveFile only validates the envelope. A v3 envelope with
       // snapshot=null parses fine but reading snapshot.simVersion would
       // throw and crash the dialog. Treat as incompatible.
-      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: SAVE_FORMAT_VERSION,
-        seed: 1,
-        inputLog: [],
-        snapshot: null,
-      }));
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: SAVE_FORMAT_VERSION,
+          seed: 1,
+          inputLog: [],
+          snapshot: null,
+        }),
+      );
       expect(hasIncompatibleSave()).toBe(true);
     });
 
     it('Codex round-3 P1: returns true when snapshot is a non-object (string / number)', () => {
-      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: SAVE_FORMAT_VERSION,
-        seed: 1,
-        inputLog: [],
-        snapshot: 'not an object',
-      }));
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: SAVE_FORMAT_VERSION,
+          seed: 1,
+          inputLog: [],
+          snapshot: 'not an object',
+        }),
+      );
       expect(hasIncompatibleSave()).toBe(true);
     });
 
@@ -1506,12 +1753,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // appear enabled — but bootFromSave would throw on missing required
       // fields and silently fall through to bootFresh. Now flagged via
       // the full-deserialize boundary check.
-      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: SAVE_FORMAT_VERSION,
-        seed: 1,
-        inputLog: [],
-        snapshot: {},
-      }));
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: SAVE_FORMAT_VERSION,
+          seed: 1,
+          inputLog: [],
+          snapshot: {},
+        }),
+      );
       expect(hasIncompatibleSave()).toBe(true);
     });
 
@@ -1520,23 +1770,29 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       const world = createScenario(7);
       const snap = serializeWorldState(world);
       snap.simVersion = LEGACY_SIM_VERSION - 1;
-      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: SAVE_FORMAT_VERSION,
-        seed: 7,
-        inputLog: [],
-        snapshot: snap,
-        savedAtMs: Date.now(),
-      }));
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: SAVE_FORMAT_VERSION,
+          seed: 7,
+          inputLog: [],
+          snapshot: snap,
+          savedAtMs: Date.now(),
+        }),
+      );
       expect(hasIncompatibleSave()).toBe(true);
     });
 
     it('round-4 (Rob): returns true when snapshot.colonies is missing (deserialize would throw)', () => {
-      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: SAVE_FORMAT_VERSION,
-        seed: 1,
-        inputLog: [],
-        snapshot: { tick: 0, rngState: 0, nextEntityId: 0, commandQueue: [] },
-      }));
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: SAVE_FORMAT_VERSION,
+          seed: 1,
+          inputLog: [],
+          snapshot: { tick: 0, rngState: 0, nextEntityId: 0, commandQueue: [] },
+        }),
+      );
       expect(hasIncompatibleSave()).toBe(true);
     });
   });
@@ -1619,12 +1875,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // the "incompatible" warning + can use Delete/New Game to recover.
       // Pre-fix this case threw inside getSaveInfo and crashed dialog
       // rendering before the user could click anything.
-      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: SAVE_FORMAT_VERSION,
-        seed: 1,
-        inputLog: [],
-        snapshot: null,
-      }));
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: SAVE_FORMAT_VERSION,
+          seed: 1,
+          inputLog: [],
+          snapshot: null,
+        }),
+      );
       expect(() => getSaveInfo()).not.toThrow();
       expect(getSaveInfo()).toBeNull();
     });
@@ -1632,12 +1891,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     it('Codex round-3 P1: does NOT throw when snapshot.colonies is missing', () => {
       // A snapshot with tick/rngState/etc. but no `colonies` field.
       // Pre-fix: dereferencing colonies[playerKey] would throw TypeError.
-      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: SAVE_FORMAT_VERSION,
-        seed: 1,
-        inputLog: [],
-        snapshot: { tick: 5, rngState: 1, nextEntityId: 0 },
-      }));
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: SAVE_FORMAT_VERSION,
+          seed: 1,
+          inputLog: [],
+          snapshot: { tick: 5, rngState: 1, nextEntityId: 0 },
+        }),
+      );
       expect(() => getSaveInfo()).not.toThrow();
       const info = getSaveInfo();
       expect(info).not.toBeNull();
@@ -1647,12 +1909,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     });
 
     it('Codex round-3 P1: returns 0 fields when snapshot.tick is missing/non-numeric', () => {
-      window.localStorage.setItem(SAVE_KEY, JSON.stringify({
-        version: SAVE_FORMAT_VERSION,
-        seed: 1,
-        inputLog: [],
-        snapshot: { colonies: {} },
-      }));
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({
+          version: SAVE_FORMAT_VERSION,
+          seed: 1,
+          inputLog: [],
+          snapshot: { colonies: {} },
+        }),
+      );
       const info = getSaveInfo();
       expect(info).not.toBeNull();
       expect(info!.tick).toBe(0);
@@ -1671,10 +1936,27 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           rngState: 1,
           nextEntityId: 0,
           commandQueue: [],
-          ants: { count: 0, posX: [], posY: [], colonyId: [], task: [], subTask: [],
-                  speed: [], foodCarrying: [], starvationTimer: [], age: [], alive: [],
-                  lifespan: [], zone: [], digTileX: [], digTileY: [], digTicksRemaining: [],
-                  targetPosX: [], targetPosY: [], targetSet: [] },
+          ants: {
+            count: 0,
+            posX: [],
+            posY: [],
+            colonyId: [],
+            task: [],
+            subTask: [],
+            speed: [],
+            foodCarrying: [],
+            starvationTimer: [],
+            age: [],
+            alive: [],
+            lifespan: [],
+            zone: [],
+            digTileX: [],
+            digTileY: [],
+            digTicksRemaining: [],
+            targetPosX: [],
+            targetPosY: [],
+            targetSet: [],
+          },
           colonies: {}, // PLAYER_COLONY_ID intentionally missing
           pheromoneGrids: {},
           surface: { width: 1, height: 1, data: [0] },

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -17,7 +17,10 @@ import { AI_MAX_OPERATION_FIGHTERS, SPIDER_HUNT_INTERVAL_TICKS } from '../sim/co
 import type { AntComponents } from '../sim/ant/ant-store.js';
 import { createAntComponents } from '../sim/ant/ant-store.js';
 import type {
-  ColonyId, ColonyRecord, WorkerAllocation, ChamberRecord,
+  ColonyId,
+  ColonyRecord,
+  WorkerAllocation,
+  ChamberRecord,
 } from '../sim/colony/colony-store.js';
 import { createColonyRecord } from '../sim/colony/colony-store.js';
 import type { NestEntrance } from '../sim/colony/entrance.js';
@@ -76,7 +79,10 @@ export const SAVE_KEY = 'subterrans:save:v3' as const;
 export const AUTOSAVE_INTERVAL_MS = 30_000 as const;
 
 export class SaveVersionMismatchError extends Error {
-  constructor(public expected: number, public got: number) {
+  constructor(
+    public expected: number,
+    public got: number,
+  ) {
     super(`Save format version mismatch: expected ${expected}, got ${got}`);
     this.name = 'SaveVersionMismatchError';
   }
@@ -95,7 +101,10 @@ export class SaveVersionMismatchError extends Error {
  * fresh without deleting; user can recover by upgrading the build.
  */
 export class FutureSimVersionError extends Error {
-  constructor(public got: number, public latest: number) {
+  constructor(
+    public got: number,
+    public latest: number,
+  ) {
     super(`Save's simVersion (${got}) is newer than this build's LATEST (${latest})`);
     this.name = 'FutureSimVersionError';
   }
@@ -106,7 +115,9 @@ export const MIN_ACCEPTED_SIM_VERSION = SIM_VERSION_V22_DIFFICULTY;
 export class OldSimVersionError extends Error {
   constructor(public got: number | null) {
     const gotStr = got !== null ? String(got) : 'unknown';
-    super(`Save is from an older version (simVersion=${gotStr}); minimum accepted is ${MIN_ACCEPTED_SIM_VERSION}. Please start a new game.`);
+    super(
+      `Save is from an older version (simVersion=${gotStr}); minimum accepted is ${MIN_ACCEPTED_SIM_VERSION}. Please start a new game.`,
+    );
     this.name = 'OldSimVersionError';
   }
 }
@@ -132,20 +143,22 @@ function isTileCoord(value: unknown, max: number): boolean {
 
 /** Issue #110 — envelope seed must round-trip `seed | 0` losslessly (int32). */
 function isInt32(value: unknown): value is number {
-  return typeof value === 'number'
-    && Number.isFinite(value)
-    && Number.isInteger(value)
-    && value >= -0x80000000
-    && value <= 0x7fffffff;
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= -0x80000000 &&
+    value <= 0x7fffffff
+  );
 }
 
 /** Cap on how many entries each top-level Object map may carry on load.
  *  Issue #99 — defense against memory-DoS via unbounded `Object.entries`
  *  loops in deserializeWorldState. Numbers are 4-8× current scenario use,
  *  ample headroom for future scenario tweaks; anything above is tampering. */
-const MAX_COLONIES_LOAD = 16;       // current LIVE_COLONY_COUNT = 2.
+const MAX_COLONIES_LOAD = 16; // current LIVE_COLONY_COUNT = 2.
 const MAX_PHEROMONE_GRID_KEYS = 16; // current = 8 (2 colonies × 2 types × 2 zones).
-const MAX_PENDING_CHAMBERS = 256;   // few per colony in normal play.
+const MAX_PENDING_CHAMBERS = 256; // few per colony in normal play.
 const MAX_FOOD_PILES = FOOD_PILE_COUNT * 4; // issue #109.
 
 /** Issue #99 — verify a serialized grid object matches the canonical
@@ -153,12 +166,7 @@ const MAX_FOOD_PILES = FOOD_PILE_COUNT * 4; // issue #109.
  *  (`src/sim/constants.ts`); a future change to grid size would correctly
  *  require a save-format bump anyway, so a strict equality check is the
  *  right strictness level here. */
-function validateGridShape(
-  s: unknown,
-  expectedW: number,
-  expectedH: number,
-  label: string,
-): void {
+function validateGridShape(s: unknown, expectedW: number, expectedH: number, label: string): void {
   if (s === null || typeof s !== 'object') {
     throw new Error(`Invalid ${label}: not an object`);
   }
@@ -166,7 +174,7 @@ function validateGridShape(
   if (g.width !== expectedW || g.height !== expectedH) {
     throw new Error(
       `Invalid ${label} dimensions: ${String(g.width)}x${String(g.height)} ` +
-      `(expected ${expectedW}x${expectedH})`,
+        `(expected ${expectedW}x${expectedH})`,
     );
   }
   if (!Array.isArray(g.data) && !ArrayBuffer.isView(g.data)) {
@@ -184,44 +192,54 @@ function validateChamberRecord(ch: unknown, label: string): void {
     throw new Error(`Invalid ${label}: not an object`);
   }
   const c = ch as Partial<ChamberRecord>;
-  if (typeof c.chamberId !== 'number'
-      || !Number.isInteger(c.chamberId)
-      || c.chamberId < 0
-      || c.chamberId > MAX_ENTITIES) {
+  if (
+    typeof c.chamberId !== 'number' ||
+    !Number.isInteger(c.chamberId) ||
+    c.chamberId < 0 ||
+    c.chamberId > MAX_ENTITIES
+  ) {
     throw new Error(`Invalid ${label}.chamberId: ${String(c.chamberId)}`);
   }
-  if (typeof c.chamberType !== 'number'
-      || !Number.isInteger(c.chamberType)
-      || c.chamberType < 0
-      || c.chamberType > 2) {
+  if (
+    typeof c.chamberType !== 'number' ||
+    !Number.isInteger(c.chamberType) ||
+    c.chamberType < 0 ||
+    c.chamberType > 2
+  ) {
     throw new Error(`Invalid ${label}.chamberType: ${String(c.chamberType)}`);
   }
   const dims = CHAMBER_DIMENSIONS[c.chamberType as ChamberType];
   if (c.width !== dims.width || c.height !== dims.height) {
     throw new Error(
       `Invalid ${label} dims for type ${c.chamberType}: ` +
-      `${String(c.width)}x${String(c.height)} (expected ${dims.width}x${dims.height})`,
+        `${String(c.width)}x${String(c.height)} (expected ${dims.width}x${dims.height})`,
     );
   }
   // posX/posY are FP coords; require integer in [0, gridSize<<FP_SHIFT).
   const ugWidthFp = UNDERGROUND_GRID_WIDTH << FP_SHIFT;
   const ugHeightFp = UNDERGROUND_GRID_HEIGHT << FP_SHIFT;
-  if (typeof c.posX !== 'number'
-      || !Number.isInteger(c.posX)
-      || c.posX < 0
-      || c.posX >= ugWidthFp) {
+  if (
+    typeof c.posX !== 'number' ||
+    !Number.isInteger(c.posX) ||
+    c.posX < 0 ||
+    c.posX >= ugWidthFp
+  ) {
     throw new Error(`Invalid ${label}.posX: ${String(c.posX)}`);
   }
-  if (typeof c.posY !== 'number'
-      || !Number.isInteger(c.posY)
-      || c.posY < 0
-      || c.posY >= ugHeightFp) {
+  if (
+    typeof c.posY !== 'number' ||
+    !Number.isInteger(c.posY) ||
+    c.posY < 0 ||
+    c.posY >= ugHeightFp
+  ) {
     throw new Error(`Invalid ${label}.posY: ${String(c.posY)}`);
   }
-  if (typeof c.foodStored !== 'number'
-      || !Number.isInteger(c.foodStored)
-      || c.foodStored < 0
-      || c.foodStored > FOOD_CHAMBER_CAPACITY) {
+  if (
+    typeof c.foodStored !== 'number' ||
+    !Number.isInteger(c.foodStored) ||
+    c.foodStored < 0 ||
+    c.foodStored > FOOD_CHAMBER_CAPACITY
+  ) {
     throw new Error(`Invalid ${label}.foodStored: ${String(c.foodStored)}`);
   }
 }
@@ -238,10 +256,12 @@ function validatePendingChamber(pc: unknown, label: string): void {
   if (typeof p.colonyId !== 'number' || !Number.isInteger(p.colonyId) || p.colonyId < 0) {
     throw new Error(`Invalid ${label}.colonyId: ${String(p.colonyId)}`);
   }
-  if (typeof p.chamberType !== 'number'
-      || !Number.isInteger(p.chamberType)
-      || p.chamberType < 0
-      || p.chamberType > 2) {
+  if (
+    typeof p.chamberType !== 'number' ||
+    !Number.isInteger(p.chamberType) ||
+    p.chamberType < 0 ||
+    p.chamberType > 2
+  ) {
     throw new Error(`Invalid ${label}.chamberType: ${String(p.chamberType)}`);
   }
   if (!isTileCoord(p.anchorTileX, UNDERGROUND_GRID_WIDTH)) {
@@ -254,14 +274,16 @@ function validatePendingChamber(pc: unknown, label: string): void {
   if (p.width !== dims.width || p.height !== dims.height) {
     throw new Error(
       `Invalid ${label} dims for type ${p.chamberType}: ` +
-      `${String(p.width)}x${String(p.height)} (expected ${dims.width}x${dims.height})`,
+        `${String(p.width)}x${String(p.height)} (expected ${dims.width}x${dims.height})`,
     );
   }
-  if ((p.anchorTileX as number) + dims.width > UNDERGROUND_GRID_WIDTH
-      || (p.anchorTileY as number) + dims.height > UNDERGROUND_GRID_HEIGHT) {
+  if (
+    (p.anchorTileX as number) + dims.width > UNDERGROUND_GRID_WIDTH ||
+    (p.anchorTileY as number) + dims.height > UNDERGROUND_GRID_HEIGHT
+  ) {
     throw new Error(
       `${label} footprint extends past grid: anchor ` +
-      `(${p.anchorTileX}, ${p.anchorTileY}) + ${dims.width}x${dims.height}`,
+        `(${p.anchorTileX}, ${p.anchorTileY}) + ${dims.width}x${dims.height}`,
     );
   }
 }
@@ -272,10 +294,12 @@ function validateFoodPile(p: unknown, label: string): void {
     throw new Error(`Invalid ${label}: not an object`);
   }
   const fp = p as Partial<FoodPile>;
-  if (typeof fp.foodPileId !== 'number'
-      || !Number.isInteger(fp.foodPileId)
-      || fp.foodPileId < 0
-      || fp.foodPileId > MAX_ENTITIES) {
+  if (
+    typeof fp.foodPileId !== 'number' ||
+    !Number.isInteger(fp.foodPileId) ||
+    fp.foodPileId < 0 ||
+    fp.foodPileId > MAX_ENTITIES
+  ) {
     throw new Error(`Invalid ${label}.foodPileId: ${String(fp.foodPileId)}`);
   }
   if (!isTileCoord(fp.tileX, SURFACE_GRID_WIDTH)) {
@@ -290,19 +314,23 @@ function validateFoodPile(p: unknown, label: string): void {
   // range, so any save with `pickupsInitial < MIN` represents a state the
   // sim cannot generate (either tampered, or a back-port from a build with
   // looser constants — neither survives the contract).
-  if (typeof fp.pickupsInitial !== 'number'
-      || !Number.isInteger(fp.pickupsInitial)
-      || fp.pickupsInitial < FOOD_PILE_INITIAL_PICKUPS_MIN
-      || fp.pickupsInitial > FOOD_PILE_INITIAL_PICKUPS_MAX) {
+  if (
+    typeof fp.pickupsInitial !== 'number' ||
+    !Number.isInteger(fp.pickupsInitial) ||
+    fp.pickupsInitial < FOOD_PILE_INITIAL_PICKUPS_MIN ||
+    fp.pickupsInitial > FOOD_PILE_INITIAL_PICKUPS_MAX
+  ) {
     throw new Error(`Invalid ${label}.pickupsInitial: ${String(fp.pickupsInitial)}`);
   }
   // pickupsRemaining: integer in [1, pickupsInitial]. Live piles always have
   // at least one charge — the runtime splices at zero so saves should never
   // observe a 0 here. Above-initial means tampering or accidental re-creation.
-  if (typeof fp.pickupsRemaining !== 'number'
-      || !Number.isInteger(fp.pickupsRemaining)
-      || fp.pickupsRemaining <= 0
-      || fp.pickupsRemaining > fp.pickupsInitial) {
+  if (
+    typeof fp.pickupsRemaining !== 'number' ||
+    !Number.isInteger(fp.pickupsRemaining) ||
+    fp.pickupsRemaining <= 0 ||
+    fp.pickupsRemaining > fp.pickupsInitial
+  ) {
     throw new Error(`Invalid ${label}.pickupsRemaining: ${String(fp.pickupsRemaining)}`);
   }
 }
@@ -338,15 +366,25 @@ function validateDepletionRecord(d: unknown, label: string): void {
 // ---------------------------------------------------------------------------
 
 interface SerializedAnts {
-  count: number;   // we persist capacity = MAX_ENTITIES; no separate count field exists on AntComponents
+  count: number; // we persist capacity = MAX_ENTITIES; no separate count field exists on AntComponents
   // All 18 Int32Array fields as plain number[]:
-  posX: number[]; posY: number[]; colonyId: number[];
-  task: number[]; subTask: number[]; speed: number[];
-  foodCarrying: number[]; starvationTimer: number[];
-  age: number[]; alive: number[]; lifespan: number[];
+  posX: number[];
+  posY: number[];
+  colonyId: number[];
+  task: number[];
+  subTask: number[];
+  speed: number[];
+  foodCarrying: number[];
+  starvationTimer: number[];
+  age: number[];
+  alive: number[];
+  lifespan: number[];
   zone: number[];
-  digTileX: number[]; digTileY: number[]; digTicksRemaining: number[];
-  targetPosX: number[]; targetPosY: number[];
+  digTileX: number[];
+  digTileY: number[];
+  digTicksRemaining: number[];
+  targetPosX: number[];
+  targetPosY: number[];
   searchWave: number[];
   searchHeadingX: number[];
   searchHeadingY: number[];
@@ -369,15 +407,24 @@ interface SerializedAnts {
 }
 
 interface SerializedColony {
-  colonyId: ColonyId; queenEntityId: EntityId; queenStarvationTimer: number;
-  foodStored: number; workerCount: number; eggCount: number; larvaeCount: number; nurseCount: number;
-  eggs: EntityId[]; larvae: EntityId[]; workers: EntityId[];
+  colonyId: ColonyId;
+  queenEntityId: EntityId;
+  queenStarvationTimer: number;
+  foodStored: number;
+  workerCount: number;
+  eggCount: number;
+  larvaeCount: number;
+  nurseCount: number;
+  eggs: EntityId[];
+  larvae: EntityId[];
+  workers: EntityId[];
   chambers: ChamberRecord[];
   queenLastEggTick: number;
   targetRatio: { forage: number; fight: number };
   computedAllocation: WorkerAllocation;
   taskCensus: WorkerAllocation;
-  defeated: boolean; reconcileCountdown: number;
+  defeated: boolean;
+  reconcileCountdown: number;
   entrances: NestEntrance[];
   rallyPoint: { tileX: number; tileY: number } | null;
   digFlowFieldDirty: boolean;
@@ -387,7 +434,11 @@ interface SerializedColony {
   eggIntervalNumerator: number;
 }
 
-interface SerializedGrid { width: number; height: number; data: number[] }
+interface SerializedGrid {
+  width: number;
+  height: number;
+  data: number[];
+}
 
 /** S3 — serialized form of SpiderState. All fields are plain numbers/strings. */
 interface SerializedSpiderState {
@@ -495,29 +546,29 @@ function serializeAnts(a: AntComponents): SerializedAnts {
   // same size, so unused slots (alive=0) round-trip faithfully.
   return {
     count: a.alive.length,
-    posX:              Array.from(a.posX),
-    posY:              Array.from(a.posY),
-    colonyId:          Array.from(a.colonyId),
-    task:              Array.from(a.task),
-    subTask:           Array.from(a.subTask),
-    speed:             Array.from(a.speed),
-    foodCarrying:      Array.from(a.foodCarrying),
-    starvationTimer:   Array.from(a.starvationTimer),
-    age:               Array.from(a.age),
-    alive:             Array.from(a.alive),
-    lifespan:          Array.from(a.lifespan),
-    zone:              Array.from(a.zone),
-    digTileX:          Array.from(a.digTileX),
-    digTileY:          Array.from(a.digTileY),
+    posX: Array.from(a.posX),
+    posY: Array.from(a.posY),
+    colonyId: Array.from(a.colonyId),
+    task: Array.from(a.task),
+    subTask: Array.from(a.subTask),
+    speed: Array.from(a.speed),
+    foodCarrying: Array.from(a.foodCarrying),
+    starvationTimer: Array.from(a.starvationTimer),
+    age: Array.from(a.age),
+    alive: Array.from(a.alive),
+    lifespan: Array.from(a.lifespan),
+    zone: Array.from(a.zone),
+    digTileX: Array.from(a.digTileX),
+    digTileY: Array.from(a.digTileY),
     digTicksRemaining: Array.from(a.digTicksRemaining),
-    targetPosX:        Array.from(a.targetPosX),
-    targetPosY:        Array.from(a.targetPosY),
-    searchWave:        Array.from(a.searchWave),
-    searchHeadingX:    Array.from(a.searchHeadingX),
-    searchHeadingY:    Array.from(a.searchHeadingY),
-    searchHeadingTicks:Array.from(a.searchHeadingTicks),
-    searchPrevTileX:   Array.from(a.searchPrevTileX),
-    searchPrevTileY:   Array.from(a.searchPrevTileY),
+    targetPosX: Array.from(a.targetPosX),
+    targetPosY: Array.from(a.targetPosY),
+    searchWave: Array.from(a.searchWave),
+    searchHeadingX: Array.from(a.searchHeadingX),
+    searchHeadingY: Array.from(a.searchHeadingY),
+    searchHeadingTicks: Array.from(a.searchHeadingTicks),
+    searchPrevTileX: Array.from(a.searchPrevTileX),
+    searchPrevTileY: Array.from(a.searchPrevTileY),
     // Phase 09.1 Chunk 0 — grid-of-occupancy byte. Array.from works for both
     // Int32Array and Uint8Array, so the shape is identical to the other
     // per-ant fields (number[]).
@@ -529,46 +580,46 @@ function serializeAnts(a: AntComponents): SerializedAnts {
     // Issue #42 — recent-tiles ring buffer. The X/Y arrays are flat
     // (length = maxEntities * RECENT_TILES_LEN); the head array indexes
     // into them. All three round-trip for v6 SCEN-06 replay determinism.
-    recentTilesX:    Array.from(a.recentTilesX),
-    recentTilesY:    Array.from(a.recentTilesY),
+    recentTilesX: Array.from(a.recentTilesX),
+    recentTilesY: Array.from(a.recentTilesY),
     recentTilesHead: Array.from(a.recentTilesHead),
     // Issue #17 Phase 1 — visible brood carry slot + reverse pointer.
     carryingBroodId: Array.from(a.carryingBroodId),
-    carriedBy:       Array.from(a.carriedBy),
+    carriedBy: Array.from(a.carriedBy),
     // S1 — combat HP/damage/cooldown fields.
-    hp:               Array.from(a.hp),
-    homeGroundBonusHp:Array.from(a.homeGroundBonusHp),
-    attackCooldown:   Array.from(a.attackCooldown),
+    hp: Array.from(a.hp),
+    homeGroundBonusHp: Array.from(a.homeGroundBonusHp),
+    attackCooldown: Array.from(a.attackCooldown),
     combatOpponentId: Array.from(a.combatOpponentId),
   };
 }
 
 function serializeColony(c: ColonyRecord): SerializedColony {
   return {
-    colonyId:             c.colonyId,
-    queenEntityId:        c.queenEntityId,
+    colonyId: c.colonyId,
+    queenEntityId: c.queenEntityId,
     queenStarvationTimer: c.queenStarvationTimer,
-    foodStored:           c.foodStored,
-    workerCount:          c.workerCount,
-    eggCount:             c.eggCount,
-    larvaeCount:          c.larvaeCount,
-    nurseCount:           c.nurseCount,
-    eggs:                 [...c.eggs],
-    larvae:               [...c.larvae],
-    workers:              [...c.workers],
-    chambers:             c.chambers.map((ch) => ({ ...ch })),
-    targetRatio:          { ...c.targetRatio },
-    computedAllocation:   { ...c.computedAllocation },
-    taskCensus:           { ...c.taskCensus },
-    defeated:             c.defeated,
-    reconcileCountdown:   c.reconcileCountdown,
-    queenLastEggTick:     c.queenLastEggTick,
-    entrances:            c.entrances.map((e) => ({ ...e })),
-    rallyPoint:           c.rallyPoint === null ? null : { ...c.rallyPoint },
-    digFlowFieldDirty:    c.digFlowFieldDirty,
-    foodFlowFieldDirty:   c.foodFlowFieldDirty,
-    killCount:            c.killCount,
-    priorityFoodPileId:   c.priorityFoodPileId,
+    foodStored: c.foodStored,
+    workerCount: c.workerCount,
+    eggCount: c.eggCount,
+    larvaeCount: c.larvaeCount,
+    nurseCount: c.nurseCount,
+    eggs: [...c.eggs],
+    larvae: [...c.larvae],
+    workers: [...c.workers],
+    chambers: c.chambers.map((ch) => ({ ...ch })),
+    targetRatio: { ...c.targetRatio },
+    computedAllocation: { ...c.computedAllocation },
+    taskCensus: { ...c.taskCensus },
+    defeated: c.defeated,
+    reconcileCountdown: c.reconcileCountdown,
+    queenLastEggTick: c.queenLastEggTick,
+    entrances: c.entrances.map((e) => ({ ...e })),
+    rallyPoint: c.rallyPoint === null ? null : { ...c.rallyPoint },
+    digFlowFieldDirty: c.digFlowFieldDirty,
+    foodFlowFieldDirty: c.foodFlowFieldDirty,
+    killCount: c.killCount,
+    priorityFoodPileId: c.priorityFoodPileId,
     eggIntervalNumerator: c.eggIntervalNumerator,
   };
 }
@@ -608,7 +659,7 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
     nextEntityId: world.nextEntityId,
     simVersion: world.simVersion,
     terrainSeed: world.terrainSeed,
-    commandQueue: world.commandQueue.map((c) => ({ ...c })),  // Pitfall 7 — preserve
+    commandQueue: world.commandQueue.map((c) => ({ ...c })), // Pitfall 7 — preserve
     ants: serializeAnts(world.ants),
     colonies: coloniesOut,
     pheromoneGrids: pheromoneOut,
@@ -653,7 +704,6 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
 // ---------------------------------------------------------------------------
 // Deserialize helpers
 // ---------------------------------------------------------------------------
-
 
 /**
  * Validate `simVersion` at the save boundary.
@@ -739,30 +789,32 @@ function deserializeAnts(saved: SerializedAnts, capacity: number): AntComponents
 function deserializeColony(s: SerializedColony): ColonyRecord {
   const c = createColonyRecord(s.colonyId, s.queenEntityId);
   c.queenStarvationTimer = s.queenStarvationTimer;
-  c.foodStored           = s.foodStored;
-  c.workerCount          = s.workerCount;
-  c.eggCount             = s.eggCount;
-  c.larvaeCount          = s.larvaeCount;
-  c.nurseCount           = s.nurseCount;
-  c.eggs                 = [...s.eggs];
-  c.larvae               = [...s.larvae];
-  c.workers              = [...s.workers];
-  c.chambers             = s.chambers.map((ch) => ({ ...ch }));
-  c.targetRatio          = { ...s.targetRatio };
-  c.computedAllocation   = { ...s.computedAllocation };
-  c.taskCensus           = { ...s.taskCensus };
-  c.defeated             = s.defeated;
-  c.reconcileCountdown   = s.reconcileCountdown;
-  c.entrances            = s.entrances.map((e) => ({ ...e }));
-  c.rallyPoint           = s.rallyPoint === null ? null : { ...s.rallyPoint };
-  c.digFlowFieldDirty    = s.digFlowFieldDirty;
-  c.foodFlowFieldDirty   = s.foodFlowFieldDirty;
-  c.killCount            = s.killCount;
-  c.priorityFoodPileId   = s.priorityFoodPileId;
-  c.queenLastEggTick     = s.queenLastEggTick;
+  c.foodStored = s.foodStored;
+  c.workerCount = s.workerCount;
+  c.eggCount = s.eggCount;
+  c.larvaeCount = s.larvaeCount;
+  c.nurseCount = s.nurseCount;
+  c.eggs = [...s.eggs];
+  c.larvae = [...s.larvae];
+  c.workers = [...s.workers];
+  c.chambers = s.chambers.map((ch) => ({ ...ch }));
+  c.targetRatio = { ...s.targetRatio };
+  c.computedAllocation = { ...s.computedAllocation };
+  c.taskCensus = { ...s.taskCensus };
+  c.defeated = s.defeated;
+  c.reconcileCountdown = s.reconcileCountdown;
+  c.entrances = s.entrances.map((e) => ({ ...e }));
+  c.rallyPoint = s.rallyPoint === null ? null : { ...s.rallyPoint };
+  c.digFlowFieldDirty = s.digFlowFieldDirty;
+  c.foodFlowFieldDirty = s.foodFlowFieldDirty;
+  c.killCount = s.killCount;
+  c.priorityFoodPileId = s.priorityFoodPileId;
+  c.queenLastEggTick = s.queenLastEggTick;
   // Valid difficulty numerators are 3, 4, 5. Reject any out-of-range value (tampered save or future compat).
-  c.eggIntervalNumerator = (s.eggIntervalNumerator === 3 || s.eggIntervalNumerator === 4 || s.eggIntervalNumerator === 5)
-    ? s.eggIntervalNumerator : 4;
+  c.eggIntervalNumerator =
+    s.eggIntervalNumerator === 3 || s.eggIntervalNumerator === 4 || s.eggIntervalNumerator === 5
+      ? s.eggIntervalNumerator
+      : 4;
   // Issue #101 — validate chamber records before they reach the runtime.
   // Done after the spread so the validator inspects the persisted shape;
   // throw aborts deserializeWorldState's map() and propagates to bootFromSave.
@@ -796,13 +848,13 @@ function deserializeAIStateArray(s: SerializedWorldState): AIStateRecord[] {
     const r = raw[i]!;
     if (r === null || typeof r !== 'object') continue;
     const fightIds = Array.isArray(r.operationFighterIds)
-      ? r.operationFighterIds as number[]
+      ? (r.operationFighterIds as number[])
       : [];
     const buf = new Int32Array(AI_MAX_OPERATION_FIGHTERS).fill(-1);
     const copyLen = Math.min(fightIds.length, AI_MAX_OPERATION_FIGHTERS);
     for (let j = 0; j < copyLen; j++) {
       const val = fightIds[j];
-      buf[j] = (typeof val === 'number' && Number.isInteger(val)) ? val : -1;
+      buf[j] = typeof val === 'number' && Number.isInteger(val) ? val : -1;
     }
     result.push({
       colonyId: typeof r.colonyId === 'number' ? r.colonyId : 0,
@@ -816,21 +868,38 @@ function deserializeAIStateArray(s: SerializedWorldState): AIStateRecord[] {
       recoveryEndTick: typeof r.recoveryEndTick === 'number' ? r.recoveryEndTick : 0,
       operationKind: isValidOperationKind(r.operationKind) ? r.operationKind : 'None',
       operationStartTick: typeof r.operationStartTick === 'number' ? r.operationStartTick : 0,
-      operationTargetTileX: typeof r.operationTargetTileX === 'number' ? r.operationTargetTileX : -1,
-      operationTargetTileY: typeof r.operationTargetTileY === 'number' ? r.operationTargetTileY : -1,
+      operationTargetTileX:
+        typeof r.operationTargetTileX === 'number' ? r.operationTargetTileX : -1,
+      operationTargetTileY:
+        typeof r.operationTargetTileY === 'number' ? r.operationTargetTileY : -1,
       operationFighterIds: buf,
-      operationFighterCount: typeof r.operationFighterCount === 'number' ? Math.min(Math.max(0, r.operationFighterCount), AI_MAX_OPERATION_FIGHTERS) : 0,
-      operationStartFighterCount: typeof r.operationStartFighterCount === 'number' ? r.operationStartFighterCount : 0,
-      operationAttackerDeaths: typeof r.operationAttackerDeaths === 'number' ? r.operationAttackerDeaths : 0,
-      operationDefenderDeaths: typeof r.operationDefenderDeaths === 'number' ? r.operationDefenderDeaths : 0,
+      operationFighterCount:
+        typeof r.operationFighterCount === 'number'
+          ? Math.min(Math.max(0, r.operationFighterCount), AI_MAX_OPERATION_FIGHTERS)
+          : 0,
+      operationStartFighterCount:
+        typeof r.operationStartFighterCount === 'number' ? r.operationStartFighterCount : 0,
+      operationAttackerDeaths:
+        typeof r.operationAttackerDeaths === 'number' ? r.operationAttackerDeaths : 0,
+      operationDefenderDeaths:
+        typeof r.operationDefenderDeaths === 'number' ? r.operationDefenderDeaths : 0,
     });
   }
   return result;
 }
 
-function isValidSpiderBehaviorState(v: unknown): v is import('../sim/types.js').SpiderBehaviorState {
-  return v === 'Patrolling' || v === 'Hunting' || v === 'Chasing' || v === 'Striking' ||
-         v === 'Feeding' || v === 'Rampaging' || v === 'Retreating';
+function isValidSpiderBehaviorState(
+  v: unknown,
+): v is import('../sim/types.js').SpiderBehaviorState {
+  return (
+    v === 'Patrolling' ||
+    v === 'Hunting' ||
+    v === 'Chasing' ||
+    v === 'Striking' ||
+    v === 'Feeding' ||
+    v === 'Rampaging' ||
+    v === 'Retreating'
+  );
 }
 
 function deserializeSpider(s: SerializedWorldState): SpiderState | null {
@@ -839,18 +908,28 @@ function deserializeSpider(s: SerializedWorldState): SpiderState | null {
   if (typeof raw !== 'object') return null;
   const r = raw as Partial<SerializedSpiderState>;
   const rawState = isValidSpiderBehaviorState(r.state) ? r.state : 'Patrolling';
-  const rawHuntX = typeof r.huntTargetTileX === 'number' && Number.isInteger(r.huntTargetTileX) ? r.huntTargetTileX : -1;
-  const rawHuntY = typeof r.huntTargetTileY === 'number' && Number.isInteger(r.huntTargetTileY) ? r.huntTargetTileY : -1;
+  const rawHuntX =
+    typeof r.huntTargetTileX === 'number' && Number.isInteger(r.huntTargetTileX)
+      ? r.huntTargetTileX
+      : -1;
+  const rawHuntY =
+    typeof r.huntTargetTileY === 'number' && Number.isInteger(r.huntTargetTileY)
+      ? r.huntTargetTileY
+      : -1;
   // Guard: Hunting/Striking require a valid (non-sentinel) hunt target. A save with
   // state=Hunting but target=-1 (corrupt or truncated) would route the spider to (0,0)
   // for the full telegraph duration. Fall back to Patrolling in that case.
   const huntTargetValid = rawHuntX >= 0 && rawHuntY >= 0;
   // V23: Chasing requires a valid (non-sentinel) ant id; fall back to Patrolling otherwise.
-  const rawChaseId = typeof r.chaseTargetAntId === 'number' && Number.isInteger(r.chaseTargetAntId) ? r.chaseTargetAntId : -1;
+  const rawChaseId =
+    typeof r.chaseTargetAntId === 'number' && Number.isInteger(r.chaseTargetAntId)
+      ? r.chaseTargetAntId
+      : -1;
   const chaseTargetValid = rawChaseId >= 0;
-  let safeState = (rawState === 'Hunting' || rawState === 'Striking') && !huntTargetValid
-    ? 'Patrolling'
-    : rawState;
+  let safeState =
+    (rawState === 'Hunting' || rawState === 'Striking') && !huntTargetValid
+      ? 'Patrolling'
+      : rawState;
   if (safeState === 'Chasing' && !chaseTargetValid) safeState = 'Patrolling';
   return {
     state: safeState,
@@ -858,34 +937,94 @@ function deserializeSpider(s: SerializedWorldState): SpiderState | null {
     posY: typeof r.posY === 'number' && Number.isInteger(r.posY) ? r.posY : 0,
     lairTileX: typeof r.lairTileX === 'number' && Number.isInteger(r.lairTileX) ? r.lairTileX : 0,
     lairTileY: typeof r.lairTileY === 'number' && Number.isInteger(r.lairTileY) ? r.lairTileY : 0,
-    territoryRadiusTiles: typeof r.territoryRadiusTiles === 'number' && Number.isInteger(r.territoryRadiusTiles) ? r.territoryRadiusTiles : 24,
+    territoryRadiusTiles:
+      typeof r.territoryRadiusTiles === 'number' && Number.isInteger(r.territoryRadiusTiles)
+        ? r.territoryRadiusTiles
+        : 24,
     hp: typeof r.hp === 'number' && Number.isInteger(r.hp) ? r.hp : 80,
-    attackCooldown: typeof r.attackCooldown === 'number' && Number.isInteger(r.attackCooldown) ? r.attackCooldown : 0,
-    hungerTicks: typeof r.hungerTicks === 'number' && Number.isInteger(r.hungerTicks) ? r.hungerTicks : 0,
-    nextHuntTick: typeof r.nextHuntTick === 'number' && Number.isInteger(r.nextHuntTick) ? r.nextHuntTick : SPIDER_HUNT_INTERVAL_TICKS,
-    huntStartTick: typeof r.huntStartTick === 'number' && Number.isInteger(r.huntStartTick) ? r.huntStartTick : 0,
-    strikeStartTick: typeof r.strikeStartTick === 'number' && Number.isInteger(r.strikeStartTick) ? r.strikeStartTick : 0,
-    feedingStartTick: typeof r.feedingStartTick === 'number' && Number.isInteger(r.feedingStartTick) ? r.feedingStartTick : 0,
-    retreatStartTick: typeof r.retreatStartTick === 'number' && Number.isInteger(r.retreatStartTick) ? r.retreatStartTick : 0,
-    rampageStartTick: typeof r.rampageStartTick === 'number' && Number.isInteger(r.rampageStartTick) ? r.rampageStartTick : 0,
+    attackCooldown:
+      typeof r.attackCooldown === 'number' && Number.isInteger(r.attackCooldown)
+        ? r.attackCooldown
+        : 0,
+    hungerTicks:
+      typeof r.hungerTicks === 'number' && Number.isInteger(r.hungerTicks) ? r.hungerTicks : 0,
+    nextHuntTick:
+      typeof r.nextHuntTick === 'number' && Number.isInteger(r.nextHuntTick)
+        ? r.nextHuntTick
+        : SPIDER_HUNT_INTERVAL_TICKS,
+    huntStartTick:
+      typeof r.huntStartTick === 'number' && Number.isInteger(r.huntStartTick)
+        ? r.huntStartTick
+        : 0,
+    strikeStartTick:
+      typeof r.strikeStartTick === 'number' && Number.isInteger(r.strikeStartTick)
+        ? r.strikeStartTick
+        : 0,
+    feedingStartTick:
+      typeof r.feedingStartTick === 'number' && Number.isInteger(r.feedingStartTick)
+        ? r.feedingStartTick
+        : 0,
+    retreatStartTick:
+      typeof r.retreatStartTick === 'number' && Number.isInteger(r.retreatStartTick)
+        ? r.retreatStartTick
+        : 0,
+    rampageStartTick:
+      typeof r.rampageStartTick === 'number' && Number.isInteger(r.rampageStartTick)
+        ? r.rampageStartTick
+        : 0,
     huntTargetTileX: huntTargetValid ? rawHuntX : -1,
     huntTargetTileY: huntTargetValid ? rawHuntY : -1,
-    killsThisStrike: typeof r.killsThisStrike === 'number' && Number.isInteger(r.killsThisStrike) ? r.killsThisStrike : 0,
-    rampageKillsThisRampage: typeof r.rampageKillsThisRampage === 'number' && Number.isInteger(r.rampageKillsThisRampage) ? r.rampageKillsThisRampage : 0,
-    rampageTargetColonyId: safeState === 'Rampaging' && typeof r.rampageTargetColonyId === 'number' && r.rampageTargetColonyId > 0 ? r.rampageTargetColonyId : -1,
+    killsThisStrike:
+      typeof r.killsThisStrike === 'number' && Number.isInteger(r.killsThisStrike)
+        ? r.killsThisStrike
+        : 0,
+    rampageKillsThisRampage:
+      typeof r.rampageKillsThisRampage === 'number' && Number.isInteger(r.rampageKillsThisRampage)
+        ? r.rampageKillsThisRampage
+        : 0,
+    rampageTargetColonyId:
+      safeState === 'Rampaging' &&
+      typeof r.rampageTargetColonyId === 'number' &&
+      r.rampageTargetColonyId > 0
+        ? r.rampageTargetColonyId
+        : -1,
     chaseTargetAntId: safeState === 'Chasing' ? rawChaseId : -1,
-    chaseStartTick: typeof r.chaseStartTick === 'number' && Number.isInteger(r.chaseStartTick) ? r.chaseStartTick : 0,
+    chaseStartTick:
+      typeof r.chaseStartTick === 'number' && Number.isInteger(r.chaseStartTick)
+        ? r.chaseStartTick
+        : 0,
     killedThisTick: 0,
-    lastKillTileX: typeof r.lastKillTileX === 'number' && Number.isInteger(r.lastKillTileX) ? r.lastKillTileX : -1,
-    lastKillTileY: typeof r.lastKillTileY === 'number' && Number.isInteger(r.lastKillTileY) ? r.lastKillTileY : -1,
-    feedAwayTileX: typeof r.feedAwayTileX === 'number' && Number.isInteger(r.feedAwayTileX) ? r.feedAwayTileX : -1,
-    feedAwayTileY: typeof r.feedAwayTileY === 'number' && Number.isInteger(r.feedAwayTileY) ? r.feedAwayTileY : -1,
-    feedArrivedTick: typeof r.feedArrivedTick === 'number' && Number.isInteger(r.feedArrivedTick) ? r.feedArrivedTick : -1,
+    lastKillTileX:
+      typeof r.lastKillTileX === 'number' && Number.isInteger(r.lastKillTileX)
+        ? r.lastKillTileX
+        : -1,
+    lastKillTileY:
+      typeof r.lastKillTileY === 'number' && Number.isInteger(r.lastKillTileY)
+        ? r.lastKillTileY
+        : -1,
+    feedAwayTileX:
+      typeof r.feedAwayTileX === 'number' && Number.isInteger(r.feedAwayTileX)
+        ? r.feedAwayTileX
+        : -1,
+    feedAwayTileY:
+      typeof r.feedAwayTileY === 'number' && Number.isInteger(r.feedAwayTileY)
+        ? r.feedAwayTileY
+        : -1,
+    feedArrivedTick:
+      typeof r.feedArrivedTick === 'number' && Number.isInteger(r.feedArrivedTick)
+        ? r.feedArrivedTick
+        : -1,
   };
 }
 
 function isValidAIState(v: unknown): v is import('../sim/types.js').AIState {
-  return v === 'Peacetime' || v === 'WarFooting' || v === 'Probing' || v === 'Invading' || v === 'Recovery';
+  return (
+    v === 'Peacetime' ||
+    v === 'WarFooting' ||
+    v === 'Probing' ||
+    v === 'Invading' ||
+    v === 'Recovery'
+  );
 }
 
 function isValidOperationKind(v: unknown): v is 'None' | 'Probe' | 'Invasion' {
@@ -925,10 +1064,17 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
   // so a count > MAX_ENTITIES at this point is genuine tampering — a future
   // build raising MAX_ENTITIES would have bumped simVersion to flag the change.
   const rawCount = s.ants.count;
-  if (typeof rawCount !== 'number' || !Number.isInteger(rawCount) || rawCount < 0 || rawCount > MAX_ENTITIES) {
+  if (
+    typeof rawCount !== 'number' ||
+    !Number.isInteger(rawCount) ||
+    rawCount < 0 ||
+    rawCount > MAX_ENTITIES
+  ) {
     // Use String() so NaN/Infinity render as their canonical names; JSON.stringify
     // would coerce them to 'null', which is more confusing than less.
-    throw new Error(`Invalid ants.count in save: ${String(rawCount)} (require integer in [0, ${MAX_ENTITIES}])`);
+    throw new Error(
+      `Invalid ants.count in save: ${String(rawCount)} (require integer in [0, ${MAX_ENTITIES}])`,
+    );
   }
   const capacity = rawCount > 0 ? rawCount : MAX_ENTITIES;
 
@@ -947,21 +1093,27 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
   }
   const ugKeys = Object.keys(s.undergroundGrids);
   if (ugKeys.length > MAX_COLONIES_LOAD) {
-    throw new Error(`Too many undergroundGrids in save: ${ugKeys.length} (cap ${MAX_COLONIES_LOAD})`);
+    throw new Error(
+      `Too many undergroundGrids in save: ${ugKeys.length} (cap ${MAX_COLONIES_LOAD})`,
+    );
   }
   if (s.pheromoneGrids === null || typeof s.pheromoneGrids !== 'object') {
     throw new Error('Invalid save shape: missing or non-object pheromoneGrids');
   }
   const pheroKeys = Object.keys(s.pheromoneGrids);
   if (pheroKeys.length > MAX_PHEROMONE_GRID_KEYS) {
-    throw new Error(`Too many pheromoneGrids in save: ${pheroKeys.length} (cap ${MAX_PHEROMONE_GRID_KEYS})`);
+    throw new Error(
+      `Too many pheromoneGrids in save: ${pheroKeys.length} (cap ${MAX_PHEROMONE_GRID_KEYS})`,
+    );
   }
   if (s.pendingChambers === null || typeof s.pendingChambers !== 'object') {
     throw new Error('Invalid save shape: missing or non-object pendingChambers');
   }
   const pcKeys = Object.keys(s.pendingChambers);
   if (pcKeys.length > MAX_PENDING_CHAMBERS) {
-    throw new Error(`Too many pendingChambers in save: ${pcKeys.length} (cap ${MAX_PENDING_CHAMBERS})`);
+    throw new Error(
+      `Too many pendingChambers in save: ${pcKeys.length} (cap ${MAX_PENDING_CHAMBERS})`,
+    );
   }
 
   const colonies: Record<ColonyId, ColonyRecord> = {};
@@ -980,8 +1132,12 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
       throw new Error(`Invalid undergroundGrids key: ${cidStr}`);
     }
     // Issue #99 — verify grid shape before allocator runs.
-    validateGridShape(sg, UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT,
-      `undergroundGrids[${cidStr}]`);
+    validateGridShape(
+      sg,
+      UNDERGROUND_GRID_WIDTH,
+      UNDERGROUND_GRID_HEIGHT,
+      `undergroundGrids[${cidStr}]`,
+    );
     undergroundGrids[Number(cidStr) as ColonyId] = deserializeUndergroundGrid(sg);
   }
   const pheromoneGrids: Record<string, PheromoneGrid> = {};
@@ -994,13 +1150,18 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     }
     let validated = false;
     try {
-      validateGridShape(sg, SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT,
-        `pheromoneGrids[${key}]`);
+      validateGridShape(sg, SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT, `pheromoneGrids[${key}]`);
       validated = true;
-    } catch { /* try underground next */ }
+    } catch {
+      /* try underground next */
+    }
     if (!validated) {
-      validateGridShape(sg, UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT,
-        `pheromoneGrids[${key}]`);
+      validateGridShape(
+        sg,
+        UNDERGROUND_GRID_WIDTH,
+        UNDERGROUND_GRID_HEIGHT,
+        `pheromoneGrids[${key}]`,
+      );
     }
     pheromoneGrids[key] = deserializePheromoneGrid(sg);
   }
@@ -1025,27 +1186,34 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
   // the snapshot was written. Match the count check: integer in
   // [0, MAX_ENTITIES] required, anything else throws.
   const rawNext = s.nextEntityId;
-  if (typeof rawNext !== 'number' || !Number.isInteger(rawNext) || rawNext < 0 || rawNext > MAX_ENTITIES) {
-    throw new Error(`Invalid nextEntityId in save: ${String(rawNext)} (require integer in [0, ${MAX_ENTITIES}])`);
+  if (
+    typeof rawNext !== 'number' ||
+    !Number.isInteger(rawNext) ||
+    rawNext < 0 ||
+    rawNext > MAX_ENTITIES
+  ) {
+    throw new Error(
+      `Invalid nextEntityId in save: ${String(rawNext)} (require integer in [0, ${MAX_ENTITIES}])`,
+    );
   }
 
   // Issue #104 — boundary validation for snapshot tick. Same pattern as
   // nextEntityId: `tick: s.tick` previously passed strings/NaN through,
   // and `world.tick += 1` became unbounded string concatenation.
   const rawTick = s.tick;
-  if (typeof rawTick !== 'number'
-      || !Number.isFinite(rawTick)
-      || !Number.isInteger(rawTick)
-      || rawTick < 0) {
+  if (
+    typeof rawTick !== 'number' ||
+    !Number.isFinite(rawTick) ||
+    !Number.isInteger(rawTick) ||
+    rawTick < 0
+  ) {
     throw new Error(`Invalid tick in save: ${String(rawTick)} (require non-negative integer)`);
   }
   // rngState — same hardening for symmetry. Rng's `state | 0` would coerce
   // NaN/strings to 0 on first use, but boundary validation surfaces tampering
   // explicitly instead of silently snapping.
   const rawRng = s.rngState;
-  if (typeof rawRng !== 'number'
-      || !Number.isFinite(rawRng)
-      || !Number.isInteger(rawRng)) {
+  if (typeof rawRng !== 'number' || !Number.isFinite(rawRng) || !Number.isInteger(rawRng)) {
     throw new Error(`Invalid rngState in save: ${String(rawRng)} (require integer)`);
   }
 
@@ -1108,14 +1276,15 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     nextEntityId: rawNext,
     simVersion: validatedSimVersion,
     // terrainSeed: uint32-coerce to guard against NaN/string/negative tampered values.
-    terrainSeed: typeof s.terrainSeed === 'number' && Number.isInteger(s.terrainSeed)
-      ? s.terrainSeed >>> 0
-      : 0,
+    terrainSeed:
+      typeof s.terrainSeed === 'number' && Number.isInteger(s.terrainSeed)
+        ? s.terrainSeed >>> 0
+        : 0,
     // Issue #105 — filter null/non-object entries before the spread so the
     // runtime queue is always consistent with the dispatcher's expectations.
     commandQueue: (Array.isArray(s.commandQueue) ? s.commandQueue : [])
       .filter((c) => c !== null && typeof c === 'object')
-      .map((c) => ({ ...c } as SimCommand)),
+      .map((c) => ({ ...c }) as SimCommand),
     ants: deserializeAnts(s.ants, capacity),
     colonies,
     pheromoneGrids,
@@ -1128,7 +1297,13 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     pendingQueenDeathContexts: [],
     aiState: deserializeAIStateArray(s),
     spider: _deserializedSpider,
-    spiderPriorityColonyId: (_deserializedSpider !== null && typeof s.spiderPriorityColonyId === 'number' && Number.isInteger(s.spiderPriorityColonyId) && s.spiderPriorityColonyId > 0) ? s.spiderPriorityColonyId : null,
+    spiderPriorityColonyId:
+      _deserializedSpider !== null &&
+      typeof s.spiderPriorityColonyId === 'number' &&
+      Number.isInteger(s.spiderPriorityColonyId) &&
+      s.spiderPriorityColonyId > 0
+        ? s.spiderPriorityColonyId
+        : null,
     scatterReticleTile: (() => {
       if (_deserializedSpider === null) return null;
       const r = s.scatterReticleTile;
@@ -1150,7 +1325,7 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
       s.droppedStructuralCount >= 0
         ? s.droppedStructuralCount
         : 0,
-    difficulty: (s.difficulty === 'Easy' || s.difficulty === 'Hard') ? s.difficulty : 'Normal',
+    difficulty: s.difficulty === 'Easy' || s.difficulty === 'Hard' ? s.difficulty : 'Normal',
   };
 }
 
@@ -1171,7 +1346,6 @@ function buildSaveFile(seed: number, inputLog: readonly SimCommand[], world: Wor
     savedAtMs: Date.now(),
   };
 }
-
 
 // Exported for issue #112 v2-rejection test — verifies that parseSaveFile
 // throws SaveVersionMismatchError on pre-v3 envelopes. loadSave swallows the
@@ -1218,8 +1392,16 @@ export function parseSaveFile(raw: string): SaveFile {
  * Issue #112 — added v2 to the purge list when SAVE_KEY moved to v3.
  */
 function purgeLegacySaves(): void {
-  try { localStorage.removeItem('subterrans:save:v1'); } catch { /* quota / private mode — silent: best-effort cleanup, no UX signal */ }
-  try { localStorage.removeItem('subterrans:save:v2'); } catch { /* quota / private mode — silent: best-effort cleanup, no UX signal */ }
+  try {
+    localStorage.removeItem('subterrans:save:v1');
+  } catch {
+    /* quota / private mode — silent: best-effort cleanup, no UX signal */
+  }
+  try {
+    localStorage.removeItem('subterrans:save:v2');
+  } catch {
+    /* quota / private mode — silent: best-effort cleanup, no UX signal */
+  }
 }
 
 export function hasSave(): boolean {
@@ -1406,32 +1588,31 @@ export function getSaveInfo(): SaveInfo | null {
   const playerKey = String(PLAYER_COLONY_ID);
   // colonies may be undefined / null / a non-object on a malformed envelope;
   // probe defensively before keying into it.
-  const playerColony = colonies !== undefined && colonies !== null && typeof colonies === 'object'
-    ? colonies[playerKey]
-    : undefined;
+  const playerColony =
+    colonies !== undefined && colonies !== null && typeof colonies === 'object'
+      ? colonies[playerKey]
+      : undefined;
   // foodStored is fixed-point; convert to whole-food units for display.
   // Right-shift on a non-number short-circuits cleanly via the ?? fallback.
   const foodFpRaw = playerColony?.foodStored;
-  const foodFp = typeof foodFpRaw === 'number' && Number.isFinite(foodFpRaw) && foodFpRaw >= 0
-    ? foodFpRaw
-    : 0;
+  const foodFp =
+    typeof foodFpRaw === 'number' && Number.isFinite(foodFpRaw) && foodFpRaw >= 0 ? foodFpRaw : 0;
   const workerCountRaw = playerColony?.workerCount;
-  const playerWorkers = typeof workerCountRaw === 'number' && Number.isFinite(workerCountRaw) && workerCountRaw >= 0
-    ? workerCountRaw
-    : 0;
+  const playerWorkers =
+    typeof workerCountRaw === 'number' && Number.isFinite(workerCountRaw) && workerCountRaw >= 0
+      ? workerCountRaw
+      : 0;
   // tick may also be missing on a malformed envelope — surface 0 rather
   // than rendering "Tick undefined" in the dialog.
   const tickRaw = (snapshot as { tick?: unknown }).tick;
-  const tick = typeof tickRaw === 'number' && Number.isFinite(tickRaw) && tickRaw >= 0
-    ? tickRaw
-    : 0;
+  const tick =
+    typeof tickRaw === 'number' && Number.isFinite(tickRaw) && tickRaw >= 0 ? tickRaw : 0;
   // Issue #115 — savedAtMs is optional in the envelope; pre-fix saves and
   // any tampered/malformed timestamp fall back to 0 ("unknown") so the
   // dialog can render a sensible placeholder.
   const stampRaw = (file as { savedAtMs?: unknown }).savedAtMs;
-  const savedAtMs = typeof stampRaw === 'number' && Number.isFinite(stampRaw) && stampRaw >= 0
-    ? stampRaw
-    : 0;
+  const savedAtMs =
+    typeof stampRaw === 'number' && Number.isFinite(stampRaw) && stampRaw >= 0 ? stampRaw : 0;
   return {
     tick,
     playerWorkers,

--- a/src/platform/settings.test.ts
+++ b/src/platform/settings.test.ts
@@ -43,10 +43,13 @@ describe('loadSettings', () => {
   });
 
   it('falls back to DEFAULT_SETTINGS when version is newer than this build supports', () => {
-    localStorage.setItem(SETTINGS_KEY, JSON.stringify({
-      version: SETTINGS_VERSION + 1,
-      settings: { pheromoneOverlay: false },
-    }));
+    localStorage.setItem(
+      SETTINGS_KEY,
+      JSON.stringify({
+        version: SETTINGS_VERSION + 1,
+        settings: { pheromoneOverlay: false },
+      }),
+    );
     expect(loadSettings()).toEqual(DEFAULT_SETTINGS);
   });
 
@@ -54,18 +57,24 @@ describe('loadSettings', () => {
     // Permissive merge: a single corrupt field shouldn't wipe valid neighbors.
     // Today we only have one boolean field; this guards the merge logic so a
     // future field is safe to add.
-    localStorage.setItem(SETTINGS_KEY, JSON.stringify({
-      version: SETTINGS_VERSION,
-      settings: { pheromoneOverlay: 'not-a-bool' },
-    }));
+    localStorage.setItem(
+      SETTINGS_KEY,
+      JSON.stringify({
+        version: SETTINGS_VERSION,
+        settings: { pheromoneOverlay: 'not-a-bool' },
+      }),
+    );
     expect(loadSettings()).toEqual({ pheromoneOverlay: DEFAULT_SETTINGS.pheromoneOverlay });
   });
 
   it('ignores unknown extra keys in the settings object', () => {
-    localStorage.setItem(SETTINGS_KEY, JSON.stringify({
-      version: SETTINGS_VERSION,
-      settings: { pheromoneOverlay: false, futureKey: 'whatever' },
-    }));
+    localStorage.setItem(
+      SETTINGS_KEY,
+      JSON.stringify({
+        version: SETTINGS_VERSION,
+        settings: { pheromoneOverlay: false, futureKey: 'whatever' },
+      }),
+    );
     expect(loadSettings()).toEqual({ pheromoneOverlay: false });
   });
 });

--- a/src/platform/settings.ts
+++ b/src/platform/settings.ts
@@ -63,9 +63,10 @@ export function loadSettings(): Settings {
   // doesn't wipe valid neighbors.
   const s = env.settings as Partial<Settings>;
   return {
-    pheromoneOverlay: typeof s.pheromoneOverlay === 'boolean'
-      ? s.pheromoneOverlay
-      : DEFAULT_SETTINGS.pheromoneOverlay,
+    pheromoneOverlay:
+      typeof s.pheromoneOverlay === 'boolean'
+        ? s.pheromoneOverlay
+        : DEFAULT_SETTINGS.pheromoneOverlay,
   };
 }
 

--- a/src/platform/test-setup.ts
+++ b/src/platform/test-setup.ts
@@ -6,9 +6,13 @@
 class InMemoryStorage implements Storage {
   private _store: Map<string, string> = new Map();
 
-  get length(): number { return this._store.size; }
+  get length(): number {
+    return this._store.size;
+  }
 
-  clear(): void { this._store.clear(); }
+  clear(): void {
+    this._store.clear();
+  }
 
   getItem(key: string): string | null {
     return this._store.has(key) ? this._store.get(key)! : null;
@@ -19,9 +23,13 @@ class InMemoryStorage implements Storage {
     return index < keys.length ? keys[index]! : null;
   }
 
-  removeItem(key: string): void { this._store.delete(key); }
+  removeItem(key: string): void {
+    this._store.delete(key);
+  }
 
-  setItem(key: string, value: string): void { this._store.set(key, value); }
+  setItem(key: string, value: string): void {
+    this._store.set(key, value);
+  }
 }
 
 const store = new InMemoryStorage();

--- a/src/render/ai-controller.integration.test.ts
+++ b/src/render/ai-controller.integration.test.ts
@@ -44,13 +44,13 @@ const SEED = 42;
 // per the acceptance criteria), so the slower bootstrap is the intended
 // trade-off.
 const TOTAL_TICKS = 8000;
-const TRAJECTORY_WINDOW_START = 7000;   // track workerCount from tick 7000..8000
+const TRAJECTORY_WINDOW_START = 7000; // track workerCount from tick 7000..8000
 // S4 change: queen now lays on first eligible tick (elapsed-since-last-lay gate), not at modulo
 // boundaries. In the AI scenario, chambers complete ~tick 4000; first egg lays immediately,
 // creating ~6 larvae by tick 6000. First new worker matures at ~tick 6700 (4000+2700).
 // Window extended from 5500..6000 → 7000..8000 so the monitoring window contains the
 // stable post-first-worker-maturation state.
-const DIAGNOSTIC_INTERVAL = 500;         // log snapshot every 500 ticks (pre-audit)
+const DIAGNOSTIC_INTERVAL = 500; // log snapshot every 500 ticks (pre-audit)
 
 // -----------------------------------------------------------------------------
 // Helpers
@@ -136,7 +136,8 @@ describe('AI-only scenario 6000 ticks', () => {
 
     // --- End-state snapshot (for failure diagnostics) ---
     const finalState = snapshotColony(world, aiColony!);
-    const ctx = `Final state: ${JSON.stringify(finalState)}. ` +
+    const ctx =
+      `Final state: ${JSON.stringify(finalState)}. ` +
       `Trajectory[${TRAJECTORY_WINDOW_START}..${TOTAL_TICKS}] workerCount (${workerCountTrajectory.length} samples): ` +
       `first=${workerCountTrajectory[0]} last=${workerCountTrajectory[workerCountTrajectory.length - 1]}. ` +
       `Diagnostics: ${JSON.stringify(diagnostics)}`;
@@ -180,8 +181,7 @@ describe('AI-only scenario 6000 ticks', () => {
     // assertion is testing.)
     {
       const total = colonyFoodTotal(aiColony!);
-      expect(total, `AI colony food total is not > 0 (found ${total}). ${ctx}`)
-        .toBeGreaterThan(0);
+      expect(total, `AI colony food total is not > 0 (found ${total}). ${ctx}`).toBeGreaterThan(0);
     }
 
     // 7. Chamber uniqueness: exactly 1 Queen, exactly 1 Nursery, ≥1 FoodStorage
@@ -205,7 +205,7 @@ describe('AI-only scenario 6000 ticks', () => {
     expect(
       endWC,
       `workerCount declined across ticks ${TRAJECTORY_WINDOW_START}..${TOTAL_TICKS}: ` +
-      `started=${startWC} ended=${endWC}. ${ctx}`,
+        `started=${startWC} ended=${endWC}. ${ctx}`,
     ).toBeGreaterThanOrEqual(startWC);
   }, 120_000); // 8000 ticks at ~8ms/tick; allow 120s budget (S4 extended window).
 });
@@ -232,7 +232,9 @@ describe('AI-only scenario 18000 ticks (issue #33)', () => {
     }
 
     const grid = world.undergroundGrids[ENEMY_COLONY_ID]!;
-    let minX = Infinity, maxX = -Infinity, maxY = -Infinity;
+    let minX = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
     for (const ch of aiColony.chambers) {
       const x = ch.posX >> FP_SHIFT;
       const y = ch.posY >> FP_SHIFT;
@@ -247,7 +249,7 @@ describe('AI-only scenario 18000 ticks (issue #33)', () => {
       `widthSpan=${widthSpan} (${(widthRatio * 100).toFixed(1)}%), ` +
       `maxChamberY=${maxY}`;
     expect(
-      widthRatio >= 0.30 || maxY > 15,
+      widthRatio >= 0.3 || maxY > 15,
       `Issue #33 acceptance: span >= 30% width OR max chamber Y > 15. Got ${ctx}.`,
     ).toBe(true);
   }, 120_000);

--- a/src/render/ai-controller.test.ts
+++ b/src/render/ai-controller.test.ts
@@ -100,10 +100,8 @@ function makeChamber(
 // ---------------------------------------------------------------------------
 
 describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
-
   // -------------------------------------------------------------------------
   describe('runAIController', () => {
-
     it('no-ops when aiColonyId does not exist (world.colonies[id] === undefined)', () => {
       const world = makeWorld(0);
       // No colony added
@@ -150,7 +148,7 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       // Issue #75 — aiInitialSetup is now post-condition-gated. Matching the
       // AI ratio AND having an entrance means setup is complete.
       colony.targetRatio.forage = AI_BEHAVIOR_RATIO.forage;
-      colony.targetRatio.fight  = AI_BEHAVIOR_RATIO.fight;
+      colony.targetRatio.fight = AI_BEHAVIOR_RATIO.fight;
       setQueenPos(world, 0, 10, 5);
       addUndergroundGrid(world, 2 as ColonyId);
       runAIController(world, 2 as ColonyId);
@@ -161,12 +159,10 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       const nonSyncCmds = world.commandQueue.filter((c) => c.type !== 'SyncAIState');
       expect(nonSyncCmds).toHaveLength(0);
     });
-
   });
 
   // -------------------------------------------------------------------------
   describe('aiInitialSetup (CMBT-02 tick-0 setup)', () => {
-
     it('in V17+, does NOT push SetBehaviorRatio (owned by _syncBehaviorRatioToAIState)', () => {
       const world = makeWorld(0);
       // world.simVersion is already V17 (LATEST_SIM_VERSION via createWorldState)
@@ -177,7 +173,7 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       expect(ratioCmd).toBeUndefined();
     });
 
-    it('on tick 0, pushes DesignateEntrance for the AI queen\'s surface tile', () => {
+    it("on tick 0, pushes DesignateEntrance for the AI queen's surface tile", () => {
       const world = makeWorld(0);
       const colony = addColony(world, 2 as ColonyId, 0);
       // Place queen at tile (15, 8) → fixed-point
@@ -187,7 +183,7 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       expect(entranceCmd).toBeDefined();
       const ec = entranceCmd as { surfaceTileX: number; surfaceTileY: number };
       expect(ec.surfaceTileX).toBe(15); // derived from queen posX >> FP_SHIFT
-      expect(ec.surfaceTileY).toBe(0);  // surface row
+      expect(ec.surfaceTileY).toBe(0); // surface row
       expect(entranceCmd!.issuedAtTick).toBe(0);
     });
 
@@ -200,7 +196,7 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       const colony = addColony(world, 2 as ColonyId, 0);
       colony.entrances = [{ entranceId: 1, surfaceTileX: 10, surfaceTileY: 0, isOpen: true }];
       colony.targetRatio.forage = AI_BEHAVIOR_RATIO.forage;
-      colony.targetRatio.fight  = AI_BEHAVIOR_RATIO.fight;
+      colony.targetRatio.fight = AI_BEHAVIOR_RATIO.fight;
       setQueenPos(world, 0, 10, 5);
       aiInitialSetup(world, colony);
       expect(world.commandQueue).toHaveLength(0);
@@ -214,12 +210,10 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
         expect(cmd.issuedAtTick).toBe(0);
       }
     });
-
   });
 
   // -------------------------------------------------------------------------
   describe('aiDigHeuristic', () => {
-
     it('does nothing when tick % AI_DIG_INTERVAL !== 0', () => {
       const world = makeWorld(1);
       const colony = addColony(world, 2 as ColonyId, 0);
@@ -273,10 +267,10 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       const grid = world.undergroundGrids[2 as ColonyId]!;
       // Place chamber at (10,10); mark all neighbors Open
       colony.chambers.push(makeChamber(ChamberType.Queen, 10, 10, 1, 1));
-      ugSet(grid, 10, 9, UndergroundTileState.Open);   // N
-      ugSet(grid, 11, 10, UndergroundTileState.Open);  // E
-      ugSet(grid, 10, 11, UndergroundTileState.Open);  // S
-      ugSet(grid, 9, 10, UndergroundTileState.Open);   // W
+      ugSet(grid, 10, 9, UndergroundTileState.Open); // N
+      ugSet(grid, 11, 10, UndergroundTileState.Open); // E
+      ugSet(grid, 10, 11, UndergroundTileState.Open); // S
+      ugSet(grid, 9, 10, UndergroundTileState.Open); // W
       aiDigHeuristic(world, colony);
       // No Solid neighbors → no commands
       expect(world.commandQueue).toHaveLength(0);
@@ -333,12 +327,10 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       const run2 = buildWorldAndRunDig();
       expect(run1).toEqual(run2);
     });
-
   });
 
   // -------------------------------------------------------------------------
   describe('aiChamberPlacement', () => {
-
     it('issues PlaceChamber Queen when no queen chamber exists, using anchorTileX/anchorTileY', () => {
       const world = makeWorld(0);
       const colony = addColony(world, 2 as ColonyId, 0);
@@ -391,7 +383,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       ugSet(grid, 10, 5, UndergroundTileState.Open);
       aiChamberPlacement(world, colony);
       const fsCmd = world.commandQueue.find(
-        (c) => c.type === 'PlaceChamber' && (c as { chamberType: number }).chamberType === ChamberType.FoodStorage,
+        (c) =>
+          c.type === 'PlaceChamber' &&
+          (c as { chamberType: number }).chamberType === ChamberType.FoodStorage,
       );
       expect(fsCmd).toBeUndefined();
     });
@@ -408,7 +402,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       ugSet(grid, 10, 7, UndergroundTileState.Open);
       aiChamberPlacement(world, colony);
       const nurseryCmd = world.commandQueue.find(
-        (c) => c.type === 'PlaceChamber' && (c as { chamberType: number }).chamberType === ChamberType.Nursery,
+        (c) =>
+          c.type === 'PlaceChamber' &&
+          (c as { chamberType: number }).chamberType === ChamberType.Nursery,
       );
       expect(nurseryCmd).toBeDefined();
     });
@@ -442,12 +438,10 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
         }
       }
     });
-
   });
 
   // -------------------------------------------------------------------------
   describe('aiEntranceDesignation', () => {
-
     it('issues DesignateEntrance (with surfaceTileX/surfaceTileY) when colony has zero entrances', () => {
       const world = makeWorld(10);
       const colony = addColony(world, 2 as ColonyId, 0);
@@ -491,12 +485,10 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       const entranceCmds = world.commandQueue.filter((c) => c.type === 'DesignateEntrance');
       expect(entranceCmds).toHaveLength(1);
     });
-
   });
 
   // -------------------------------------------------------------------------
   describe('isDirtTileUnderground helper (via aiDigHeuristic)', () => {
-
     it('returns false (no commands) when grid does not exist for colonyId', () => {
       const world = makeWorld(AI_DIG_INTERVAL);
       const colony = addColony(world, 2 as ColonyId, 0);
@@ -578,12 +570,10 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       aiDigHeuristic(world, colony);
       expect(world.commandQueue).toHaveLength(0);
     });
-
   });
 
   // -------------------------------------------------------------------------
   describe('findOpenChamberSpot helper (via aiChamberPlacement)', () => {
-
     it('returns null (no command) when colony has no underground grid', () => {
       const world = makeWorld(0);
       const colony = addColony(world, 2 as ColonyId, 0);
@@ -617,7 +607,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       ugSet(grid, 10, 30, UndergroundTileState.Open);
       aiChamberPlacement(world, colony);
       const queenCmd = world.commandQueue.find(
-        (c) => c.type === 'PlaceChamber' && (c as { chamberType: number }).chamberType === ChamberType.Queen,
+        (c) =>
+          c.type === 'PlaceChamber' &&
+          (c as { chamberType: number }).chamberType === ChamberType.Queen,
       );
       expect(queenCmd).toBeDefined();
       const qc = queenCmd as { anchorTileY: number };
@@ -638,7 +630,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       ugSet(grid, 12, AI_QUEEN_CHAMBER_DEPTH, UndergroundTileState.Open);
       aiChamberPlacement(world, colony);
       const queenCmd = world.commandQueue.find(
-        (c) => c.type === 'PlaceChamber' && (c as { chamberType: number }).chamberType === ChamberType.Queen,
+        (c) =>
+          c.type === 'PlaceChamber' &&
+          (c as { chamberType: number }).chamberType === ChamberType.Queen,
       );
       // Should NOT place at (10, AI_QUEEN_CHAMBER_DEPTH) — that's occupied
       if (queenCmd !== undefined) {
@@ -659,7 +653,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
         ugSet(grid, 12, AI_QUEEN_CHAMBER_DEPTH, UndergroundTileState.Open);
         aiChamberPlacement(world, colony);
         const queenCmd = world.commandQueue.find(
-          (c) => c.type === 'PlaceChamber' && (c as { chamberType: number }).chamberType === ChamberType.Queen,
+          (c) =>
+            c.type === 'PlaceChamber' &&
+            (c as { chamberType: number }).chamberType === ChamberType.Queen,
         );
         if (queenCmd === undefined) return undefined;
         return {
@@ -671,7 +667,6 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       const run2 = runAndGetQueenAnchor();
       expect(run1).toEqual(run2);
     });
-
   });
 
   // ---------------------------------------------------------------------------
@@ -691,7 +686,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       ugSet(grid, 10, 2, UndergroundTileState.Open);
       aiChamberPlacement(world, colony);
       const queenCmd = world.commandQueue.find(
-        (c) => c.type === 'PlaceChamber' && (c as { chamberType: number }).chamberType === ChamberType.Queen,
+        (c) =>
+          c.type === 'PlaceChamber' &&
+          (c as { chamberType: number }).chamberType === ChamberType.Queen,
       );
       expect(queenCmd).toBeUndefined();
     });
@@ -706,7 +703,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       ugSet(grid, 10, 14, UndergroundTileState.Open);
       aiChamberPlacement(world, colony);
       const queenCmd = world.commandQueue.find(
-        (c) => c.type === 'PlaceChamber' && (c as { chamberType: number }).chamberType === ChamberType.Queen,
+        (c) =>
+          c.type === 'PlaceChamber' &&
+          (c as { chamberType: number }).chamberType === ChamberType.Queen,
       ) as { anchorTileY: number } | undefined;
       expect(queenCmd).toBeDefined();
       expect(queenCmd!.anchorTileY).toBe(14);
@@ -730,7 +729,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       ugSet(grid, 40, 7, UndergroundTileState.Open);
       aiChamberPlacement(world, colony);
       const nurseryCmd = world.commandQueue.find(
-        (c) => c.type === 'PlaceChamber' && (c as { chamberType: number }).chamberType === ChamberType.Nursery,
+        (c) =>
+          c.type === 'PlaceChamber' &&
+          (c as { chamberType: number }).chamberType === ChamberType.Nursery,
       ) as { anchorTileX: number; anchorTileY: number } | undefined;
       expect(nurseryCmd).toBeDefined();
       // Nursery lands at X=40 — farther from the existing chambers at X=10.
@@ -751,7 +752,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       ugSet(grid, 10, 5, UndergroundTileState.Open);
       aiChamberPlacement(world, colony);
       const fsCmd = world.commandQueue.find(
-        (c) => c.type === 'PlaceChamber' && (c as { chamberType: number }).chamberType === ChamberType.FoodStorage,
+        (c) =>
+          c.type === 'PlaceChamber' &&
+          (c as { chamberType: number }).chamberType === ChamberType.FoodStorage,
       );
       expect(fsCmd).toBeUndefined();
     });
@@ -808,7 +811,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       ugSet(grid, 30, 20, UndergroundTileState.Open);
       aiChamberPlacement(world, colony);
       const fsCmd = world.commandQueue.find(
-        (c) => c.type === 'PlaceChamber' && (c as { chamberType: number }).chamberType === ChamberType.FoodStorage,
+        (c) =>
+          c.type === 'PlaceChamber' &&
+          (c as { chamberType: number }).chamberType === ChamberType.FoodStorage,
       ) as { anchorTileX: number; anchorTileY: number } | undefined;
       // FS should land at the only valid anchor, despite Y=20 being far
       // outside the Queen-style depth gate's ±4 tolerance.
@@ -832,13 +837,14 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       // Place A at right edge, B at left edge. Both 1x1 to keep the
       // arithmetic crisp.
       const RIGHT_EDGE = 63; // GRID_W - 1, matches addUndergroundGrid GRID_W=64
-      colony.chambers.push(makeChamber(ChamberType.Queen,        RIGHT_EDGE, 5, 1, 1));
-      colony.chambers.push(makeChamber(ChamberType.FoodStorage,  0,          5, 1, 1));
+      colony.chambers.push(makeChamber(ChamberType.Queen, RIGHT_EDGE, 5, 1, 1));
+      colony.chambers.push(makeChamber(ChamberType.FoodStorage, 0, 5, 1, 1));
 
       aiDigHeuristic(world, colony);
-      const digCmds = world.commandQueue.filter(
-        (c) => c.type === 'MarkDigTile',
-      ) as Array<{ tileX: number; tileY: number }>;
+      const digCmds = world.commandQueue.filter((c) => c.type === 'MarkDigTile') as Array<{
+        tileX: number;
+        tileY: number;
+      }>;
       // The right-edge chamber's top tile (RIGHT_EDGE, 4) must appear in
       // the dig commands — either via the frontier pass or the legacy
       // perimeter pass. Without the bounds fix, the frontier pass falsely
@@ -846,9 +852,7 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       // bug manifested as "no frontier extension" rather than "no dig at
       // all". Assert a stronger property: the (RIGHT_EDGE, 4) command
       // must be present.
-      const hasTopRightMark = digCmds.some(
-        (c) => c.tileX === RIGHT_EDGE && c.tileY === 4,
-      );
+      const hasTopRightMark = digCmds.some((c) => c.tileX === RIGHT_EDGE && c.tileY === 4);
       expect(hasTopRightMark).toBe(true);
     });
 
@@ -873,7 +877,9 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       ugSet(grid, 10, 5, UndergroundTileState.Open);
       aiChamberPlacement(world, colony);
       const fsCmd = world.commandQueue.find(
-        (c) => c.type === 'PlaceChamber' && (c as { chamberType: number }).chamberType === ChamberType.FoodStorage,
+        (c) =>
+          c.type === 'PlaceChamber' &&
+          (c as { chamberType: number }).chamberType === ChamberType.FoodStorage,
       );
       expect(fsCmd).toBeDefined();
     });
@@ -881,7 +887,6 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
 
   // -------------------------------------------------------------------------
   describe('CLNY-08 compliance', () => {
-
     it('all pushed commands use the AI colonyId passed in (never the player colony)', () => {
       const PLAYER_COLONY_ID = 1 as ColonyId;
       const AI_COLONY_ID = 2 as ColonyId;
@@ -948,12 +953,10 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
         }
       }
     });
-
   });
 
   // -------------------------------------------------------------------------
   describe('exported constants', () => {
-
     it('AI_DIG_INTERVAL is 40', () => expect(AI_DIG_INTERVAL).toBe(40));
     it('AI_DIG_MARK_BUDGET is 5', () => expect(AI_DIG_MARK_BUDGET).toBe(5));
     it('AI_QUEEN_CHAMBER_DEPTH is 18 (issue #33 — deeper to satisfy maxDepth>15 acceptance criterion)', () =>
@@ -968,7 +971,6 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       expect(AI_BEHAVIOR_RATIO).toMatchObject({ forage: 7, fight: 3 });
       expect(AI_BEHAVIOR_RATIO).not.toHaveProperty('dig');
     });
-
   });
 
   // -------------------------------------------------------------------------
@@ -985,7 +987,6 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
   // — these prove the AI's natural cadence flows through the same wire.
   // -------------------------------------------------------------------------
   describe('Phase 10 / D-05 — AI auto-dig parity', () => {
-
     it('AI ant reaches AntTask.Digging via auto-dig path within reasonable tick budget', () => {
       // Build a real 2-colony scenario; AI drives ENEMY_COLONY_ID only — same
       // pattern as ai-controller.integration.test.ts.
@@ -1039,7 +1040,5 @@ describe('ai-controller (CMBT-01..03, CLNY-08)', () => {
       expect(src).not.toMatch(/PLAYER_COLONY_ID\s*===/);
       expect(src).not.toMatch(/if\s*\([^)]*\bisPlayer\b/);
     });
-
   });
-
 });

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -27,13 +27,11 @@ import {
   AI_MAX_OPERATION_FIGHTERS,
 } from '../sim/constants.js';
 import { colonyFoodTotal } from '../sim/colony/colony-system.js';
-import {
-  aiFighterCount,
-} from '../sim/ai-state.js';
+import { aiFighterCount } from '../sim/ai-state.js';
 
 import { AntTask } from '../sim/enums.js';
 
-export const AI_DIG_INTERVAL = 40 as const;       // every 2 seconds @ 20Hz
+export const AI_DIG_INTERVAL = 40 as const; // every 2 seconds @ 20Hz
 /**
  * Issue #74 — chamber placement BFS cadence. Chamber placement is a
  * strategic decision (Queen, Nursery, FoodStorage in some order, then
@@ -112,8 +110,10 @@ export function runAIController(world: WorldState, aiColonyId: ColonyId): void {
     const curState = aiStateRecord.state;
     if (curState === 'WarFooting') {
       const ticksSinceLast = world.tick - aiStateRecord.lastProbeEndTick;
-      if (ticksSinceLast >= AI_PROBE_INTERVAL_TICKS
-          && aiFighterCount(world, aiColonyId) >= AI_PROBE_FIGHTER_COUNT) {
+      if (
+        ticksSinceLast >= AI_PROBE_INTERVAL_TICKS &&
+        aiFighterCount(world, aiColonyId) >= AI_PROBE_FIGHTER_COUNT
+      ) {
         aiStateMachineTick_probeEntry(world, aiColonyId, colony);
       }
     }
@@ -163,7 +163,7 @@ export function aiInitialSetup(world: WorldState, colony: ColonyRecord): void {
       type: 'DesignateEntrance',
       colonyId: colony.colonyId,
       surfaceTileX: queenTileX,
-      surfaceTileY: 0,   // surface row
+      surfaceTileY: 0, // surface row
       issuedAtTick: world.tick,
     };
     world.commandQueue.push(designateCmd);
@@ -226,12 +226,17 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
             }
           }
         }
-        if (deepestY !== -1) break;  // first row with any Open = deepest
+        if (deepestY !== -1) break; // first row with any Open = deepest
       }
       if (deepestY !== -1) {
         // Mark diggable neighbors of the deepest Open tile: prefer deeper (S) first,
         // then sideways (E/W), then up (N). Deterministic ordering.
-        for (const [dx, dy] of [[0, 1], [1, 0], [-1, 0], [0, -1]] as const) {
+        for (const [dx, dy] of [
+          [0, 1],
+          [1, 0],
+          [-1, 0],
+          [0, -1],
+        ] as const) {
           if (budget <= 0) break;
           const tx = deepestX + dx;
           const ty = deepestY + dy;
@@ -323,7 +328,13 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      world.commandQueue.push({ type: 'MarkDigTile', colonyId: colony.colonyId, tileX: tx, tileY: ty, issuedAtTick: world.tick });
+      world.commandQueue.push({
+        type: 'MarkDigTile',
+        colonyId: colony.colonyId,
+        tileX: tx,
+        tileY: ty,
+        issuedAtTick: world.tick,
+      });
       budget -= 1;
     }
     // Bottom border
@@ -334,7 +345,13 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      world.commandQueue.push({ type: 'MarkDigTile', colonyId: colony.colonyId, tileX: tx, tileY: ty, issuedAtTick: world.tick });
+      world.commandQueue.push({
+        type: 'MarkDigTile',
+        colonyId: colony.colonyId,
+        tileX: tx,
+        tileY: ty,
+        issuedAtTick: world.tick,
+      });
       budget -= 1;
     }
     // Left border
@@ -345,7 +362,13 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      world.commandQueue.push({ type: 'MarkDigTile', colonyId: colony.colonyId, tileX: tx, tileY: ty, issuedAtTick: world.tick });
+      world.commandQueue.push({
+        type: 'MarkDigTile',
+        colonyId: colony.colonyId,
+        tileX: tx,
+        tileY: ty,
+        issuedAtTick: world.tick,
+      });
       budget -= 1;
     }
     // Right border
@@ -356,7 +379,13 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      world.commandQueue.push({ type: 'MarkDigTile', colonyId: colony.colonyId, tileX: tx, tileY: ty, issuedAtTick: world.tick });
+      world.commandQueue.push({
+        type: 'MarkDigTile',
+        colonyId: colony.colonyId,
+        tileX: tx,
+        tileY: ty,
+        issuedAtTick: world.tick,
+      });
       budget -= 1;
     }
   }
@@ -414,11 +443,11 @@ export function aiChamberPlacement(world: WorldState, colony: ColonyRecord): voi
   // chamber per colony — same as before this PR; the sim layer would
   // accept additional FS but the AI does not issue them.
   if (
-    hasChamberOrPending(world, colony, ChamberType.Queen)
-    && colonyFoodTotal(colony) >= AI_FOOD_STORAGE_THRESHOLD
-    && !hasChamberOrPending(world, colony, ChamberType.FoodStorage)
+    hasChamberOrPending(world, colony, ChamberType.Queen) &&
+    colonyFoodTotal(colony) >= AI_FOOD_STORAGE_THRESHOLD &&
+    !hasChamberOrPending(world, colony, ChamberType.FoodStorage)
   ) {
-    const placement = findOpenChamberSpot(world, colony, 5, ChamberType.FoodStorage);  // near-surface storage
+    const placement = findOpenChamberSpot(world, colony, 5, ChamberType.FoodStorage); // near-surface storage
     if (placement !== null) {
       const cmd: PlaceChamberCommand = {
         type: 'PlaceChamber',
@@ -452,7 +481,7 @@ export function aiChamberPlacement(world: WorldState, colony: ColonyRecord): voi
     // one Nursery, multiple FoodStorage).
     const hasNursery = hasChamberOrPending(world, colony, ChamberType.Nursery);
     const hasQueen = colony.chambers.some((c) => c.chamberType === ChamberType.Queen);
-    const broodPressure = (colony.eggCount + colony.larvaeCount) >= AI_NURSERY_THRESHOLD;
+    const broodPressure = colony.eggCount + colony.larvaeCount >= AI_NURSERY_THRESHOLD;
     if (!hasNursery && (hasQueen || broodPressure)) {
       const placement = findOpenChamberSpot(world, colony, 7, ChamberType.Nursery);
       if (placement !== null) {
@@ -491,27 +520,36 @@ export function aiEntranceDesignation(world: WorldState, colony: ColonyRecord): 
   }
 }
 
-
 // ---------------------------------------------------------------------------
 // S2: AI state machine subroutines
 // ---------------------------------------------------------------------------
 
 /** Behavior ratios per AI state (forage:fight on 0-10 scale). */
 const AI_STATE_RATIOS: Record<string, { forage: number; fight: number }> = {
-  Peacetime:  { forage: 7, fight: 3 },
+  Peacetime: { forage: 7, fight: 3 },
   WarFooting: { forage: 3, fight: 7 },
-  Probing:    { forage: 3, fight: 7 },
-  Invading:   { forage: 2, fight: 8 },
-  Recovery:   { forage: 6, fight: 4 },
+  Probing: { forage: 3, fight: 7 },
+  Invading: { forage: 2, fight: 8 },
+  Recovery: { forage: 6, fight: 4 },
 };
 
 interface _SyncSnapshot {
-  state: string; enteredTick: number; probeCount: number; lastProbeEndTick: number;
-  invasionStartTick: number; invasionRallyTileX: number; invasionRallyTileY: number;
-  recoveryEndTick: number; operationKind: string; operationStartTick: number;
-  operationTargetTileX: number; operationTargetTileY: number;
-  operationFighterCount: number; operationStartFighterCount: number;
-  operationAttackerDeaths: number; operationDefenderDeaths: number;
+  state: string;
+  enteredTick: number;
+  probeCount: number;
+  lastProbeEndTick: number;
+  invasionStartTick: number;
+  invasionRallyTileX: number;
+  invasionRallyTileY: number;
+  recoveryEndTick: number;
+  operationKind: string;
+  operationStartTick: number;
+  operationTargetTileX: number;
+  operationTargetTileY: number;
+  operationFighterCount: number;
+  operationStartFighterCount: number;
+  operationAttackerDeaths: number;
+  operationDefenderDeaths: number;
 }
 const _syncCache = new Map<ColonyId, _SyncSnapshot>();
 
@@ -526,35 +564,44 @@ function _pushSyncAIState(world: WorldState, aiColonyId: ColonyId): void {
   if (rec === undefined) return;
 
   const cached = _syncCache.get(aiColonyId);
-  const changed = cached === undefined
-    || cached.state !== rec.state
-    || cached.enteredTick !== rec.enteredTick
-    || cached.probeCount !== rec.probeCount
-    || cached.lastProbeEndTick !== rec.lastProbeEndTick
-    || cached.invasionStartTick !== rec.invasionStartTick
-    || cached.invasionRallyTileX !== rec.invasionRallyTileX
-    || cached.invasionRallyTileY !== rec.invasionRallyTileY
-    || cached.recoveryEndTick !== rec.recoveryEndTick
-    || cached.operationKind !== rec.operationKind
-    || cached.operationStartTick !== rec.operationStartTick
-    || cached.operationTargetTileX !== rec.operationTargetTileX
-    || cached.operationTargetTileY !== rec.operationTargetTileY
-    || cached.operationFighterCount !== rec.operationFighterCount
-    || cached.operationStartFighterCount !== rec.operationStartFighterCount
-    || cached.operationAttackerDeaths !== rec.operationAttackerDeaths
-    || cached.operationDefenderDeaths !== rec.operationDefenderDeaths;
+  const changed =
+    cached === undefined ||
+    cached.state !== rec.state ||
+    cached.enteredTick !== rec.enteredTick ||
+    cached.probeCount !== rec.probeCount ||
+    cached.lastProbeEndTick !== rec.lastProbeEndTick ||
+    cached.invasionStartTick !== rec.invasionStartTick ||
+    cached.invasionRallyTileX !== rec.invasionRallyTileX ||
+    cached.invasionRallyTileY !== rec.invasionRallyTileY ||
+    cached.recoveryEndTick !== rec.recoveryEndTick ||
+    cached.operationKind !== rec.operationKind ||
+    cached.operationStartTick !== rec.operationStartTick ||
+    cached.operationTargetTileX !== rec.operationTargetTileX ||
+    cached.operationTargetTileY !== rec.operationTargetTileY ||
+    cached.operationFighterCount !== rec.operationFighterCount ||
+    cached.operationStartFighterCount !== rec.operationStartFighterCount ||
+    cached.operationAttackerDeaths !== rec.operationAttackerDeaths ||
+    cached.operationDefenderDeaths !== rec.operationDefenderDeaths;
 
   if (!changed) return;
 
   _syncCache.set(aiColonyId, {
-    state: rec.state, enteredTick: rec.enteredTick, probeCount: rec.probeCount,
-    lastProbeEndTick: rec.lastProbeEndTick, invasionStartTick: rec.invasionStartTick,
-    invasionRallyTileX: rec.invasionRallyTileX, invasionRallyTileY: rec.invasionRallyTileY,
-    recoveryEndTick: rec.recoveryEndTick, operationKind: rec.operationKind,
-    operationStartTick: rec.operationStartTick, operationTargetTileX: rec.operationTargetTileX,
-    operationTargetTileY: rec.operationTargetTileY, operationFighterCount: rec.operationFighterCount,
+    state: rec.state,
+    enteredTick: rec.enteredTick,
+    probeCount: rec.probeCount,
+    lastProbeEndTick: rec.lastProbeEndTick,
+    invasionStartTick: rec.invasionStartTick,
+    invasionRallyTileX: rec.invasionRallyTileX,
+    invasionRallyTileY: rec.invasionRallyTileY,
+    recoveryEndTick: rec.recoveryEndTick,
+    operationKind: rec.operationKind,
+    operationStartTick: rec.operationStartTick,
+    operationTargetTileX: rec.operationTargetTileX,
+    operationTargetTileY: rec.operationTargetTileY,
+    operationFighterCount: rec.operationFighterCount,
     operationStartFighterCount: rec.operationStartFighterCount,
-    operationAttackerDeaths: rec.operationAttackerDeaths, operationDefenderDeaths: rec.operationDefenderDeaths,
+    operationAttackerDeaths: rec.operationAttackerDeaths,
+    operationDefenderDeaths: rec.operationDefenderDeaths,
   });
 
   const cmd: SyncAIStateCommand = {
@@ -597,8 +644,10 @@ function _syncBehaviorRatioToAIState(
     }
   }
   const targetRatio = AI_STATE_RATIOS[currentState] ?? AI_BEHAVIOR_RATIO;
-  if (colony.targetRatio.forage !== targetRatio.forage
-      || colony.targetRatio.fight !== targetRatio.fight) {
+  if (
+    colony.targetRatio.forage !== targetRatio.forage ||
+    colony.targetRatio.fight !== targetRatio.fight
+  ) {
     const setRatioCmd: SetBehaviorRatioCommand = {
       type: 'SetBehaviorRatio',
       colonyId: aiColonyId,
@@ -653,7 +702,10 @@ function aiStateMachineTick_probeEntry(
 function aiProbeTick(world: WorldState, aiColonyId: ColonyId): void {
   let aiState: import('../sim/types.js').AIStateRecord | null = null;
   for (let i = 0; i < world.aiState.length; i++) {
-    if (world.aiState[i]!.colonyId === aiColonyId) { aiState = world.aiState[i]!; break; }
+    if (world.aiState[i]!.colonyId === aiColonyId) {
+      aiState = world.aiState[i]!;
+      break;
+    }
   }
   if (aiState === null) return;
   // Re-emit rally only if rally is active in sim-state but colony.rallyPoint is null.
@@ -673,7 +725,10 @@ function aiProbeTick(world: WorldState, aiColonyId: ColonyId): void {
 function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
   let aiState: import('../sim/types.js').AIStateRecord | null = null;
   for (let i = 0; i < world.aiState.length; i++) {
-    if (world.aiState[i]!.colonyId === aiColonyId) { aiState = world.aiState[i]!; break; }
+    if (world.aiState[i]!.colonyId === aiColonyId) {
+      aiState = world.aiState[i]!;
+      break;
+    }
   }
   if (aiState === null) return;
 
@@ -717,7 +772,10 @@ function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
 }
 
 /** Select probe target (Q3 spec). */
-function _selectProbeTarget(world: WorldState, aiColonyId: ColonyId): { tileX: number; tileY: number } | null {
+function _selectProbeTarget(
+  world: WorldState,
+  aiColonyId: ColonyId,
+): { tileX: number; tileY: number } | null {
   // Priority 1: closest player-marked food pile by ascending pile ID for ties.
   const playerColony = world.colonies[PLAYER_COLONY_ID];
   if (playerColony === undefined) return null;
@@ -725,18 +783,22 @@ function _selectProbeTarget(world: WorldState, aiColonyId: ColonyId): { tileX: n
   let bestPile: { tileX: number; tileY: number; id: number; dist: number } | null = null;
   const aiCol = world.colonies[aiColonyId];
   // We need a reference point: AI's entrance or colony start.
-  const aiEntranceX = aiCol !== undefined && aiCol.entrances.length > 0
-    ? aiCol.entrances[0]!.surfaceTileX
-    : ENEMY_START_X;
-  const aiEntranceY = aiCol !== undefined && aiCol.entrances.length > 0
-    ? aiCol.entrances[0]!.surfaceTileY
-    : 0; // surface row — all current entrances have surfaceTileY=0
+  const aiEntranceX =
+    aiCol !== undefined && aiCol.entrances.length > 0
+      ? aiCol.entrances[0]!.surfaceTileX
+      : ENEMY_START_X;
+  const aiEntranceY =
+    aiCol !== undefined && aiCol.entrances.length > 0 ? aiCol.entrances[0]!.surfaceTileY : 0; // surface row — all current entrances have surfaceTileY=0
 
   for (const pile of world.foodPiles) {
     const isMarked = playerColony.priorityFoodPileId === pile.foodPileId;
     if (!isMarked) continue;
     const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - aiEntranceY);
-    if (bestPile === null || dist < bestPile.dist || (dist === bestPile.dist && pile.foodPileId < bestPile.id)) {
+    if (
+      bestPile === null ||
+      dist < bestPile.dist ||
+      (dist === bestPile.dist && pile.foodPileId < bestPile.id)
+    ) {
       bestPile = { tileX: pile.tileX, tileY: pile.tileY, id: pile.foodPileId, dist };
     }
   }
@@ -749,13 +811,21 @@ function _selectProbeTarget(world: WorldState, aiColonyId: ColonyId): { tileX: n
     let withinRadius = false;
     for (const entrance of playerColony.entrances) {
       if (!entrance.isOpen) continue;
-      const dist = Math.abs(pile.tileX - entrance.surfaceTileX) + Math.abs(pile.tileY - entrance.surfaceTileY);
-      if (dist <= AI_PROBE_FALLBACK_RADIUS_TILES) { withinRadius = true; break; }
+      const dist =
+        Math.abs(pile.tileX - entrance.surfaceTileX) + Math.abs(pile.tileY - entrance.surfaceTileY);
+      if (dist <= AI_PROBE_FALLBACK_RADIUS_TILES) {
+        withinRadius = true;
+        break;
+      }
     }
     if (!withinRadius) continue;
     // Pick closest to AI entrance by ascending pile ID for ties.
     const dist = Math.abs(pile.tileX - aiEntranceX) + Math.abs(pile.tileY - aiEntranceY);
-    if (bestPile === null || dist < bestPile.dist || (dist === bestPile.dist && pile.foodPileId < bestPile.id)) {
+    if (
+      bestPile === null ||
+      dist < bestPile.dist ||
+      (dist === bestPile.dist && pile.foodPileId < bestPile.id)
+    ) {
       bestPile = { tileX: pile.tileX, tileY: pile.tileY, id: pile.foodPileId, dist };
     }
   }
@@ -801,8 +871,10 @@ function _selectInvasionEntrance(
   if (openEntrances.length === 1) return openEntrances[0]!;
 
   // Use last probe target as reference (invasionRallyTileX/Y from a prior probe).
-  const refX = aiState.invasionRallyTileX !== -1 ? aiState.invasionRallyTileX : aiState.operationTargetTileX;
-  const refY = aiState.invasionRallyTileY !== -1 ? aiState.invasionRallyTileY : aiState.operationTargetTileY;
+  const refX =
+    aiState.invasionRallyTileX !== -1 ? aiState.invasionRallyTileX : aiState.operationTargetTileX;
+  const refY =
+    aiState.invasionRallyTileY !== -1 ? aiState.invasionRallyTileY : aiState.operationTargetTileY;
   if (refX === -1) return openEntrances[0]!;
 
   let best = openEntrances[0]!;
@@ -810,13 +882,21 @@ function _selectInvasionEntrance(
   for (let i = 1; i < openEntrances.length; i++) {
     const e = openEntrances[i]!;
     const dist = Math.abs(e.surfaceTileX - refX) + Math.abs(e.surfaceTileY - refY);
-    if (dist < bestDist) { best = e; bestDist = dist; }
+    if (dist < bestDist) {
+      best = e;
+      bestDist = dist;
+    }
   }
   return best;
 }
 
 /** Emit SetRallyPoint command for the AI colony. */
-function _emitSetRallyPoint(world: WorldState, aiColonyId: ColonyId, tileX: number, tileY: number): void {
+function _emitSetRallyPoint(
+  world: WorldState,
+  aiColonyId: ColonyId,
+  tileX: number,
+  tileY: number,
+): void {
   const cmd = {
     type: 'SetRallyPoint' as const,
     colonyId: aiColonyId,
@@ -879,7 +959,7 @@ function collectFrontierTiles(
   let cx = 0;
   let cy = 0;
   for (const ch of chambersSorted) {
-    cx += (ch.posX >> FP_SHIFT) + (ch.width  >> 1);
+    cx += (ch.posX >> FP_SHIFT) + (ch.width >> 1);
     cy += (ch.posY >> FP_SHIFT) + (ch.height >> 1);
   }
   cx = (cx / chambersSorted.length) | 0;
@@ -924,7 +1004,7 @@ function collectFrontierTiles(
   for (const ch of chambersSorted) {
     const chTileX = ch.posX >> FP_SHIFT;
     const chTileY = ch.posY >> FP_SHIFT;
-    const chCenterX = chTileX + (ch.width  >> 1);
+    const chCenterX = chTileX + (ch.width >> 1);
     const chCenterY = chTileY + (ch.height >> 1);
     const chDist = Math.abs(chCenterX - cx) + Math.abs(chCenterY - cy);
 
@@ -933,12 +1013,53 @@ function collectFrontierTiles(
       // Reject tiles 4-adjacent to ANOTHER chamber's footprint (those are
       // "between" tiles; the legacy pass picks them up later if budget
       // remains).
-      if (isFootprint(tx - 1, ty) && !(tx - 1 >= chTileX && tx - 1 < chTileX + ch.width  && ty >= chTileY && ty < chTileY + ch.height)) return;
-      if (isFootprint(tx + 1, ty) && !(tx + 1 >= chTileX && tx + 1 < chTileX + ch.width  && ty >= chTileY && ty < chTileY + ch.height)) return;
-      if (isFootprint(tx, ty - 1) && !(tx >= chTileX && tx < chTileX + ch.width  && ty - 1 >= chTileY && ty - 1 < chTileY + ch.height)) return;
-      if (isFootprint(tx, ty + 1) && !(tx >= chTileX && tx < chTileX + ch.width  && ty + 1 >= chTileY && ty + 1 < chTileY + ch.height)) return;
+      if (
+        isFootprint(tx - 1, ty) &&
+        !(
+          tx - 1 >= chTileX &&
+          tx - 1 < chTileX + ch.width &&
+          ty >= chTileY &&
+          ty < chTileY + ch.height
+        )
+      )
+        return;
+      if (
+        isFootprint(tx + 1, ty) &&
+        !(
+          tx + 1 >= chTileX &&
+          tx + 1 < chTileX + ch.width &&
+          ty >= chTileY &&
+          ty < chTileY + ch.height
+        )
+      )
+        return;
+      if (
+        isFootprint(tx, ty - 1) &&
+        !(
+          tx >= chTileX &&
+          tx < chTileX + ch.width &&
+          ty - 1 >= chTileY &&
+          ty - 1 < chTileY + ch.height
+        )
+      )
+        return;
+      if (
+        isFootprint(tx, ty + 1) &&
+        !(
+          tx >= chTileX &&
+          tx < chTileX + ch.width &&
+          ty + 1 >= chTileY &&
+          ty + 1 < chTileY + ch.height
+        )
+      )
+        return;
       const outward = Math.abs(tx - cx) + Math.abs(ty - cy);
-      candidates.push({ tileX: tx, tileY: ty, chamberDistFromCentroid: chDist, outwardScore: outward });
+      candidates.push({
+        tileX: tx,
+        tileY: ty,
+        chamberDistFromCentroid: chDist,
+        outwardScore: outward,
+      });
     };
 
     // Walk the four borders.
@@ -947,8 +1068,8 @@ function collectFrontierTiles(
       consider(chTileX + ox, chTileY + ch.height);
     }
     for (let oy = 0; oy < ch.height; oy++) {
-      consider(chTileX - 1,           chTileY + oy);
-      consider(chTileX + ch.width,    chTileY + oy);
+      consider(chTileX - 1, chTileY + oy);
+      consider(chTileX + ch.width, chTileY + oy);
     }
   }
 
@@ -1045,9 +1166,10 @@ function findOpenChamberSpot(
   // depth band the AI actually wants to build at. Documented per plan 09.1-01
   // Task 2 pre-audit (commit dee93e5).
   const queenTileX = Math.min(Math.max(rawQueenTileX, 0), grid.width - 1);
-  const queenTileY = rawQueenTileY >= grid.height
-    ? Math.min(Math.max(preferredDepth, 0), grid.height - 1)
-    : Math.min(Math.max(rawQueenTileY, 0), grid.height - 1);
+  const queenTileY =
+    rawQueenTileY >= grid.height
+      ? Math.min(Math.max(preferredDepth, 0), grid.height - 1)
+      : Math.min(Math.max(rawQueenTileY, 0), grid.height - 1);
 
   const RADIUS = 32;
 
@@ -1084,10 +1206,21 @@ function findOpenChamberSpot(
     if (ugGet(grid, ax, ay) !== UndergroundTileState.Open) return false;
     // At least one 4-connected neighbor of anchor is Solid
     let hasAdjSolid = false;
-    if (ax - 1 >= 0          && ugGet(grid, ax - 1, ay) === UndergroundTileState.Solid) hasAdjSolid = true;
-    if (!hasAdjSolid && ax + 1 < grid.width  && ugGet(grid, ax + 1, ay) === UndergroundTileState.Solid) hasAdjSolid = true;
-    if (!hasAdjSolid && ay - 1 >= 0          && ugGet(grid, ax,     ay - 1) === UndergroundTileState.Solid) hasAdjSolid = true;
-    if (!hasAdjSolid && ay + 1 < grid.height && ugGet(grid, ax,     ay + 1) === UndergroundTileState.Solid) hasAdjSolid = true;
+    if (ax - 1 >= 0 && ugGet(grid, ax - 1, ay) === UndergroundTileState.Solid) hasAdjSolid = true;
+    if (
+      !hasAdjSolid &&
+      ax + 1 < grid.width &&
+      ugGet(grid, ax + 1, ay) === UndergroundTileState.Solid
+    )
+      hasAdjSolid = true;
+    if (!hasAdjSolid && ay - 1 >= 0 && ugGet(grid, ax, ay - 1) === UndergroundTileState.Solid)
+      hasAdjSolid = true;
+    if (
+      !hasAdjSolid &&
+      ay + 1 < grid.height &&
+      ugGet(grid, ax, ay + 1) === UndergroundTileState.Solid
+    )
+      hasAdjSolid = true;
     if (!hasAdjSolid) return false;
     // No footprint tile may be BeingDug, and no footprint tile may overlap an
     // existing/pending chamber (precomputed `occupied` set above).
@@ -1119,7 +1252,12 @@ function findOpenChamberSpot(
     }
 
     // Expand N,E,S,W deterministically.
-    for (const [dx, dy] of [[0, -1], [1, 0], [0, 1], [-1, 0]] as const) {
+    for (const [dx, dy] of [
+      [0, -1],
+      [1, 0],
+      [0, 1],
+      [-1, 0],
+    ] as const) {
       const nx = tx + dx;
       const ny = ty + dy;
       // Issue #64 — bounds-check before computing the visited-set key.

--- a/src/render/ant-activity-panel-state.ts
+++ b/src/render/ant-activity-panel-state.ts
@@ -29,23 +29,23 @@
 // Tests use `hideAntActivityPanel()` for immediate synchronous reset.
 
 export interface AntActivityPanelState {
-  visible:     boolean;
+  visible: boolean;
   /** Set by requestHideAntActivityPanel; cleared by applyPendingAntActivityPanelHide on the next update frame. */
   pendingHide: boolean;
 }
 
 export const antActivityPanelState: AntActivityPanelState = {
-  visible:     false,
+  visible: false,
   pendingHide: false,
 };
 
 export function toggleAntActivityPanel(): void {
-  antActivityPanelState.visible     = !antActivityPanelState.visible;
+  antActivityPanelState.visible = !antActivityPanelState.visible;
   antActivityPanelState.pendingHide = false;
 }
 
 export function showAntActivityPanel(): void {
-  antActivityPanelState.visible     = true;
+  antActivityPanelState.visible = true;
   antActivityPanelState.pendingHide = false;
 }
 
@@ -54,7 +54,7 @@ export function showAntActivityPanel(): void {
  * contexts where there is no concurrent pointer dispatch to race with.
  */
 export function hideAntActivityPanel(): void {
-  antActivityPanelState.visible     = false;
+  antActivityPanelState.visible = false;
   antActivityPanelState.pendingHide = false;
 }
 
@@ -74,7 +74,7 @@ export function requestHideAntActivityPanel(): void {
  */
 export function applyPendingAntActivityPanelHide(): void {
   if (antActivityPanelState.pendingHide) {
-    antActivityPanelState.visible     = false;
+    antActivityPanelState.visible = false;
     antActivityPanelState.pendingHide = false;
   }
 }

--- a/src/render/ant-activity.test.ts
+++ b/src/render/ant-activity.test.ts
@@ -3,11 +3,7 @@
 // semantics, and formatted output stability.
 
 import { describe, it, expect } from 'vitest';
-import {
-  computeAntActivity,
-  formatAntActivityLines,
-  ANT_ACTIVITY_PANEL,
-} from './ant-activity.js';
+import { computeAntActivity, formatAntActivityLines, ANT_ACTIVITY_PANEL } from './ant-activity.js';
 import { createWorldState, allocateEntityId } from '../sim/types.js';
 import type { WorldState } from '../sim/types.js';
 import { initAnt, killAnt } from '../sim/ant/ant-store.js';
@@ -133,7 +129,7 @@ describe('computeAntActivity — capable count', () => {
 
   it('brood counts come from the colony record, not the worker array', () => {
     const { world, colony } = setupWorld();
-    colony.eggCount    = 5;
+    colony.eggCount = 5;
     colony.larvaeCount = 2;
     const a = computeAntActivity(world, colony);
     expect(a.eggs).toBe(5);
@@ -146,7 +142,7 @@ describe('computeAntActivity — dead-worker filtering', () => {
   it('dead workers are skipped entirely', () => {
     const { world, colony } = setupWorld();
     const alive = spawnWorker(world, colony, AntTask.Foraging, ForagingSubState.SearchingFood);
-    const dead  = spawnWorker(world, colony, AntTask.Foraging, ForagingSubState.SearchingFood);
+    const dead = spawnWorker(world, colony, AntTask.Foraging, ForagingSubState.SearchingFood);
     killAnt(world.ants, dead);
     expect(alive).not.toBe(dead);
     const a = computeAntActivity(world, colony);
@@ -158,7 +154,7 @@ describe('computeAntActivity — dead-worker filtering', () => {
 describe('formatAntActivityLines', () => {
   it('emits a stable set of labeled lines', () => {
     const { world, colony } = setupWorld();
-    colony.eggCount    = 3;
+    colony.eggCount = 3;
     colony.larvaeCount = 1;
     spawnWorker(world, colony, AntTask.Foraging, ForagingSubState.SearchingFood);
     spawnWorker(world, colony, AntTask.Foraging, ForagingSubState.CarryingFood);
@@ -205,11 +201,8 @@ describe('antActivityPanelState — state machine', () => {
   // tests lock the state-level contract that handler relies on so a future
   // refactor can't silently break the open-dismiss-reopen cycle.
   it('toggle opens then closes on successive calls (click on Ants)', async () => {
-    const {
-      antActivityPanelState,
-      toggleAntActivityPanel,
-      hideAntActivityPanel,
-    } = await import('./ant-activity-panel-state.js');
+    const { antActivityPanelState, toggleAntActivityPanel, hideAntActivityPanel } =
+      await import('./ant-activity-panel-state.js');
     hideAntActivityPanel(); // reset
     toggleAntActivityPanel();
     expect(antActivityPanelState.visible).toBe(true);
@@ -221,11 +214,8 @@ describe('antActivityPanelState — state machine', () => {
     // Locks the invariant UIScene depends on: the "click inside panel is
     // absorbed" path simply returns without touching panel state — it does
     // NOT schedule a hide. Only click-outside paths call requestHide.
-    const {
-      antActivityPanelState,
-      showAntActivityPanel,
-      hideAntActivityPanel,
-    } = await import('./ant-activity-panel-state.js');
+    const { antActivityPanelState, showAntActivityPanel, hideAntActivityPanel } =
+      await import('./ant-activity-panel-state.js');
     showAntActivityPanel();
     expect(antActivityPanelState.visible).toBe(true);
     expect(antActivityPanelState.pendingHide).toBe(false);

--- a/src/render/ant-activity.ts
+++ b/src/render/ant-activity.ts
@@ -40,26 +40,26 @@ import { HUD } from './sprites.js';
 export interface ForagingBreakdown {
   searching: number;
   returning: number;
-  carrying:  number;
-  total:     number;
+  carrying: number;
+  total: number;
 }
 
 export interface DiggingBreakdown {
   movingToSite: number;
-  excavating:   number;
-  total:        number;
+  excavating: number;
+  total: number;
 }
 
 export interface AntActivity {
-  capableAnts:  number;
-  queenAlive:   boolean;
-  eggs:         number;
-  larvae:       number;
-  foraging:     ForagingBreakdown;
-  digging:      DiggingBreakdown;
-  fighting:     number;
-  nursing:      number;
-  idle:         number;
+  capableAnts: number;
+  queenAlive: boolean;
+  eggs: number;
+  larvae: number;
+  foraging: ForagingBreakdown;
+  digging: DiggingBreakdown;
+  fighting: number;
+  nursing: number;
+  idle: number;
   totalWorkers: number;
 }
 
@@ -67,15 +67,15 @@ export function computeAntActivity(world: WorldState, colony: ColonyRecord): Ant
   const ants = world.ants;
   const queenAlive = isAlive(ants, colony.queenEntityId);
 
-  let searching    = 0;
-  let returning    = 0;
-  let carrying     = 0;
+  let searching = 0;
+  let returning = 0;
+  let carrying = 0;
   let movingToSite = 0;
-  let excavating   = 0;
-  let fighting     = 0;
-  let nursing      = 0;
-  let idle         = 0;
-  let workers      = 0;
+  let excavating = 0;
+  let fighting = 0;
+  let nursing = 0;
+  let idle = 0;
+  let workers = 0;
 
   for (let i = 0; i < colony.workers.length; i++) {
     const id = colony.workers[i]!;
@@ -83,7 +83,7 @@ export function computeAntActivity(world: WorldState, colony: ColonyRecord): Ant
     workers += 1;
 
     const task = ants.task[id]!;
-    const sub  = ants.subTask[id]!;
+    const sub = ants.subTask[id]!;
 
     if (task === AntTask.Foraging) {
       if (sub === ForagingSubState.CarryingFood) {
@@ -109,17 +109,17 @@ export function computeAntActivity(world: WorldState, colony: ColonyRecord): Ant
   }
 
   return {
-    capableAnts:  workers + (queenAlive ? 1 : 0),
+    capableAnts: workers + (queenAlive ? 1 : 0),
     queenAlive,
-    eggs:         colony.eggCount,
-    larvae:       colony.larvaeCount,
-    foraging:     {
+    eggs: colony.eggCount,
+    larvae: colony.larvaeCount,
+    foraging: {
       searching,
       returning,
       carrying,
       total: searching + returning + carrying,
     },
-    digging:      { movingToSite, excavating, total: movingToSite + excavating },
+    digging: { movingToSite, excavating, total: movingToSite + excavating },
     fighting,
     nursing,
     idle,
@@ -180,8 +180,8 @@ export const ANT_ACTIVITY_PANEL = {
 } as const;
 
 export const ANT_ACTIVITY_PANEL_COLORS = {
-  background:      0x000000,
+  background: 0x000000,
   backgroundAlpha: 0.78,
-  border:          0x444444,
-  textCss:         '#ffffff',
+  border: 0x444444,
+  textCss: '#ffffff',
 } as const;

--- a/src/render/ant-facing-cache.test.ts
+++ b/src/render/ant-facing-cache.test.ts
@@ -37,8 +37,14 @@ describe('AntFacingCache', () => {
     // that as alternating axis-aligned deltas of constant magnitude; the cache
     // should blend them into a consistent southeast-ish heading.
     const deltas: Array<[number, number]> = [
-      [16, 0], [0, 16], [16, 0], [0, 16],
-      [16, 0], [0, 16], [16, 0], [0, 16],
+      [16, 0],
+      [0, 16],
+      [16, 0],
+      [0, 16],
+      [16, 0],
+      [0, 16],
+      [16, 0],
+      [0, 16],
     ];
     let last = 0;
     for (const [dx, dy] of deltas) {
@@ -51,10 +57,10 @@ describe('AntFacingCache', () => {
     expect(last).toBeGreaterThan(-Math.PI);
     expect(last).toBeLessThan(-Math.PI / 2);
     // And specifically closer to the diagonal (-3π/4) than to either axis.
-    const diag = -3 * Math.PI / 4;
-    const distDiag    = Math.abs(last - diag);
-    const distRight   = Math.abs(last - -Math.PI);     // axis-aligned right
-    const distDown    = Math.abs(last - -Math.PI / 2); // axis-aligned down
+    const diag = (-3 * Math.PI) / 4;
+    const distDiag = Math.abs(last - diag);
+    const distRight = Math.abs(last - -Math.PI); // axis-aligned right
+    const distDown = Math.abs(last - -Math.PI / 2); // axis-aligned down
     expect(distDiag).toBeLessThan(distRight);
     expect(distDiag).toBeLessThan(distDown);
   });

--- a/src/render/ant-facing-cache.ts
+++ b/src/render/ant-facing-cache.ts
@@ -25,10 +25,10 @@
  * (e.g. reversing course) converges within a few frames.
  */
 const SMOOTHING_PREV = 0.65;
-const SMOOTHING_NEW  = 0.35;
+const SMOOTHING_NEW = 0.35;
 
 /** Pixel-space delta threshold below which we treat motion as "no signal". */
-const DELTA_EPSILON  = 0.01;
+const DELTA_EPSILON = 0.01;
 
 /** Minimum blended heading magnitude to emit a rotation from. */
 const HEADING_EPSILON = 0.001;

--- a/src/render/ant-sprite-layer.ts
+++ b/src/render/ant-sprite-layer.ts
@@ -72,34 +72,34 @@ export interface AntSpriteLayer {
 
 // Texture keys shared by preload (game-scene.ts) and pool (ant-sprite-pool.ts).
 export const ANT_TEXTURE_WORKER = 'ant-worker';
-export const ANT_TEXTURE_QUEEN  = 'ant-queen';
-export const EGG_TEXTURE        = 'egg';
-export const LARVA_TEXTURE      = 'larva';
+export const ANT_TEXTURE_QUEEN = 'ant-queen';
+export const EGG_TEXTURE = 'egg';
+export const LARVA_TEXTURE = 'larva';
 export const FOOD_CACHE_TEXTURE = 'food-cache';
 
 // S3 spider
-export const SPIDER_TEXTURE       = 'spider';
-export const SPIDER_SPRITE_WIDTH  = 48;
+export const SPIDER_TEXTURE = 'spider';
+export const SPIDER_SPRITE_WIDTH = 48;
 export const SPIDER_SPRITE_HEIGHT = 48;
-export const SPIDER_SPRITE_DEPTH  = 52; // above ants (depth 50); exported unlike ant/static depths which are pool-internal
+export const SPIDER_SPRITE_DEPTH = 52; // above ants (depth 50); exported unlike ant/static depths which are pool-internal
 
 // Rasterization sizes — keep in sync with the SVG viewBox values in
 // code/public/assets/sprites/{worker,queen}-ant.svg. Phaser's load.svg
 // rasterizes at these dimensions; the resulting texture is what renders
 // in the scene.
-export const WORKER_SPRITE_WIDTH  = 12;
+export const WORKER_SPRITE_WIDTH = 12;
 export const WORKER_SPRITE_HEIGHT = 8;
-export const QUEEN_SPRITE_WIDTH   = 20;
-export const QUEEN_SPRITE_HEIGHT  = 14;
+export const QUEEN_SPRITE_WIDTH = 20;
+export const QUEEN_SPRITE_HEIGHT = 14;
 
 // Static entity rasterization sizes — these are rasterized at 2× the tile
 // footprint so rotation-less scaling from the pool center keeps crisp edges.
 // Visual size still fits inside TILE_SIZE_PX (16) via draw-underground's
 // setDisplaySize clamp; the higher raster preserves SVG detail when Phaser
 // tints/scales.
-export const EGG_SPRITE_WIDTH        = 10;
-export const EGG_SPRITE_HEIGHT       = 10;
-export const LARVA_SPRITE_WIDTH      = 12;
-export const LARVA_SPRITE_HEIGHT     = 10;
-export const FOOD_CACHE_SPRITE_WIDTH  = 16;
+export const EGG_SPRITE_WIDTH = 10;
+export const EGG_SPRITE_HEIGHT = 10;
+export const LARVA_SPRITE_WIDTH = 12;
+export const LARVA_SPRITE_HEIGHT = 10;
+export const FOOD_CACHE_SPRITE_WIDTH = 16;
 export const FOOD_CACHE_SPRITE_HEIGHT = 16;

--- a/src/render/ant-sprite-pool.ts
+++ b/src/render/ant-sprite-pool.ts
@@ -29,14 +29,14 @@ import {
   type StaticSpriteKind,
 } from './ant-sprite-layer.js';
 
-const ANT_SPRITE_DEPTH    = 50;
+const ANT_SPRITE_DEPTH = 50;
 // Static entities sit just below ants so a queen standing in the Nursery
 // still reads on top of its own eggs. Keeps Z order predictable.
 const STATIC_SPRITE_DEPTH = 48;
 
 const STATIC_TEXTURES: Record<StaticSpriteKind, string> = {
-  egg:          EGG_TEXTURE,
-  larva:        LARVA_TEXTURE,
+  egg: EGG_TEXTURE,
+  larva: LARVA_TEXTURE,
   'food-cache': FOOD_CACHE_TEXTURE,
 };
 
@@ -102,5 +102,7 @@ export class AntSpritePool implements AntSpriteLayer {
   }
 
   /** Test hook: current pool size (live + hidden). */
-  get size(): number { return this.pool.length; }
+  get size(): number {
+    return this.pool.length;
+  }
 }

--- a/src/render/camera.test.ts
+++ b/src/render/camera.test.ts
@@ -280,16 +280,16 @@ describe('clampCamera', () => {
     const cam = makeCamera(0, 0);
     clampCamera(cam, 128, 128);
     // half-viewport: 50/2 = 25, 37/2 = 18.5
-    expect(cam.x).toBe(VIEWPORT_WIDTH_TILES / 2);   // 25
-    expect(cam.y).toBe(VIEWPORT_HEIGHT_TILES / 2);  // 18.5
+    expect(cam.x).toBe(VIEWPORT_WIDTH_TILES / 2); // 25
+    expect(cam.y).toBe(VIEWPORT_HEIGHT_TILES / 2); // 18.5
   });
 
   it('clamps camera too far right/down to worldSize - half-viewport boundary', () => {
     const cam = makeCamera(200, 200);
     clampCamera(cam, 128, 128);
     // max: 128 - 25 = 103, 128 - 18.5 = 109.5
-    expect(cam.x).toBe(128 - VIEWPORT_WIDTH_TILES / 2);   // 103
-    expect(cam.y).toBe(128 - VIEWPORT_HEIGHT_TILES / 2);  // 109.5
+    expect(cam.x).toBe(128 - VIEWPORT_WIDTH_TILES / 2); // 103
+    expect(cam.y).toBe(128 - VIEWPORT_HEIGHT_TILES / 2); // 109.5
   });
 
   it('leaves camera unchanged when within valid bounds', () => {
@@ -382,7 +382,13 @@ describe('screenToTile', () => {
     const tileTopPx = (ty - top) * TILE_SIZE_PX;
 
     // Four corners + center of the drawn tile all map to (70, 70)
-    for (const [dx, dy] of [[0, 0], [15, 0], [0, 15], [15, 15], [8, 8]]) {
+    for (const [dx, dy] of [
+      [0, 0],
+      [15, 0],
+      [0, 15],
+      [15, 15],
+      [8, 8],
+    ]) {
       const r = screenToTile(tileLeftPx + dx!, tileTopPx + dy!, cam);
       expect(r.tileX).toBe(tx);
       expect(r.tileY).toBe(ty);

--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -183,11 +183,7 @@ export function createViewState(startTileX: number, startTileY: number): ViewSta
  * first-visit flag. Save files do not persist camera state, so continue-from-
  * save also starts the player back at the default surface view.
  */
-export function resetViewState(
-  viewState: ViewState,
-  startTileX: number,
-  startTileY: number,
-): void {
+export function resetViewState(viewState: ViewState, startTileX: number, startTileY: number): void {
   viewState.activeView = 'surface';
   viewState.surfaceCamera.x = startTileX;
   viewState.surfaceCamera.y = startTileY;
@@ -269,9 +265,7 @@ export function toggleView(viewState: ViewState): void {
  */
 export function toggleUndergroundColony(viewState: ViewState): void {
   viewState.activeUndergroundColonyId =
-    viewState.activeUndergroundColonyId === PLAYER_COLONY_ID
-      ? ENEMY_COLONY_ID
-      : PLAYER_COLONY_ID;
+    viewState.activeUndergroundColonyId === PLAYER_COLONY_ID ? ENEMY_COLONY_ID : PLAYER_COLONY_ID;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/render/chamber-shape.test.ts
+++ b/src/render/chamber-shape.test.ts
@@ -54,7 +54,8 @@ describe('chamberSeed', () => {
 
 describe('chamberPerimeterPoints', () => {
   // Queen chamber default: 80x48 px at TILE_SIZE_PX=16, anchored at (0,0).
-  const W = 80, H = 48;
+  const W = 80,
+    H = 48;
 
   it('returns NUM_PERIMETER_POINTS edge samples + 4 × NUM_CORNER_ARC_SAMPLES arc samples by default', () => {
     const points = chamberPerimeterPoints(0xdeadbeef, 0, 0, W, H);
@@ -154,7 +155,7 @@ describe('chamberPerimeterPoints', () => {
       // Top-edge samples have baseY = -amp; jittered y deviates outward
       // (y < -amp) or inward (y > -amp). Skip points clearly not on the
       // top edge (large |y - (-amp)| means corner arc or other edge).
-      const dy = Math.abs(p.y - (-amp));
+      const dy = Math.abs(p.y - -amp);
       // Corner arcs at TL/TR have y up to (-amp + R) ≈ 3, far from -amp.
       // Filter to "near top edge" by capping at 2*amp = 6 px deviation.
       if (dy <= 2 * amp + 0.001 && p.x > 0 && p.x < W) {
@@ -194,10 +195,13 @@ describe('chamberPerimeterPoints', () => {
     // CORNER_RADIUS_PX from one of the four arc centers (the corner
     // arcs themselves).
     const arcCenters = [
-      { cx: -WAVE_AMPLITUDE_PX + CORNER_RADIUS_PX,        cy: -WAVE_AMPLITUDE_PX + CORNER_RADIUS_PX },
-      { cx:  W + WAVE_AMPLITUDE_PX - CORNER_RADIUS_PX,    cy: -WAVE_AMPLITUDE_PX + CORNER_RADIUS_PX },
-      { cx:  W + WAVE_AMPLITUDE_PX - CORNER_RADIUS_PX,    cy:  H + WAVE_AMPLITUDE_PX - CORNER_RADIUS_PX },
-      { cx: -WAVE_AMPLITUDE_PX + CORNER_RADIUS_PX,        cy:  H + WAVE_AMPLITUDE_PX - CORNER_RADIUS_PX },
+      { cx: -WAVE_AMPLITUDE_PX + CORNER_RADIUS_PX, cy: -WAVE_AMPLITUDE_PX + CORNER_RADIUS_PX },
+      { cx: W + WAVE_AMPLITUDE_PX - CORNER_RADIUS_PX, cy: -WAVE_AMPLITUDE_PX + CORNER_RADIUS_PX },
+      {
+        cx: W + WAVE_AMPLITUDE_PX - CORNER_RADIUS_PX,
+        cy: H + WAVE_AMPLITUDE_PX - CORNER_RADIUS_PX,
+      },
+      { cx: -WAVE_AMPLITUDE_PX + CORNER_RADIUS_PX, cy: H + WAVE_AMPLITUDE_PX - CORNER_RADIUS_PX },
     ];
     let arcLikePoints = 0;
     for (const p of points) {

--- a/src/render/chamber-shape.ts
+++ b/src/render/chamber-shape.ts
@@ -164,13 +164,13 @@ export function chamberPerimeterPoints(
   // +π/2 from startAngle, which is visually clockwise in screen space.
   const arcs = [
     // TL: from end-of-left-edge (west of arc center) to start-of-top-edge (north).
-    { cx: inflTLX + cornerR,           cy: inflTLY + cornerR,           startAngle: Math.PI },
+    { cx: inflTLX + cornerR, cy: inflTLY + cornerR, startAngle: Math.PI },
     // TR: from end-of-top (north) to start-of-right (east).
-    { cx: inflTLX + inflW - cornerR,   cy: inflTLY + cornerR,           startAngle: -Math.PI / 2 },
+    { cx: inflTLX + inflW - cornerR, cy: inflTLY + cornerR, startAngle: -Math.PI / 2 },
     // BR: from end-of-right (east) to start-of-bottom (south).
-    { cx: inflTLX + inflW - cornerR,   cy: inflTLY + inflH - cornerR,   startAngle: 0 },
+    { cx: inflTLX + inflW - cornerR, cy: inflTLY + inflH - cornerR, startAngle: 0 },
     // BL: from end-of-bottom (south) to start-of-left (west).
-    { cx: inflTLX + cornerR,           cy: inflTLY + inflH - cornerR,   startAngle: Math.PI / 2 },
+    { cx: inflTLX + cornerR, cy: inflTLY + inflH - cornerR, startAngle: Math.PI / 2 },
   ];
 
   const points: PerimeterPoint[] = [];
@@ -201,22 +201,26 @@ export function chamberPerimeterPoints(
       // TOP edge — between TL and TR arcs.
       baseX = inflTLX + cornerR + t;
       baseY = inflTLY;
-      nx = 0; ny = -1;
+      nx = 0;
+      ny = -1;
     } else if (t < truncW + truncH) {
       // RIGHT edge — between TR and BR arcs.
       baseX = inflTLX + inflW;
       baseY = inflTLY + cornerR + (t - truncW);
-      nx = 1; ny = 0;
+      nx = 1;
+      ny = 0;
     } else if (t < 2 * truncW + truncH) {
       // BOTTOM edge — between BR and BL arcs.
       baseX = inflTLX + inflW - cornerR - (t - truncW - truncH);
       baseY = inflTLY + inflH;
-      nx = 0; ny = 1;
+      nx = 0;
+      ny = 1;
     } else {
       // LEFT edge — between BL arc and the TL arc that opens the next loop.
       baseX = inflTLX;
       baseY = inflTLY + inflH - cornerR - (t - 2 * truncW - truncH);
-      nx = -1; ny = 0;
+      nx = -1;
+      ny = 0;
     }
 
     const jitter = sampleWaveAt(nodes, i, numEdgeSamples);
@@ -241,12 +245,7 @@ export function chamberPerimeterPoints(
  * Lower bound of 0 is allowed: at R=0 the arcs degenerate to single points
  * at each inflated corner — equivalent to the pre-rounding behavior.
  */
-function clampCornerRadius(
-  requested: number,
-  amp: number,
-  inflW: number,
-  inflH: number,
-): number {
+function clampCornerRadius(requested: number, amp: number, inflW: number, inflH: number): number {
   const halfMin = Math.min(inflW, inflH) / 2;
   const ampCap = amp > 0 ? 3 * amp : Infinity; // R=0 fine when amp=0
   return Math.max(0, Math.min(requested, halfMin, ampCap));

--- a/src/render/context-menu-layout.test.ts
+++ b/src/render/context-menu-layout.test.ts
@@ -18,17 +18,35 @@ import { createWorldState, type WorldState } from '../sim/types.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
 import type { GfxLike } from './draw-surface.js';
 
-interface GfxCall { method: string; args: unknown[] }
+interface GfxCall {
+  method: string;
+  args: unknown[];
+}
 
 class MockGfx implements GfxLike {
   calls: GfxCall[] = [];
-  private rec(method: string, args: unknown[]): this { this.calls.push({ method, args }); return this; }
-  clear()                                                                         { return this.rec('clear', []); }
-  fillStyle(c: number, a?: number)                                                { return this.rec('fillStyle', [c, a]); }
-  lineStyle(w: number, c: number, a?: number)                                     { return this.rec('lineStyle', [w, c, a]); }
-  fillRect(x: number, y: number, w: number, h: number)                            { return this.rec('fillRect', [x, y, w, h]); }
-  fillCircle(x: number, y: number, r: number)                                     { return this.rec('fillCircle', [x, y, r]); }
-  strokeCircle(x: number, y: number, r: number)                                   { return this.rec('strokeCircle', [x, y, r]); }
+  private rec(method: string, args: unknown[]): this {
+    this.calls.push({ method, args });
+    return this;
+  }
+  clear() {
+    return this.rec('clear', []);
+  }
+  fillStyle(c: number, a?: number) {
+    return this.rec('fillStyle', [c, a]);
+  }
+  lineStyle(w: number, c: number, a?: number) {
+    return this.rec('lineStyle', [w, c, a]);
+  }
+  fillRect(x: number, y: number, w: number, h: number) {
+    return this.rec('fillRect', [x, y, w, h]);
+  }
+  fillCircle(x: number, y: number, r: number) {
+    return this.rec('fillCircle', [x, y, r]);
+  }
+  strokeCircle(x: number, y: number, r: number) {
+    return this.rec('strokeCircle', [x, y, r]);
+  }
   fillTriangle(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number) {
     return this.rec('fillTriangle', [x0, y0, x1, y1, x2, y2]);
   }
@@ -37,7 +55,15 @@ class MockGfx implements GfxLike {
 // Test fixtures --------------------------------------------------------------
 
 function makeQueenChamber(): ChamberRecord {
-  return { chamberId: 1, chamberType: ChamberType.Queen, foodStored: 0, posX: 0, posY: 0, width: 5, height: 3 };
+  return {
+    chamberId: 1,
+    chamberType: ChamberType.Queen,
+    foodStored: 0,
+    posX: 0,
+    posY: 0,
+    width: 5,
+    height: 3,
+  };
 }
 
 function makeWorld(): WorldState {
@@ -75,16 +101,16 @@ describe('contextMenuItemAt (full list)', () => {
   const AY = 200;
 
   it('returns the chamber type for each row', () => {
-    expect(contextMenuItemAt(AX + 10, AY + 5,  AX, AY)).toBe(ChamberType.Queen);
+    expect(contextMenuItemAt(AX + 10, AY + 5, AX, AY)).toBe(ChamberType.Queen);
     expect(contextMenuItemAt(AX + 10, AY + 25, AX, AY)).toBe(ChamberType.Nursery);
     expect(contextMenuItemAt(AX + 10, AY + 50, AX, AY)).toBe(ChamberType.FoodStorage);
   });
 
   it('returns null above, below, left, right of the menu', () => {
-    expect(contextMenuItemAt(AX + 10, AY - 1,                                AX, AY)).toBeNull();
-    expect(contextMenuItemAt(AX + 10, AY + CONTEXT_MENU_HEIGHT,              AX, AY)).toBeNull();
-    expect(contextMenuItemAt(AX - 1,  AY + 5,                                AX, AY)).toBeNull();
-    expect(contextMenuItemAt(AX + CONTEXT_MENU.WIDTH, AY + 5,                AX, AY)).toBeNull();
+    expect(contextMenuItemAt(AX + 10, AY - 1, AX, AY)).toBeNull();
+    expect(contextMenuItemAt(AX + 10, AY + CONTEXT_MENU_HEIGHT, AX, AY)).toBeNull();
+    expect(contextMenuItemAt(AX - 1, AY + 5, AX, AY)).toBeNull();
+    expect(contextMenuItemAt(AX + CONTEXT_MENU.WIDTH, AY + 5, AX, AY)).toBeNull();
   });
 });
 
@@ -93,10 +119,10 @@ describe('contextMenuItemAt (filtered list)', () => {
   const AY = 0;
 
   it('with Queen filtered: row 0 = Nursery, row 1 = FoodStorage', () => {
-    const items = CONTEXT_MENU_ITEMS.filter(i => i.chamberType !== ChamberType.Queen);
-    expect(contextMenuItemAt(5,  5,  AX, AY, items)).toBe(ChamberType.Nursery);
-    expect(contextMenuItemAt(5,  25, AX, AY, items)).toBe(ChamberType.FoodStorage);
-    expect(contextMenuItemAt(5,  48, AX, AY, items)).toBeNull(); // past 2-item height
+    const items = CONTEXT_MENU_ITEMS.filter((i) => i.chamberType !== ChamberType.Queen);
+    expect(contextMenuItemAt(5, 5, AX, AY, items)).toBe(ChamberType.Nursery);
+    expect(contextMenuItemAt(5, 25, AX, AY, items)).toBe(ChamberType.FoodStorage);
+    expect(contextMenuItemAt(5, 48, AX, AY, items)).toBeNull(); // past 2-item height
   });
 });
 
@@ -106,24 +132,22 @@ describe('isInsideContextMenu', () => {
 
   it('true for interior points (full list)', () => {
     expect(isInsideContextMenu(AX + 1, AY + 1, AX, AY)).toBe(true);
-    expect(isInsideContextMenu(
-      AX + CONTEXT_MENU.WIDTH - 1,
-      AY + CONTEXT_MENU_HEIGHT - 1,
-      AX, AY,
-    )).toBe(true);
+    expect(
+      isInsideContextMenu(AX + CONTEXT_MENU.WIDTH - 1, AY + CONTEXT_MENU_HEIGHT - 1, AX, AY),
+    ).toBe(true);
   });
 
   it('false for boundary-out and exterior points', () => {
-    expect(isInsideContextMenu(AX - 1, AY + 1,                         AX, AY)).toBe(false);
-    expect(isInsideContextMenu(AX + CONTEXT_MENU.WIDTH, AY + 1,        AX, AY)).toBe(false);
-    expect(isInsideContextMenu(AX + 1, AY - 1,                         AX, AY)).toBe(false);
-    expect(isInsideContextMenu(AX + 1, AY + CONTEXT_MENU_HEIGHT,       AX, AY)).toBe(false);
+    expect(isInsideContextMenu(AX - 1, AY + 1, AX, AY)).toBe(false);
+    expect(isInsideContextMenu(AX + CONTEXT_MENU.WIDTH, AY + 1, AX, AY)).toBe(false);
+    expect(isInsideContextMenu(AX + 1, AY - 1, AX, AY)).toBe(false);
+    expect(isInsideContextMenu(AX + 1, AY + CONTEXT_MENU_HEIGHT, AX, AY)).toBe(false);
   });
 
   it('filtered list shortens the hit rect', () => {
-    const items = CONTEXT_MENU_ITEMS.filter(i => i.chamberType !== ChamberType.Queen);
-    expect(isInsideContextMenu(AX + 1, AY + 47, AX, AY, items)).toBe(true);   // inside 48px
-    expect(isInsideContextMenu(AX + 1, AY + 48, AX, AY, items)).toBe(false);  // now outside
+    const items = CONTEXT_MENU_ITEMS.filter((i) => i.chamberType !== ChamberType.Queen);
+    expect(isInsideContextMenu(AX + 1, AY + 47, AX, AY, items)).toBe(true); // inside 48px
+    expect(isInsideContextMenu(AX + 1, AY + 48, AX, AY, items)).toBe(false); // now outside
     expect(isInsideContextMenu(AX + 1, AY + 60, AX, AY, items)).toBe(false);
   });
 });
@@ -147,7 +171,7 @@ describe('drawContextMenuGeometry', () => {
   it('emits one background fillRect + 3 stripe fillRects (full list)', () => {
     const g = new MockGfx();
     drawContextMenuGeometry(g, 100, 200);
-    const rects = g.calls.filter(c => c.method === 'fillRect');
+    const rects = g.calls.filter((c) => c.method === 'fillRect');
     expect(rects.length).toBe(4); // 1 bg + 3 stripes
     expect(rects[0]!.args).toEqual([100, 200, CONTEXT_MENU.WIDTH, CONTEXT_MENU_HEIGHT]);
   });
@@ -155,7 +179,7 @@ describe('drawContextMenuGeometry', () => {
   it('uses the CONTEXT_MENU_ITEMS stripeColor for each stripe (in order)', () => {
     const g = new MockGfx();
     drawContextMenuGeometry(g, 0, 0);
-    const fillStyles = g.calls.filter(c => c.method === 'fillStyle');
+    const fillStyles = g.calls.filter((c) => c.method === 'fillStyle');
     // 1 bg + 3 stripes = 4 fillStyle calls
     expect(fillStyles[1]!.args[0]).toBe(CONTEXT_MENU_ITEMS[0]!.stripeColor);
     expect(fillStyles[2]!.args[0]).toBe(CONTEXT_MENU_ITEMS[1]!.stripeColor);
@@ -164,9 +188,9 @@ describe('drawContextMenuGeometry', () => {
 
   it('filtered list → fewer stripes + shorter background', () => {
     const g = new MockGfx();
-    const items = CONTEXT_MENU_ITEMS.filter(i => i.chamberType !== ChamberType.Queen);
+    const items = CONTEXT_MENU_ITEMS.filter((i) => i.chamberType !== ChamberType.Queen);
     drawContextMenuGeometry(g, 0, 0, items);
-    const rects = g.calls.filter(c => c.method === 'fillRect');
+    const rects = g.calls.filter((c) => c.method === 'fillRect');
     expect(rects.length).toBe(3); // 1 bg + 2 stripes
     // background height matches filtered height
     expect(rects[0]!.args).toEqual([0, 0, CONTEXT_MENU.WIDTH, 48]);
@@ -180,8 +204,10 @@ describe('visibleContextMenuItems', () => {
     world.colonies[PLAYER_COLONY_ID] = colony;
     const items = visibleContextMenuItems(colony, world);
     expect(items.length).toBe(3);
-    expect(items.map(i => i.chamberType)).toEqual([
-      ChamberType.Queen, ChamberType.Nursery, ChamberType.FoodStorage,
+    expect(items.map((i) => i.chamberType)).toEqual([
+      ChamberType.Queen,
+      ChamberType.Nursery,
+      ChamberType.FoodStorage,
     ]);
   });
 
@@ -192,9 +218,7 @@ describe('visibleContextMenuItems', () => {
     world.colonies[PLAYER_COLONY_ID] = colony;
     const items = visibleContextMenuItems(colony, world);
     expect(items.length).toBe(2);
-    expect(items.map(i => i.chamberType)).toEqual([
-      ChamberType.Nursery, ChamberType.FoodStorage,
-    ]);
+    expect(items.map((i) => i.chamberType)).toEqual([ChamberType.Nursery, ChamberType.FoodStorage]);
   });
 
   it('drops Queen when a pending Queen chamber exists for this colony', () => {
@@ -202,17 +226,15 @@ describe('visibleContextMenuItems', () => {
     const colony = createColonyRecord(PLAYER_COLONY_ID, 0);
     world.colonies[PLAYER_COLONY_ID] = colony;
     world.pendingChambers[`${PLAYER_COLONY_ID}:10:5`] = {
-      colonyId:     PLAYER_COLONY_ID,
-      chamberType:  ChamberType.Queen,
-      anchorTileX:  10,
-      anchorTileY:  5,
-      width:        5,
-      height:       3,
+      colonyId: PLAYER_COLONY_ID,
+      chamberType: ChamberType.Queen,
+      anchorTileX: 10,
+      anchorTileY: 5,
+      width: 5,
+      height: 3,
     };
     const items = visibleContextMenuItems(colony, world);
-    expect(items.map(i => i.chamberType)).toEqual([
-      ChamberType.Nursery, ChamberType.FoodStorage,
-    ]);
+    expect(items.map((i) => i.chamberType)).toEqual([ChamberType.Nursery, ChamberType.FoodStorage]);
   });
 
   it('does NOT drop Queen when only another colony has a pending Queen chamber', () => {
@@ -220,12 +242,12 @@ describe('visibleContextMenuItems', () => {
     const colony = createColonyRecord(PLAYER_COLONY_ID, 0);
     world.colonies[PLAYER_COLONY_ID] = colony;
     world.pendingChambers[`99:10:5`] = {
-      colonyId:     99,
-      chamberType:  ChamberType.Queen,
-      anchorTileX:  10,
-      anchorTileY:  5,
-      width:        5,
-      height:       3,
+      colonyId: 99,
+      chamberType: ChamberType.Queen,
+      anchorTileX: 10,
+      anchorTileY: 5,
+      width: 5,
+      height: 3,
     };
     const items = visibleContextMenuItems(colony, world);
     expect(items.length).toBe(3);
@@ -235,23 +257,45 @@ describe('visibleContextMenuItems', () => {
     const world = makeWorld();
     const colony = createColonyRecord(PLAYER_COLONY_ID, 0);
     colony.chambers.push(
-      { chamberId: 2, chamberType: ChamberType.FoodStorage, foodStored: 0, posX: 0, posY: 0, width: 4, height: 3 },
-      { chamberId: 3, chamberType: ChamberType.FoodStorage, foodStored: 0, posX: 0, posY: 0, width: 4, height: 3 },
+      {
+        chamberId: 2,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 0,
+        posX: 0,
+        posY: 0,
+        width: 4,
+        height: 3,
+      },
+      {
+        chamberId: 3,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 0,
+        posX: 0,
+        posY: 0,
+        width: 4,
+        height: 3,
+      },
     );
     world.colonies[PLAYER_COLONY_ID] = colony;
     const items = visibleContextMenuItems(colony, world);
-    expect(items.map(i => i.chamberType)).toContain(ChamberType.FoodStorage);
+    expect(items.map((i) => i.chamberType)).toContain(ChamberType.FoodStorage);
     expect(items.length).toBe(3); // Queen still present, Nursery still present
   });
 
   it('Nursery unchanged: still present regardless of nursery state (policy undecided)', () => {
     const world = makeWorld();
     const colony = createColonyRecord(PLAYER_COLONY_ID, 0);
-    colony.chambers.push(
-      { chamberId: 4, chamberType: ChamberType.Nursery, foodStored: 0, posX: 0, posY: 0, width: 4, height: 3 },
-    );
+    colony.chambers.push({
+      chamberId: 4,
+      chamberType: ChamberType.Nursery,
+      foodStored: 0,
+      posX: 0,
+      posY: 0,
+      width: 4,
+      height: 3,
+    });
     world.colonies[PLAYER_COLONY_ID] = colony;
     const items = visibleContextMenuItems(colony, world);
-    expect(items.map(i => i.chamberType)).toContain(ChamberType.Nursery);
+    expect(items.map((i) => i.chamberType)).toContain(ChamberType.Nursery);
   });
 });

--- a/src/render/context-menu-layout.ts
+++ b/src/render/context-menu-layout.ts
@@ -28,10 +28,10 @@ import type { WorldState } from '../sim/types.js';
 import type { GfxLike } from './draw-surface.js';
 
 export const CONTEXT_MENU = {
-  WIDTH:       120,
+  WIDTH: 120,
   ITEM_HEIGHT: 24,
   /** Maximum number of rows the menu can display (= CONTEXT_MENU_ITEMS.length). */
-  ITEM_COUNT:  3,
+  ITEM_COUNT: 3,
 } as const;
 
 /** Maximum possible menu height when every item is visible. */
@@ -44,7 +44,7 @@ export function contextMenuHeight(items: readonly ContextMenuItem[]): number {
 
 export interface ContextMenuItem {
   chamberType: ChamberType;
-  label:       string;
+  label: string;
   stripeColor: number;
 }
 
@@ -54,8 +54,8 @@ export interface ContextMenuItem {
  * contextMenuItemAt — do not reorder without updating callers and tests.
  */
 export const CONTEXT_MENU_ITEMS: readonly ContextMenuItem[] = [
-  { chamberType: ChamberType.Queen,       label: 'Queen',        stripeColor: 0x4a1a4a },
-  { chamberType: ChamberType.Nursery,     label: 'Nursery',      stripeColor: 0x1a4a1a },
+  { chamberType: ChamberType.Queen, label: 'Queen', stripeColor: 0x4a1a4a },
+  { chamberType: ChamberType.Nursery, label: 'Nursery', stripeColor: 0x1a4a1a },
   { chamberType: ChamberType.FoodStorage, label: 'Food Storage', stripeColor: 0x4a3a1a },
 ];
 
@@ -70,18 +70,18 @@ export const CONTEXT_MENU_ITEMS: readonly ContextMenuItem[] = [
  */
 export function visibleContextMenuItems(
   colony: ColonyRecord,
-  world:  WorldState,
+  world: WorldState,
 ): readonly ContextMenuItem[] {
   const queenBlocked =
-    hasCompletedChamber(colony, ChamberType.Queen)
-    || hasPendingChamber(colony, world, ChamberType.Queen);
+    hasCompletedChamber(colony, ChamberType.Queen) ||
+    hasPendingChamber(colony, world, ChamberType.Queen);
   if (!queenBlocked) return CONTEXT_MENU_ITEMS;
-  return CONTEXT_MENU_ITEMS.filter(it => it.chamberType !== ChamberType.Queen);
+  return CONTEXT_MENU_ITEMS.filter((it) => it.chamberType !== ChamberType.Queen);
 }
 
 function hasPendingChamber(
-  colony:      ColonyRecord,
-  world:       WorldState,
+  colony: ColonyRecord,
+  world: WorldState,
   chamberType: ChamberType,
 ): boolean {
   for (const key in world.pendingChambers) {
@@ -97,16 +97,16 @@ function hasPendingChamber(
  * `items` is the filtered list returned by visibleContextMenuItems.
  */
 export function contextMenuItemAt(
-  px:      number,
-  py:      number,
+  px: number,
+  py: number,
   anchorX: number,
   anchorY: number,
-  items:   readonly ContextMenuItem[] = CONTEXT_MENU_ITEMS,
+  items: readonly ContextMenuItem[] = CONTEXT_MENU_ITEMS,
 ): ChamberType | null {
   const relX = px - anchorX;
   const relY = py - anchorY;
-  if (relX < 0 || relX >= CONTEXT_MENU.WIDTH)             return null;
-  if (relY < 0 || relY >= contextMenuHeight(items))       return null;
+  if (relX < 0 || relX >= CONTEXT_MENU.WIDTH) return null;
+  if (relY < 0 || relY >= contextMenuHeight(items)) return null;
   const idx = Math.floor(relY / CONTEXT_MENU.ITEM_HEIGHT);
   const item = items[idx];
   return item ? item.chamberType : null;
@@ -116,15 +116,17 @@ export function contextMenuItemAt(
  * True if the screen point is inside the (filtered) menu's outer rectangle.
  */
 export function isInsideContextMenu(
-  px:      number,
-  py:      number,
+  px: number,
+  py: number,
   anchorX: number,
   anchorY: number,
-  items:   readonly ContextMenuItem[] = CONTEXT_MENU_ITEMS,
+  items: readonly ContextMenuItem[] = CONTEXT_MENU_ITEMS,
 ): boolean {
   return (
-    px >= anchorX && px < anchorX + CONTEXT_MENU.WIDTH &&
-    py >= anchorY && py < anchorY + contextMenuHeight(items)
+    px >= anchorX &&
+    px < anchorX + CONTEXT_MENU.WIDTH &&
+    py >= anchorY &&
+    py < anchorY + contextMenuHeight(items)
   );
 }
 
@@ -134,7 +136,7 @@ export function isInsideContextMenu(
  * `i` is the row offset within the FILTERED item list.
  */
 export function itemLabelPos(
-  i:       number,
+  i: number,
   anchorX: number,
   anchorY: number,
 ): { x: number; y: number } {
@@ -151,10 +153,10 @@ export function itemLabelPos(
  * has no text API.
  */
 export function drawContextMenuGeometry(
-  gfx:     GfxLike,
+  gfx: GfxLike,
   anchorX: number,
   anchorY: number,
-  items:   readonly ContextMenuItem[] = CONTEXT_MENU_ITEMS,
+  items: readonly ContextMenuItem[] = CONTEXT_MENU_ITEMS,
 ): void {
   const h = contextMenuHeight(items);
   gfx.fillStyle(0x222222, 0.95);

--- a/src/render/context-menu-state.test.ts
+++ b/src/render/context-menu-state.test.ts
@@ -12,11 +12,11 @@ import {
 } from './context-menu-state.js';
 
 beforeEach(() => {
-  contextMenuState.visible     = false;
+  contextMenuState.visible = false;
   contextMenuState.pendingHide = false;
   contextMenuState.pendingShow = false;
-  contextMenuState.screenX     = 0;
-  contextMenuState.screenY     = 0;
+  contextMenuState.screenX = 0;
+  contextMenuState.screenY = 0;
   contextMenuState.anchorTileX = 0;
   contextMenuState.anchorTileY = 0;
 });

--- a/src/render/context-menu-state.ts
+++ b/src/render/context-menu-state.ts
@@ -25,9 +25,9 @@
 // Tests use `hideContextMenu()` for immediate synchronous reset between cases.
 
 export interface ContextMenuState {
-  visible:     boolean;
-  screenX:     number;
-  screenY:     number;
+  visible: boolean;
+  screenX: number;
+  screenY: number;
   anchorTileX: number;
   anchorTileY: number;
   /** Set by requestHideContextMenu; cleared by applyPendingContextMenuHide on the next update frame. */
@@ -37,9 +37,9 @@ export interface ContextMenuState {
 }
 
 export const contextMenuState: ContextMenuState = {
-  visible:     false,
-  screenX:     0,
-  screenY:     0,
+  visible: false,
+  screenX: 0,
+  screenY: 0,
   anchorTileX: 0,
   anchorTileY: 0,
   pendingHide: false,
@@ -53,7 +53,7 @@ export const contextMenuState: ContextMenuState = {
  * stale request doesn't resurrect the menu a frame later.
  */
 export function hideContextMenu(): void {
-  contextMenuState.visible     = false;
+  contextMenuState.visible = false;
   contextMenuState.pendingHide = false;
   contextMenuState.pendingShow = false;
 }
@@ -79,13 +79,13 @@ export function requestHideContextMenu(): void {
  * right-click as a menu item selection.
  */
 export function requestShowContextMenu(
-  screenX:     number,
-  screenY:     number,
+  screenX: number,
+  screenY: number,
   anchorTileX: number,
   anchorTileY: number,
 ): void {
-  contextMenuState.screenX     = screenX;
-  contextMenuState.screenY     = screenY;
+  contextMenuState.screenX = screenX;
+  contextMenuState.screenY = screenY;
   contextMenuState.anchorTileX = anchorTileX;
   contextMenuState.anchorTileY = anchorTileY;
   contextMenuState.pendingShow = true;
@@ -97,7 +97,7 @@ export function requestShowContextMenu(
  */
 export function applyPendingContextMenuHide(): void {
   if (contextMenuState.pendingHide) {
-    contextMenuState.visible     = false;
+    contextMenuState.visible = false;
     contextMenuState.pendingHide = false;
   }
 }
@@ -111,7 +111,7 @@ export function applyPendingContextMenuHide(): void {
  */
 export function applyPendingContextMenuShow(): void {
   if (contextMenuState.pendingShow) {
-    contextMenuState.visible     = true;
+    contextMenuState.visible = true;
     contextMenuState.pendingShow = false;
   }
 }

--- a/src/render/debug-snapshot-download.ts
+++ b/src/render/debug-snapshot-download.ts
@@ -18,10 +18,7 @@ import { defaultDebugSnapshotFilename } from '../platform/debug-snapshot.js';
  * @param snap      Payload from buildDebugSnapshot.
  * @param filename  Optional override; defaults to defaultDebugSnapshotFilename.
  */
-export function downloadDebugSnapshot(
-  snap: DebugSnapshot,
-  filename?: string,
-): void {
+export function downloadDebugSnapshot(snap: DebugSnapshot, filename?: string): void {
   const json = JSON.stringify(snap);
   const blob = new Blob([json], { type: 'application/json' });
   const url = URL.createObjectURL(blob);

--- a/src/render/draw-pheromone.test.ts
+++ b/src/render/draw-pheromone.test.ts
@@ -19,10 +19,7 @@ import { createWorldState } from '../sim/types.js';
 import { createPheromoneGrid, phSet, pheromoneGridKey } from '../sim/pheromone/pheromone-store.js';
 import { PheromoneType } from '../sim/enums.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
-import {
-  COLOR_PHEROMONE_FOOD_FAINT,
-  COLOR_PHEROMONE_FOOD_STRONG,
-} from './sprites.js';
+import { COLOR_PHEROMONE_FOOD_FAINT, COLOR_PHEROMONE_FOOD_STRONG } from './sprites.js';
 import type { CameraState } from './camera.js';
 
 // ---------------------------------------------------------------------------
@@ -37,31 +34,42 @@ interface GfxCall {
 class MockGfx implements GfxLike {
   calls: GfxCall[] = [];
 
-  clear(): GfxLike { this.calls.push({ method: 'clear', args: [] }); return this; }
+  clear(): GfxLike {
+    this.calls.push({ method: 'clear', args: [] });
+    return this;
+  }
   fillStyle(color: number, alpha?: number): GfxLike {
-    this.calls.push({ method: 'fillStyle', args: [color, alpha] }); return this;
+    this.calls.push({ method: 'fillStyle', args: [color, alpha] });
+    return this;
   }
   lineStyle(width: number, color: number, alpha?: number): GfxLike {
-    this.calls.push({ method: 'lineStyle', args: [width, color, alpha] }); return this;
+    this.calls.push({ method: 'lineStyle', args: [width, color, alpha] });
+    return this;
   }
   fillRect(x: number, y: number, w: number, h: number): GfxLike {
-    this.calls.push({ method: 'fillRect', args: [x, y, w, h] }); return this;
+    this.calls.push({ method: 'fillRect', args: [x, y, w, h] });
+    return this;
   }
   fillCircle(x: number, y: number, r: number): GfxLike {
-    this.calls.push({ method: 'fillCircle', args: [x, y, r] }); return this;
+    this.calls.push({ method: 'fillCircle', args: [x, y, r] });
+    return this;
   }
   strokeCircle(x: number, y: number, r: number): GfxLike {
-    this.calls.push({ method: 'strokeCircle', args: [x, y, r] }); return this;
+    this.calls.push({ method: 'strokeCircle', args: [x, y, r] });
+    return this;
   }
   fillTriangle(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number): GfxLike {
-    this.calls.push({ method: 'fillTriangle', args: [x0, y0, x1, y1, x2, y2] }); return this;
+    this.calls.push({ method: 'fillTriangle', args: [x0, y0, x1, y1, x2, y2] });
+    return this;
   }
 
   callsOf(method: string): GfxCall[] {
-    return this.calls.filter(c => c.method === method);
+    return this.calls.filter((c) => c.method === method);
   }
 
-  reset(): void { this.calls = []; }
+  reset(): void {
+    this.calls = [];
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -89,7 +97,11 @@ function makeWorldWithFoodGrid(width: number, height: number): WorldState {
 
 describe('pheromoneRenderParams', () => {
   it('value=0 → alpha=0, color=faintColor', () => {
-    const result = pheromoneRenderParams(0, COLOR_PHEROMONE_FOOD_FAINT, COLOR_PHEROMONE_FOOD_STRONG);
+    const result = pheromoneRenderParams(
+      0,
+      COLOR_PHEROMONE_FOOD_FAINT,
+      COLOR_PHEROMONE_FOOD_STRONG,
+    );
     expect(result.alpha).toBe(0);
     expect(result.color).toBe(COLOR_PHEROMONE_FOOD_FAINT);
   });
@@ -145,9 +157,9 @@ describe('drawPheromoneOverlay — FoodTrail grid', () => {
     const key = pheromoneGridKey(PLAYER_COLONY_ID, PheromoneType.FoodTrail, 'surface');
     const grid = world.pheromoneGrids[key]!;
     phSet(grid, 0, 0, 0);
-    phSet(grid, 1, 0, PHEROMONE_VISUAL_MAX >> 2);   // ¼ → normalized 0.25
-    phSet(grid, 2, 0, PHEROMONE_VISUAL_MAX >> 1);   // ½ → normalized 0.5
-    phSet(grid, 3, 0, PHEROMONE_VISUAL_MAX);         // full → normalized 1.0
+    phSet(grid, 1, 0, PHEROMONE_VISUAL_MAX >> 2); // ¼ → normalized 0.25
+    phSet(grid, 2, 0, PHEROMONE_VISUAL_MAX >> 1); // ½ → normalized 0.5
+    phSet(grid, 3, 0, PHEROMONE_VISUAL_MAX); // full → normalized 1.0
   });
 
   it('produces exactly 3 fillRect calls (skips the zero tile)', () => {
@@ -163,7 +175,7 @@ describe('drawPheromoneOverlay — FoodTrail grid', () => {
     const styles = gfx.callsOf('fillStyle');
     // fillStyle is called once per non-zero tile, in order tx=1,2,3
     expect(styles.length).toBe(3);
-    const alphas = styles.map(s => s.args[1] as number);
+    const alphas = styles.map((s) => s.args[1] as number);
     // alpha should be strictly increasing
     expect(alphas[0]).toBeLessThan(alphas[1]!);
     expect(alphas[1]).toBeLessThan(alphas[2]!);
@@ -241,7 +253,7 @@ describe('drawPheromoneOverlay — both pheromone types', () => {
     drawPheromoneOverlay(gfx, world, cam, 'surface');
 
     const styles = gfx.callsOf('fillStyle');
-    const colors = styles.map(s => s.args[0] as number);
+    const colors = styles.map((s) => s.args[0] as number);
 
     // At full intensity: food → FOOD_STRONG, danger → DANGER_STRONG
     expect(colors).toContain(COLOR_PHEROMONE_FOOD_STRONG);

--- a/src/render/draw-pheromone.ts
+++ b/src/render/draw-pheromone.ts
@@ -106,8 +106,8 @@ export function drawPheromoneOverlay(
   zone: 'surface' | 'underground',
 ): void {
   // Compute visible tile range
-  const left   = Math.floor(cam.x - cam.viewportWidth  / 2);
-  const top    = Math.floor(cam.y - cam.viewportHeight / 2);
+  const left = Math.floor(cam.x - cam.viewportWidth / 2);
+  const top = Math.floor(cam.y - cam.viewportHeight / 2);
 
   const pheromoneTypes = [PheromoneType.FoodTrail, PheromoneType.DangerTrail] as const;
 
@@ -117,16 +117,18 @@ export function drawPheromoneOverlay(
     if (grid === undefined) continue;
 
     // Clamp right/bottom to grid bounds
-    const right  = Math.min(left + cam.viewportWidth  + 1, grid.width);
-    const bottom = Math.min(top  + cam.viewportHeight + 1, grid.height);
+    const right = Math.min(left + cam.viewportWidth + 1, grid.width);
+    const bottom = Math.min(top + cam.viewportHeight + 1, grid.height);
 
     // Choose faint/strong palette by pheromone type
-    const faintColor  = pheromoneType === PheromoneType.FoodTrail
-      ? COLOR_PHEROMONE_FOOD_FAINT
-      : COLOR_PHEROMONE_DANGER_FAINT;
-    const strongColor = pheromoneType === PheromoneType.FoodTrail
-      ? COLOR_PHEROMONE_FOOD_STRONG
-      : COLOR_PHEROMONE_DANGER_STRONG;
+    const faintColor =
+      pheromoneType === PheromoneType.FoodTrail
+        ? COLOR_PHEROMONE_FOOD_FAINT
+        : COLOR_PHEROMONE_DANGER_FAINT;
+    const strongColor =
+      pheromoneType === PheromoneType.FoodTrail
+        ? COLOR_PHEROMONE_FOOD_STRONG
+        : COLOR_PHEROMONE_DANGER_STRONG;
 
     for (let ty = Math.max(top, 0); ty < bottom; ty++) {
       for (let tx = Math.max(left, 0); tx < right; tx++) {
@@ -137,7 +139,7 @@ export function drawPheromoneOverlay(
         gfx.fillStyle(params.color, params.alpha);
         gfx.fillRect(
           (tx - left) * TILE_SIZE_PX,
-          (ty - top)  * TILE_SIZE_PX,
+          (ty - top) * TILE_SIZE_PX,
           TILE_SIZE_PX,
           TILE_SIZE_PX,
         );

--- a/src/render/draw-surface.test.ts
+++ b/src/render/draw-surface.test.ts
@@ -8,11 +8,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
-import {
-  drawSurfaceTerrain,
-  drawSurfaceEntities,
-  drawSurface,
-} from './draw-surface.js';
+import { drawSurfaceTerrain, drawSurfaceEntities, drawSurface } from './draw-surface.js';
 import type { GfxLike } from './draw-surface.js';
 import type {
   AntSpriteDrawOptions,
@@ -57,32 +53,43 @@ type Rect = { x: number; y: number; w: number; h: number };
 class MockGfx implements GfxLike {
   calls: GfxCall[] = [];
 
-  clear(): GfxLike { this.calls.push({ method: 'clear', args: [] }); return this; }
+  clear(): GfxLike {
+    this.calls.push({ method: 'clear', args: [] });
+    return this;
+  }
   fillStyle(color: number, alpha?: number): GfxLike {
-    this.calls.push({ method: 'fillStyle', args: [color, alpha] }); return this;
+    this.calls.push({ method: 'fillStyle', args: [color, alpha] });
+    return this;
   }
   lineStyle(width: number, color: number, alpha?: number): GfxLike {
-    this.calls.push({ method: 'lineStyle', args: [width, color, alpha] }); return this;
+    this.calls.push({ method: 'lineStyle', args: [width, color, alpha] });
+    return this;
   }
   fillRect(x: number, y: number, w: number, h: number): GfxLike {
-    this.calls.push({ method: 'fillRect', args: [x, y, w, h] }); return this;
+    this.calls.push({ method: 'fillRect', args: [x, y, w, h] });
+    return this;
   }
   fillCircle(x: number, y: number, r: number): GfxLike {
-    this.calls.push({ method: 'fillCircle', args: [x, y, r] }); return this;
+    this.calls.push({ method: 'fillCircle', args: [x, y, r] });
+    return this;
   }
   strokeCircle(x: number, y: number, r: number): GfxLike {
-    this.calls.push({ method: 'strokeCircle', args: [x, y, r] }); return this;
+    this.calls.push({ method: 'strokeCircle', args: [x, y, r] });
+    return this;
   }
   fillTriangle(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number): GfxLike {
-    this.calls.push({ method: 'fillTriangle', args: [x0, y0, x1, y1, x2, y2] }); return this;
+    this.calls.push({ method: 'fillTriangle', args: [x0, y0, x1, y1, x2, y2] });
+    return this;
   }
 
   /** Filter calls by method name. */
   callsOf(method: string): GfxCall[] {
-    return this.calls.filter(c => c.method === method);
+    return this.calls.filter((c) => c.method === method);
   }
 
-  reset(): void { this.calls = []; }
+  reset(): void {
+    this.calls = [];
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -94,14 +101,26 @@ class MockAntSprites implements AntSpriteLayer {
   staticCalls: StaticSpriteDrawOptions[] = [];
   beginFrames = 0;
   endFrames = 0;
-  beginFrame(): void { this.beginFrames++; }
-  drawAnt(opts: AntSpriteDrawOptions): void { this.calls.push({ ...opts }); }
-  drawStatic(opts: StaticSpriteDrawOptions): void { this.staticCalls.push({ ...opts }); }
-  drawSpider(_opts: SpiderSpriteDrawOptions): void { /* no-op in tests */ }
-  endFrame(): void { this.endFrames++; }
+  beginFrame(): void {
+    this.beginFrames++;
+  }
+  drawAnt(opts: AntSpriteDrawOptions): void {
+    this.calls.push({ ...opts });
+  }
+  drawStatic(opts: StaticSpriteDrawOptions): void {
+    this.staticCalls.push({ ...opts });
+  }
+  drawSpider(_opts: SpiderSpriteDrawOptions): void {
+    /* no-op in tests */
+  }
+  endFrame(): void {
+    this.endFrames++;
+  }
   reset(): void {
-    this.calls = []; this.staticCalls = [];
-    this.beginFrames = 0; this.endFrames = 0;
+    this.calls = [];
+    this.staticCalls = [];
+    this.beginFrames = 0;
+    this.endFrames = 0;
   }
 }
 
@@ -132,7 +151,12 @@ function textureRectsInsideTile(gfx: MockGfx, screenX: number, screenY: number):
   for (const call of gfx.calls) {
     if (call.method !== 'fillRect') continue;
     const [x, y, w, h] = call.args as [number, number, number, number];
-    if (x >= screenX && y >= screenY && x + w <= screenX + TILE_SIZE_PX && y + h <= screenY + TILE_SIZE_PX) {
+    if (
+      x >= screenX &&
+      y >= screenY &&
+      x + w <= screenX + TILE_SIZE_PX &&
+      y + h <= screenY + TILE_SIZE_PX
+    ) {
       rects.push({ x: x - screenX, y: y - screenY, w, h });
     }
   }
@@ -146,7 +170,9 @@ function textureRectsInsideTile(gfx: MockGfx, screenX: number, screenY: number):
 describe('drawSurfaceTerrain', () => {
   let gfx: MockGfx;
 
-  beforeEach(() => { gfx = new MockGfx(); });
+  beforeEach(() => {
+    gfx = new MockGfx();
+  });
 
   it('renders every visible tile with the barren-earth substrate (issue #40)', () => {
     // Issue #40: surface is universally barren-earth substrate (with motifs
@@ -155,7 +181,7 @@ describe('drawSurfaceTerrain', () => {
     const world = makeWorld4x4();
     const cam = makeCamera(1.5, 1.5, 3, 3);
     drawSurfaceTerrain(gfx, world, cam);
-    const earthStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_BARREN_EARTH);
+    const earthStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_BARREN_EARTH);
     // 4×4 visible tiles = 16; each tile applies the barren-earth fill once.
     expect(earthStyles.length).toBe(16);
   });
@@ -169,14 +195,22 @@ describe('drawSurfaceTerrain', () => {
     drawSurfaceTerrain(gfx, world, camA);
     const leftA = Math.floor(camA.x - camA.viewportWidth / 2);
     const topA = Math.floor(camA.y - camA.viewportHeight / 2);
-    const rectsA = textureRectsInsideTile(gfx, (tileX - leftA) * TILE_SIZE_PX, (tileY - topA) * TILE_SIZE_PX);
+    const rectsA = textureRectsInsideTile(
+      gfx,
+      (tileX - leftA) * TILE_SIZE_PX,
+      (tileY - topA) * TILE_SIZE_PX,
+    );
 
     gfx.reset();
     const camB = makeCamera(21, 20, 20, 20);
     drawSurfaceTerrain(gfx, world, camB);
     const leftB = Math.floor(camB.x - camB.viewportWidth / 2);
     const topB = Math.floor(camB.y - camB.viewportHeight / 2);
-    const rectsB = textureRectsInsideTile(gfx, (tileX - leftB) * TILE_SIZE_PX, (tileY - topB) * TILE_SIZE_PX);
+    const rectsB = textureRectsInsideTile(
+      gfx,
+      (tileX - leftB) * TILE_SIZE_PX,
+      (tileY - topB) * TILE_SIZE_PX,
+    );
 
     expect(rectsA.length).toBeGreaterThan(0);
     expect(rectsA).toEqual(rectsB);
@@ -252,8 +286,20 @@ describe('drawSurfaceEntities', () => {
     playerColony.digFlowFieldDirty = false;
     playerColony.priorityFoodPileId = 1;
     world.colonies[PLAYER_COLONY_ID] = playerColony;
-    world.foodPiles.push({ foodPileId: 1, tileX: 5, tileY: 5 , pickupsRemaining: 50, pickupsInitial: 50});
-    world.foodPiles.push({ foodPileId: 2, tileX: 6, tileY: 5 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 5,
+      tileY: 5,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
+    world.foodPiles.push({
+      foodPileId: 2,
+      tileX: 6,
+      tileY: 5,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     const cam = makeCamera(5, 5, 20, 20);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     const circles = gfx.callsOf('fillCircle');
@@ -267,12 +313,28 @@ describe('drawSurfaceEntities', () => {
     playerColony.digFlowFieldDirty = false;
     playerColony.priorityFoodPileId = 1;
     world.colonies[PLAYER_COLONY_ID] = playerColony;
-    world.foodPiles.push({ foodPileId: 1, tileX: 5, tileY: 5 , pickupsRemaining: 50, pickupsInitial: 50});
-    world.foodPiles.push({ foodPileId: 2, tileX: 6, tileY: 5 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 5,
+      tileY: 5,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
+    world.foodPiles.push({
+      foodPileId: 2,
+      tileX: 6,
+      tileY: 5,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     const cam = makeCamera(5, 5, 20, 20);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
-    const markedStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_FOOD_PILE_MARKED);
-    const normalStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_FOOD_PILE_NORMAL);
+    const markedStyles = gfx
+      .callsOf('fillStyle')
+      .filter((c) => c.args[0] === COLOR_FOOD_PILE_MARKED);
+    const normalStyles = gfx
+      .callsOf('fillStyle')
+      .filter((c) => c.args[0] === COLOR_FOOD_PILE_NORMAL);
     expect(markedStyles.length).toBe(1);
     expect(normalStyles.length).toBe(1);
   });
@@ -291,10 +353,18 @@ describe('drawSurfaceEntities', () => {
     enemyColony.priorityFoodPileId = 1;
     world.colonies[PLAYER_COLONY_ID] = playerColony;
     world.colonies[enemyColonyId] = enemyColony;
-    world.foodPiles.push({ foodPileId: 1, tileX: 5, tileY: 5 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 5,
+      tileY: 5,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     const cam = makeCamera(5, 5, 20, 20);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
-    const markedStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_FOOD_PILE_MARKED);
+    const markedStyles = gfx
+      .callsOf('fillStyle')
+      .filter((c) => c.args[0] === COLOR_FOOD_PILE_MARKED);
     expect(markedStyles.length).toBe(0);
   });
 
@@ -318,13 +388,13 @@ describe('drawSurfaceEntities', () => {
     initAnt(prev.ants, workerId, {
       colonyId,
       posX: (10 << FP_SHIFT) + HALF_FP,
-      posY: (5 << FP_SHIFT)  + HALF_FP,
+      posY: (5 << FP_SHIFT) + HALF_FP,
       zone: 0,
     });
     initAnt(curr.ants, workerId, {
       colonyId,
       posX: (10 << FP_SHIFT) + HALF_FP,
-      posY: (5 << FP_SHIFT)  + HALF_FP,
+      posY: (5 << FP_SHIFT) + HALF_FP,
       zone: 0,
     });
 
@@ -332,13 +402,14 @@ describe('drawSurfaceEntities', () => {
     drawSurfaceEntities(gfx, sprites, prev, curr, 0, cam);
 
     const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const expectedScreenX = 10.5 * TILE_SIZE_PX - left * TILE_SIZE_PX;
-    const expectedScreenY = 5.5  * TILE_SIZE_PX - top  * TILE_SIZE_PX;
-    const antCall = sprites.calls.find(c =>
-      c.kind === 'worker' &&
-      Math.abs(c.x - expectedScreenX) < 0.01 &&
-      Math.abs(c.y - expectedScreenY) < 0.01,
+    const expectedScreenY = 5.5 * TILE_SIZE_PX - top * TILE_SIZE_PX;
+    const antCall = sprites.calls.find(
+      (c) =>
+        c.kind === 'worker' &&
+        Math.abs(c.x - expectedScreenX) < 0.01 &&
+        Math.abs(c.y - expectedScreenY) < 0.01,
     );
     expect(antCall).toBeDefined();
   });
@@ -364,9 +435,9 @@ describe('drawSurfaceEntities', () => {
     drawSurfaceEntities(gfx, sprites, prev, curr, 0.5, cam);
 
     const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const expectedScreenX = (10 * 16 + (20 * 16 - 10 * 16) * 0.5) - left * TILE_SIZE_PX;
-    const antCall = sprites.calls.find(c =>
-      c.kind === 'worker' && Math.abs(c.x - expectedScreenX) < 0.5,
+    const expectedScreenX = 10 * 16 + (20 * 16 - 10 * 16) * 0.5 - left * TILE_SIZE_PX;
+    const antCall = sprites.calls.find(
+      (c) => c.kind === 'worker' && Math.abs(c.x - expectedScreenX) < 0.5,
     );
     expect(antCall).toBeDefined();
   });
@@ -410,7 +481,7 @@ describe('drawSurfaceEntities', () => {
 
   it('tints player ants with COLOR_PLAYER_COLONY and enemy ants with COLOR_ENEMY_COLONY', () => {
     const playerAntId = 0;
-    const enemyAntId  = 1;
+    const enemyAntId = 1;
     const playerColony = createColonyRecord(PLAYER_COLONY_ID, 99);
     playerColony.entrances = [];
     playerColony.rallyPoint = null;
@@ -424,14 +495,24 @@ describe('drawSurfaceEntities', () => {
     enemyColony.digFlowFieldDirty = false;
     world.colonies[ENEMY_COLONY_ID] = enemyColony;
 
-    initAnt(world.ants, playerAntId, { colonyId: PLAYER_COLONY_ID, posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 0 });
-    initAnt(world.ants, enemyAntId,  { colonyId: ENEMY_COLONY_ID,  posX: 7 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 0 });
+    initAnt(world.ants, playerAntId, {
+      colonyId: PLAYER_COLONY_ID,
+      posX: 5 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      zone: 0,
+    });
+    initAnt(world.ants, enemyAntId, {
+      colonyId: ENEMY_COLONY_ID,
+      posX: 7 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      zone: 0,
+    });
 
     const cam = makeCamera(5, 5, 20, 20);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
 
-    const playerTints = sprites.calls.filter(c => c.tint === COLOR_PLAYER_COLONY);
-    const enemyTints  = sprites.calls.filter(c => c.tint === COLOR_ENEMY_COLONY);
+    const playerTints = sprites.calls.filter((c) => c.tint === COLOR_PLAYER_COLONY);
+    const enemyTints = sprites.calls.filter((c) => c.tint === COLOR_ENEMY_COLONY);
     expect(playerTints.length).toBe(1);
     expect(enemyTints.length).toBe(1);
   });
@@ -439,10 +520,17 @@ describe('drawSurfaceEntities', () => {
   it('does NOT draw ants with zone=1 (underground ants)', () => {
     world.colonies[PLAYER_COLONY_ID] = (() => {
       const c = createColonyRecord(PLAYER_COLONY_ID, 99);
-      c.entrances = []; c.rallyPoint = null; c.digFlowFieldDirty = false;
+      c.entrances = [];
+      c.rallyPoint = null;
+      c.digFlowFieldDirty = false;
       return c;
     })();
-    initAnt(world.ants, 0, { colonyId: PLAYER_COLONY_ID, posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 1 });
+    initAnt(world.ants, 0, {
+      colonyId: PLAYER_COLONY_ID,
+      posX: 5 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      zone: 1,
+    });
     const cam = makeCamera(5, 5, 20, 20);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     expect(sprites.calls.length).toBe(0);
@@ -464,7 +552,9 @@ describe('drawSurfaceEntities — ant facing direction', () => {
     const world = createWorldState(1);
     const antId = 0;
     const colony = createColonyRecord(PLAYER_COLONY_ID, 999);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     world.colonies[PLAYER_COLONY_ID] = colony;
     initAnt(world.ants, antId, {
       colonyId: PLAYER_COLONY_ID,
@@ -555,7 +645,9 @@ describe('drawSurfaceEntities — facing cache smoothing', () => {
   function makeSurfaceAntWorld(posX: number, posY: number): WorldState {
     const w = createWorldState(1);
     const colony = createColonyRecord(PLAYER_COLONY_ID, 999);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     w.colonies[PLAYER_COLONY_ID] = colony;
     initAnt(w.ants, 0, {
       colonyId: PLAYER_COLONY_ID,
@@ -575,13 +667,14 @@ describe('drawSurfaceEntities — facing cache smoothing', () => {
     // Walk an 8-step southeast zig-zag: (5,5)→(6,5)→(6,6)→(7,6)→(7,7)…
     // Each adjacent pair is one frame's prev→curr. Shared cache accumulates
     // the blended heading across frames.
-    let x = 5, y = 5;
+    let x = 5,
+      y = 5;
     let lastRotation = 0;
     const path: Array<[number, number]> = [];
     for (let i = 0; i < 8; i++) {
       // Alternate axis: 0,2,4,6 move +x; 1,3,5,7 move +y.
       if (i % 2 === 0) x += 1;
-      else             y += 1;
+      else y += 1;
       path.push([x, y]);
     }
 
@@ -600,7 +693,7 @@ describe('drawSurfaceEntities — facing cache smoothing', () => {
     expect(lastRotation).toBeGreaterThan(-Math.PI);
     expect(lastRotation).toBeLessThan(-Math.PI / 2);
     // And closer to the diagonal (-3π/4) than to either axis.
-    const diag = -3 * Math.PI / 4;
+    const diag = (-3 * Math.PI) / 4;
     expect(Math.abs(lastRotation - diag)).toBeLessThan(Math.abs(lastRotation - -Math.PI));
     expect(Math.abs(lastRotation - diag)).toBeLessThan(Math.abs(lastRotation - -Math.PI / 2));
   });
@@ -613,7 +706,10 @@ describe('drawSurfaceEntities — facing cache smoothing', () => {
 
     // First ant (id=0) builds up a rightward heading over a couple frames.
     let prev = makeSurfaceAntWorld(5, 5);
-    for (const [nx, ny] of [[6, 5], [7, 5]] as Array<[number, number]>) {
+    for (const [nx, ny] of [
+      [6, 5],
+      [7, 5],
+    ] as Array<[number, number]>) {
       const curr = makeSurfaceAntWorld(nx, ny);
       drawSurfaceEntities(gfx, sprites, prev, curr, 1, cam, null, facing);
       prev = curr;
@@ -624,7 +720,9 @@ describe('drawSurfaceEntities — facing cache smoothing', () => {
     // rotation is the stable default (0), not carried over from the old ant.
     const freshPrev = createWorldState(1);
     const freshColony = createColonyRecord(PLAYER_COLONY_ID, 999);
-    freshColony.entrances = []; freshColony.rallyPoint = null; freshColony.digFlowFieldDirty = false;
+    freshColony.entrances = [];
+    freshColony.rallyPoint = null;
+    freshColony.digFlowFieldDirty = false;
     freshPrev.colonies[PLAYER_COLONY_ID] = freshColony;
     // id=0 intentionally not initialized in freshPrev — isAlive=false.
 
@@ -679,7 +777,9 @@ describe('drawSurfaceEntities — wrong-plane flicker guard', () => {
     const antId = 0;
     const colonyId = PLAYER_COLONY_ID;
     const colony = createColonyRecord(colonyId, 999);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     prev.colonies[colonyId] = colony;
     curr.colonies[colonyId] = colony;
 
@@ -704,7 +804,9 @@ describe('drawSurfaceEntities — wrong-plane flicker guard', () => {
     const antId = 0;
     const colonyId = PLAYER_COLONY_ID;
     const colony = createColonyRecord(colonyId, 999);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     prev.colonies[colonyId] = colony;
     curr.colonies[colonyId] = colony;
 
@@ -780,10 +882,10 @@ describe('drawSurfaceEntities — rally-point marker', () => {
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     const rects = rallyRects(gfx);
     expect(rects.length).toBeGreaterThan(0);
-    const left = Math.floor(cam.x - cam.viewportWidth  / 2);
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const left = Math.floor(cam.x - cam.viewportWidth / 2);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const sx = (10 - left) * TILE_SIZE_PX;
-    const sy = (4  - top)  * TILE_SIZE_PX;
+    const sy = (4 - top) * TILE_SIZE_PX;
     for (const r of rects) {
       const rx = r.args[0] as number;
       const ry = r.args[1] as number;
@@ -840,35 +942,34 @@ describe('drawSurfaceEntities — rally-point marker', () => {
     expect(rects.length).toBe(3);
 
     // Derive expected pixel coords for the marker's tile.
-    const left = Math.floor(cam.x - cam.viewportWidth  / 2);
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const left = Math.floor(cam.x - cam.viewportWidth / 2);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const sx = (5 - left) * TILE_SIZE_PX;
-    const sy = (5 - top)  * TILE_SIZE_PX;
+    const sy = (5 - top) * TILE_SIZE_PX;
 
     // Horizontal bar: full-tile-width minus edges, 2-px thick, centered vertically.
-    const hBar = rects.find(r =>
-      r.args[0] === sx + 1 &&
-      r.args[1] === sy + 7 &&
-      r.args[2] === TILE_SIZE_PX - 2 &&
-      r.args[3] === 2,
+    const hBar = rects.find(
+      (r) =>
+        r.args[0] === sx + 1 &&
+        r.args[1] === sy + 7 &&
+        r.args[2] === TILE_SIZE_PX - 2 &&
+        r.args[3] === 2,
     );
     expect(hBar).toBeDefined();
 
     // Vertical bar: 2-px wide, full-tile-height minus edges, centered horizontally.
-    const vBar = rects.find(r =>
-      r.args[0] === sx + 7 &&
-      r.args[1] === sy + 1 &&
-      r.args[2] === 2 &&
-      r.args[3] === TILE_SIZE_PX - 2,
+    const vBar = rects.find(
+      (r) =>
+        r.args[0] === sx + 7 &&
+        r.args[1] === sy + 1 &&
+        r.args[2] === 2 &&
+        r.args[3] === TILE_SIZE_PX - 2,
     );
     expect(vBar).toBeDefined();
 
     // Center accent: 4×4 square at tile center — required for pop against busy terrain.
-    const accent = rects.find(r =>
-      r.args[0] === sx + 6 &&
-      r.args[1] === sy + 6 &&
-      r.args[2] === 4 &&
-      r.args[3] === 4,
+    const accent = rects.find(
+      (r) => r.args[0] === sx + 6 && r.args[1] === sy + 6 && r.args[2] === 4 && r.args[3] === 4,
     );
     expect(accent).toBeDefined();
   });
@@ -928,7 +1029,12 @@ describe('drawSurfaceEntities — spider health bar (issue #148)', () => {
         pendingColor = c.args[0] as number;
         if (track !== null && fill === null) fillColor = pendingColor;
       } else if (c.method === 'fillRect') {
-        const rect = { x: c.args[0] as number, y: c.args[1] as number, w: c.args[2] as number, h: c.args[3] as number };
+        const rect = {
+          x: c.args[0] as number,
+          y: c.args[1] as number,
+          w: c.args[2] as number,
+          h: c.args[3] as number,
+        };
         if (pendingColor === 0x333333) track = rect;
         else if (track !== null && fill === null && pendingColor === fillColor) fill = rect;
       }
@@ -967,16 +1073,30 @@ describe('drawSurfaceEntities — spider health bar (issue #148)', () => {
     drawSurfaceEntities(gfx, new MockAntSprites(), world, world, 0, cam);
     const bar = findHealthBar(gfx)!;
     // Sprite center screen-y is tile 5 → 80px (camera left/top = -5 tiles).
-    const spriteCenterY = 80 - (-5 * TILE_SIZE_PX);
+    const spriteCenterY = 80 - -5 * TILE_SIZE_PX;
     expect(bar.track.y).toBeLessThan(spriteCenterY - SPIDER_SPRITE_HEIGHT / 2);
   });
 
   it('fill colour skews green at high hp and red at low hp', () => {
     const camY = makeCamera(5, 5, 20, 20);
     const highGfx = new MockGfx();
-    drawSurfaceEntities(highGfx, new MockAntSprites(), makeWorldWithSpider(SPIDER_HP_FULL * 0.9), makeWorldWithSpider(SPIDER_HP_FULL * 0.9), 0, camY);
+    drawSurfaceEntities(
+      highGfx,
+      new MockAntSprites(),
+      makeWorldWithSpider(SPIDER_HP_FULL * 0.9),
+      makeWorldWithSpider(SPIDER_HP_FULL * 0.9),
+      0,
+      camY,
+    );
     const lowGfx = new MockGfx();
-    drawSurfaceEntities(lowGfx, new MockAntSprites(), makeWorldWithSpider(SPIDER_HP_FULL * 0.1), makeWorldWithSpider(SPIDER_HP_FULL * 0.1), 0, camY);
+    drawSurfaceEntities(
+      lowGfx,
+      new MockAntSprites(),
+      makeWorldWithSpider(SPIDER_HP_FULL * 0.1),
+      makeWorldWithSpider(SPIDER_HP_FULL * 0.1),
+      0,
+      camY,
+    );
     const high = findHealthBar(highGfx)!.fillColor;
     const low = findHealthBar(lowGfx)!.fillColor;
     const green = (c: number) => (c >> 8) & 0xff;
@@ -1003,7 +1123,20 @@ describe('drawSurfaceEntities — spider health bar (issue #148)', () => {
     const overlay = new MockGfx();
     const world = makeWorldWithSpider(SPIDER_HP_FULL / 2);
     const cam = makeCamera(5, 5, 20, 20);
-    drawSurfaceEntities(base, new MockAntSprites(), world, world, 0, cam, null, undefined, 0, undefined, 0, overlay);
+    drawSurfaceEntities(
+      base,
+      new MockAntSprites(),
+      world,
+      world,
+      0,
+      cam,
+      null,
+      undefined,
+      0,
+      undefined,
+      0,
+      overlay,
+    );
     expect(findHealthBar(overlay)).not.toBeNull();
     expect(findHealthBar(base)).toBeNull();
   });
@@ -1051,7 +1184,7 @@ describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
     enemy.digFlowFieldDirty = false;
     enemy.priorityFoodPileId = null;
     w.colonies[PLAYER_COLONY_ID] = player;
-    w.colonies[enemyId]         = enemy;
+    w.colonies[enemyId] = enemy;
     return w;
   }
 
@@ -1078,11 +1211,11 @@ describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
     expect(enemyStrokes.length).toBe(1);
 
     // Center on tile center, radius = mound outer radius (TILE_SIZE_PX/2 + 2).
-    const left = Math.floor(cam.x - cam.viewportWidth  / 2);
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const left = Math.floor(cam.x - cam.viewportWidth / 2);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const expectedCx = (tileX - left) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
-    const expectedCy = (tileY - top)  * TILE_SIZE_PX + TILE_SIZE_PX / 2;
-    const expectedR  = TILE_SIZE_PX / 2 + 2;
+    const expectedCy = (tileY - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    const expectedR = TILE_SIZE_PX / 2 + 2;
     expect(enemyStrokes[0]).toEqual([expectedCx, expectedCy, expectedR]);
 
     // No enemy-colored fillRect should remain — the four-rect rectangle is gone.
@@ -1148,10 +1281,10 @@ describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
     expect(circlesByColor.get(0x1a0f00)?.length).toBe(1); // COLOR_SURFACE_ENTRANCE_HOLE
 
     // Concentric and centered on the tile center; radii match mound > body > hole.
-    const left = Math.floor(cam.x - cam.viewportWidth  / 2);
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const left = Math.floor(cam.x - cam.viewportWidth / 2);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const cx = (tileX - left) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
-    const cy = (tileY - top)  * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    const cy = (tileY - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
     expect(circlesByColor.get(0x6d563a)![0]).toEqual([cx, cy, TILE_SIZE_PX / 2 + 2]);
     expect(circlesByColor.get(0x5a4a30)![0]).toEqual([cx, cy, TILE_SIZE_PX / 2 + 1]);
     expect(circlesByColor.get(0x1a0f00)![0]).toEqual([cx, cy, TILE_SIZE_PX / 2 - 2]);
@@ -1167,7 +1300,13 @@ describe('drawSurface', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
     const world = createWorldState(1);
-    world.foodPiles.push({ foodPileId: 1, tileX: 5, tileY: 5 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 5,
+      tileY: 5,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     const cam = makeCamera(5, 5, 10, 10);
     drawSurface(gfx, sprites, world, world, 0, cam);
     expect(gfx.callsOf('fillRect').length).toBeGreaterThan(0);

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -41,10 +41,7 @@ import {
 } from './terrain-atlas.js';
 export type { AntSpriteLayer } from './ant-sprite-layer.js';
 import type { CameraState } from './camera.js';
-import {
-  SPIDER_SPRITE_HEIGHT,
-  SPIDER_SPRITE_WIDTH,
-} from './ant-sprite-layer.js';
+import { SPIDER_SPRITE_HEIGHT, SPIDER_SPRITE_WIDTH } from './ant-sprite-layer.js';
 import { SPIDER_HUNGER_MAX_TICKS, SPIDER_HP_FULL } from '../sim/constants.js';
 import { tierIndex } from '../sim/ai-state.js';
 
@@ -75,10 +72,10 @@ function visibleRange(
   gridWidth: number,
   gridHeight: number,
 ): { left: number; top: number; right: number; bottom: number } {
-  const left   = Math.floor(cam.x - cam.viewportWidth  / 2);
-  const top    = Math.floor(cam.y - cam.viewportHeight / 2);
-  const right  = Math.min(left + cam.viewportWidth  + 1, gridWidth);
-  const bottom = Math.min(top  + cam.viewportHeight + 1, gridHeight);
+  const left = Math.floor(cam.x - cam.viewportWidth / 2);
+  const top = Math.floor(cam.y - cam.viewportHeight / 2);
+  const right = Math.min(left + cam.viewportWidth + 1, gridWidth);
+  const bottom = Math.min(top + cam.viewportHeight + 1, gridHeight);
   return { left, top, right, bottom };
 }
 
@@ -108,7 +105,7 @@ export function drawSurfaceTerrain(gfx: GfxLike, world: WorldState, cam: CameraS
       // the universal substrate.
       void sgGet(world.surface, tx, ty);
       const screenX = (tx - left) * TILE_SIZE_PX;
-      const screenY = (ty - top)  * TILE_SIZE_PX;
+      const screenY = (ty - top) * TILE_SIZE_PX;
       drawBarrenEarthTile(gfx, world, screenX, screenY, tx, ty);
     }
   }
@@ -146,10 +143,10 @@ export function drawSurfaceEntities(
   // base gfx, preserving the previous single-layer behaviour.
   overlayGfx: GfxLike = gfx,
 ): void {
-  const left = Math.floor(cam.x - cam.viewportWidth  / 2);
-  const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+  const left = Math.floor(cam.x - cam.viewportWidth / 2);
+  const top = Math.floor(cam.y - cam.viewportHeight / 2);
 
-  const canvasW = cam.viewportWidth  * TILE_SIZE_PX;
+  const canvasW = cam.viewportWidth * TILE_SIZE_PX;
   const canvasH = cam.viewportHeight * TILE_SIZE_PX;
 
   // --- Food piles ---
@@ -171,10 +168,11 @@ export function drawSurfaceEntities(
   const baseRadius = TILE_SIZE_PX / 2 - 2;
   for (const pile of curr.foodPiles) {
     const sx = (pile.tileX - left) * TILE_SIZE_PX;
-    const sy = (pile.tileY - top)  * TILE_SIZE_PX;
+    const sy = (pile.tileY - top) * TILE_SIZE_PX;
     // Trivial viewport cull
     if (sx < -TILE_SIZE_PX || sx > canvasW || sy < -TILE_SIZE_PX || sy > canvasH) continue;
-    const isPlayerMarked = playerPriorityPileId !== null && pile.foodPileId === playerPriorityPileId;
+    const isPlayerMarked =
+      playerPriorityPileId !== null && pile.foodPileId === playerPriorityPileId;
     const color = isPlayerMarked ? COLOR_FOOD_PILE_MARKED : COLOR_FOOD_PILE_NORMAL;
     const cx = sx + TILE_SIZE_PX / 2;
     const cy = sy + TILE_SIZE_PX / 2;
@@ -185,7 +183,7 @@ export function drawSurfaceEntities(
     const pct = pile.pickupsRemaining / pile.pickupsInitial;
     let r = baseRadius;
     if (pct <= 0.75) r = baseRadius - 2;
-    if (pct <= 0.50) r = baseRadius - 4;
+    if (pct <= 0.5) r = baseRadius - 4;
     if (pct <= 0.25) r = baseRadius - 6;
     // Floor at 1: with TILE_SIZE_PX = 16, baseRadius = 6, so the smallest
     // bucket would compute to r = 0 — invisible. Snap to 1px so a not-yet-
@@ -218,18 +216,23 @@ export function drawSurfaceEntities(
   // Issue #14 cue: enemy entrances get a 1-px enemy-colony stroke around the
   // mound so the player reads them as "rally here to invade" targets.
   const MOUND_SPILL_PX = 2;
-  const MOUND_OUTER_R  = TILE_SIZE_PX / 2 + MOUND_SPILL_PX; // 10
-  const MOUND_BODY_R   = TILE_SIZE_PX / 2 + 1;              // 9 — 1px lighter rim shows around the body
-  const HOLE_R         = TILE_SIZE_PX / 2 - 2;              // 6 — matches food pile baseRadius
+  const MOUND_OUTER_R = TILE_SIZE_PX / 2 + MOUND_SPILL_PX; // 10
+  const MOUND_BODY_R = TILE_SIZE_PX / 2 + 1; // 9 — 1px lighter rim shows around the body
+  const HOLE_R = TILE_SIZE_PX / 2 - 2; // 6 — matches food pile baseRadius
   for (const colony of Object.values(curr.colonies)) {
     if (!colony.entrances) continue;
     const isEnemy = colony.colonyId !== PLAYER_COLONY_ID;
     for (const entrance of colony.entrances) {
       const sx = (entrance.surfaceTileX - left) * TILE_SIZE_PX;
-      const sy = (entrance.surfaceTileY - top)  * TILE_SIZE_PX;
+      const sy = (entrance.surfaceTileY - top) * TILE_SIZE_PX;
       const cullMargin = TILE_SIZE_PX + MOUND_SPILL_PX + 1;
-      if (sx < -cullMargin || sx > canvasW + MOUND_SPILL_PX
-        || sy < -cullMargin || sy > canvasH + MOUND_SPILL_PX) continue;
+      if (
+        sx < -cullMargin ||
+        sx > canvasW + MOUND_SPILL_PX ||
+        sy < -cullMargin ||
+        sy > canvasH + MOUND_SPILL_PX
+      )
+        continue;
       const cx = sx + TILE_SIZE_PX / 2;
       const cy = sy + TILE_SIZE_PX / 2;
       // Outer mound rim: lighter spoil tone — reads as "raised dirt edge."
@@ -257,7 +260,7 @@ export function drawSurfaceEntities(
   // the raw orange. A 5-frame fade-out is tracked via contestedGlowFrames.
   {
     const tileColony = new Map<number, number>(); // tileKey → first colonyId
-    const contested  = new Set<number>();
+    const contested = new Set<number>();
     const n = curr.ants.alive.length;
     for (let id = 0; id < n; id++) {
       if (!isAlive(curr.ants, id)) continue;
@@ -288,10 +291,10 @@ export function drawSurfaceEntities(
       const tx = key & 0xffff;
       const ty = (key >> 16) & 0xffff;
       const sx = (tx - left) * TILE_SIZE_PX;
-      const sy = (ty - top)  * TILE_SIZE_PX;
+      const sy = (ty - top) * TILE_SIZE_PX;
       if (sx < -TILE_SIZE_PX || sx > canvasW || sy < -TILE_SIZE_PX || sy > canvasH) continue;
       // Fade alpha based on frames since last seen.
-      const framesAgo = tilesToDraw ? (currentFrame - (tilesToDraw.get(key) ?? currentFrame)) : 0;
+      const framesAgo = tilesToDraw ? currentFrame - (tilesToDraw.get(key) ?? currentFrame) : 0;
       const alpha_g = 0.15 * (1 - framesAgo / GLOW_FADE_FRAMES);
       if (alpha_g <= 0) continue;
       // Soft edge: draw the center tile at full alpha, then draw 1px-thin
@@ -299,9 +302,9 @@ export function drawSurfaceEntities(
       gfx.fillStyle(COLOR_NEUTRAL_CONTESTED_GLOW, alpha_g);
       gfx.fillRect(sx + 2, sy + 2, TILE_SIZE_PX - 4, TILE_SIZE_PX - 4);
       gfx.fillStyle(COLOR_NEUTRAL_CONTESTED_GLOW, alpha_g * 0.5);
-      gfx.fillRect(sx,      sy,      TILE_SIZE_PX, 2);
-      gfx.fillRect(sx,      sy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2);
-      gfx.fillRect(sx,      sy + 2,  2, TILE_SIZE_PX - 4);
+      gfx.fillRect(sx, sy, TILE_SIZE_PX, 2);
+      gfx.fillRect(sx, sy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2);
+      gfx.fillRect(sx, sy + 2, 2, TILE_SIZE_PX - 4);
       gfx.fillRect(sx + TILE_SIZE_PX - 2, sy + 2, 2, TILE_SIZE_PX - 4);
     }
     // Prune stale entries so the map doesn't grow without bound.
@@ -317,7 +320,7 @@ export function drawSurfaceEntities(
   if (curr.scatterReticleTile !== null) {
     const { x: rtx, y: rty } = curr.scatterReticleTile;
     const rsx = (rtx - left) * TILE_SIZE_PX;
-    const rsy = (rty - top)  * TILE_SIZE_PX;
+    const rsy = (rty - top) * TILE_SIZE_PX;
     if (rsx > -TILE_SIZE_PX && rsx < canvasW && rsy > -TILE_SIZE_PX && rsy < canvasH) {
       // Pulse: alpha oscillates between 0.4 and 0.7 at 1 Hz.
       const pulse = 0.55 + 0.15 * Math.sin((2 * Math.PI * frameTimeMs) / 1000);
@@ -327,8 +330,10 @@ export function drawSurfaceEntities(
       // Tile fill at 0.3 alpha.
       gfx.fillStyle(0xcc1010, 0.3);
       gfx.fillRect(
-        rsx - sizeOffset, rsy - sizeOffset,
-        TILE_SIZE_PX * scalePulse, TILE_SIZE_PX * scalePulse,
+        rsx - sizeOffset,
+        rsy - sizeOffset,
+        TILE_SIZE_PX * scalePulse,
+        TILE_SIZE_PX * scalePulse,
       );
       // Border at pulsed alpha: draw as 2-px edge strips.
       const bw = TILE_SIZE_PX * scalePulse;
@@ -336,10 +341,10 @@ export function drawSurfaceEntities(
       const bx = rsx - sizeOffset;
       const by = rsy - sizeOffset;
       gfx.fillStyle(0xcc1010, pulse);
-      gfx.fillRect(bx,          by,          bw, 2);
-      gfx.fillRect(bx,          by + bh - 2, bw, 2);
-      gfx.fillRect(bx,          by + 2,      2,  bh - 4);
-      gfx.fillRect(bx + bw - 2, by + 2,      2,  bh - 4);
+      gfx.fillRect(bx, by, bw, 2);
+      gfx.fillRect(bx, by + bh - 2, bw, 2);
+      gfx.fillRect(bx, by + 2, 2, bh - 4);
+      gfx.fillRect(bx + bw - 2, by + 2, 2, bh - 4);
     }
   }
 
@@ -368,10 +373,16 @@ export function drawSurfaceEntities(
     const baseX = useInterp ? prevPxX + (currPxX - prevPxX) * alpha : currPxX;
     const baseY = useInterp ? prevPxY + (currPxY - prevPxY) * alpha : currPxY;
     const screenX = baseX - left * TILE_SIZE_PX;
-    const screenY = baseY - top  * TILE_SIZE_PX;
+    const screenY = baseY - top * TILE_SIZE_PX;
 
     // Trivial viewport cull
-    if (screenX < -TILE_SIZE_PX || screenX > canvasW || screenY < -TILE_SIZE_PX || screenY > canvasH) continue;
+    if (
+      screenX < -TILE_SIZE_PX ||
+      screenX > canvasW ||
+      screenY < -TILE_SIZE_PX ||
+      screenY > canvasH
+    )
+      continue;
 
     const colonyId = curr.ants.colonyId[id]!;
     const colony = curr.colonies[colonyId];
@@ -422,11 +433,14 @@ export function drawSurfaceEntities(
     const baseSX = useSpiderInterp ? prevPxX + (currPxX - prevPxX) * alpha : currPxX;
     const baseSY = useSpiderInterp ? prevPxY + (currPxY - prevPxY) * alpha : currPxY;
     const spiderScreenX = baseSX - left * TILE_SIZE_PX;
-    const spiderScreenY = baseSY - top  * TILE_SIZE_PX;
+    const spiderScreenY = baseSY - top * TILE_SIZE_PX;
 
-    if (spiderScreenX > -SPIDER_SPRITE_WIDTH  && spiderScreenX < canvasW + SPIDER_SPRITE_WIDTH
-      && spiderScreenY > -SPIDER_SPRITE_HEIGHT && spiderScreenY < canvasH + SPIDER_SPRITE_HEIGHT) {
-
+    if (
+      spiderScreenX > -SPIDER_SPRITE_WIDTH &&
+      spiderScreenX < canvasW + SPIDER_SPRITE_WIDTH &&
+      spiderScreenY > -SPIDER_SPRITE_HEIGHT &&
+      spiderScreenY < canvasH + SPIDER_SPRITE_HEIGHT
+    ) {
       const hungerFraction = Math.min(
         curr.spider.hungerTicks / SPIDER_HUNGER_MAX_TICKS[tierIndex(curr.difficulty)],
         1,
@@ -442,36 +456,35 @@ export function drawSurfaceEntities(
       if (hungerFraction > 0.7) {
         const baseRingAlpha = ((hungerFraction - 0.7) / 0.3) * 0.85;
         // S6: rampage warning pulse at ≥80% hunger.
-        const rampagePulse = hungerFraction >= 0.8
-          ? 0.1 * Math.sin((2 * Math.PI * frameTimeMs) / 2000)
-          : 0;
+        const rampagePulse =
+          hungerFraction >= 0.8 ? 0.1 * Math.sin((2 * Math.PI * frameTimeMs) / 2000) : 0;
         const ringAlpha = Math.min(1, baseRingAlpha + rampagePulse);
-        const rl = Math.round(spiderScreenX - SPIDER_SPRITE_WIDTH  / 2);
+        const rl = Math.round(spiderScreenX - SPIDER_SPRITE_WIDTH / 2);
         const rt = Math.round(spiderScreenY - SPIDER_SPRITE_HEIGHT / 2);
         const rw = SPIDER_SPRITE_WIDTH;
         const rh = SPIDER_SPRITE_HEIGHT;
         // S6: smooth gradient by color-lerping the ring toward deep red.
         const ringColor = lerpColor(0xffeecc, 0xcc2020, hungerFraction);
         gfx.fillStyle(ringColor, ringAlpha);
-        gfx.fillRect(rl,          rt,          rw, 2);
-        gfx.fillRect(rl,          rt + rh - 2, rw, 2);
-        gfx.fillRect(rl,          rt + 2,      2,  rh - 4);
-        gfx.fillRect(rl + rw - 2, rt + 2,      2,  rh - 4);
+        gfx.fillRect(rl, rt, rw, 2);
+        gfx.fillRect(rl, rt + rh - 2, rw, 2);
+        gfx.fillRect(rl, rt + 2, 2, rh - 4);
+        gfx.fillRect(rl + rw - 2, rt + 2, 2, rh - 4);
       }
 
       // S7/D1: spider priority indicator — white border when player has set priority.
       // Drawn 2px outside the sprite bounding box so it remains visible alongside
       // the hunger ring (which occupies the same edge pixels as the sprite boundary).
       if (curr.spiderPriorityColonyId === PLAYER_COLONY_ID) {
-        const pl = Math.round(spiderScreenX - SPIDER_SPRITE_WIDTH  / 2) - 2;
+        const pl = Math.round(spiderScreenX - SPIDER_SPRITE_WIDTH / 2) - 2;
         const pt = Math.round(spiderScreenY - SPIDER_SPRITE_HEIGHT / 2) - 2;
-        const pw = SPIDER_SPRITE_WIDTH  + 4;
+        const pw = SPIDER_SPRITE_WIDTH + 4;
         const ph = SPIDER_SPRITE_HEIGHT + 4;
         gfx.fillStyle(0xffffff, 1);
-        gfx.fillRect(pl,          pt,          pw, 2);
-        gfx.fillRect(pl,          pt + ph - 2, pw, 2);
-        gfx.fillRect(pl,          pt + 2,      2,  ph - 4);
-        gfx.fillRect(pl + pw - 2, pt + 2,      2,  ph - 4);
+        gfx.fillRect(pl, pt, pw, 2);
+        gfx.fillRect(pl, pt + ph - 2, pw, 2);
+        gfx.fillRect(pl, pt + 2, 2, ph - 4);
+        gfx.fillRect(pl + pw - 2, pt + 2, 2, ph - 4);
       }
 
       // Health bar (issue #148): render-only HP indicator floating just above
@@ -488,17 +501,17 @@ export function drawSurfaceEntities(
         // which sits 2px outside the box).
         const barY = Math.round(spiderScreenY - SPIDER_SPRITE_HEIGHT / 2 - barH - 4);
         // green (full) → yellow (half) → red (empty).
-        const fillColor = hpRatio > 0.5
-          ? lerpColor(0xffcc00, 0x33cc33, (hpRatio - 0.5) / 0.5)
-          : lerpColor(0xcc2020, 0xffcc00, hpRatio / 0.5);
+        const fillColor =
+          hpRatio > 0.5
+            ? lerpColor(0xffcc00, 0x33cc33, (hpRatio - 0.5) / 0.5)
+            : lerpColor(0xcc2020, 0xffcc00, hpRatio / 0.5);
         // Quantize the fill so a damaged spider never reads as full and a
         // barely-alive one never reads as empty: any 0 < ratio < 1 paints
         // between 1px and barW-1px. hp == 0 paints an empty track. Without
         // this, hp=79/80 rounds to the full 24px (looks undamaged) and hp=1/80
         // rounds to 0px (looks dead).
-        const fillW = hpRatio <= 0
-          ? 0
-          : Math.max(1, Math.min(barW - 1, Math.round(barW * hpRatio)));
+        const fillW =
+          hpRatio <= 0 ? 0 : Math.max(1, Math.min(barW - 1, Math.round(barW * hpRatio)));
         // Dark outline + track so a near-empty bar still reads against terrain.
         overlayGfx.fillStyle(0x000000, 0.7);
         overlayGfx.fillRect(barX - 1, barY - 1, barW + 2, barH + 2);
@@ -523,7 +536,7 @@ export function drawSurfaceEntities(
   if (playerColony && playerColony.rallyPoint !== null) {
     const rp = playerColony.rallyPoint;
     const sx = (rp.tileX - left) * TILE_SIZE_PX;
-    const sy = (rp.tileY - top)  * TILE_SIZE_PX;
+    const sy = (rp.tileY - top) * TILE_SIZE_PX;
     if (sx > -TILE_SIZE_PX && sx < canvasW && sy > -TILE_SIZE_PX && sy < canvasH) {
       gfx.fillStyle(COLOR_RALLY_POINT, 1);
       // Horizontal bar across the tile (leave 1-px edges so adjacent tiles don't fuse)
@@ -541,13 +554,13 @@ export function drawSurfaceEntities(
   // automatically once the player left-clicks the same tileX to confirm.
   if (pendingEntrance !== null) {
     const sx = (pendingEntrance.tileX - left) * TILE_SIZE_PX;
-    const sy = (pendingEntrance.tileY - top)  * TILE_SIZE_PX;
+    const sy = (pendingEntrance.tileY - top) * TILE_SIZE_PX;
     if (sx > -TILE_SIZE_PX && sx < canvasW && sy > -TILE_SIZE_PX && sy < canvasH) {
       gfx.fillStyle(COLOR_QUEEN_OUTLINE, 0.7);
-      gfx.fillRect(sx,                      sy,                      TILE_SIZE_PX, 2);            // top
-      gfx.fillRect(sx,                      sy + TILE_SIZE_PX - 2,   TILE_SIZE_PX, 2);            // bottom
-      gfx.fillRect(sx,                      sy,                      2,            TILE_SIZE_PX); // left
-      gfx.fillRect(sx + TILE_SIZE_PX - 2,   sy,                      2,            TILE_SIZE_PX); // right
+      gfx.fillRect(sx, sy, TILE_SIZE_PX, 2); // top
+      gfx.fillRect(sx, sy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2); // bottom
+      gfx.fillRect(sx, sy, 2, TILE_SIZE_PX); // left
+      gfx.fillRect(sx + TILE_SIZE_PX - 2, sy, 2, TILE_SIZE_PX); // right
     }
   }
 }

--- a/src/render/draw-underground.test.ts
+++ b/src/render/draw-underground.test.ts
@@ -42,11 +42,7 @@ import {
   COLOR_PLAYER_COLONY,
   COLOR_QUEEN_OUTLINE,
 } from './sprites.js';
-import {
-  COLOR_ROCK_BASE,
-  COLOR_FLOOR_BASE,
-  COLOR_BARREN_EARTH,
-} from './terrain-atlas.js';
+import { COLOR_ROCK_BASE, COLOR_FLOOR_BASE, COLOR_BARREN_EARTH } from './terrain-atlas.js';
 import { FOOD_CHAMBER_CAPACITY } from '../sim/constants.js';
 import type { CameraState } from './camera.js';
 import { AntFacingCache } from './ant-facing-cache.js';
@@ -63,31 +59,42 @@ interface GfxCall {
 class MockGfx implements GfxLike {
   calls: GfxCall[] = [];
 
-  clear(): GfxLike { this.calls.push({ method: 'clear', args: [] }); return this; }
+  clear(): GfxLike {
+    this.calls.push({ method: 'clear', args: [] });
+    return this;
+  }
   fillStyle(color: number, alpha?: number): GfxLike {
-    this.calls.push({ method: 'fillStyle', args: [color, alpha] }); return this;
+    this.calls.push({ method: 'fillStyle', args: [color, alpha] });
+    return this;
   }
   lineStyle(width: number, color: number, alpha?: number): GfxLike {
-    this.calls.push({ method: 'lineStyle', args: [width, color, alpha] }); return this;
+    this.calls.push({ method: 'lineStyle', args: [width, color, alpha] });
+    return this;
   }
   fillRect(x: number, y: number, w: number, h: number): GfxLike {
-    this.calls.push({ method: 'fillRect', args: [x, y, w, h] }); return this;
+    this.calls.push({ method: 'fillRect', args: [x, y, w, h] });
+    return this;
   }
   fillCircle(x: number, y: number, r: number): GfxLike {
-    this.calls.push({ method: 'fillCircle', args: [x, y, r] }); return this;
+    this.calls.push({ method: 'fillCircle', args: [x, y, r] });
+    return this;
   }
   strokeCircle(x: number, y: number, r: number): GfxLike {
-    this.calls.push({ method: 'strokeCircle', args: [x, y, r] }); return this;
+    this.calls.push({ method: 'strokeCircle', args: [x, y, r] });
+    return this;
   }
   fillTriangle(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number): GfxLike {
-    this.calls.push({ method: 'fillTriangle', args: [x0, y0, x1, y1, x2, y2] }); return this;
+    this.calls.push({ method: 'fillTriangle', args: [x0, y0, x1, y1, x2, y2] });
+    return this;
   }
 
   callsOf(method: string): GfxCall[] {
-    return this.calls.filter(c => c.method === method);
+    return this.calls.filter((c) => c.method === method);
   }
 
-  reset(): void { this.calls = []; }
+  reset(): void {
+    this.calls = [];
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -99,17 +106,29 @@ class MockAntSprites implements AntSpriteLayer {
   staticCalls: StaticSpriteDrawOptions[] = [];
   beginFrames = 0;
   endFrames = 0;
-  beginFrame(): void { this.beginFrames++; }
-  drawAnt(opts: AntSpriteDrawOptions): void { this.calls.push({ ...opts }); }
-  drawStatic(opts: StaticSpriteDrawOptions): void { this.staticCalls.push({ ...opts }); }
-  drawSpider(_opts: SpiderSpriteDrawOptions): void { /* no-op in tests */ }
-  endFrame(): void { this.endFrames++; }
+  beginFrame(): void {
+    this.beginFrames++;
+  }
+  drawAnt(opts: AntSpriteDrawOptions): void {
+    this.calls.push({ ...opts });
+  }
+  drawStatic(opts: StaticSpriteDrawOptions): void {
+    this.staticCalls.push({ ...opts });
+  }
+  drawSpider(_opts: SpiderSpriteDrawOptions): void {
+    /* no-op in tests */
+  }
+  endFrame(): void {
+    this.endFrames++;
+  }
   staticOfKind(kind: StaticSpriteDrawOptions['kind']): StaticSpriteDrawOptions[] {
-    return this.staticCalls.filter(c => c.kind === kind);
+    return this.staticCalls.filter((c) => c.kind === kind);
   }
   reset(): void {
-    this.calls = []; this.staticCalls = [];
-    this.beginFrames = 0; this.endFrames = 0;
+    this.calls = [];
+    this.staticCalls = [];
+    this.beginFrames = 0;
+    this.endFrames = 0;
   }
 }
 
@@ -161,7 +180,9 @@ describe('drawUndergroundTerrain', () => {
     // floor tiles.
     const cam = makeCamera(5, 0.5, 10, 1);
     drawUndergroundTerrain(gfx, world, cam);
-    const ceilingTintStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_UNDERGROUND_CEILING_STRIP);
+    const ceilingTintStyles = gfx
+      .callsOf('fillStyle')
+      .filter((c) => c.args[0] === COLOR_UNDERGROUND_CEILING_STRIP);
     expect(ceilingTintStyles.length).toBeGreaterThan(0);
   });
 
@@ -172,7 +193,9 @@ describe('drawUndergroundTerrain', () => {
     const cam = makeCamera(5, 0.5, 10, 1);
     drawUndergroundTerrain(gfx, world, cam);
 
-    const ceilingTintStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_UNDERGROUND_CEILING_STRIP);
+    const ceilingTintStyles = gfx
+      .callsOf('fillStyle')
+      .filter((c) => c.args[0] === COLOR_UNDERGROUND_CEILING_STRIP);
     // 9 non-entrance columns each apply the ceiling tint exactly once.
     expect(ceilingTintStyles.length).toBe(9);
   });
@@ -180,7 +203,7 @@ describe('drawUndergroundTerrain', () => {
   it('renders Solid tiles with the rock substrate (issue #40 — procedural rock palette)', () => {
     const cam = makeCamera(5, 5, 4, 4);
     drawUndergroundTerrain(gfx, world, cam);
-    const rockBaseStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_ROCK_BASE);
+    const rockBaseStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_ROCK_BASE);
     expect(rockBaseStyles.length).toBeGreaterThan(0);
   });
 
@@ -188,7 +211,7 @@ describe('drawUndergroundTerrain', () => {
     ugSet(world.undergroundGrids[PLAYER_COLONY_ID]!, 5, 5, UndergroundTileState.Open);
     const cam = makeCamera(5, 5, 2, 2);
     drawUndergroundTerrain(gfx, world, cam);
-    const floorStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_FLOOR_BASE);
+    const floorStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_FLOOR_BASE);
     expect(floorStyles.length).toBeGreaterThan(0);
   });
 
@@ -196,8 +219,10 @@ describe('drawUndergroundTerrain', () => {
     ugSet(world.undergroundGrids[PLAYER_COLONY_ID]!, 5, 5, UndergroundTileState.Marked);
     const cam = makeCamera(5.5, 5.5, 2, 2);
     drawUndergroundTerrain(gfx, world, cam);
-    const floorStyles  = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_FLOOR_BASE);
-    const markedStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_MARKED_TILE_OVERLAY);
+    const floorStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_FLOOR_BASE);
+    const markedStyles = gfx
+      .callsOf('fillStyle')
+      .filter((c) => c.args[0] === COLOR_MARKED_TILE_OVERLAY);
     expect(floorStyles.length).toBeGreaterThan(0);
     expect(markedStyles.length).toBeGreaterThan(0);
   });
@@ -206,8 +231,10 @@ describe('drawUndergroundTerrain', () => {
     ugSet(world.undergroundGrids[PLAYER_COLONY_ID]!, 5, 5, UndergroundTileState.BeingDug);
     const cam = makeCamera(5.5, 5.5, 2, 2);
     drawUndergroundTerrain(gfx, world, cam);
-    const floorStyles    = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_FLOOR_BASE);
-    const beingDugStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_BEING_DUG_OVERLAY);
+    const floorStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_FLOOR_BASE);
+    const beingDugStyles = gfx
+      .callsOf('fillStyle')
+      .filter((c) => c.args[0] === COLOR_BEING_DUG_OVERLAY);
     expect(floorStyles.length).toBeGreaterThan(0);
     expect(beingDugStyles.length).toBeGreaterThan(0);
   });
@@ -219,7 +246,9 @@ describe('drawUndergroundTerrain', () => {
     ];
     const cam = makeCamera(5, 0.5, 10, 1);
     drawUndergroundTerrain(gfx, world, cam);
-    const ceilingTintStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_UNDERGROUND_CEILING_STRIP);
+    const ceilingTintStyles = gfx
+      .callsOf('fillStyle')
+      .filter((c) => c.args[0] === COLOR_UNDERGROUND_CEILING_STRIP);
     // 10 columns - 2 entrances = 8 tinted ceiling tiles.
     expect(ceilingTintStyles.length).toBe(8);
   });
@@ -233,7 +262,7 @@ describe('drawUndergroundTerrain', () => {
     ];
     const cam = makeCamera(5, 0.5, 10, 1);
     drawUndergroundTerrain(gfx, world, cam);
-    const earthStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_BARREN_EARTH);
+    const earthStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_BARREN_EARTH);
     expect(earthStyles.length).toBeGreaterThan(0);
   });
 
@@ -295,13 +324,12 @@ describe('drawUndergroundEntities', () => {
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const expectedX = 5.5 * TILE_SIZE_PX - left * TILE_SIZE_PX;
-    const expectedY = 3.5 * TILE_SIZE_PX - top  * TILE_SIZE_PX;
-    const antCall = sprites.calls.find(c =>
-      c.kind === 'worker' &&
-      Math.abs(c.x - expectedX) < 0.01 &&
-      Math.abs(c.y - expectedY) < 0.01,
+    const expectedY = 3.5 * TILE_SIZE_PX - top * TILE_SIZE_PX;
+    const antCall = sprites.calls.find(
+      (c) =>
+        c.kind === 'worker' && Math.abs(c.x - expectedX) < 0.01 && Math.abs(c.y - expectedY) < 0.01,
     );
     expect(antCall).toBeDefined();
   });
@@ -321,13 +349,12 @@ describe('drawUndergroundEntities', () => {
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const expectedX = (5 - left) * TILE_SIZE_PX;
-    const expectedY = (3 - top)  * TILE_SIZE_PX;
-    const antCall = sprites.calls.find(c =>
-      c.kind === 'worker' &&
-      Math.abs(c.x - expectedX) < 0.5 &&
-      Math.abs(c.y - expectedY) < 0.5,
+    const expectedY = (3 - top) * TILE_SIZE_PX;
+    const antCall = sprites.calls.find(
+      (c) =>
+        c.kind === 'worker' && Math.abs(c.x - expectedX) < 0.5 && Math.abs(c.y - expectedY) < 0.5,
     );
     expect(antCall).toBeDefined();
   });
@@ -373,13 +400,13 @@ describe('drawUndergroundEntities', () => {
   it('draws a queen chamber as a wavy polygon with COLOR_CHAMBER_QUEEN', () => {
     const queenDims = CHAMBER_DIMENSIONS[ChamberType.Queen];
     const chamber: ChamberRecord = {
-      chamberId:   1,
+      chamberId: 1,
       chamberType: ChamberType.Queen,
-      foodStored:  0,
-      posX:        5 << FP_SHIFT,
-      posY:        10 << FP_SHIFT,
-      width:       queenDims.width,
-      height:      queenDims.height,
+      foodStored: 0,
+      posX: 5 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      width: queenDims.width,
+      height: queenDims.height,
     };
     world.colonies[PLAYER_COLONY_ID]!.chambers = [chamber];
 
@@ -387,7 +414,7 @@ describe('drawUndergroundEntities', () => {
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     // Chamber color is applied at least once before the shape is drawn.
-    const queenStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_CHAMBER_QUEEN);
+    const queenStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_CHAMBER_QUEEN);
     expect(queenStyles.length).toBeGreaterThanOrEqual(1);
 
     // Fill is a fan triangulation from chamber center: 32 perimeter points
@@ -398,17 +425,17 @@ describe('drawUndergroundEntities', () => {
     // chamber-color fillStyle and the outline-color fillStyle.
     const allCalls = gfx.calls;
     const chamberStyleIdx = allCalls.findIndex(
-      c => c.method === 'fillStyle' && c.args[0] === COLOR_CHAMBER_QUEEN,
+      (c) => c.method === 'fillStyle' && c.args[0] === COLOR_CHAMBER_QUEEN,
     );
     const outlineStyleIdx = allCalls.findIndex(
-      c => c.method === 'fillStyle' && c.args[0] === COLOR_QUEEN_OUTLINE,
+      (c) => c.method === 'fillStyle' && c.args[0] === COLOR_QUEEN_OUTLINE,
     );
     expect(chamberStyleIdx).toBeGreaterThan(-1);
     expect(outlineStyleIdx).toBeGreaterThan(chamberStyleIdx);
 
     const fillTrianglesInBetween = allCalls
       .slice(chamberStyleIdx + 1, outlineStyleIdx)
-      .filter(c => c.method === 'fillTriangle');
+      .filter((c) => c.method === 'fillTriangle');
     // 32 wave-driven edge samples + 4 × 5 corner-arc samples = 52 perimeter
     // points → 52 fan triangles.
     expect(fillTrianglesInBetween.length).toBeGreaterThanOrEqual(52);
@@ -417,13 +444,13 @@ describe('drawUndergroundEntities', () => {
   it('queen outline traces the wavy perimeter as line-segment triangle pairs (no axis-aligned strips)', () => {
     const queenDims = CHAMBER_DIMENSIONS[ChamberType.Queen];
     const chamber: ChamberRecord = {
-      chamberId:   2,
+      chamberId: 2,
       chamberType: ChamberType.Queen,
-      foodStored:  0,
-      posX:        5 << FP_SHIFT,
-      posY:        10 << FP_SHIFT,
-      width:       queenDims.width,
-      height:      queenDims.height,
+      foodStored: 0,
+      posX: 5 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      width: queenDims.width,
+      height: queenDims.height,
     };
     world.colonies[PLAYER_COLONY_ID]!.chambers = [chamber];
 
@@ -431,26 +458,26 @@ describe('drawUndergroundEntities', () => {
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     // Outline pass switches fillStyle to COLOR_QUEEN_OUTLINE exactly once.
-    const goldFillStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_QUEEN_OUTLINE);
+    const goldFillStyles = gfx
+      .callsOf('fillStyle')
+      .filter((c) => c.args[0] === COLOR_QUEEN_OUTLINE);
     expect(goldFillStyles.length).toBe(1);
 
     // 52 perimeter points (32 edge + 4 × 5 corner-arc) × 2 triangles per
     // segment = 104 outline triangles.
     const allCalls = gfx.calls;
     const outlineStyleIdx = allCalls.findIndex(
-      c => c.method === 'fillStyle' && c.args[0] === COLOR_QUEEN_OUTLINE,
+      (c) => c.method === 'fillStyle' && c.args[0] === COLOR_QUEEN_OUTLINE,
     );
     const trianglesAfter = allCalls
       .slice(outlineStyleIdx + 1)
-      .filter(c => c.method === 'fillTriangle');
+      .filter((c) => c.method === 'fillTriangle');
     expect(trianglesAfter.length).toBeGreaterThanOrEqual(104);
 
     // No axis-aligned-strip fillRects in the outline pass — the wave produces
     // non-axis-aligned segments, and the previous rounded-rect implementation
     // emitted exactly 4 thin fillRects here. Regression guard.
-    const rectsAfter = allCalls
-      .slice(outlineStyleIdx + 1)
-      .filter(c => c.method === 'fillRect');
+    const rectsAfter = allCalls.slice(outlineStyleIdx + 1).filter((c) => c.method === 'fillRect');
     expect(rectsAfter.length).toBe(0);
 
     // No strokeCircle either (a previous iteration tried using it for corner
@@ -463,22 +490,22 @@ describe('drawUndergroundEntities', () => {
     // over/under-lap between adjacent segment quads at alpha 0.7.
     const circlesAfter = allCalls
       .slice(outlineStyleIdx + 1)
-      .filter(c => c.method === 'fillCircle');
+      .filter((c) => c.method === 'fillCircle');
     expect(circlesAfter.length).toBe(52);
     // All round-caps are 1-px-radius (half of the 2-px outline thickness).
-    expect(circlesAfter.every(c => Number(c.args[2]) === 1)).toBe(true);
+    expect(circlesAfter.every((c) => Number(c.args[2]) === 1)).toBe(true);
   });
 
   it('non-queen chambers do NOT receive a gold outline (only queen gets the landmark trim)', () => {
     const dims = CHAMBER_DIMENSIONS[ChamberType.Nursery];
     const chamber: ChamberRecord = {
-      chamberId:   3,
+      chamberId: 3,
       chamberType: ChamberType.Nursery,
-      foodStored:  0,
-      posX:        5 << FP_SHIFT,
-      posY:        10 << FP_SHIFT,
-      width:       dims.width,
-      height:      dims.height,
+      foodStored: 0,
+      posX: 5 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      width: dims.width,
+      height: dims.height,
     };
     world.colonies[PLAYER_COLONY_ID]!.chambers = [chamber];
 
@@ -486,35 +513,39 @@ describe('drawUndergroundEntities', () => {
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     // No fillStyle call with COLOR_QUEEN_OUTLINE → no gold outline emitted.
-    const goldFillStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_QUEEN_OUTLINE);
+    const goldFillStyles = gfx
+      .callsOf('fillStyle')
+      .filter((c) => c.args[0] === COLOR_QUEEN_OUTLINE);
     expect(goldFillStyles.length).toBe(0);
   });
 
   it('chamber rendering is deterministic per chamber identity (same triangle vertices across calls)', () => {
     const queenDims = CHAMBER_DIMENSIONS[ChamberType.Queen];
     const chamber: ChamberRecord = {
-      chamberId:   42,
+      chamberId: 42,
       chamberType: ChamberType.Queen,
-      foodStored:  0,
-      posX:        5 << FP_SHIFT,
-      posY:        10 << FP_SHIFT,
-      width:       queenDims.width,
-      height:      queenDims.height,
+      foodStored: 0,
+      posX: 5 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      width: queenDims.width,
+      height: queenDims.height,
     };
     world.colonies[PLAYER_COLONY_ID]!.chambers = [chamber];
 
     const cam = makeCamera(5, 10, 20, 20);
 
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
-    const trianglesA = gfx.callsOf('fillTriangle')
-      .map(c => c.args.map(n => Number(n).toFixed(3)).join(','))
+    const trianglesA = gfx
+      .callsOf('fillTriangle')
+      .map((c) => c.args.map((n) => Number(n).toFixed(3)).join(','))
       .sort();
 
     gfx.reset();
     sprites.reset();
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
-    const trianglesB = gfx.callsOf('fillTriangle')
-      .map(c => c.args.map(n => Number(n).toFixed(3)).join(','))
+    const trianglesB = gfx
+      .callsOf('fillTriangle')
+      .map((c) => c.args.map((n) => Number(n).toFixed(3)).join(','))
       .sort();
 
     // Triangle-vertex equality across calls catches both per-frame wave
@@ -545,11 +576,11 @@ describe('drawUndergroundEntities', () => {
     // it only asserted the egg sprite was emitted, not that no ant sprite was.
     expect(sprites.calls.length).toBe(0);
     // Sprite is positioned at the tile center.
-    const left = Math.floor(cam.x - cam.viewportWidth  / 2);
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const left = Math.floor(cam.x - cam.viewportWidth / 2);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const eggCall = sprites.staticOfKind('egg')[0]!;
     expect(eggCall.x).toBe((4 - left) * TILE_SIZE_PX + TILE_SIZE_PX / 2);
-    expect(eggCall.y).toBe((5 - top)  * TILE_SIZE_PX + TILE_SIZE_PX / 2);
+    expect(eggCall.y).toBe((5 - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2);
   });
 
   // Issue #17 Phase 1.6 — visible carry render offset.
@@ -575,8 +606,8 @@ describe('drawUndergroundEntities', () => {
     const cam = makeCamera(5, 5, 20, 20);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
-    const left = Math.floor(cam.x - cam.viewportWidth  / 2);
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const left = Math.floor(cam.x - cam.viewportWidth / 2);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const eggCall = sprites.staticOfKind('egg')[0]!;
     expect(eggCall.x).toBe((4 - left) * TILE_SIZE_PX + TILE_SIZE_PX / 2);
     // y is shifted upward (smaller value) by ~1/4 tile vs. the un-carried baseline.
@@ -591,11 +622,15 @@ describe('drawUndergroundEntities', () => {
     world.colonies[PLAYER_COLONY_ID]!.queenEntityId = 999;
     initAnt(world.ants, eggId, {
       colonyId: PLAYER_COLONY_ID,
-      posX: 4 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 1,
+      posX: 4 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      zone: 1,
     });
     initAnt(world.ants, carrierId, {
       colonyId: PLAYER_COLONY_ID,
-      posX: 4 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 1,
+      posX: 4 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      zone: 1,
     });
     // Dead carrier: alive flips to 0; carriedBy still points at it (this is
     // the dead-carrier orphan state — sim treats the brood as reclaimable,
@@ -637,22 +672,26 @@ describe('drawUndergroundEntities', () => {
   it('FoodStorage chamber with colony.foodStored=0 draws NO food-cache sprites', () => {
     const foodDims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage];
     world.colonies[PLAYER_COLONY_ID]!.foodStored = 0;
-    world.colonies[PLAYER_COLONY_ID]!.chambers = [{
-      chamberId:   9,
-      chamberType: ChamberType.FoodStorage,
-      foodStored:  0,
-      posX:        5 << FP_SHIFT,
-      posY:        5 << FP_SHIFT,
-      width:       foodDims.width,
-      height:      foodDims.height,
-    }];
+    world.colonies[PLAYER_COLONY_ID]!.chambers = [
+      {
+        chamberId: 9,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 0,
+        posX: 5 << FP_SHIFT,
+        posY: 5 << FP_SHIFT,
+        width: foodDims.width,
+        height: foodDims.height,
+      },
+    ];
 
     const cam = makeCamera(5, 5, 20, 20);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     expect(sprites.staticOfKind('food-cache').length).toBe(0);
     // Legacy overlay path must also be gone — no amber fillRect.
-    const fillStyles = gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_CHAMBER_FOOD_STORAGE_FILL);
+    const fillStyles = gfx
+      .callsOf('fillStyle')
+      .filter((c) => c.args[0] === COLOR_CHAMBER_FOOD_STORAGE_FILL);
     expect(fillStyles.length).toBe(0);
   });
 
@@ -660,15 +699,17 @@ describe('drawUndergroundEntities', () => {
     const foodDims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage];
     const totalTiles = foodDims.width * foodDims.height;
     // Issue #15: chamber.foodStored is the authoritative per-chamber stockpile.
-    world.colonies[PLAYER_COLONY_ID]!.chambers = [{
-      chamberId:   10,
-      chamberType: ChamberType.FoodStorage,
-      foodStored:  Math.floor(FOOD_CHAMBER_CAPACITY / 2),
-      posX:        5 << FP_SHIFT,
-      posY:        5 << FP_SHIFT,
-      width:       foodDims.width,
-      height:      foodDims.height,
-    }];
+    world.colonies[PLAYER_COLONY_ID]!.chambers = [
+      {
+        chamberId: 10,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: Math.floor(FOOD_CHAMBER_CAPACITY / 2),
+        posX: 5 << FP_SHIFT,
+        posY: 5 << FP_SHIFT,
+        width: foodDims.width,
+        height: foodDims.height,
+      },
+    ];
 
     const cam = makeCamera(5, 5, 20, 20);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
@@ -683,15 +724,17 @@ describe('drawUndergroundEntities', () => {
 
   it('FoodStorage full → food-cache sprite per tile, bottom row included', () => {
     const foodDims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage];
-    world.colonies[PLAYER_COLONY_ID]!.chambers = [{
-      chamberId:   11,
-      chamberType: ChamberType.FoodStorage,
-      foodStored:  FOOD_CHAMBER_CAPACITY,
-      posX:        5 << FP_SHIFT,
-      posY:        5 << FP_SHIFT,
-      width:       foodDims.width,
-      height:      foodDims.height,
-    }];
+    world.colonies[PLAYER_COLONY_ID]!.chambers = [
+      {
+        chamberId: 11,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: FOOD_CHAMBER_CAPACITY,
+        posX: 5 << FP_SHIFT,
+        posY: 5 << FP_SHIFT,
+        width: foodDims.width,
+        height: foodDims.height,
+      },
+    ];
 
     const cam = makeCamera(5, 5, 20, 20);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
@@ -704,17 +747,19 @@ describe('drawUndergroundEntities', () => {
       expect(c.tint).toBe(COLOR_CHAMBER_FOOD_STORAGE_FILL);
     }
     // At least one cache sits on the chamber floor row (bottom tiles).
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
-    const bottomRowY = (5 - top) * TILE_SIZE_PX + (foodDims.height - 1) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
-    const bottomCaches = caches.filter(c => Math.abs(c.y - bottomRowY) < 0.01);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
+    const bottomRowY =
+      (5 - top) * TILE_SIZE_PX + (foodDims.height - 1) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    const bottomCaches = caches.filter((c) => Math.abs(c.y - bottomRowY) < 0.01);
     expect(bottomCaches.length).toBe(foodDims.width);
     // And at least one sits on the top row — chamber is fully packed.
     const topRowY = (5 - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
-    expect(caches.some(c => Math.abs(c.y - topRowY) < 0.01)).toBe(true);
+    expect(caches.some((c) => Math.abs(c.y - topRowY) < 0.01)).toBe(true);
     // Chamber floor is still drawn as COLOR_CHAMBER_FOOD_STORAGE (unchanged
     // baseline). Just make sure the legacy amber fillRect path isn't emitted.
-    expect(gfx.callsOf('fillStyle').filter(c => c.args[0] === COLOR_CHAMBER_FOOD_STORAGE).length)
-      .toBeGreaterThanOrEqual(1);
+    expect(
+      gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_CHAMBER_FOOD_STORAGE).length,
+    ).toBeGreaterThanOrEqual(1);
   });
 
   it('FoodStorage fill reads chamber.foodStored directly (issue #15 chamber-authoritative)', () => {
@@ -726,15 +771,17 @@ describe('drawUndergroundEntities', () => {
     // Set the entrance pool full just to confirm it does NOT bleed into the
     // chamber visual — the bug we fixed.
     world.colonies[PLAYER_COLONY_ID]!.foodStored = 9999;
-    world.colonies[PLAYER_COLONY_ID]!.chambers = [{
-      chamberId:   12,
-      chamberType: ChamberType.FoodStorage,
-      foodStored:  FOOD_CHAMBER_CAPACITY, // full per chamber.foodStored
-      posX:        5 << FP_SHIFT,
-      posY:        5 << FP_SHIFT,
-      width:       foodDims.width,
-      height:      foodDims.height,
-    }];
+    world.colonies[PLAYER_COLONY_ID]!.chambers = [
+      {
+        chamberId: 12,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: FOOD_CHAMBER_CAPACITY, // full per chamber.foodStored
+        posX: 5 << FP_SHIFT,
+        posY: 5 << FP_SHIFT,
+        width: foodDims.width,
+        height: foodDims.height,
+      },
+    ];
 
     const cam = makeCamera(5, 5, 20, 20);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
@@ -749,12 +796,33 @@ describe('drawUndergroundEntities', () => {
     const capa = FOOD_CHAMBER_CAPACITY;
     const colony = createColonyRecord(PLAYER_COLONY_ID, 999);
     colony.chambers = [
-      { chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: capa,
-        posX: 0, posY: 0, width: foodDims.width, height: foodDims.height },
-      { chamberId: 2, chamberType: ChamberType.FoodStorage, foodStored: Math.floor(capa / 2),
-        posX: 0, posY: 0, width: foodDims.width, height: foodDims.height },
-      { chamberId: 3, chamberType: ChamberType.FoodStorage, foodStored: 0,
-        posX: 0, posY: 0, width: foodDims.width, height: foodDims.height },
+      {
+        chamberId: 1,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: capa,
+        posX: 0,
+        posY: 0,
+        width: foodDims.width,
+        height: foodDims.height,
+      },
+      {
+        chamberId: 2,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: Math.floor(capa / 2),
+        posX: 0,
+        posY: 0,
+        width: foodDims.width,
+        height: foodDims.height,
+      },
+      {
+        chamberId: 3,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 0,
+        posX: 0,
+        posY: 0,
+        width: foodDims.width,
+        height: foodDims.height,
+      },
     ];
     // Entrance pool is irrelevant to the per-chamber readout.
     colony.foodStored = 12345;
@@ -793,7 +861,7 @@ describe('drawUndergroundEntities', () => {
     // depth 50 for every brood, which painted on top of the egg/larva sprite
     // (depth 48) emitted by the brood loop. User-visible artifact: "eggs
     // appear to have ants drawn on them".
-    const eggId   = 5;
+    const eggId = 5;
     const larvaId = 6;
     world.colonies[PLAYER_COLONY_ID]!.queenEntityId = 999; // avoid id-collision with brood
     initAnt(world.ants, eggId, {
@@ -808,7 +876,7 @@ describe('drawUndergroundEntities', () => {
       posY: 5 << FP_SHIFT,
       zone: 1,
     });
-    world.colonies[PLAYER_COLONY_ID]!.eggs   = [eggId];
+    world.colonies[PLAYER_COLONY_ID]!.eggs = [eggId];
     world.colonies[PLAYER_COLONY_ID]!.larvae = [larvaId];
 
     const cam = makeCamera(5, 5, 20, 20);
@@ -826,8 +894,8 @@ describe('drawUndergroundEntities', () => {
     // Mixed-occupancy regression: a real chamber has worker nurses tending
     // brood. The fix must skip ONLY brood from the ant loop, not workers.
     const workerId = 4;
-    const eggId    = 5;
-    const larvaId  = 6;
+    const eggId = 5;
+    const larvaId = 6;
     world.colonies[PLAYER_COLONY_ID]!.queenEntityId = 999;
     initAnt(world.ants, workerId, {
       colonyId: PLAYER_COLONY_ID,
@@ -847,7 +915,7 @@ describe('drawUndergroundEntities', () => {
       posY: 5 << FP_SHIFT,
       zone: 1,
     });
-    world.colonies[PLAYER_COLONY_ID]!.eggs   = [eggId];
+    world.colonies[PLAYER_COLONY_ID]!.eggs = [eggId];
     world.colonies[PLAYER_COLONY_ID]!.larvae = [larvaId];
 
     const cam = makeCamera(5, 5, 20, 20);
@@ -944,11 +1012,12 @@ describe('drawUndergroundEntities — facing cache smoothing', () => {
     const cam = makeCamera(5, 5, 30, 30);
     const facing = new AntFacingCache();
 
-    let x = 3, y = 3;
+    let x = 3,
+      y = 3;
     const path: Array<[number, number]> = [];
     for (let i = 0; i < 8; i++) {
       if (i % 2 === 0) x += 1;
-      else             y += 1;
+      else y += 1;
       path.push([x, y]);
     }
 
@@ -965,7 +1034,7 @@ describe('drawUndergroundEntities — facing cache smoothing', () => {
     // SVG head native on -x → southeast motion lands rotation in (-π, -π/2).
     expect(lastRotation).toBeGreaterThan(-Math.PI);
     expect(lastRotation).toBeLessThan(-Math.PI / 2);
-    const diag = -3 * Math.PI / 4;
+    const diag = (-3 * Math.PI) / 4;
     expect(Math.abs(lastRotation - diag)).toBeLessThan(Math.abs(lastRotation - -Math.PI));
     expect(Math.abs(lastRotation - diag)).toBeLessThan(Math.abs(lastRotation - -Math.PI / 2));
   });
@@ -998,7 +1067,10 @@ describe('drawUndergroundEntities — facing cache smoothing', () => {
 
     // Build up a heading for id=0.
     let prev = makeUndergroundAntWorld(3, 3);
-    for (const [nx, ny] of [[4, 3], [5, 3]] as Array<[number, number]>) {
+    for (const [nx, ny] of [
+      [4, 3],
+      [5, 3],
+    ] as Array<[number, number]>) {
       const curr = makeUndergroundAntWorld(nx, ny);
       drawUndergroundEntities(gfx, sprites, prev, curr, 1, cam, PLAYER_COLONY_ID, facing);
       prev = curr;
@@ -1057,9 +1129,9 @@ describe('drawUndergroundEntities — wrong-plane flicker guard', () => {
 
     expect(sprites.calls.length).toBe(1);
     const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const expectedCurrX = 6 * TILE_SIZE_PX - left * TILE_SIZE_PX;
-    const expectedCurrY = 7 * TILE_SIZE_PX - top  * TILE_SIZE_PX;
+    const expectedCurrY = 7 * TILE_SIZE_PX - top * TILE_SIZE_PX;
     expect(sprites.calls[0]!.x).toBeCloseTo(expectedCurrX, 5);
     expect(sprites.calls[0]!.y).toBeCloseTo(expectedCurrY, 5);
     expect(sprites.calls[0]!.rotation).toBe(0);
@@ -1087,9 +1159,9 @@ describe('drawUndergroundEntities — wrong-plane flicker guard', () => {
 
     expect(sprites.calls.length).toBe(1);
     const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const expectedCurrX = 6 * TILE_SIZE_PX - left * TILE_SIZE_PX;
-    const expectedCurrY = 7 * TILE_SIZE_PX - top  * TILE_SIZE_PX;
+    const expectedCurrY = 7 * TILE_SIZE_PX - top * TILE_SIZE_PX;
     expect(sprites.calls[0]!.x).toBeCloseTo(expectedCurrX, 5);
     expect(sprites.calls[0]!.y).toBeCloseTo(expectedCurrY, 5);
     expect(sprites.calls[0]!.rotation).toBe(0);

--- a/src/render/draw-underground.ts
+++ b/src/render/draw-underground.ts
@@ -46,10 +46,7 @@ import {
   COLOR_PLAYER_HOME_GLOW,
   COLOR_ENEMY_HOME_GLOW,
 } from './sprites.js';
-import {
-  drawBarrenEarthSubstrate,
-  drawOpenFloorTile,
-} from './terrain-atlas.js';
+import { drawBarrenEarthSubstrate, drawOpenFloorTile } from './terrain-atlas.js';
 import { drawAutotiledUndergroundTile, drawUndergroundRim } from './underground-autotile.js';
 import { gatherUnderground3x3Neighbors, type Neighbors3x3 } from './underground-neighbors.js';
 import { chamberSeed, chamberPerimeterPoints } from './chamber-shape.js';
@@ -60,8 +57,8 @@ import type { CameraState } from './camera.js';
 // ---------------------------------------------------------------------------
 
 const CHAMBER_COLORS: Record<number, number> = {
-  [ChamberType.Queen]:       COLOR_CHAMBER_QUEEN,
-  [ChamberType.Nursery]:     COLOR_CHAMBER_NURSERY,
+  [ChamberType.Queen]: COLOR_CHAMBER_QUEEN,
+  [ChamberType.Nursery]: COLOR_CHAMBER_NURSERY,
   [ChamberType.FoodStorage]: COLOR_CHAMBER_FOOD_STORAGE,
 };
 
@@ -80,8 +77,10 @@ const CHAMBER_COLORS: Record<number, number> = {
 
 function drawOutlineSegment(
   gfx: GfxLike,
-  ax: number, ay: number,
-  bx: number, by: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
   thickness: number,
 ): void {
   const dx = bx - ax;
@@ -91,7 +90,7 @@ function drawOutlineSegment(
   // Perpendicular direction × half-thickness. (-dy, dx) is the 90° rotation.
   const halfT = thickness * 0.5;
   const px = (-dy / len) * halfT;
-  const py = ( dx / len) * halfT;
+  const py = (dx / len) * halfT;
   // Quad as two triangles. Vertex order: a+, b+, a-, b-, a-.
   gfx.fillTriangle(ax + px, ay + py, bx + px, by + py, ax - px, ay - py);
   gfx.fillTriangle(bx + px, by + py, bx - px, by - py, ax - px, ay - py);
@@ -153,10 +152,10 @@ export function drawUndergroundTerrain(
   const grid = world.undergroundGrids[activeUndergroundColonyId];
   if (grid === undefined) return;
 
-  const left   = Math.floor(cam.x - cam.viewportWidth  / 2);
-  const top    = Math.floor(cam.y - cam.viewportHeight / 2);
-  const right  = Math.min(left + cam.viewportWidth  + 1, grid.width);
-  const bottom = Math.min(top  + cam.viewportHeight + 1, grid.height);
+  const left = Math.floor(cam.x - cam.viewportWidth / 2);
+  const top = Math.floor(cam.y - cam.viewportHeight / 2);
+  const right = Math.min(left + cam.viewportWidth + 1, grid.width);
+  const bottom = Math.min(top + cam.viewportHeight + 1, grid.height);
 
   // Collect entrance X positions for ceiling gap rendering — uses the viewed
   // colony's entrances so the player sees enemy entrances when inspecting the
@@ -174,15 +173,21 @@ export function drawUndergroundTerrain(
   // Neighbors3x3 per visible tile. Per codex P2 review: a 200-tile
   // viewport at 60fps was spawning ~12k short-lived objects/sec.
   const neighbors: Neighbors3x3 = {
-    nw: 'wall', n: 'wall', ne: 'wall',
-    w:  'wall', c: 'wall', e:  'wall',
-    sw: 'wall', s: 'wall', se: 'wall',
+    nw: 'wall',
+    n: 'wall',
+    ne: 'wall',
+    w: 'wall',
+    c: 'wall',
+    e: 'wall',
+    sw: 'wall',
+    s: 'wall',
+    se: 'wall',
   };
 
   for (let ty = Math.max(top, 0); ty < bottom; ty++) {
     for (let tx = Math.max(left, 0); tx < right; tx++) {
       const screenX = (tx - left) * TILE_SIZE_PX;
-      const screenY = (ty - top)  * TILE_SIZE_PX;
+      const screenY = (ty - top) * TILE_SIZE_PX;
 
       if (ty === 0) {
         // Ceiling strip: open gap at entrance columns, surface earth elsewhere.
@@ -275,10 +280,10 @@ export function drawUndergroundEntities(
   const colony = curr.colonies[activeUndergroundColonyId];
   if (colony === undefined) return;
 
-  const left = Math.floor(cam.x - cam.viewportWidth  / 2);
-  const top  = Math.floor(cam.y - cam.viewportHeight / 2);
+  const left = Math.floor(cam.x - cam.viewportWidth / 2);
+  const top = Math.floor(cam.y - cam.viewportHeight / 2);
 
-  const canvasW = cam.viewportWidth  * TILE_SIZE_PX;
+  const canvasW = cam.viewportWidth * TILE_SIZE_PX;
   const canvasH = cam.viewportHeight * TILE_SIZE_PX;
 
   // --- Chambers ---
@@ -301,9 +306,9 @@ export function drawUndergroundEntities(
     const tileX = chamber.posX >> FP_SHIFT;
     const tileY = chamber.posY >> FP_SHIFT;
     const screenX = (tileX - left) * TILE_SIZE_PX;
-    const screenY = (tileY - top)  * TILE_SIZE_PX;
+    const screenY = (tileY - top) * TILE_SIZE_PX;
     const color = CHAMBER_COLORS[chamber.chamberType] ?? COLOR_CHAMBER_QUEEN;
-    const w = dims.width  * TILE_SIZE_PX;
+    const w = dims.width * TILE_SIZE_PX;
     const h = dims.height * TILE_SIZE_PX;
     const seed = chamberSeed(colony.colonyId, chamber.chamberId, chamber.chamberType);
     const points = chamberPerimeterPoints(seed, screenX, screenY, w, h);
@@ -420,9 +425,10 @@ export function drawUndergroundEntities(
   // Per-grid color: blue for player grid, orange for enemy grid.
   // Fade-out over 5 frames once combat ants leave a tile.
   {
-    const glowColor = activeUndergroundColonyId === PLAYER_COLONY_ID
-      ? COLOR_PLAYER_HOME_GLOW
-      : COLOR_ENEMY_HOME_GLOW;
+    const glowColor =
+      activeUndergroundColonyId === PLAYER_COLONY_ID
+        ? COLOR_PLAYER_HOME_GLOW
+        : COLOR_ENEMY_HOME_GLOW;
     const BASE_ALPHA = 0.2;
     const GLOW_FADE_FRAMES = 5;
 
@@ -453,19 +459,20 @@ export function drawUndergroundEntities(
     // Draw glows for all contested or recently-contested tiles.
     const drawKeys = undergoundGlowFrames
       ? Array.from(undergoundGlowFrames.entries())
-          .filter(([key, frame]) =>
-            (key >>> 24) === activeUndergroundColonyId &&
-            currentFrame - frame < GLOW_FADE_FRAMES)
+          .filter(
+            ([key, frame]) =>
+              key >>> 24 === activeUndergroundColonyId && currentFrame - frame < GLOW_FADE_FRAMES,
+          )
           .map(([key]) => key)
       : Array.from(contested);
     for (const key of drawKeys) {
-      const tx = key & 0xff;         // bits 0-7; tx max = 127
+      const tx = key & 0xff; // bits 0-7; tx max = 127
       const ty = (key >> 16) & 0xff; // bits 16-23; top byte (24+) holds colony ID
       const sx = (tx - left) * TILE_SIZE_PX;
-      const sy = (ty - top)  * TILE_SIZE_PX;
+      const sy = (ty - top) * TILE_SIZE_PX;
       if (sx < -TILE_SIZE_PX || sx > canvasW || sy < -TILE_SIZE_PX || sy > canvasH) continue;
       const framesAgo = undergoundGlowFrames
-        ? (currentFrame - (undergoundGlowFrames.get(key) ?? currentFrame))
+        ? currentFrame - (undergoundGlowFrames.get(key) ?? currentFrame)
         : 0;
       const alpha_g = BASE_ALPHA * (1 - framesAgo / GLOW_FADE_FRAMES);
       if (alpha_g <= 0) continue;
@@ -473,9 +480,9 @@ export function drawUndergroundEntities(
       gfx.fillStyle(glowColor, alpha_g);
       gfx.fillRect(sx + 2, sy + 2, TILE_SIZE_PX - 4, TILE_SIZE_PX - 4);
       gfx.fillStyle(glowColor, alpha_g * 0.5);
-      gfx.fillRect(sx,      sy,      TILE_SIZE_PX, 2);
-      gfx.fillRect(sx,      sy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2);
-      gfx.fillRect(sx,      sy + 2,  2, TILE_SIZE_PX - 4);
+      gfx.fillRect(sx, sy, TILE_SIZE_PX, 2);
+      gfx.fillRect(sx, sy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2);
+      gfx.fillRect(sx, sy + 2, 2, TILE_SIZE_PX - 4);
       gfx.fillRect(sx + TILE_SIZE_PX - 2, sy + 2, 2, TILE_SIZE_PX - 4);
     }
     // Prune stale entries.
@@ -489,7 +496,7 @@ export function drawUndergroundEntities(
   const broodIds = new Set<number>();
   for (const c of Object.values(curr.colonies)) {
     if (c === undefined) continue;
-    for (let i = 0; i < c.eggs.length;   i++) broodIds.add(c.eggs[i]!);
+    for (let i = 0; i < c.eggs.length; i++) broodIds.add(c.eggs[i]!);
     for (let i = 0; i < c.larvae.length; i++) broodIds.add(c.larvae[i]!);
   }
   const maxId = curr.ants.alive.length;
@@ -513,10 +520,16 @@ export function drawUndergroundEntities(
     const baseX = useInterp ? prevPxX + (currPxX - prevPxX) * alpha : currPxX;
     const baseY = useInterp ? prevPxY + (currPxY - prevPxY) * alpha : currPxY;
     const screenX = baseX - left * TILE_SIZE_PX;
-    const screenY = baseY - top  * TILE_SIZE_PX;
+    const screenY = baseY - top * TILE_SIZE_PX;
 
     // Trivial viewport cull
-    if (screenX < -TILE_SIZE_PX || screenX > canvasW || screenY < -TILE_SIZE_PX || screenY > canvasH) continue;
+    if (
+      screenX < -TILE_SIZE_PX ||
+      screenX > canvasW ||
+      screenY < -TILE_SIZE_PX ||
+      screenY > canvasH
+    )
+      continue;
 
     // Facing: rotate the SVG (head on -x natively) toward the motion vector.
     // Smoothing is applied by the AntFacingCache when one is supplied — the
@@ -563,8 +576,28 @@ export function drawUndergroundEntities(
   // from the brood entity positions exactly — the sim's nurses have already
   // moved them into the nursery footprint, so rendering at the entity's
   // current tile is what places them inside the chamber visually.
-  drawBrood(sprites, curr, colony.eggs, 'egg', left, top, canvasW, canvasH, activeUndergroundColonyId);
-  drawBrood(sprites, curr, colony.larvae, 'larva', left, top, canvasW, canvasH, activeUndergroundColonyId);
+  drawBrood(
+    sprites,
+    curr,
+    colony.eggs,
+    'egg',
+    left,
+    top,
+    canvasW,
+    canvasH,
+    activeUndergroundColonyId,
+  );
+  drawBrood(
+    sprites,
+    curr,
+    colony.larvae,
+    'larva',
+    left,
+    top,
+    canvasW,
+    canvasH,
+    activeUndergroundColonyId,
+  );
 }
 
 /**
@@ -601,8 +634,14 @@ function drawBrood(
     const tileX = ants.posX[id]! >> FP_SHIFT;
     const tileY = ants.posY[id]! >> FP_SHIFT;
     const screenX = (tileX - left) * TILE_SIZE_PX;
-    const screenY = (tileY - top)  * TILE_SIZE_PX;
-    if (screenX < -TILE_SIZE_PX || screenX > canvasW || screenY < -TILE_SIZE_PX || screenY > canvasH) continue;
+    const screenY = (tileY - top) * TILE_SIZE_PX;
+    if (
+      screenX < -TILE_SIZE_PX ||
+      screenX > canvasW ||
+      screenY < -TILE_SIZE_PX ||
+      screenY > canvasH
+    )
+      continue;
     // Visible-carry offset: when this brood is on a carrier's tile and
     // the carrier is alive, lift it ~1/4 tile so it visually sits
     // above the carrier instead of being hidden under the ant sprite.

--- a/src/render/game-scene-logic.ts
+++ b/src/render/game-scene-logic.ts
@@ -17,7 +17,7 @@ export const GamePhase = {
   GameOver: 2,
   SavePrompt: 3,
 } as const;
-export type GamePhase = typeof GamePhase[keyof typeof GamePhase];
+export type GamePhase = (typeof GamePhase)[keyof typeof GamePhase];
 
 // ---------------------------------------------------------------------------
 // decideBootMode — pure boot-path decider

--- a/src/render/game-scene.test.ts
+++ b/src/render/game-scene.test.ts
@@ -24,10 +24,7 @@ import {
   toggleView,
   UNDERGROUND_INITIAL_CAMERA_Y,
 } from './camera.js';
-import {
-  resetSurfaceInputState,
-  type SurfaceInputState,
-} from '../input/surface-input.js';
+import { resetSurfaceInputState, type SurfaceInputState } from '../input/surface-input.js';
 import {
   resetUndergroundInputState,
   type UndergroundInputState,
@@ -38,10 +35,7 @@ import {
   resetDragState,
   type DragState,
 } from '../input/camera-input.js';
-import {
-  contextMenuState,
-  hideContextMenu,
-} from './context-menu-state.js';
+import { contextMenuState, hideContextMenu } from './context-menu-state.js';
 import { PLAYER_START_X, PLAYER_START_Y } from '../sim/constants.js';
 import type { WorldState } from '../sim/types.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
@@ -52,15 +46,31 @@ import type { SimCommand } from '../sim/commands.js';
 // ---------------------------------------------------------------------------
 
 /** Build a minimal WorldState-like object with a given colonies plain object. */
-function makeWorldWithColonies(
-  coloniesObj: Record<number, object>,
-): WorldState {
+function makeWorldWithColonies(coloniesObj: Record<number, object>): WorldState {
   return {
     tick: 0,
     rngState: 0,
     nextEntityId: 0,
     commandQueue: [],
-    ants: { posX: new Int32Array(0), posY: new Int32Array(0), colonyId: new Int32Array(0), task: new Int32Array(0), subTask: new Int32Array(0), speed: new Int32Array(0), foodCarrying: new Int32Array(0), starvationTimer: new Int32Array(0), age: new Int32Array(0), alive: new Int32Array(0), lifespan: new Int32Array(0), zone: new Int32Array(0), digTileX: new Int32Array(0), digTileY: new Int32Array(0), digTicksRemaining: new Int32Array(0), targetPosX: new Int32Array(0), targetPosY: new Int32Array(0) },
+    ants: {
+      posX: new Int32Array(0),
+      posY: new Int32Array(0),
+      colonyId: new Int32Array(0),
+      task: new Int32Array(0),
+      subTask: new Int32Array(0),
+      speed: new Int32Array(0),
+      foodCarrying: new Int32Array(0),
+      starvationTimer: new Int32Array(0),
+      age: new Int32Array(0),
+      alive: new Int32Array(0),
+      lifespan: new Int32Array(0),
+      zone: new Int32Array(0),
+      digTileX: new Int32Array(0),
+      digTileY: new Int32Array(0),
+      digTicksRemaining: new Int32Array(0),
+      targetPosX: new Int32Array(0),
+      targetPosY: new Int32Array(0),
+    },
     colonies: coloniesObj as WorldState['colonies'],
     pheromoneGrids: {},
     surface: { data: new Uint8Array(0), width: 0, height: 0 },

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -30,16 +30,22 @@ import { createScenario } from '../sim/scenario.js';
 import { copyWorldState, type WorldState } from '../sim/types.js';
 import { tick, resetFlowFieldCaches } from '../sim/tick.js';
 import { createGameLoop, type GameLoop, MS_PER_TICK } from '../platform/game-loop.js';
-import { hasSave, hasIncompatibleSave, loadSave, deleteSave, tickAutosave, FutureSimVersionError, OldSimVersionError, manualSave } from '../platform/save.js';
+import {
+  hasSave,
+  hasIncompatibleSave,
+  loadSave,
+  deleteSave,
+  tickAutosave,
+  FutureSimVersionError,
+  OldSimVersionError,
+  manualSave,
+} from '../platform/save.js';
 import { deserializeWorldState } from '../platform/save.js';
 import { loadSettings, saveSettings } from '../platform/settings.js';
 import { runAIController, resetAIControllerCache } from './ai-controller.js';
 import { buildDebugSnapshot } from '../platform/debug-snapshot.js';
 import { downloadDebugSnapshot } from './debug-snapshot-download.js';
-import {
-  submitPlaytrace,
-  type PlaytraceSurvey,
-} from './playtrace-upload.js';
+import { submitPlaytrace, type PlaytraceSurvey } from './playtrace-upload.js';
 import {
   GamePhase,
   deriveAIColonyIds,
@@ -58,9 +64,12 @@ import {
 } from './camera.js';
 import {
   PLAYER_COLONY_ID,
-  PLAYER_START_X, PLAYER_START_Y,
-  SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT,
-  UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT,
+  PLAYER_START_X,
+  PLAYER_START_Y,
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
+  UNDERGROUND_GRID_WIDTH,
+  UNDERGROUND_GRID_HEIGHT,
   STARVATION_GRACE_TICKS,
 } from '../sim/constants.js';
 import { GameOutcome } from '../sim/game-over.js';
@@ -136,7 +145,12 @@ import { CANVAS_W, CANVAS_H } from './sprites.js';
 // UIScenePhase9 — subset of UIScene public API added in Plan 06 Task 3.
 // Typed here to avoid circular imports; UIScene implements these methods.
 interface UIScenePhase9 {
-  showGameOverOverlay(outcome: GameOutcome, cause: import('./ui-scene-logic.js').QueenDeathCause, onRestart: () => void, narrativeSeed?: string | null): void;
+  showGameOverOverlay(
+    outcome: GameOutcome,
+    cause: import('./ui-scene-logic.js').QueenDeathCause,
+    onRestart: () => void,
+    narrativeSeed?: string | null,
+  ): void;
   hideGameOverOverlay(): void;
   showSavePromptOverlay(callbacks: { onContinue: () => void; onNewGame: () => void }): void;
   hideSavePromptOverlay(): void;
@@ -174,7 +188,9 @@ interface UIScenePhase9 {
   }): void;
   hideSurveyOverlay(): void;
   // S5 — difficulty select overlay. Shown before every new game.
-  showDifficultySelectOverlay(callbacks: { onSelect: (d: 'Easy' | 'Normal' | 'Hard') => void }): void;
+  showDifficultySelectOverlay(callbacks: {
+    onSelect: (d: 'Easy' | 'Normal' | 'Hard') => void;
+  }): void;
   hideDifficultySelectOverlay(): void;
   // S6 — first-occurrence caption overlay (light onboarding).
   showCaption(text: string, screenX: number, screenY: number): void;
@@ -203,7 +219,12 @@ export class GameScene extends Phaser.Scene {
   // so a recycled ant id never inherits a stale heading across sessions.
   private readonly antFacingCache: AntFacingCache = new AntFacingCache();
   private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
-  private wasd!: { W: Phaser.Input.Keyboard.Key; A: Phaser.Input.Keyboard.Key; S: Phaser.Input.Keyboard.Key; D: Phaser.Input.Keyboard.Key };
+  private wasd!: {
+    W: Phaser.Input.Keyboard.Key;
+    A: Phaser.Input.Keyboard.Key;
+    S: Phaser.Input.Keyboard.Key;
+    D: Phaser.Input.Keyboard.Key;
+  };
   private tabKey!: Phaser.Input.Keyboard.Key;
   private dragState!: { isDragging: boolean; lastX: number; lastY: number; active: boolean };
   private surfaceInputState!: SurfaceInputState;
@@ -237,11 +258,11 @@ export class GameScene extends Phaser.Scene {
   private speedMultiplier: 1 | 2 | 4 = 1;
 
   // S6 — render-side scratch (per-session, reset in resetSessionState).
-  private lastProcessedEventTick = -1;  // tick-based cursor for consumeEventsForRender
+  private lastProcessedEventTick = -1; // tick-based cursor for consumeEventsForRender
   private prevQueenCombinedHp: number | null = null; // queen HP tracking for damage pulse
-  private queenStarvationTriggered = false;           // starvation onset caption/pulse guard
-  private renderFrame = 0;              // frame counter for glow fade maps
-  private readonly contestedGlowFrames: Map<number, number> = new Map();  // surface glow fade
+  private queenStarvationTriggered = false; // starvation onset caption/pulse guard
+  private renderFrame = 0; // frame counter for glow fade maps
+  private readonly contestedGlowFrames: Map<number, number> = new Map(); // surface glow fade
   private readonly undergroundGlowFrames: Map<number, number> = new Map(); // underground glow fade
 
   // Issue #122 / ADR 0013 — playtrace upload state. The endpoint string is
@@ -252,7 +273,9 @@ export class GameScene extends Phaser.Scene {
   private playtraceEndpoint: string = '';
   private playtraceSessionId: string = '';
 
-  constructor() { super({ key: 'GameScene' }); }
+  constructor() {
+    super({ key: 'GameScene' });
+  }
 
   preload() {
     // Load ant SVG sprites. Phaser rasterizes at the given width/height; the
@@ -267,27 +290,33 @@ export class GameScene extends Phaser.Scene {
     if (typeof assetsBaseRaw !== 'string' || assetsBaseRaw.length === 0) {
       throw new Error(
         'GameScene.preload: assetsBase registry value missing or invalid. ' +
-        'GameScene must be mounted via main.ts mount() (sets the registry in callbacks.preBoot).',
+          'GameScene must be mounted via main.ts mount() (sets the registry in callbacks.preBoot).',
       );
     }
     const spriteBase = `${assetsBaseRaw}sprites/`;
     this.load.svg(ANT_TEXTURE_WORKER, `${spriteBase}worker-ant.svg`, {
-      width: WORKER_SPRITE_WIDTH, height: WORKER_SPRITE_HEIGHT,
+      width: WORKER_SPRITE_WIDTH,
+      height: WORKER_SPRITE_HEIGHT,
     });
     this.load.svg(ANT_TEXTURE_QUEEN, `${spriteBase}queen-ant.svg`, {
-      width: QUEEN_SPRITE_WIDTH, height: QUEEN_SPRITE_HEIGHT,
+      width: QUEEN_SPRITE_WIDTH,
+      height: QUEEN_SPRITE_HEIGHT,
     });
     this.load.svg(EGG_TEXTURE, `${spriteBase}egg.svg`, {
-      width: EGG_SPRITE_WIDTH, height: EGG_SPRITE_HEIGHT,
+      width: EGG_SPRITE_WIDTH,
+      height: EGG_SPRITE_HEIGHT,
     });
     this.load.svg(LARVA_TEXTURE, `${spriteBase}larva.svg`, {
-      width: LARVA_SPRITE_WIDTH, height: LARVA_SPRITE_HEIGHT,
+      width: LARVA_SPRITE_WIDTH,
+      height: LARVA_SPRITE_HEIGHT,
     });
     this.load.svg(FOOD_CACHE_TEXTURE, `${spriteBase}food-cache.svg`, {
-      width: FOOD_CACHE_SPRITE_WIDTH, height: FOOD_CACHE_SPRITE_HEIGHT,
+      width: FOOD_CACHE_SPRITE_WIDTH,
+      height: FOOD_CACHE_SPRITE_HEIGHT,
     });
     this.load.svg(SPIDER_TEXTURE, `${spriteBase}spider.svg`, {
-      width: SPIDER_SPRITE_WIDTH, height: SPIDER_SPRITE_HEIGHT,
+      width: SPIDER_SPRITE_WIDTH,
+      height: SPIDER_SPRITE_HEIGHT,
     });
   }
 
@@ -317,7 +346,11 @@ export class GameScene extends Phaser.Scene {
     this.input.mouse!.disableContextMenu();
 
     // Drag-pan registration — returns dragState ref for processCameraInput
-    this.dragState = registerDragPan(this, this.viewState, () => this.gamePhase === GamePhase.GameOver);
+    this.dragState = registerDragPan(
+      this,
+      this.viewState,
+      () => this.gamePhase === GamePhase.GameOver,
+    );
 
     // Issue #116 — Esc opens the pause menu overlay (which also pauses the
     // sim). The Esc keybinding itself lives in UIScene (which already owned
@@ -405,7 +438,7 @@ export class GameScene extends Phaser.Scene {
     // restart. Capturing the current (undefined) reference here would freeze
     // the HUD + world input against a pre-boot world (see Phase 9 stabilization).
     const getWorld = (): WorldState | undefined => this.world;
-    const getPrevWorld = (): WorldState | null => this.world ? this.prevState : null;
+    const getPrevWorld = (): WorldState | null => (this.world ? this.prevState : null);
 
     // Launch HUD scene on top.
     this.scene.launch('UIScene', {
@@ -531,9 +564,7 @@ export class GameScene extends Phaser.Scene {
     // The single-in-flight discipline is instead enforced inside
     // submitPlaytrace itself — each new submission cancels its predecessor.
     this.playtraceSessionId =
-      typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID()
-        : '';
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : '';
   }
 
   // ---------------------------------------------------------------------------
@@ -573,12 +604,15 @@ export class GameScene extends Phaser.Scene {
       if (ev.type === 'invasion_start') {
         // Screen-edge flash in the direction of the invasion entrance.
         const playerColony = this.world.colonies[PLAYER_COLONY_ID];
-        const queenChamber = playerColony?.chambers.find(ch => ch.chamberType === ChamberType.Queen);
+        const queenChamber = playerColony?.chambers.find(
+          (ch) => ch.chamberType === ChamberType.Queen,
+        );
         if (queenChamber) {
           const queenTileX = queenChamber.posX >> 8;
           const queenTileY = queenChamber.posY >> 8;
           const direction = inferFlashDirection(
-            queenTileX, queenTileY,
+            queenTileX,
+            queenTileY,
             ev.payload.rallyTile?.x ?? queenTileX,
             ev.payload.rallyTile?.y ?? queenTileY,
           );
@@ -769,7 +803,8 @@ export class GameScene extends Phaser.Scene {
     // screen flashes / captions for invasions that already happened.
     if (nextWorld.events.length > 0) {
       this.lastProcessedEventTick = nextWorld.events.reduce(
-        (m, e) => (e.tick > m ? e.tick : m), -1,
+        (m, e) => (e.tick > m ? e.tick : m),
+        -1,
       );
     }
     // If the queen's starvation timer was already running at save time, mark the
@@ -777,8 +812,7 @@ export class GameScene extends Phaser.Scene {
     // not fire a spurious flash + onboarding caption for a condition that already
     // started before the save.
     const playerColonyOnLoad = nextWorld.colonies[PLAYER_COLONY_ID];
-    if (playerColonyOnLoad &&
-        playerColonyOnLoad.queenStarvationTimer < STARVATION_GRACE_TICKS) {
+    if (playerColonyOnLoad && playerColonyOnLoad.queenStarvationTimer < STARVATION_GRACE_TICKS) {
       this.queenStarvationTriggered = true;
     }
     // SCEN-06 replay truth: restore inputLog completely so the continued session
@@ -822,7 +856,8 @@ export class GameScene extends Phaser.Scene {
               [ChamberType.Nursery]: 'Nursery',
               [ChamberType.FoodStorage]: 'Food Storage',
             };
-            const chamberTypeName = chamberTypeLabel[cmd.chamberType] ?? `chamber type ${cmd.chamberType}`;
+            const chamberTypeName =
+              chamberTypeLabel[cmd.chamberType] ?? `chamber type ${cmd.chamberType}`;
             const text = checkAndTrigger('chamber', chamberTypeName);
             if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);
           } else if (cmd.type === 'MarkFoodPile') {
@@ -856,16 +891,22 @@ export class GameScene extends Phaser.Scene {
         let cause: import('./ui-scene-logic.js').QueenDeathCause = null;
         for (let i = 0; i < evts.length; i++) {
           const ev = evts[i];
-          if (ev && ev.type === 'queen_death' && ev.tick === deathTick) { cause = ev.payload.cause; break; }
+          if (ev && ev.type === 'queen_death' && ev.tick === deathTick) {
+            cause = ev.payload.cause;
+            break;
+          }
         }
         this.currentCause = cause;
 
         // S6: build narrative for the loss screen.
         const outcomeLabel: GameOutcomeLabel | undefined =
-          outcome === GameOutcome.Victory          ? 'Victory'
-          : outcome === GameOutcome.Defeat         ? 'Defeat'
-          : outcome === GameOutcome.MutualDestruction ? 'MutualDestruction'
-          : undefined;
+          outcome === GameOutcome.Victory
+            ? 'Victory'
+            : outcome === GameOutcome.Defeat
+              ? 'Defeat'
+              : outcome === GameOutcome.MutualDestruction
+                ? 'MutualDestruction'
+                : undefined;
         const summary = buildPlaytraceSummary(this.world, this.resumedFromSave, outcomeLabel);
         const narrativeSeed = summary.outcomeAttribution.narrativeSeed;
 
@@ -885,7 +926,7 @@ export class GameScene extends Phaser.Scene {
     });
 
     this.gamePhase = GamePhase.Playing;
-    this.gameLoop.resume();  // ensure running (createGameLoop default is not paused)
+    this.gameLoop.resume(); // ensure running (createGameLoop default is not paused)
     this.lastAutosaveMs = performance.now();
     // UIScene and world-input handlers resolve `this.world` lazily via the
     // getWorld accessor installed in create(), so the new reference is picked
@@ -930,7 +971,9 @@ export class GameScene extends Phaser.Scene {
       // The shortcuts are Playing-only-gated; the menu surface gives the
       // same control a discoverable home while paused.
       getSpeedMultiplier: () => this.speedMultiplier,
-      onCycleSpeed: (next: 1 | 2 | 4) => { this.speedMultiplier = next; },
+      onCycleSpeed: (next: 1 | 2 | 4) => {
+        this.speedMultiplier = next;
+      },
     };
     // Issue #122 — only attach onQuitAndSurvey when the feature flag is on.
     // The pause menu treats `undefined` as "hide the row" so an open-source
@@ -1195,9 +1238,14 @@ export class GameScene extends Phaser.Scene {
       });
     }
 
-    const cam = this.viewState.activeView === 'surface' ? this.viewState.surfaceCamera : this.viewState.undergroundCamera;
-    const worldW = this.viewState.activeView === 'surface' ? SURFACE_GRID_WIDTH : UNDERGROUND_GRID_WIDTH;
-    const worldH = this.viewState.activeView === 'surface' ? SURFACE_GRID_HEIGHT : UNDERGROUND_GRID_HEIGHT;
+    const cam =
+      this.viewState.activeView === 'surface'
+        ? this.viewState.surfaceCamera
+        : this.viewState.undergroundCamera;
+    const worldW =
+      this.viewState.activeView === 'surface' ? SURFACE_GRID_WIDTH : UNDERGROUND_GRID_WIDTH;
+    const worldH =
+      this.viewState.activeView === 'surface' ? SURFACE_GRID_HEIGHT : UNDERGROUND_GRID_HEIGHT;
     clampCamera(cam, worldW, worldH);
 
     // S6: advance render frame counter and drain events for render effects.
@@ -1252,10 +1300,10 @@ export class GameScene extends Phaser.Scene {
         cam,
         pending,
         this.antFacingCache,
-        this.time.now,          // S6: frameTimeMs for reticle/hunger pulse
+        this.time.now, // S6: frameTimeMs for reticle/hunger pulse
         this.contestedGlowFrames, // S6: surface glow fade map
-        this.renderFrame,       // S6: current render frame
-        overlayGfx,             // #148: health bar renders above sprites
+        this.renderFrame, // S6: current render frame
+        overlayGfx, // #148: health bar renders above sprites
       );
     } else {
       drawUndergroundTerrain(gfx, this.world, cam, this.viewState.activeUndergroundColonyId);
@@ -1272,7 +1320,7 @@ export class GameScene extends Phaser.Scene {
         this.viewState.activeUndergroundColonyId,
         this.antFacingCache,
         this.undergroundGlowFrames, // S6: underground glow fade map
-        this.renderFrame,           // S6: current render frame
+        this.renderFrame, // S6: current render frame
       );
     }
     this.antSprites.endFrame();
@@ -1293,6 +1341,10 @@ export class GameScene extends Phaser.Scene {
   }
 
   /** Accessor for UIScene / Plan 05 / Plan 06 — safe read-only reference. */
-  getWorld(): WorldState { return this.world; }
-  getViewState(): ViewState { return this.viewState; }
+  getWorld(): WorldState {
+    return this.world;
+  }
+  getViewState(): ViewState {
+    return this.viewState;
+  }
 }

--- a/src/render/hud-stats.test.ts
+++ b/src/render/hud-stats.test.ts
@@ -45,11 +45,11 @@ function setupWorld(): { world: WorldState; colony: ColonyRecord; queenId: numbe
 
 function makeStats(overrides: Partial<HudStats> = {}): HudStats {
   return {
-    antCount:       1,
-    foodDisplay:    0,
-    foodCapacity:   BASE_FOOD_STORAGE_CAPACITY >> FP_SHIFT,
+    antCount: 1,
+    foodDisplay: 0,
+    foodCapacity: BASE_FOOD_STORAGE_CAPACITY >> FP_SHIFT,
     queenHealthPct: 100,
-    queenAlive:     true,
+    queenAlive: true,
     ...overrides,
   };
 }
@@ -61,7 +61,7 @@ describe('computeHudStats', () => {
     // many workers were available to forage/dig.
     const { world, colony } = setupWorld();
     colony.workerCount = 5;
-    colony.eggCount    = 3;
+    colony.eggCount = 3;
     colony.larvaeCount = 2;
     const s = computeHudStats(world, colony);
     expect(s.antCount).toBe(5 + 1);
@@ -71,7 +71,7 @@ describe('computeHudStats', () => {
   it('antCount excludes the queen when queen dead (and still excludes brood)', () => {
     const { world, colony, queenId } = setupWorld();
     colony.workerCount = 4;
-    colony.eggCount    = 1;
+    colony.eggCount = 1;
     colony.larvaeCount = 0;
     killAnt(world.ants, queenId);
     const s = computeHudStats(world, colony);
@@ -100,12 +100,22 @@ describe('computeHudStats', () => {
     // Two completed FoodStorage chambers → capacity = BASE + 2 × CHAMBER.
     // Matches colonyFoodCapacity source-of-truth (sim/colony/colony-system).
     colony.chambers.push({
-      chamberId: 9001, chamberType: ChamberType.FoodStorage,
-      foodStored: 0, posX: 0, posY: 0, width: 3, height: 3,
+      chamberId: 9001,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 0,
+      posX: 0,
+      posY: 0,
+      width: 3,
+      height: 3,
     });
     colony.chambers.push({
-      chamberId: 9002, chamberType: ChamberType.FoodStorage,
-      foodStored: 0, posX: 10, posY: 10, width: 3, height: 3,
+      chamberId: 9002,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 0,
+      posX: 10,
+      posY: 10,
+      width: 3,
+      height: 3,
     });
     const s = computeHudStats(world, colony);
     const expected = (BASE_FOOD_STORAGE_CAPACITY + 2 * FOOD_CHAMBER_CAPACITY) >> FP_SHIFT;
@@ -155,20 +165,17 @@ describe('label formatters', () => {
     // 09 HUD clarity pass: food label is now "Food: C/M" so players can
     // see headroom at a glance. At base capacity with nothing stored:
     // "Food: 0/8" (BASE_FOOD_STORAGE_CAPACITY = 2048fp → 8 human units).
-    expect(formatFoodLabel(makeStats({ foodDisplay: 0, foodCapacity: 8 })))
-      .toBe('Food: 0/8');
-    expect(formatFoodLabel(makeStats({ foodDisplay: 8, foodCapacity: 8 })))
-      .toBe('Food: 8/8');
+    expect(formatFoodLabel(makeStats({ foodDisplay: 0, foodCapacity: 8 }))).toBe('Food: 0/8');
+    expect(formatFoodLabel(makeStats({ foodDisplay: 8, foodCapacity: 8 }))).toBe('Food: 8/8');
     // One FoodStorage chamber added: base 8 + chamber 20 = capacity 28.
-    expect(formatFoodLabel(makeStats({ foodDisplay: 8, foodCapacity: 28 })))
-      .toBe('Food: 8/28');
-    expect(formatFoodLabel(makeStats({ foodDisplay: 48, foodCapacity: 48 })))
-      .toBe('Food: 48/48');
+    expect(formatFoodLabel(makeStats({ foodDisplay: 8, foodCapacity: 28 }))).toBe('Food: 8/28');
+    expect(formatFoodLabel(makeStats({ foodDisplay: 48, foodCapacity: 48 }))).toBe('Food: 48/48');
   });
 
   it('formatStatsPrefix combines both with two-space separator', () => {
-    expect(formatStatsPrefix(makeStats({ antCount: 11, foodDisplay: 4, foodCapacity: 8 })))
-      .toBe('Ants: 11  Food: 4/8');
+    expect(formatStatsPrefix(makeStats({ antCount: 11, foodDisplay: 4, foodCapacity: 8 }))).toBe(
+      'Ants: 11  Food: 4/8',
+    );
   });
 
   it('formatQueenLabel returns the readable "Queen" word, not a single char', () => {
@@ -184,8 +191,7 @@ describe('label formatters', () => {
 
 describe('queenHealthState (PRD §6c thresholds)', () => {
   it('returns "dead" when queen is dead regardless of pct', () => {
-    expect(queenHealthState(makeStats({ queenAlive: false, queenHealthPct: 100 })))
-      .toBe('dead');
+    expect(queenHealthState(makeStats({ queenAlive: false, queenHealthPct: 100 }))).toBe('dead');
   });
 
   it('returns "healthy" when pct > 50', () => {
@@ -207,32 +213,39 @@ describe('queenHealthState (PRD §6c thresholds)', () => {
 
 describe('queenHealthBarColor', () => {
   it('maps each health state to its PRD color', () => {
-    expect(queenHealthBarColor(makeStats({ queenHealthPct: 100 })))
-      .toBe(HUD_STATS_COLORS.barHealthy);
-    expect(queenHealthBarColor(makeStats({ queenHealthPct: 40 })))
-      .toBe(HUD_STATS_COLORS.barModerate);
-    expect(queenHealthBarColor(makeStats({ queenHealthPct: 10 })))
-      .toBe(HUD_STATS_COLORS.barCritical);
-    expect(queenHealthBarColor(makeStats({ queenAlive: false })))
-      .toBe(HUD_STATS_COLORS.barCritical);
+    expect(queenHealthBarColor(makeStats({ queenHealthPct: 100 }))).toBe(
+      HUD_STATS_COLORS.barHealthy,
+    );
+    expect(queenHealthBarColor(makeStats({ queenHealthPct: 40 }))).toBe(
+      HUD_STATS_COLORS.barModerate,
+    );
+    expect(queenHealthBarColor(makeStats({ queenHealthPct: 10 }))).toBe(
+      HUD_STATS_COLORS.barCritical,
+    );
+    expect(queenHealthBarColor(makeStats({ queenAlive: false }))).toBe(
+      HUD_STATS_COLORS.barCritical,
+    );
   });
 });
 
 describe('queenHealthBarFillWidth', () => {
   it('scales proportionally to pct', () => {
     expect(queenHealthBarFillWidth(makeStats({ queenHealthPct: 100 }), 48)).toBe(48);
-    expect(queenHealthBarFillWidth(makeStats({ queenHealthPct: 50 }),  48)).toBe(24);
-    expect(queenHealthBarFillWidth(makeStats({ queenHealthPct: 25 }),  48)).toBe(12);
+    expect(queenHealthBarFillWidth(makeStats({ queenHealthPct: 50 }), 48)).toBe(24);
+    expect(queenHealthBarFillWidth(makeStats({ queenHealthPct: 25 }), 48)).toBe(12);
   });
 
   it('returns 0 when queen is dead', () => {
-    expect(queenHealthBarFillWidth(makeStats({ queenAlive: false, queenHealthPct: 99 }), 48))
-      .toBe(0);
+    expect(queenHealthBarFillWidth(makeStats({ queenAlive: false, queenHealthPct: 99 }), 48)).toBe(
+      0,
+    );
   });
 
   it('clamps within [0, totalW]', () => {
     expect(queenHealthBarFillWidth(makeStats({ queenHealthPct: 200 }), 48)).toBeLessThanOrEqual(48);
-    expect(queenHealthBarFillWidth(makeStats({ queenHealthPct: -10 }), 48)).toBeGreaterThanOrEqual(0);
+    expect(queenHealthBarFillWidth(makeStats({ queenHealthPct: -10 }), 48)).toBeGreaterThanOrEqual(
+      0,
+    );
   });
 });
 
@@ -265,7 +278,7 @@ describe('queenLabelRect (09 HUD clarity pass — two-row layout)', () => {
 
   it('label and queen bar on the same row do not overlap', () => {
     const stats = { x: 8, y: 8, w: 200, h: 24 };
-    const bar   = queenBarRect(stats);
+    const bar = queenBarRect(stats);
     const label = queenLabelRect(stats);
     // Label ends before bar starts — leaves visible spacing.
     expect(label.x + label.w).toBeLessThan(bar.x);
@@ -304,15 +317,15 @@ describe('two-row stats layout (09 HUD clarity pass)', () => {
 
   it('ants + food on row 1 stay disjoint at realistic colony sizes', () => {
     const antsX = stats.x + HUD_STATS_LAYOUT.leftTextInset;
-    const antsTextWidth = 60;  // "Ants: 999" ≈ 54px, leave headroom
-    const foodTextWidth = 72;  // "Food: 999/999" generous estimate
+    const antsTextWidth = 60; // "Ants: 999" ≈ 54px, leave headroom
+    const foodTextWidth = 72; // "Food: 999/999" generous estimate
     const foodX = stats.x + stats.w - FOOD_RIGHT_INSET - foodTextWidth;
     expect(antsX + antsTextWidth).toBeLessThanOrEqual(foodX);
   });
 
   it('queen label + bar on row 2 stay disjoint', () => {
     const label = queenLabelRect(stats);
-    const bar   = queenBarRect(stats);
+    const bar = queenBarRect(stats);
     expect(label.x + label.w).toBeLessThanOrEqual(bar.x);
   });
 

--- a/src/render/hud-stats.ts
+++ b/src/render/hud-stats.ts
@@ -39,25 +39,25 @@ import { STARVATION_GRACE_TICKS } from '../sim/constants.js';
 import { colonyFoodCapacity, colonyFoodTotal } from '../sim/colony/colony-system.js';
 
 export interface HudStats {
-  antCount:       number;
-  foodDisplay:    number;
-  foodCapacity:   number;
+  antCount: number;
+  foodDisplay: number;
+  foodCapacity: number;
   queenHealthPct: number;
-  queenAlive:     boolean;
+  queenAlive: boolean;
 }
 
 export type QueenHealthState = 'dead' | 'critical' | 'moderate' | 'healthy';
 
 export const HUD_STATS_COLORS = {
-  background:      0x000000,
+  background: 0x000000,
   backgroundAlpha: 0.6,
-  barTrack:        0x333333,
-  barHealthy:      0x22bb44,
-  barModerate:     0xddaa22,
-  barCritical:     0xcc3322,
-  antsTextCss:     '#ffffff',
-  foodTextCss:     '#22bb44',
-  queenLabelCss:   '#ffffff',
+  barTrack: 0x333333,
+  barHealthy: 0x22bb44,
+  barModerate: 0xddaa22,
+  barCritical: 0xcc3322,
+  antsTextCss: '#ffffff',
+  foodTextCss: '#22bb44',
+  queenLabelCss: '#ffffff',
 } as const;
 
 export const HUD_STATS_LAYOUT = {
@@ -65,42 +65,42 @@ export const HUD_STATS_LAYOUT = {
   // Ants+Food; row 2 carries the Queen label + health bar. yOffsets are
   // relative to HUD.STATS.y and chosen so the 10px Text widgets + the 6px
   // bar all sit inside the 24px rect.
-  row1YOffset: 1,  // canvas y = 9
+  row1YOffset: 1, // canvas y = 9
   row2YOffset: 13, // canvas y = 21
   leftTextInset: 4,
   queenBar: {
-    w:          48,
-    h:          6,
-    yOffset:    16, // canvas y = 24 → bar spans y=24..30 (inside rect)
+    w: 48,
+    h: 6,
+    yOffset: 16, // canvas y = 24 → bar spans y=24..30 (inside rect)
     rightInset: 6,
   },
   queenLabel: {
     // Restored to a readable "Queen" label (09 HUD clarity pass). The
     // single-char 'Q' was ambiguous enough that players couldn't tell which
     // stat the color-coded bar belonged to. Two-row layout makes space.
-    text:       'Queen',
-    w:          32, // 5 chars × ~6.4px monospace at 10px
-    yOffset:    13, // matches row 2
+    text: 'Queen',
+    w: 32, // 5 chars × ~6.4px monospace at 10px
+    yOffset: 13, // matches row 2
   },
 } as const;
 
 export function computeHudStats(world: WorldState, colony: ColonyRecord): HudStats {
-  const queenAlive  = isAlive(world.ants, colony.queenEntityId);
-  const queenBit    = queenAlive ? 1 : 0;
+  const queenAlive = isAlive(world.ants, colony.queenEntityId);
+  const queenBit = queenAlive ? 1 : 0;
   // Phase 9 fix: count capable ants only (workers + living queen). Eggs and
   // larvae are excluded because they cannot execute any task; folding them in
   // produced a "total headcount" the player read as "usable headcount".
-  const antCount     = colony.workerCount + queenBit;
+  const antCount = colony.workerCount + queenBit;
   // Issue #15: foodTotal sums the entrance pool (colony.foodStored) plus every
   // FoodStorage chamber's per-chamber foodStored — the HUD must show the
   // player the whole stash, not just the chamberless fallback bucket.
-  const foodDisplay  = colonyFoodTotal(colony) >> FP_SHIFT;
+  const foodDisplay = colonyFoodTotal(colony) >> FP_SHIFT;
   const foodCapacity = colonyFoodCapacity(colony) >> FP_SHIFT;
 
   let queenHealthPct = 0;
   if (queenAlive) {
     const raw = colony.queenStarvationTimer / STARVATION_GRACE_TICKS;
-    const t   = raw < 0 ? 0 : (raw > 1 ? 1 : raw);
+    const t = raw < 0 ? 0 : raw > 1 ? 1 : raw;
     queenHealthPct = Math.round(t * 100);
   }
 
@@ -116,32 +116,45 @@ export function formatFoodLabel(s: HudStats): string {
 }
 
 export function queenHealthState(s: HudStats): QueenHealthState {
-  if (!s.queenAlive)       return 'dead';
-  if (s.queenHealthPct > 50)  return 'healthy';
+  if (!s.queenAlive) return 'dead';
+  if (s.queenHealthPct > 50) return 'healthy';
   if (s.queenHealthPct >= 25) return 'moderate';
   return 'critical';
 }
 
 export function queenHealthBarColor(s: HudStats): number {
   switch (queenHealthState(s)) {
-    case 'healthy':  return HUD_STATS_COLORS.barHealthy;
-    case 'moderate': return HUD_STATS_COLORS.barModerate;
+    case 'healthy':
+      return HUD_STATS_COLORS.barHealthy;
+    case 'moderate':
+      return HUD_STATS_COLORS.barModerate;
     case 'dead':
-    case 'critical': return HUD_STATS_COLORS.barCritical;
+    case 'critical':
+      return HUD_STATS_COLORS.barCritical;
   }
 }
 
 export function queenHealthBarFillWidth(s: HudStats, totalW: number): number {
   if (!s.queenAlive) return 0;
   const w = Math.round((totalW * s.queenHealthPct) / 100);
-  if (w < 0)      return 0;
+  if (w < 0) return 0;
   if (w > totalW) return totalW;
   return w;
 }
 
-export interface QueenBarRect { x: number; y: number; w: number; h: number; }
+export interface QueenBarRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
 
-export function queenBarRect(statsRect: { x: number; y: number; w: number; h: number }): QueenBarRect {
+export function queenBarRect(statsRect: {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}): QueenBarRect {
   const { w, h, yOffset, rightInset } = HUD_STATS_LAYOUT.queenBar;
   return {
     x: statsRect.x + statsRect.w - rightInset - w,
@@ -151,7 +164,12 @@ export function queenBarRect(statsRect: { x: number; y: number; w: number; h: nu
   };
 }
 
-export interface QueenLabelRect { x: number; y: number; w: number; h: number; }
+export interface QueenLabelRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
 
 /**
  * queenLabelRect — placement for the "Queen" label on row 2 of the HUD stats
@@ -159,7 +177,12 @@ export interface QueenLabelRect { x: number; y: number; w: number; h: number; }
  * health bar is right-anchored on the same row, so the label and bar read
  * as a horizontal unit without needing to overlap the Food total on row 1.
  */
-export function queenLabelRect(statsRect: { x: number; y: number; w: number; h: number }): QueenLabelRect {
+export function queenLabelRect(statsRect: {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}): QueenLabelRect {
   const { w, yOffset } = HUD_STATS_LAYOUT.queenLabel;
   return {
     x: statsRect.x + HUD_STATS_LAYOUT.leftTextInset,

--- a/src/render/minimap.test.ts
+++ b/src/render/minimap.test.ts
@@ -23,21 +23,41 @@ import { SurfaceTileState, sgSet } from '../sim/terrain.js';
 // MockGfx — records calls, does not render anything
 // ---------------------------------------------------------------------------
 
-interface GfxCall { method: string; args: unknown[] }
+interface GfxCall {
+  method: string;
+  args: unknown[];
+}
 
 class MockGfx implements GfxLike {
   calls: GfxCall[] = [];
-  private rec(method: string, args: unknown[]): this { this.calls.push({ method, args }); return this; }
-  clear()                                                        { return this.rec('clear', []); }
-  fillStyle(c: number, a?: number)                               { return this.rec('fillStyle', [c, a]); }
-  lineStyle(w: number, c: number, a?: number)                    { return this.rec('lineStyle', [w, c, a]); }
-  fillRect(x: number, y: number, w: number, h: number)           { return this.rec('fillRect', [x, y, w, h]); }
-  fillCircle(x: number, y: number, r: number)                    { return this.rec('fillCircle', [x, y, r]); }
-  strokeCircle(x: number, y: number, r: number)                  { return this.rec('strokeCircle', [x, y, r]); }
+  private rec(method: string, args: unknown[]): this {
+    this.calls.push({ method, args });
+    return this;
+  }
+  clear() {
+    return this.rec('clear', []);
+  }
+  fillStyle(c: number, a?: number) {
+    return this.rec('fillStyle', [c, a]);
+  }
+  lineStyle(w: number, c: number, a?: number) {
+    return this.rec('lineStyle', [w, c, a]);
+  }
+  fillRect(x: number, y: number, w: number, h: number) {
+    return this.rec('fillRect', [x, y, w, h]);
+  }
+  fillCircle(x: number, y: number, r: number) {
+    return this.rec('fillCircle', [x, y, r]);
+  }
+  strokeCircle(x: number, y: number, r: number) {
+    return this.rec('strokeCircle', [x, y, r]);
+  }
   fillTriangle(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number) {
     return this.rec('fillTriangle', [x0, y0, x1, y1, x2, y2]);
   }
-  callsOf(method: string) { return this.calls.filter(c => c.method === method); }
+  callsOf(method: string) {
+    return this.calls.filter((c) => c.method === method);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -47,31 +67,33 @@ class MockGfx implements GfxLike {
 const stubAnts = {
   posX: new Int32Array(10),
   posY: new Int32Array(10),
-  alive:             new Int32Array(10),
-  task:              new Int32Array(10),
-  subTask:           new Int32Array(10),
-  colonyId:          new Int32Array(10),
-  speed:             new Int32Array(10),
-  foodCarrying:      new Int32Array(10),
-  starvationTimer:   new Int32Array(10),
-  age:               new Int32Array(10),
-  lifespan:          new Int32Array(10),
-  zone:              new Int32Array(10),
-  digTileX:          new Int32Array(10).fill(-1),
-  digTileY:          new Int32Array(10).fill(-1),
+  alive: new Int32Array(10),
+  task: new Int32Array(10),
+  subTask: new Int32Array(10),
+  colonyId: new Int32Array(10),
+  speed: new Int32Array(10),
+  foodCarrying: new Int32Array(10),
+  starvationTimer: new Int32Array(10),
+  age: new Int32Array(10),
+  lifespan: new Int32Array(10),
+  zone: new Int32Array(10),
+  digTileX: new Int32Array(10).fill(-1),
+  digTileY: new Int32Array(10).fill(-1),
   digTicksRemaining: new Int32Array(10),
-  targetPosX:        new Int32Array(10).fill(-1),
-  targetPosY:        new Int32Array(10).fill(-1),
+  targetPosX: new Int32Array(10).fill(-1),
+  targetPosY: new Int32Array(10).fill(-1),
 } as unknown as WorldState['ants'];
 
 const stubSurface = {
-  width: 128, height: 128,
+  width: 128,
+  height: 128,
   data: new Uint8Array(128 * 128),
 } as unknown as WorldState['surface'];
 
-function makeMinimalWorld(
-  overrides?: { foodPiles?: WorldState['foodPiles']; colonies?: WorldState['colonies'] },
-): WorldState {
+function makeMinimalWorld(overrides?: {
+  foodPiles?: WorldState['foodPiles'];
+  colonies?: WorldState['colonies'];
+}): WorldState {
   return {
     tick: 0,
     rngState: 0,
@@ -191,10 +213,18 @@ const stubColonies: WorldState['colonies'] = {
     // (WorkerAllocation per D-03).
     targetRatio: { forage: 100, fight: 0 },
     computedAllocation: { nurse: 0, forage: 0, dig: 0, fight: 0 },
-    eggCount: 0, larvaeCount: 0, nurseCount: 0,
-    eggs: [], larvae: [], workers: [], chambers: [],
-    defeated: false, reconcileCountdown: 0,
-    rallyPoint: null, digFlowFieldDirty: false, foodFlowFieldDirty: false,
+    eggCount: 0,
+    larvaeCount: 0,
+    nurseCount: 0,
+    eggs: [],
+    larvae: [],
+    workers: [],
+    chambers: [],
+    defeated: false,
+    reconcileCountdown: 0,
+    rallyPoint: null,
+    digFlowFieldDirty: false,
+    foodFlowFieldDirty: false,
     killCount: 0,
     priorityFoodPileId: null,
     queenLastEggTick: -300,
@@ -203,7 +233,13 @@ const stubColonies: WorldState['colonies'] = {
 };
 
 const stubFoodPiles: WorldState['foodPiles'] = [
-  { foodPileId: 1, tileX: 20, tileY: 30 , pickupsRemaining: 50, pickupsInitial: 50} as WorldState['foodPiles'][0],
+  {
+    foodPileId: 1,
+    tileX: 20,
+    tileY: 30,
+    pickupsRemaining: 50,
+    pickupsInitial: 50,
+  } as WorldState['foodPiles'][0],
 ];
 
 describe('drawMinimap smoke test', () => {
@@ -246,16 +282,16 @@ describe('drawMinimap smoke test', () => {
 
     const styles = gfx.callsOf('fillStyle');
     // No black background anywhere.
-    const hasBlack = styles.some(c => c.args[0] === 0x000000);
+    const hasBlack = styles.some((c) => c.args[0] === 0x000000);
     expect(hasBlack).toBe(false);
     // Issue #40 reframe: minimap base is barren-earth, not grass-green. The
     // surface terrain at large now reads as ant-scale ground, and the
     // minimap must mirror that so the player's mental model matches.
-    const hasEarth = styles.some(c => c.args[0] === COLOR_BARREN_EARTH);
+    const hasEarth = styles.some((c) => c.args[0] === COLOR_BARREN_EARTH);
     expect(hasEarth).toBe(true);
     // A darker dapple is sprinkled deterministically per tile — gives the
     // minimap a textured feel rather than a flat brown rectangle.
-    const hasDapple = styles.some(c => c.args[0] === COLOR_BARREN_EARTH_DARK);
+    const hasDapple = styles.some((c) => c.args[0] === COLOR_BARREN_EARTH_DARK);
     expect(hasDapple).toBe(true);
 
     // Cleanup so other tests see a clean surface

--- a/src/render/minimap.ts
+++ b/src/render/minimap.ts
@@ -9,17 +9,16 @@
 //   applyMinimapClick(viewState, px, py) — pan surface camera + X-link underground camera
 //   MINIMAP_SCALE_X, MINIMAP_SCALE_Y — pixel-to-tile scale factors
 
+import { HUD, COLOR_PLAYER_COLONY, COLOR_ENEMY_COLONY, COLOR_FOOD_PILE_NORMAL } from './sprites.js';
+import { COLOR_BARREN_EARTH, COLOR_BARREN_EARTH_DARK } from './terrain-atlas.js';
 import {
-  HUD,
-  COLOR_PLAYER_COLONY,
-  COLOR_ENEMY_COLONY,
-  COLOR_FOOD_PILE_NORMAL,
-} from './sprites.js';
-import {
-  COLOR_BARREN_EARTH,
-  COLOR_BARREN_EARTH_DARK,
-} from './terrain-atlas.js';
-import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT, UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT, PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
+  UNDERGROUND_GRID_WIDTH,
+  UNDERGROUND_GRID_HEIGHT,
+  PLAYER_COLONY_ID,
+  ENEMY_COLONY_ID,
+} from '../sim/constants.js';
 import { FP_SHIFT } from '../sim/fixed.js';
 import { isAlive } from '../sim/ant/ant-store.js';
 import { sgGet } from '../sim/terrain.js';
@@ -29,8 +28,8 @@ import type { ViewState } from './camera.js';
 import { clampCamera } from './camera.js';
 import type { GfxLike } from './draw-surface.js';
 
-export const MINIMAP_SCALE_X = HUD.MINIMAP.w / SURFACE_GRID_WIDTH;   // 160 / 128 = 1.25
-export const MINIMAP_SCALE_Y = HUD.MINIMAP.h / SURFACE_GRID_HEIGHT;  // 1.25
+export const MINIMAP_SCALE_X = HUD.MINIMAP.w / SURFACE_GRID_WIDTH; // 160 / 128 = 1.25
+export const MINIMAP_SCALE_Y = HUD.MINIMAP.h / SURFACE_GRID_HEIGHT; // 1.25
 
 // Issue #76 — memorial marker color/size for fully-dead colonies (queen
 // dead AND no live entrances). Distinct dark gray (not a darkened
@@ -100,9 +99,12 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
   for (const colonyIdStr of Object.keys(world.colonies)) {
     const colonyId = Number(colonyIdStr);
     const colony = world.colonies[colonyId]!;
-    const liveColor = colonyId === PLAYER_COLONY_ID ? COLOR_PLAYER_COLONY
-                    : colonyId === ENEMY_COLONY_ID  ? COLOR_ENEMY_COLONY
-                    : COLOR_PLAYER_COLONY;
+    const liveColor =
+      colonyId === PLAYER_COLONY_ID
+        ? COLOR_PLAYER_COLONY
+        : colonyId === ENEMY_COLONY_ID
+          ? COLOR_ENEMY_COLONY
+          : COLOR_PLAYER_COLONY;
     // Per #76 design: a 'live foothold' is an OPEN entrance (workers can
     // actively transition zones through it). Merely-designated closed
     // entrances are pre-excavation intent — show as live only if the
@@ -111,7 +113,8 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
     const firstOpenEntrance = liveEntrances.find((e) => e.isOpen);
     const queenAlive = isAlive(world.ants, colony.queenEntityId);
 
-    let tileX = 0, tileY = 0;
+    let tileX = 0,
+      tileY = 0;
     let color = liveColor;
     let size: 2 | 4 = 4;
     let halfOffset: 1 | 2 = 2;
@@ -149,20 +152,23 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
 
   // Viewport rect — always tracks surfaceCamera (minimap shows surface always per PRD §7a)
   const cam = viewState.surfaceCamera;
-  const rx = HUD.MINIMAP.x + (cam.x - cam.viewportWidth  / 2) * MINIMAP_SCALE_X;
+  const rx = HUD.MINIMAP.x + (cam.x - cam.viewportWidth / 2) * MINIMAP_SCALE_X;
   const ry = HUD.MINIMAP.y + (cam.y - cam.viewportHeight / 2) * MINIMAP_SCALE_Y;
-  const rw = cam.viewportWidth  * MINIMAP_SCALE_X;
+  const rw = cam.viewportWidth * MINIMAP_SCALE_X;
   const rh = cam.viewportHeight * MINIMAP_SCALE_Y;
 
   // Four one-pixel fillRects form the viewport outline (GfxLike has no strokeRect)
   gfx.fillStyle(0xffffff, 0.8);
-  gfx.fillRect(rx,          ry,          rw, 1);   // top edge
-  gfx.fillRect(rx,          ry + rh - 1, rw, 1);   // bottom edge
-  gfx.fillRect(rx,          ry,          1,  rh);  // left edge
-  gfx.fillRect(rx + rw - 1, ry,          1,  rh);  // right edge
+  gfx.fillRect(rx, ry, rw, 1); // top edge
+  gfx.fillRect(rx, ry + rh - 1, rw, 1); // bottom edge
+  gfx.fillRect(rx, ry, 1, rh); // left edge
+  gfx.fillRect(rx + rw - 1, ry, 1, rh); // right edge
 }
 
-export function minimapClickToTile(px: number, py: number): { tileX: number; tileY: number } | null {
+export function minimapClickToTile(
+  px: number,
+  py: number,
+): { tileX: number; tileY: number } | null {
   if (px < HUD.MINIMAP.x || px >= HUD.MINIMAP.x + HUD.MINIMAP.w) return null;
   if (py < HUD.MINIMAP.y || py >= HUD.MINIMAP.y + HUD.MINIMAP.h) return null;
   return {

--- a/src/render/onboarding-captions.test.ts
+++ b/src/render/onboarding-captions.test.ts
@@ -15,9 +15,16 @@ beforeEach(() => {
 describe('checkAndTrigger — first occurrence', () => {
   it('returns non-null text on the first call for every key', () => {
     const keys = [
-      'dig', 'chamber', 'spider', 'foodMark', 'rally',
-      'spiderPriority', 'aiInvading', 'spiderRampage',
-      'queenDamage', 'queenStarvation',
+      'dig',
+      'chamber',
+      'spider',
+      'foodMark',
+      'rally',
+      'spiderPriority',
+      'aiInvading',
+      'spiderRampage',
+      'queenDamage',
+      'queenStarvation',
     ] as const;
     for (const key of keys) {
       resetCaptions();
@@ -32,7 +39,9 @@ describe('checkAndTrigger — first occurrence', () => {
   });
 
   it('returns the expected text for "spider"', () => {
-    expect(checkAndTrigger('spider')).toBe('A spider is hunting your ants. Use fighters to protect your queen.');
+    expect(checkAndTrigger('spider')).toBe(
+      'A spider is hunting your ants. Use fighters to protect your queen.',
+    );
   });
 
   it('returns the expected text for "queenDamage"', () => {

--- a/src/render/onboarding-captions.ts
+++ b/src/render/onboarding-captions.ts
@@ -18,15 +18,15 @@ export type CaptionKey =
   | 'queenStarvation';
 
 const CAPTION_TEXTS: Record<CaptionKey, string> = {
-  dig:             'Your workers will excavate the marked tile.',
-  chamber:         'Chambers give workers and brood a purpose. This one is a [Chamber Type].',
-  spider:          'A spider is hunting your ants. Use fighters to protect your queen.',
-  foodMark:        'Your foragers will prioritize this pile.',
-  rally:           'Fighters will converge here.',
-  spiderPriority:  'Your fighters are engaging the spider.',
-  aiInvading:      'The enemy is attacking your hive.',
-  spiderRampage:   'The spider has gone hungry and is in the tunnels.',
-  queenDamage:     'Your queen is in danger.',
+  dig: 'Your workers will excavate the marked tile.',
+  chamber: 'Chambers give workers and brood a purpose. This one is a [Chamber Type].',
+  spider: 'A spider is hunting your ants. Use fighters to protect your queen.',
+  foodMark: 'Your foragers will prioritize this pile.',
+  rally: 'Fighters will converge here.',
+  spiderPriority: 'Your fighters are engaging the spider.',
+  aiInvading: 'The enemy is attacking your hive.',
+  spiderRampage: 'The spider has gone hungry and is in the tunnels.',
+  queenDamage: 'Your queen is in danger.',
   queenStarvation: 'Your queen is growing hungry.',
 };
 

--- a/src/render/pause-menu-layout.test.ts
+++ b/src/render/pause-menu-layout.test.ts
@@ -24,32 +24,30 @@ const ctx: PauseMenuRenderContext = {
 describe('pauseMenuItems — main page', () => {
   it('returns 4 items in the documented order', () => {
     const items = pauseMenuItems('main', ctx);
-    expect(items.map(i => i.id)).toEqual([
-      'resume', 'save-load', 'settings', 'debug-snapshot',
-    ]);
+    expect(items.map((i) => i.id)).toEqual(['resume', 'save-load', 'settings', 'debug-snapshot']);
   });
 
   it('Save/Load row is disabled when saveLoadEnabled=false (issue #115 not yet wired)', () => {
     const items = pauseMenuItems('main', { ...ctx, saveLoadEnabled: false });
-    const saveLoad = items.find(i => i.id === 'save-load')!;
+    const saveLoad = items.find((i) => i.id === 'save-load')!;
     expect(saveLoad.enabled).toBe(false);
   });
 
   it('Save/Load row is enabled when saveLoadEnabled=true', () => {
     const items = pauseMenuItems('main', { ...ctx, saveLoadEnabled: true });
-    expect(items.find(i => i.id === 'save-load')!.enabled).toBe(true);
+    expect(items.find((i) => i.id === 'save-load')!.enabled).toBe(true);
   });
 
   it('Quit & feedback row is hidden when quitAndSurveyEnabled=false (issue #122 default)', () => {
     const items = pauseMenuItems('main', { ...ctx, quitAndSurveyEnabled: false });
-    expect(items.find(i => i.id === 'quit-and-survey')).toBeUndefined();
+    expect(items.find((i) => i.id === 'quit-and-survey')).toBeUndefined();
     // The default-off path keeps the original 4-row main menu.
     expect(items).toHaveLength(4);
   });
 
   it('Quit & feedback row is emitted when quitAndSurveyEnabled=true (issue #122)', () => {
     const items = pauseMenuItems('main', { ...ctx, quitAndSurveyEnabled: true });
-    const row = items.find(i => i.id === 'quit-and-survey');
+    const row = items.find((i) => i.id === 'quit-and-survey');
     expect(row).toBeDefined();
     expect(row!.enabled).toBe(true);
     expect(items).toHaveLength(5);
@@ -97,30 +95,39 @@ describe('pauseMenuItems — main page', () => {
 describe('pauseMenuItems — settings page', () => {
   it('returns the pheromone toggle, speed cycle, and a back button', () => {
     const items = pauseMenuItems('settings', ctx);
-    expect(items.map(i => i.id)).toEqual(['pheromone-toggle', 'speed-cycle', 'back']);
+    expect(items.map((i) => i.id)).toEqual(['pheromone-toggle', 'speed-cycle', 'back']);
   });
 
   it('pheromone toggle label reflects the current ON state', () => {
     const items = pauseMenuItems('settings', { ...ctx, currentPheromoneOverlay: true });
-    expect(items.find(i => i.id === 'pheromone-toggle')!.label).toContain('ON');
+    expect(items.find((i) => i.id === 'pheromone-toggle')!.label).toContain('ON');
   });
 
   it('pheromone toggle label reflects the current OFF state', () => {
     const items = pauseMenuItems('settings', { ...ctx, currentPheromoneOverlay: false });
-    expect(items.find(i => i.id === 'pheromone-toggle')!.label).toContain('OFF');
+    expect(items.find((i) => i.id === 'pheromone-toggle')!.label).toContain('OFF');
   });
 
   it('speed-cycle label reflects the current speed multiplier', () => {
-    expect(pauseMenuItems('settings', { ...ctx, currentSpeedMultiplier: 1 })
-      .find(i => i.id === 'speed-cycle')!.label).toContain('1×');
-    expect(pauseMenuItems('settings', { ...ctx, currentSpeedMultiplier: 2 })
-      .find(i => i.id === 'speed-cycle')!.label).toContain('2×');
-    expect(pauseMenuItems('settings', { ...ctx, currentSpeedMultiplier: 4 })
-      .find(i => i.id === 'speed-cycle')!.label).toContain('4×');
+    expect(
+      pauseMenuItems('settings', { ...ctx, currentSpeedMultiplier: 1 }).find(
+        (i) => i.id === 'speed-cycle',
+      )!.label,
+    ).toContain('1×');
+    expect(
+      pauseMenuItems('settings', { ...ctx, currentSpeedMultiplier: 2 }).find(
+        (i) => i.id === 'speed-cycle',
+      )!.label,
+    ).toContain('2×');
+    expect(
+      pauseMenuItems('settings', { ...ctx, currentSpeedMultiplier: 4 }).find(
+        (i) => i.id === 'speed-cycle',
+      )!.label,
+    ).toContain('4×');
   });
 
   it('speed-cycle row is enabled', () => {
-    expect(pauseMenuItems('settings', ctx).find(i => i.id === 'speed-cycle')!.enabled).toBe(true);
+    expect(pauseMenuItems('settings', ctx).find((i) => i.id === 'speed-cycle')!.enabled).toBe(true);
   });
 });
 
@@ -134,9 +141,15 @@ describe('pageTitle', () => {
 });
 
 describe('nextSpeedMultiplier — cycle 1→2→4→1', () => {
-  it('1 → 2', () => { expect(nextSpeedMultiplier(1)).toBe(2); });
-  it('2 → 4', () => { expect(nextSpeedMultiplier(2)).toBe(4); });
-  it('4 → 1', () => { expect(nextSpeedMultiplier(4)).toBe(1); });
+  it('1 → 2', () => {
+    expect(nextSpeedMultiplier(1)).toBe(2);
+  });
+  it('2 → 4', () => {
+    expect(nextSpeedMultiplier(2)).toBe(4);
+  });
+  it('4 → 1', () => {
+    expect(nextSpeedMultiplier(4)).toBe(1);
+  });
 });
 
 describe('itemAt', () => {
@@ -154,7 +167,7 @@ describe('itemAt', () => {
 
   it('skips disabled items even when the pointer is inside their rect', () => {
     const items = pauseMenuItems('main', { ...ctx, saveLoadEnabled: false });
-    const saveLoad = items.find(i => i.id === 'save-load')!;
+    const saveLoad = items.find((i) => i.id === 'save-load')!;
     expect(itemAt(items, saveLoad.rect.x + 5, saveLoad.rect.y + 5)).toBeNull();
   });
 });

--- a/src/render/pause-menu-layout.ts
+++ b/src/render/pause-menu-layout.ts
@@ -109,9 +109,7 @@ export interface PauseMenuRenderContext {
  */
 function stackRects(n: number): MenuItemRect[] {
   const stackHeight =
-    PAUSE_MENU_TITLE_HEIGHT
-    + n * PAUSE_MENU_BUTTON_H
-    + (n - 1) * PAUSE_MENU_BUTTON_GAP;
+    PAUSE_MENU_TITLE_HEIGHT + n * PAUSE_MENU_BUTTON_H + (n - 1) * PAUSE_MENU_BUTTON_GAP;
   const top = (CANVAS_H - stackHeight) / 2 + PAUSE_MENU_TITLE_HEIGHT;
   const x = (CANVAS_W - PAUSE_MENU_BUTTON_W) / 2;
   const rects: MenuItemRect[] = [];
@@ -133,15 +131,12 @@ export function titleCenterY(itemCount: number): number {
 }
 
 /** Compose the menu items for the current page. */
-export function pauseMenuItems(
-  page: PauseMenuPage,
-  ctx: PauseMenuRenderContext,
-): PauseMenuItem[] {
+export function pauseMenuItems(page: PauseMenuPage, ctx: PauseMenuRenderContext): PauseMenuItem[] {
   if (page === 'main') {
     const labels: Array<{ id: PauseMenuItemId; label: string; enabled: boolean }> = [
-      { id: 'resume',         label: 'Resume',             enabled: true },
-      { id: 'save-load',      label: 'Save / Load',        enabled: ctx.saveLoadEnabled },
-      { id: 'settings',       label: 'Settings  >',        enabled: true },
+      { id: 'resume', label: 'Resume', enabled: true },
+      { id: 'save-load', label: 'Save / Load', enabled: ctx.saveLoadEnabled },
+      { id: 'settings', label: 'Settings  >', enabled: true },
       { id: 'debug-snapshot', label: 'Download debug log', enabled: true },
     ];
     if (ctx.quitAndSurveyEnabled) {
@@ -196,7 +191,11 @@ function pointInRect(px: number, py: number, r: MenuItemRect): boolean {
 
 /** Returns the topmost ENABLED item under the pointer, or null. Disabled items
  *  swallow no hit so callers can layer additional behavior beneath them later. */
-export function itemAt(items: readonly PauseMenuItem[], px: number, py: number): PauseMenuItem | null {
+export function itemAt(
+  items: readonly PauseMenuItem[],
+  px: number,
+  py: number,
+): PauseMenuItem | null {
   for (const it of items) {
     if (!it.enabled) continue;
     if (pointInRect(px, py, it.rect)) return it;

--- a/src/render/playtrace-upload.test.ts
+++ b/src/render/playtrace-upload.test.ts
@@ -130,9 +130,9 @@ describe('submitPlaytrace — feature flag gating', () => {
 
 describe('submitPlaytrace — wire framing', () => {
   it('sends a same-origin POST with the contracted headers and gzipped body', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ accepted: true }), { status: 202 }),
-    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ accepted: true }), { status: 202 }));
     try {
       await submitPlaytrace(makeInput());
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -152,9 +152,9 @@ describe('submitPlaytrace — wire framing', () => {
   });
 
   it('reports server-side disable (HTTP 503) cleanly so the UI silently skips', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('', { status: 503 }),
-    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('', { status: 503 }));
     try {
       const result = await submitPlaytrace(makeInput());
       expect(result).toEqual({ status: 'server-disabled' });
@@ -164,9 +164,9 @@ describe('submitPlaytrace — wire framing', () => {
   });
 
   it('surfaces a Retry-After header on HTTP 429', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('', { status: 429, headers: { 'Retry-After': '30' } }),
-    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('', { status: 429, headers: { 'Retry-After': '30' } }));
     try {
       const result = await submitPlaytrace(makeInput());
       expect(result).toEqual({ status: 'rate-limited', retryAfterSeconds: 30 });
@@ -214,18 +214,22 @@ describe('submitPlaytrace — graceful downgrade', () => {
       // Free text capped at 2000 chars — irrelevant for body size; instead
       // we inflate the inputLog with fake commands so the envelope JSON
       // crosses 5 MB on stages 1 and 2.
-      inputLog: Array.from({ length: 3 }, () => ({
-        type: 'SetBehaviorRatio',
-        colonyId: 1,
-        ratio: { forage: 50, fight: 50 },
-        issuedAtTick: 0,
-        // The padding pushes each command's stringified form past 2 MB —
-        // three of them = 6 MB stage-1 body. Stage 2 keeps the inputLog
-        // (still 6 MB). Stage 3 drops the inputLog and survives. Stage 4
-        // is the survey-only fallback (always fits).
-        _padding: fat,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any)),
+      inputLog: Array.from(
+        { length: 3 },
+        () =>
+          ({
+            type: 'SetBehaviorRatio',
+            colonyId: 1,
+            ratio: { forage: 50, fight: 50 },
+            issuedAtTick: 0,
+            // The padding pushes each command's stringified form past 2 MB —
+            // three of them = 6 MB stage-1 body. Stage 2 keeps the inputLog
+            // (still 6 MB). Stage 3 drops the inputLog and survives. Stage 4
+            // is the survey-only fallback (always fits).
+            _padding: fat,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          }) as any,
+      ),
     });
 
     const bodies: Array<Blob> = [];
@@ -256,16 +260,21 @@ describe('submitPlaytrace — graceful downgrade', () => {
     // the mock is registered.
     vi.resetModules();
     const buildSpy = vi.fn(() => ({
-      version: 1, seed: 0, tick: 0, inputLog: [], snapshot: {} as never, antTrace: [],
+      version: 1,
+      seed: 0,
+      tick: 0,
+      inputLog: [],
+      snapshot: {} as never,
+      antTrace: [],
     }));
     vi.doMock('../platform/debug-snapshot.js', async (importOriginal) => {
       const orig = await importOriginal<typeof debugSnapshot>();
       return { ...orig, buildDebugSnapshot: buildSpy };
     });
     const mod = await import('./playtrace-upload.js');
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ accepted: true }), { status: 202 }),
-    );
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ accepted: true }), { status: 202 }));
     try {
       await mod.submitPlaytrace(makeInput({ includeSnapshot: false }));
       expect(buildSpy).not.toHaveBeenCalled();
@@ -336,7 +345,9 @@ describe('submitPlaytrace — timing invariant (load-bearing)', () => {
     // body size, not by real gzip ratio.
     const IdentityCS = function (this: unknown, _format: string) {
       return new TransformStream<Uint8Array, Uint8Array>({
-        transform(chunk, controller) { controller.enqueue(chunk); },
+        transform(chunk, controller) {
+          controller.enqueue(chunk);
+        },
       });
     };
     (globalThis as unknown as { CompressionStream: unknown }).CompressionStream = IdentityCS;
@@ -346,14 +357,18 @@ describe('submitPlaytrace — timing invariant (load-bearing)', () => {
     // shrinks below 5 MB and lands at fetch.
     const fat = 'a'.repeat(2 * 1024 * 1024);
     const input = makeInput({
-      inputLog: Array.from({ length: 3 }, () => ({
-        type: 'SetBehaviorRatio',
-        colonyId: 1,
-        ratio: { forage: 50, fight: 50 },
-        issuedAtTick: 0,
-        _padding: fat,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any)),
+      inputLog: Array.from(
+        { length: 3 },
+        () =>
+          ({
+            type: 'SetBehaviorRatio',
+            colonyId: 1,
+            ratio: { forage: 50, fight: 50 },
+            issuedAtTick: 0,
+            _padding: fat,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          }) as any,
+      ),
     });
     // eslint-disable-next-line no-restricted-syntax
     input.world.tick = 5555;
@@ -401,7 +416,9 @@ describe('cancelInFlightUpload', () => {
     // `await Promise.resolve()` doesn't yield long enough for the gzip
     // pipeline + fetch dispatch to complete.
     let resolveFetchStarted!: () => void;
-    const fetchStarted = new Promise<void>((resolve) => { resolveFetchStarted = resolve; });
+    const fetchStarted = new Promise<void>((resolve) => {
+      resolveFetchStarted = resolve;
+    });
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((_url, init) => {
       return new Promise<Response>((_resolve, reject) => {
         const signal = (init as RequestInit | undefined)?.signal;

--- a/src/render/playtrace-upload.ts
+++ b/src/render/playtrace-upload.ts
@@ -120,10 +120,7 @@ export type PlaytraceUploadResult =
 /** Round end reason — orthogonal to outcome; lets telemetry join outcome ×
  *  end-reason for D-30 distribution. 'QueenDeath' is the only reason in
  *  S0b-S4; TimeoutTiebreak and StalemateTiebreak land in S5. */
-export type RoundEndReason =
-  | 'QueenDeath'
-  | 'TimeoutTiebreak'
-  | 'StalemateTiebreak';
+export type RoundEndReason = 'QueenDeath' | 'TimeoutTiebreak' | 'StalemateTiebreak';
 
 /** Envelope as it goes over the wire (pre-gzip). Exported so tests can
  *  reconstruct expectations against the same shape.
@@ -173,13 +170,14 @@ export function cancelInFlightUpload(): void {
  *  string form decouples the wire from the sim's internal numbering so the
  *  enum can be renumbered without breaking on-disk telemetry. `None` is
  *  invalid input — the survey only opens on a terminal outcome. */
-export function outcomeToWire(
-  outcome: GameOutcome,
-): 'Victory' | 'Defeat' | 'MutualDestruction' {
+export function outcomeToWire(outcome: GameOutcome): 'Victory' | 'Defeat' | 'MutualDestruction' {
   switch (outcome) {
-    case GameOutcome.Victory:           return 'Victory';
-    case GameOutcome.Defeat:            return 'Defeat';
-    case GameOutcome.MutualDestruction: return 'MutualDestruction';
+    case GameOutcome.Victory:
+      return 'Victory';
+    case GameOutcome.Defeat:
+      return 'Defeat';
+    case GameOutcome.MutualDestruction:
+      return 'MutualDestruction';
     case GameOutcome.None:
       throw new Error('playtrace-upload: outcome=None should never reach the wire');
   }
@@ -221,9 +219,7 @@ export function buildPlaytraceEnvelope(
   capturedEvents?: SimEvent[],
   capturedSummary?: PlaytraceSummary,
 ): PlaytraceEnvelope {
-  const roundEndReason = capturedEvents
-    ? deriveRoundEndReason(capturedEvents)
-    : null;
+  const roundEndReason = capturedEvents ? deriveRoundEndReason(capturedEvents) : null;
 
   const envelope: PlaytraceEnvelope = {
     sessionId: input.sessionId,
@@ -393,9 +389,7 @@ export async function submitPlaytrace(
  *  `buildPlaytraceEnvelope(input, ...)` or `buildDebugSnapshot(input.world, ...)`
  *  would race a post-restart world and produce a payload with mixed
  *  sessions on the very oversized path this loop exists to handle. */
-async function buildPayloadWithDowngrade(
-  input: PlaytraceSubmissionInput,
-): Promise<Blob> {
+async function buildPayloadWithDowngrade(input: PlaytraceSubmissionInput): Promise<Blob> {
   // Capture the world ONCE, synchronously, into JSON-safe primitives.
   // world.events.slice() and buildPlaytraceSummary must happen here (in
   // the sync prefix) before the first await yields control back to the
@@ -403,7 +397,11 @@ async function buildPayloadWithDowngrade(
   // void-casting submitPlaytrace, so the live world is mutated during the
   // async tail of this function.
   const capturedEvents: SimEvent[] = input.world.events.slice();
-  const capturedSummary = buildPlaytraceSummary(input.world, input.resumedFromSave, outcomeToWire(input.outcome));
+  const capturedSummary = buildPlaytraceSummary(
+    input.world,
+    input.resumedFromSave,
+    outcomeToWire(input.outcome),
+  );
   const fullSnap = buildDebugSnapshot(input.world, input.seed, input.inputLog);
   const fullEnvelope = buildPlaytraceEnvelope(input, fullSnap, capturedEvents, capturedSummary);
 
@@ -444,9 +442,7 @@ async function buildPayloadWithDowngrade(
  *  Capture events synchronously so roundEndReason is derived from the
  *  pre-restart event buffer (world.events may be mutated after the first
  *  await if restartGame fires immediately). */
-async function buildSurveyOnlyPayload(
-  input: PlaytraceSubmissionInput,
-): Promise<Blob> {
+async function buildSurveyOnlyPayload(input: PlaytraceSubmissionInput): Promise<Blob> {
   const capturedEvents: SimEvent[] = input.world.events.slice();
   // survey-only: snapshot is null, so events+summary are omitted from the
   // envelope body (per spec). roundEndReason IS included — it's a top-level

--- a/src/render/save-load-dialog-layout.test.ts
+++ b/src/render/save-load-dialog-layout.test.ts
@@ -23,24 +23,22 @@ const baseCtx: SaveLoadDialogContext = {
 describe('saveLoadDialogItems', () => {
   it('returns 5 items in the documented order', () => {
     const items = saveLoadDialogItems(baseCtx);
-    expect(items.map(i => i.id)).toEqual([
-      'continue', 'save-now', 'delete', 'new-game', 'back',
-    ]);
+    expect(items.map((i) => i.id)).toEqual(['continue', 'save-now', 'delete', 'new-game', 'back']);
   });
 
   it('Continue is disabled when there is no compatible save', () => {
     const items = saveLoadDialogItems(baseCtx);
-    expect(items.find(i => i.id === 'continue')!.enabled).toBe(false);
+    expect(items.find((i) => i.id === 'continue')!.enabled).toBe(false);
   });
 
   it('Continue is enabled when a compatible save exists', () => {
     const items = saveLoadDialogItems({ ...baseCtx, hasCompatibleSave: true });
-    expect(items.find(i => i.id === 'continue')!.enabled).toBe(true);
+    expect(items.find((i) => i.id === 'continue')!.enabled).toBe(true);
   });
 
   it('Delete is disabled when nothing exists in storage', () => {
     const items = saveLoadDialogItems(baseCtx);
-    expect(items.find(i => i.id === 'delete')!.enabled).toBe(false);
+    expect(items.find((i) => i.id === 'delete')!.enabled).toBe(false);
   });
 
   it('Delete is enabled when an incompatible save needs to be cleared (issue #66 path)', () => {
@@ -49,7 +47,7 @@ describe('saveLoadDialogItems', () => {
       hasCompatibleSave: false,
       hasIncompatibleSave: true,
     });
-    expect(items.find(i => i.id === 'delete')!.enabled).toBe(true);
+    expect(items.find((i) => i.id === 'delete')!.enabled).toBe(true);
   });
 
   it('Delete row swaps to "click to confirm" when confirming.delete is set', () => {
@@ -58,7 +56,7 @@ describe('saveLoadDialogItems', () => {
       hasCompatibleSave: true,
       confirming: { delete: true, newGame: false },
     });
-    const del = items.find(i => i.id === 'delete')!;
+    const del = items.find((i) => i.id === 'delete')!;
     expect(del.label.toLowerCase()).toContain('confirm');
     expect(del.confirming).toBe(true);
   });
@@ -69,7 +67,7 @@ describe('saveLoadDialogItems', () => {
       hasCompatibleSave: false,
       confirming: { delete: false, newGame: true },
     });
-    const ng = items.find(i => i.id === 'new-game')!;
+    const ng = items.find((i) => i.id === 'new-game')!;
     expect(ng.label.toLowerCase()).not.toContain('confirm');
   });
 
@@ -79,7 +77,7 @@ describe('saveLoadDialogItems', () => {
       hasCompatibleSave: true,
       confirming: { delete: false, newGame: true },
     });
-    const ng = items.find(i => i.id === 'new-game')!;
+    const ng = items.find((i) => i.id === 'new-game')!;
     expect(ng.label.toLowerCase()).toContain('confirm');
   });
 
@@ -116,7 +114,9 @@ describe('saveLoadDialogItems', () => {
 describe('formatSaveInfoLine', () => {
   it('formats a fresh save with timestamp + tick + workers + food (issue #115)', () => {
     const info: SaveInfo = {
-      tick: 42, playerWorkers: 12, playerFoodStored: 1500,
+      tick: 42,
+      playerWorkers: 12,
+      playerFoodStored: 1500,
       // 2026-01-15 09:30 local — the formatter uses local time, so we don't
       // assert exact HH:MM strings (would be flaky across CI timezones).
       savedAtMs: new Date(2026, 0, 15, 9, 30, 0).getTime(),
@@ -152,7 +152,10 @@ describe('formatSaveInfoLine', () => {
     // the warning, NOT the saved-line — otherwise the player sees
     // "Saved 14:30..." next to a grayed-out Continue and is confused.
     const info: SaveInfo = {
-      tick: 100, playerWorkers: 5, playerFoodStored: 200, savedAtMs: Date.now(),
+      tick: 100,
+      playerWorkers: 5,
+      playerFoodStored: 200,
+      savedAtMs: Date.now(),
     };
     const line = formatSaveInfoLine(info, true);
     expect(line.toLowerCase()).toContain('incompatible');
@@ -212,7 +215,7 @@ describe('itemAt', () => {
 
   it('skips disabled items', () => {
     const items = saveLoadDialogItems(baseCtx); // Continue and Delete disabled
-    const continueItem = items.find(i => i.id === 'continue')!;
+    const continueItem = items.find((i) => i.id === 'continue')!;
     expect(itemAt(items, continueItem.rect.x + 5, continueItem.rect.y + 5)).toBeNull();
   });
 });

--- a/src/render/save-load-dialog-layout.ts
+++ b/src/render/save-load-dialog-layout.ts
@@ -42,12 +42,7 @@ export const DIALOG_INFO_Y = DIALOG_TITLE_Y + DIALOG_TITLE_TO_INFO_GAP;
 // Item types
 // ---------------------------------------------------------------------------
 
-export type SaveLoadDialogItemId =
-  | 'continue'
-  | 'save-now'
-  | 'delete'
-  | 'new-game'
-  | 'back';
+export type SaveLoadDialogItemId = 'continue' | 'save-now' | 'delete' | 'new-game' | 'back';
 
 export interface DialogItemRect {
   x: number;
@@ -137,9 +132,7 @@ export function saveLoadDialogItems(ctx: SaveLoadDialogContext): SaveLoadDialogI
       id: 'new-game',
       // New Game without a save just restarts; confirm is only needed when
       // a save exists (clicking would silently discard player progress).
-      label: saveExists && ctx.confirming.newGame
-        ? 'Click to confirm new game'
-        : 'New Game',
+      label: saveExists && ctx.confirming.newGame ? 'Click to confirm new game' : 'New Game',
       enabled: true,
       confirming: ctx.confirming.newGame,
     },
@@ -167,10 +160,7 @@ export function saveLoadDialogItems(ctx: SaveLoadDialogContext): SaveLoadDialogI
  *  Continue is disabled — visually contradicting the disabled state. The
  *  warning wins so the disabled Continue and the info line tell the same
  *  story. */
-export function formatSaveInfoLine(
-  info: SaveInfo | null,
-  hasIncompatibleSave: boolean,
-): string {
+export function formatSaveInfoLine(info: SaveInfo | null, hasIncompatibleSave: boolean): string {
   if (hasIncompatibleSave) {
     // Surfaces the issue #66 case where bytes exist but this build can't read
     // them (envelope parse fails OR snapshot.simVersion > LATEST_SIM_VERSION).

--- a/src/render/screen-effects.ts
+++ b/src/render/screen-effects.ts
@@ -50,7 +50,9 @@ export function triggerScreenEdgeFlash(
     alpha: 0,
     duration: SCREEN_EDGE_FLASH_DURATION_MS,
     ease: 'Linear',
-    onComplete: () => { gfx.destroy(); },
+    onComplete: () => {
+      gfx.destroy();
+    },
   });
 }
 

--- a/src/render/sprite-shapes.ts
+++ b/src/render/sprite-shapes.ts
@@ -18,7 +18,13 @@ export function makeCanvas(width: number, height: number): number[] {
 }
 
 /** Stamp a single pixel if (x, y) is in bounds. */
-export function paintPx(canvas: number[], width: number, x: number, y: number, color: number): void {
+export function paintPx(
+  canvas: number[],
+  width: number,
+  x: number,
+  y: number,
+  color: number,
+): void {
   if (x < 0 || y < 0 || x >= width) return;
   const height = canvas.length / width;
   if (y >= height) return;
@@ -105,8 +111,14 @@ export function paintLine(
     paintPx(canvas, width, x, y, color);
     if (x === x1 && y === y1) break;
     const e2 = 2 * err;
-    if (e2 > -dy) { err -= dy; x += sx; }
-    if (e2 <  dx) { err += dx; y += sy; }
+    if (e2 > -dy) {
+      err -= dy;
+      x += sx;
+    }
+    if (e2 < dx) {
+      err += dx;
+      y += sy;
+    }
   }
 }
 
@@ -128,9 +140,9 @@ export function paintGrassBlade(
   midColor: number,
   lightColor: number,
 ): void {
-  const len = Math.max(1, baseY - tipY);  // blade goes upward (baseY > tipY)
+  const len = Math.max(1, baseY - tipY); // blade goes upward (baseY > tipY)
   for (let i = 0; i <= len; i++) {
-    const t = i / len;  // 0 at base, 1 at tip
+    const t = i / len; // 0 at base, 1 at tip
     const x = Math.round(baseX + (tipX - baseX) * t);
     const y = baseY - i;
     // Color: dark for lower 25%, mid for middle 50%, light for upper 25%.
@@ -162,7 +174,7 @@ export function paintFlecks(
   seed: number,
 ): void {
   if (color === 0) return;
-  let s = (seed >>> 0) || 1;
+  let s = seed >>> 0 || 1;
   for (let i = 0; i < count; i++) {
     s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
     const x = x0 + (s % Math.max(1, x1 - x0 + 1));

--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -124,8 +124,9 @@ describe('HUD zone layout', () => {
 
   it('UNDERGROUND_COLONY_TOGGLE sits directly above VIEW_TOGGLE without overlap (issue #14)', () => {
     expect(HUD.UNDERGROUND_COLONY_TOGGLE.x).toBe(HUD.VIEW_TOGGLE.x);
-    expect(HUD.UNDERGROUND_COLONY_TOGGLE.y + HUD.UNDERGROUND_COLONY_TOGGLE.h)
-      .toBeLessThanOrEqual(HUD.VIEW_TOGGLE.y);
+    expect(HUD.UNDERGROUND_COLONY_TOGGLE.y + HUD.UNDERGROUND_COLONY_TOGGLE.h).toBeLessThanOrEqual(
+      HUD.VIEW_TOGGLE.y,
+    );
   });
 });
 

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -58,9 +58,9 @@ export const COLOR_FIGHTER_TINT = 0xff4444;
 export const COLOR_CONTESTED_TILE = 0xff6600;
 
 /** S6 — Home-ground glow colors for per-grid combat tile highlight. */
-export const COLOR_PLAYER_HOME_GLOW        = 0x3060a0; // blue — player underground tiles
-export const COLOR_ENEMY_HOME_GLOW         = 0xa06030; // orange — enemy underground tiles
-export const COLOR_NEUTRAL_CONTESTED_GLOW  = 0xa0a030; // yellow — surface contested tiles
+export const COLOR_PLAYER_HOME_GLOW = 0x3060a0; // blue — player underground tiles
+export const COLOR_ENEMY_HOME_GLOW = 0xa06030; // orange — enemy underground tiles
+export const COLOR_NEUTRAL_CONTESTED_GLOW = 0xa0a030; // yellow — surface contested tiles
 
 /** PRD §7g — Underground solid (unexcavated) tile color. */
 export const COLOR_UNDERGROUND_SOLID = 0x2d1a0a;
@@ -138,7 +138,7 @@ export const COLOR_PHEROMONE_DANGER_STRONG = 0xff4000;
  */
 export const HUD = {
   /** Colony stats bar: ant count, food stored, queen health. */
-  STATS:       { x: 8,   y: 8,   w: 200, h: 24  },
+  STATS: { x: 8, y: 8, w: 200, h: 24 },
   /**
    * Behavior allocation slider widget. Field name retained from the Phase 8
    * 3-vertex triangle to minimize diff churn; Phase 10 / D-01 collapsed the
@@ -154,17 +154,17 @@ export const HUD = {
    * 120×120 layout so HUD-anchor pixel positions of neighboring zones are
    * not disturbed.
    */
-  TRIANGLE:    { x: 8,   y: 532, w: 120, h: 44 },
+  TRIANGLE: { x: 8, y: 532, w: 120, h: 44 },
   /**
    * Speed controls zone.
    * Phase 9 layout reservation — Phase 8 draws nothing here.
    * Phase 9 wires 1×/2×/4× speed buttons and pause button.
    */
-  SPEED:       { x: 320, y: 552, w: 160, h: 32,  PAUSE_BUTTON_W: 40, SPEED_BUTTON_W: 32 },
+  SPEED: { x: 320, y: 552, w: 160, h: 32, PAUSE_BUTTON_W: 40, SPEED_BUTTON_W: 32 },
   /** Minimap: full surface overview with colony positions and food sources. */
-  MINIMAP:     { x: 632, y: 424, w: 160, h: 160 },
+  MINIMAP: { x: 632, y: 424, w: 160, h: 160 },
   /** View toggle button: switches between surface and underground views. */
-  VIEW_TOGGLE: { x: 632, y: 396, w: 80,  h: 24  },
+  VIEW_TOGGLE: { x: 632, y: 396, w: 80, h: 24 },
   /**
    * Issue #14 — colony toggle button (underground view only). Flips the
    * underground render between PLAYER and ENEMY grids; equivalent to the
@@ -183,7 +183,7 @@ export const HUD = {
    * Phase 9 layout reservation — Phase 8 draws nothing here.
    * Phase 9 wires autosave indicator rendering.
    */
-  SAVE_ICON:   { x: 772, y: 8,   w: 20,  h: 20  },
+  SAVE_ICON: { x: 772, y: 8, w: 20, h: 20 },
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -210,8 +210,8 @@ export function lerpColor(a: number, b: number, t: number): number {
   const br = (b >> 16) & 0xff;
   const bg = (b >> 8) & 0xff;
   const bb = b & 0xff;
-  const r    = (ar + (br - ar) * tc) | 0;
-  const g    = (ag + (bg - ag) * tc) | 0;
+  const r = (ar + (br - ar) * tc) | 0;
+  const g = (ag + (bg - ag) * tc) | 0;
   const blue = (ab + (bb - ab) * tc) | 0;
   return (r << 16) | (g << 8) | blue;
 }

--- a/src/render/summary-builder.test.ts
+++ b/src/render/summary-builder.test.ts
@@ -19,7 +19,9 @@ function roundEndEvent(
   return { tick: 1200, type: 'round_end', payload: { reason, playerWorkerCount, aiWorkerCount } };
 }
 
-function queenDeathEvent(cause: 'InvasionKill' | 'SpiderRampage' | 'Starvation' | 'MutualDestruction' | null): SimEvent {
+function queenDeathEvent(
+  cause: 'InvasionKill' | 'SpiderRampage' | 'Starvation' | 'MutualDestruction' | null,
+): SimEvent {
   return {
     tick: 500,
     type: 'queen_death',
@@ -71,7 +73,9 @@ describe('buildOutcomeAttribution — StalemateTiebreak', () => {
   it('no gameOutcome provided → draw narrative', () => {
     const result = buildOutcomeAttribution([roundEndEvent('StalemateTiebreak', 0, 0)]);
     expect(result.primaryCause).toBe('StalemateTiebreak');
-    expect(result.narrativeSeed).toBe('Both colonies ran out of food and the round ended in a draw.');
+    expect(result.narrativeSeed).toBe(
+      'Both colonies ran out of food and the round ended in a draw.',
+    );
   });
 
   it('MutualDestruction gameOutcome → draw narrative (not Victory/Defeat)', () => {
@@ -80,7 +84,9 @@ describe('buildOutcomeAttribution — StalemateTiebreak', () => {
       'MutualDestruction',
     );
     expect(result.primaryCause).toBe('StalemateTiebreak');
-    expect(result.narrativeSeed).toBe('Both colonies ran out of food and the round ended in a draw.');
+    expect(result.narrativeSeed).toBe(
+      'Both colonies ran out of food and the round ended in a draw.',
+    );
   });
 });
 
@@ -92,7 +98,15 @@ describe('buildOutcomeAttribution — round_end before queen_death', () => {
   it('round_end is returned even when a queen_death event also exists', () => {
     const events: SimEvent[] = [
       roundEndEvent('TimeoutTiebreak', 7, 2),
-      { tick: 501, type: 'queen_death', payload: { cause: 'Starvation', location: { x: 0, y: 0, grid: 'underground' }, aiStateAtTime: null } },
+      {
+        tick: 501,
+        type: 'queen_death',
+        payload: {
+          cause: 'Starvation',
+          location: { x: 0, y: 0, grid: 'underground' },
+          aiStateAtTime: null,
+        },
+      },
     ];
     const result = buildOutcomeAttribution(events);
     expect(result.primaryCause).toBe('TimeoutTiebreak');

--- a/src/render/summary-builder.ts
+++ b/src/render/summary-builder.ts
@@ -111,9 +111,7 @@ function buildStrategySignals(world: WorldState): StrategySignals {
 
   // Emit current slider position as the sole history entry.
   const ratio = colony?.targetRatio ?? { forage: 10, fight: 0 };
-  const forageFightRatioHistory = [
-    { tick: 0, forage: ratio.forage, fight: ratio.fight },
-  ];
+  const forageFightRatioHistory = [{ tick: 0, forage: ratio.forage, fight: ratio.fight }];
 
   return {
     chamberCounts,
@@ -181,15 +179,15 @@ export function buildOutcomeAttribution(
       }
       // queen_death can describe either queen; use gameOutcome to pick perspective.
       const victoryNarratives: Record<string, string> = {
-        InvasionKill:      'Your fighters broke through to the enemy queen.',
-        SpiderRampage:     'The spider reached the enemy nursery and killed their queen.',
-        Starvation:        'The enemy queen starved after their colony ran out of food.',
+        InvasionKill: 'Your fighters broke through to the enemy queen.',
+        SpiderRampage: 'The spider reached the enemy nursery and killed their queen.',
+        Starvation: 'The enemy queen starved after their colony ran out of food.',
         MutualDestruction: 'Both queens died in the same final fight.',
       };
       const defeatNarratives: Record<string, string> = {
-        InvasionKill:      'Enemy fighters broke through a tunnel entrance and reached your queen.',
-        SpiderRampage:     'The spider reached your nursery and killed the queen.',
-        Starvation:        'Your queen starved after the colony ran out of food.',
+        InvasionKill: 'Enemy fighters broke through a tunnel entrance and reached your queen.',
+        SpiderRampage: 'The spider reached your nursery and killed the queen.',
+        Starvation: 'Your queen starved after the colony ran out of food.',
         MutualDestruction: 'Both queens died in the same final fight.',
       };
       const narratives = gameOutcome === 'Victory' ? victoryNarratives : defeatNarratives;
@@ -250,7 +248,7 @@ function buildTunableObserved(events: SimEvent[]): TunableObserved {
 
   return {
     defenderHomegroundWinRate: null, // populated once combat data exists (S1)
-    invasionDefenderSurvival: null,  // populated once combat data exists (S1)
+    invasionDefenderSurvival: null, // populated once combat data exists (S1)
     spiderRampageThisRound,
     totalSpiderHunts,
     totalProbes,
@@ -290,11 +288,7 @@ export function buildPlaytraceSummary(
       droppedStructural,
     },
     difficulty: world.difficulty,
-    eventsCoverage: resumedFromSave
-      ? 'since_load'
-      : totalEmitted > 0
-        ? 'full_round'
-        : 'unknown',
+    eventsCoverage: resumedFromSave ? 'since_load' : totalEmitted > 0 ? 'full_round' : 'unknown',
     eventsStartTick: events.length > 0 ? (events[0]?.tick ?? null) : null,
   };
 }

--- a/src/render/survey-overlay-layout.test.ts
+++ b/src/render/survey-overlay-layout.test.ts
@@ -22,14 +22,14 @@ import {
 describe('surveyRatingButtons', () => {
   it('emits exactly five buttons numbered 1..5 in order', () => {
     const btns = surveyRatingButtons();
-    expect(btns.map(b => b.rating)).toEqual([1, 2, 3, 4, 5]);
+    expect(btns.map((b) => b.rating)).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('button row is centered horizontally on the canvas', () => {
     const btns = surveyRatingButtons();
     const first = btns[0]!.rect;
-    const last  = btns[4]!.rect;
-    const leftMargin  = first.x;
+    const last = btns[4]!.rect;
+    const leftMargin = first.x;
     const rightMargin = SURVEY_CANVAS_W - (last.x + last.w);
     // Allow a 1px slack for rounding.
     expect(Math.abs(leftMargin - rightMargin)).toBeLessThanOrEqual(1);
@@ -45,14 +45,12 @@ describe('surveyHitTest — disjoint targets', () => {
   });
 
   it('returns broken-checkbox / upload-checkbox hits on the respective rects', () => {
-    expect(surveyHitTest(
-      SURVEY_BROKEN_CHECKBOX_RECT.x + 5,
-      SURVEY_BROKEN_CHECKBOX_RECT.y + 5,
-    )).toEqual({ kind: 'broken-checkbox' });
-    expect(surveyHitTest(
-      SURVEY_UPLOAD_CHECKBOX_RECT.x + 5,
-      SURVEY_UPLOAD_CHECKBOX_RECT.y + 5,
-    )).toEqual({ kind: 'upload-checkbox' });
+    expect(
+      surveyHitTest(SURVEY_BROKEN_CHECKBOX_RECT.x + 5, SURVEY_BROKEN_CHECKBOX_RECT.y + 5),
+    ).toEqual({ kind: 'broken-checkbox' });
+    expect(
+      surveyHitTest(SURVEY_UPLOAD_CHECKBOX_RECT.x + 5, SURVEY_UPLOAD_CHECKBOX_RECT.y + 5),
+    ).toEqual({ kind: 'upload-checkbox' });
   });
 
   it('checkbox-row clicks register over the label area too (codex P3)', () => {
@@ -61,28 +59,27 @@ describe('surveyHitTest — disjoint targets', () => {
     // checkbox — otherwise users (especially on touch) aim at the obvious
     // target and nothing happens.
     const labelX = SURVEY_BROKEN_CHECKBOX_RECT.x + SURVEY_BROKEN_CHECKBOX_RECT.w + 50;
-    expect(surveyHitTest(labelX, SURVEY_BROKEN_CHECKBOX_RECT.y + 5))
-      .toEqual({ kind: 'broken-checkbox' });
-    expect(surveyHitTest(labelX, SURVEY_UPLOAD_CHECKBOX_RECT.y + 5))
-      .toEqual({ kind: 'upload-checkbox' });
+    expect(surveyHitTest(labelX, SURVEY_BROKEN_CHECKBOX_RECT.y + 5)).toEqual({
+      kind: 'broken-checkbox',
+    });
+    expect(surveyHitTest(labelX, SURVEY_UPLOAD_CHECKBOX_RECT.y + 5)).toEqual({
+      kind: 'upload-checkbox',
+    });
   });
 
   it('returns submit / skip hits on the respective buttons', () => {
-    expect(surveyHitTest(
-      SURVEY_SUBMIT_BUTTON_RECT.x + 5,
-      SURVEY_SUBMIT_BUTTON_RECT.y + 5,
-    )).toEqual({ kind: 'submit' });
-    expect(surveyHitTest(
-      SURVEY_SKIP_BUTTON_RECT.x + 5,
-      SURVEY_SKIP_BUTTON_RECT.y + 5,
-    )).toEqual({ kind: 'skip' });
+    expect(surveyHitTest(SURVEY_SUBMIT_BUTTON_RECT.x + 5, SURVEY_SUBMIT_BUTTON_RECT.y + 5)).toEqual(
+      { kind: 'submit' },
+    );
+    expect(surveyHitTest(SURVEY_SKIP_BUTTON_RECT.x + 5, SURVEY_SKIP_BUTTON_RECT.y + 5)).toEqual({
+      kind: 'skip',
+    });
   });
 
   it('returns free-text on the textarea rect', () => {
-    expect(surveyHitTest(
-      SURVEY_FREE_TEXT_RECT.x + 5,
-      SURVEY_FREE_TEXT_RECT.y + 5,
-    )).toEqual({ kind: 'free-text' });
+    expect(surveyHitTest(SURVEY_FREE_TEXT_RECT.x + 5, SURVEY_FREE_TEXT_RECT.y + 5)).toEqual({
+      kind: 'free-text',
+    });
   });
 
   it('returns null on the panel background', () => {
@@ -105,23 +102,20 @@ describe('consent disclosure', () => {
 
 describe('surveyConfirmationHitTest — issue #131', () => {
   it('returns new-game when pointer is over the Submit button position', () => {
-    expect(surveyConfirmationHitTest(
-      SURVEY_SUBMIT_BUTTON_RECT.x + 5,
-      SURVEY_SUBMIT_BUTTON_RECT.y + 5,
-    )).toEqual({ kind: 'new-game' });
+    expect(
+      surveyConfirmationHitTest(SURVEY_SUBMIT_BUTTON_RECT.x + 5, SURVEY_SUBMIT_BUTTON_RECT.y + 5),
+    ).toEqual({ kind: 'new-game' });
   });
 
   it('returns retry when pointer is over the Skip button position', () => {
-    expect(surveyConfirmationHitTest(
-      SURVEY_SKIP_BUTTON_RECT.x + 5,
-      SURVEY_SKIP_BUTTON_RECT.y + 5,
-    )).toEqual({ kind: 'retry' });
+    expect(
+      surveyConfirmationHitTest(SURVEY_SKIP_BUTTON_RECT.x + 5, SURVEY_SKIP_BUTTON_RECT.y + 5),
+    ).toEqual({ kind: 'retry' });
   });
 
   it('returns null on background (outside both button rects)', () => {
-    expect(surveyConfirmationHitTest(
-      SURVEY_SUBMIT_BUTTON_RECT.x - 10,
-      SURVEY_SUBMIT_BUTTON_RECT.y - 10,
-    )).toBeNull();
+    expect(
+      surveyConfirmationHitTest(SURVEY_SUBMIT_BUTTON_RECT.x - 10, SURVEY_SUBMIT_BUTTON_RECT.y - 10),
+    ).toBeNull();
   });
 });

--- a/src/render/survey-overlay-layout.ts
+++ b/src/render/survey-overlay-layout.ts
@@ -53,14 +53,11 @@ export const SURVEY_FREE_TEXT_RECT = {
 export const SURVEY_CHECKBOX_SIZE = 20;
 export const SURVEY_CHECKBOX_LABEL_GAP = 12;
 
-export const SURVEY_BROKEN_CHECKBOX_Y =
-  SURVEY_FREE_TEXT_RECT.y + SURVEY_FREE_TEXT_RECT.h + 20;
-export const SURVEY_UPLOAD_CHECKBOX_Y =
-  SURVEY_BROKEN_CHECKBOX_Y + SURVEY_CHECKBOX_SIZE + 16;
+export const SURVEY_BROKEN_CHECKBOX_Y = SURVEY_FREE_TEXT_RECT.y + SURVEY_FREE_TEXT_RECT.h + 20;
+export const SURVEY_UPLOAD_CHECKBOX_Y = SURVEY_BROKEN_CHECKBOX_Y + SURVEY_CHECKBOX_SIZE + 16;
 /** Two-line consent disclosure sits below the upload checkbox, indented to
  *  align with the label text. */
-export const SURVEY_CONSENT_TEXT_Y =
-  SURVEY_UPLOAD_CHECKBOX_Y + SURVEY_CHECKBOX_SIZE + 6;
+export const SURVEY_CONSENT_TEXT_Y = SURVEY_UPLOAD_CHECKBOX_Y + SURVEY_CHECKBOX_SIZE + 6;
 
 /** Visible checkbox square rendered by UIScene. The clickable row hit
  *  zone is wider — see {@link SURVEY_BROKEN_ROW_HIT_RECT}. */
@@ -146,8 +143,7 @@ export interface SurveyRatingButton {
  *  overlay open) — the values are constant for the fixed canvas size so
  *  caching is not warranted. */
 export function surveyRatingButtons(): SurveyRatingButton[] {
-  const totalW =
-    5 * SURVEY_RATING_BUTTON_W + 4 * SURVEY_RATING_BUTTON_GAP;
+  const totalW = 5 * SURVEY_RATING_BUTTON_W + 4 * SURVEY_RATING_BUTTON_GAP;
   const startX = (SURVEY_CANVAS_W - totalW) / 2;
   const out: SurveyRatingButton[] = [];
   for (let i = 0; i < 5; i++) {
@@ -190,10 +186,10 @@ export type SurveyHitTarget =
  *  on the label text register the same as clicks on the visible square. */
 export function surveyHitTest(px: number, py: number): SurveyHitTarget {
   if (pointInRect(px, py, SURVEY_SUBMIT_BUTTON_RECT)) return { kind: 'submit' };
-  if (pointInRect(px, py, SURVEY_SKIP_BUTTON_RECT))   return { kind: 'skip' };
+  if (pointInRect(px, py, SURVEY_SKIP_BUTTON_RECT)) return { kind: 'skip' };
   if (pointInRect(px, py, SURVEY_BROKEN_ROW_HIT_RECT)) return { kind: 'broken-checkbox' };
   if (pointInRect(px, py, SURVEY_UPLOAD_ROW_HIT_RECT)) return { kind: 'upload-checkbox' };
-  if (pointInRect(px, py, SURVEY_FREE_TEXT_RECT))     return { kind: 'free-text' };
+  if (pointInRect(px, py, SURVEY_FREE_TEXT_RECT)) return { kind: 'free-text' };
   for (const btn of surveyRatingButtons()) {
     if (pointInRect(px, py, btn.rect)) {
       return { kind: 'rating', rating: btn.rating };
@@ -204,8 +200,11 @@ export function surveyHitTest(px: number, py: number): SurveyHitTarget {
 
 /** Hit-test for the post-submit/skip confirmation screen. The confirmation
  *  screen reuses the Submit/Skip button positions for New Game and Retry. */
-export function surveyConfirmationHitTest(px: number, py: number): { kind: 'new-game' } | { kind: 'retry' } | null {
+export function surveyConfirmationHitTest(
+  px: number,
+  py: number,
+): { kind: 'new-game' } | { kind: 'retry' } | null {
   if (pointInRect(px, py, SURVEY_SUBMIT_BUTTON_RECT)) return { kind: 'new-game' };
-  if (pointInRect(px, py, SURVEY_SKIP_BUTTON_RECT))   return { kind: 'retry' };
+  if (pointInRect(px, py, SURVEY_SKIP_BUTTON_RECT)) return { kind: 'retry' };
   return null;
 }

--- a/src/render/terrain-atlas.test.ts
+++ b/src/render/terrain-atlas.test.ts
@@ -10,11 +10,7 @@
 // tests live in underground-autotile.test.ts.)
 
 import { describe, expect, it } from 'vitest';
-import {
-  drawBarrenEarthTile,
-  drawSolidRockTile,
-  drawOpenFloorTile,
-} from './terrain-atlas.js';
+import { drawBarrenEarthTile, drawSolidRockTile, drawOpenFloorTile } from './terrain-atlas.js';
 import type { GfxLike } from './draw-surface.js';
 import { TILE_SIZE_PX } from './sprites.js';
 import { createWorldState } from '../sim/types.js';
@@ -37,28 +33,37 @@ interface GfxCall {
 class MockGfx implements GfxLike {
   calls: GfxCall[] = [];
 
-  clear(): GfxLike { this.calls.push({ method: 'clear', args: [] }); return this; }
+  clear(): GfxLike {
+    this.calls.push({ method: 'clear', args: [] });
+    return this;
+  }
   fillStyle(color: number, alpha?: number): GfxLike {
-    this.calls.push({ method: 'fillStyle', args: [color, alpha] }); return this;
+    this.calls.push({ method: 'fillStyle', args: [color, alpha] });
+    return this;
   }
   lineStyle(width: number, color: number, alpha?: number): GfxLike {
-    this.calls.push({ method: 'lineStyle', args: [width, color, alpha] }); return this;
+    this.calls.push({ method: 'lineStyle', args: [width, color, alpha] });
+    return this;
   }
   fillRect(x: number, y: number, w: number, h: number): GfxLike {
-    this.calls.push({ method: 'fillRect', args: [x, y, w, h] }); return this;
+    this.calls.push({ method: 'fillRect', args: [x, y, w, h] });
+    return this;
   }
   fillCircle(x: number, y: number, r: number): GfxLike {
-    this.calls.push({ method: 'fillCircle', args: [x, y, r] }); return this;
+    this.calls.push({ method: 'fillCircle', args: [x, y, r] });
+    return this;
   }
   strokeCircle(x: number, y: number, r: number): GfxLike {
-    this.calls.push({ method: 'strokeCircle', args: [x, y, r] }); return this;
+    this.calls.push({ method: 'strokeCircle', args: [x, y, r] });
+    return this;
   }
   fillTriangle(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number): GfxLike {
-    this.calls.push({ method: 'fillTriangle', args: [x0, y0, x1, y1, x2, y2] }); return this;
+    this.calls.push({ method: 'fillTriangle', args: [x0, y0, x1, y1, x2, y2] });
+    return this;
   }
 
   callsOf(method: string): GfxCall[] {
-    return this.calls.filter(c => c.method === method);
+    return this.calls.filter((c) => c.method === method);
   }
 }
 
@@ -231,12 +236,14 @@ describe('drawBarrenEarthTile + sim selector integration (issue #44 step 2)', ()
     // Install a colony with an entrance at the feature tile. surface-features
     // suppresses any anchor whose footprint enters the entrance radius (3).
     const colony = createColonyRecord(1, 0);
-    colony.entrances = [{
-      entranceId: 0,
-      surfaceTileX: featureTile!.x,
-      surfaceTileY: featureTile!.y,
-      isOpen: true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: 0,
+        surfaceTileX: featureTile!.x,
+        surfaceTileY: featureTile!.y,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     suppressed.colonies[1] = colony;

--- a/src/render/terrain-atlas.ts
+++ b/src/render/terrain-atlas.ts
@@ -22,12 +22,7 @@ import type { GfxLike } from './draw-surface.js';
 import type { WorldState } from '../sim/types.js';
 import { surfaceFeatureAt } from '../sim/surface-features.js';
 import { TILE_SIZE_PX } from './sprites.js';
-import {
-  spatialHash,
-  pixelNoise,
-  bayer4Threshold,
-  motifOffset,
-} from './terrain-noise.js';
+import { spatialHash, pixelNoise, bayer4Threshold, motifOffset } from './terrain-noise.js';
 import {
   type MotifSprite,
   type LargeFeatureSprite,
@@ -49,14 +44,14 @@ import {
 // tiles asking different questions never accidentally land on the same hash.
 // ---------------------------------------------------------------------------
 
-const SALT_BARREN_BASE     = 101;
-const SALT_BARREN_DITHER   = 102;
-const SALT_BARREN_PEBBLE   = 103;
-const SALT_BARREN_GRASS    = 104;
-const SALT_BARREN_TWIG     = 105;
-const SALT_BARREN_LEAF     = 106;
-const SALT_BARREN_STONE    = 107;
-const SALT_BARREN_SEED     = 108;
+const SALT_BARREN_BASE = 101;
+const SALT_BARREN_DITHER = 102;
+const SALT_BARREN_PEBBLE = 103;
+const SALT_BARREN_GRASS = 104;
+const SALT_BARREN_TWIG = 105;
+const SALT_BARREN_LEAF = 106;
+const SALT_BARREN_STONE = 107;
+const SALT_BARREN_SEED = 108;
 
 // Large multi-tile feature anchor salts and registry now live in
 // `src/sim/surface-features.ts` (issue #44 step 1) — render queries the
@@ -64,13 +59,13 @@ const SALT_BARREN_SEED     = 108;
 // the slice it returns. Salts 151..153 are reserved for boulder/bush/
 // grass-clump anchor channels in the sim registry.
 
-const SALT_SOLID_BASE      = 201;
-const SALT_SOLID_DITHER    = 202;
-const SALT_SOLID_FLECK     = 203;
-const SALT_SOLID_STRATA    = 204;
+const SALT_SOLID_BASE = 201;
+const SALT_SOLID_DITHER = 202;
+const SALT_SOLID_FLECK = 203;
+const SALT_SOLID_STRATA = 204;
 
-const SALT_OPEN_DITHER     = 302;
-const SALT_OPEN_DUST       = 303;
+const SALT_OPEN_DITHER = 302;
+const SALT_OPEN_DUST = 303;
 
 // ---------------------------------------------------------------------------
 // Surface palette — earthy / desaturated. Issue #40 reframe: barren earth is
@@ -78,24 +73,24 @@ const SALT_OPEN_DUST       = 303;
 // ---------------------------------------------------------------------------
 
 /** Default surface base color — dry tan earth. */
-export const COLOR_BARREN_EARTH       = 0x8e7752;
+export const COLOR_BARREN_EARTH = 0x8e7752;
 /** Slightly darker earth used in dithered cells for tonal variation. */
-export const COLOR_BARREN_EARTH_DARK  = 0x6f5a3c;
+export const COLOR_BARREN_EARTH_DARK = 0x6f5a3c;
 /** A lighter earth tone for mineral/sand specks. */
 export const COLOR_BARREN_EARTH_LIGHT = 0xa28a63;
 /** Yet darker patch for occasional damper soil regions. */
-export const COLOR_BARREN_EARTH_DAMP  = 0x5a4a30;
+export const COLOR_BARREN_EARTH_DAMP = 0x5a4a30;
 /** Piled-spoil mound around an entrance hole — between DAMP and BARREN_EARTH,
  *  reading as "fresh excavation dirt" rather than "wet soil patch." */
 export const COLOR_BARREN_EARTH_MOUND = 0x6d563a;
 
 /** Underground solid rock palette. */
-export const COLOR_ROCK_BASE     = 0x2d1f14;
+export const COLOR_ROCK_BASE = 0x2d1f14;
 export const COLOR_ROCK_BASE_DARK = 0x1d130a;
 export const COLOR_ROCK_BASE_LIGHT = 0x3f2c1c;
 
 /** Underground open-floor palette. */
-export const COLOR_FLOOR_BASE      = 0x110a06;
+export const COLOR_FLOOR_BASE = 0x110a06;
 export const COLOR_FLOOR_BASE_DARK = 0x080403;
 
 // ---------------------------------------------------------------------------
@@ -260,7 +255,11 @@ export function drawBarrenEarthSubstrate(
     gfx,
     COLOR_BARREN_EARTH,
     COLOR_BARREN_EARTH_DARK,
-    screenX, screenY, tileX, tileY, SALT_BARREN_DITHER,
+    screenX,
+    screenY,
+    tileX,
+    tileY,
+    SALT_BARREN_DITHER,
     /* ditherCoverage */ 50,
   );
   // Lighter sand specks — sparse hash-sampled positions, ~3-4 per tile.
@@ -296,7 +295,11 @@ export function drawBarrenEarthTile(
     drawMotif(gfx, GRASS_TUFT_SPRITE, screenX, screenY, off.x, off.y);
   } else if ((hGrass & 0xff) < 48) {
     // ~4% — dry grass tuft.
-    const off = motifOffset(hGrass >>> 8, DRY_GRASS_TUFT_SPRITE.width, DRY_GRASS_TUFT_SPRITE.height);
+    const off = motifOffset(
+      hGrass >>> 8,
+      DRY_GRASS_TUFT_SPRITE.width,
+      DRY_GRASS_TUFT_SPRITE.height,
+    );
     drawMotif(gfx, DRY_GRASS_TUFT_SPRITE, screenX, screenY, off.x, off.y);
   }
 
@@ -348,7 +351,11 @@ export function drawSolidRockTile(
     gfx,
     COLOR_ROCK_BASE,
     COLOR_ROCK_BASE_DARK,
-    screenX, screenY, tileX, tileY, SALT_SOLID_DITHER,
+    screenX,
+    screenY,
+    tileX,
+    tileY,
+    SALT_SOLID_DITHER,
     /* ditherCoverage */ 45,
   );
 
@@ -385,7 +392,11 @@ export function drawOpenFloorTile(
     gfx,
     COLOR_FLOOR_BASE,
     COLOR_FLOOR_BASE_DARK,
-    screenX, screenY, tileX, tileY, SALT_OPEN_DITHER,
+    screenX,
+    screenY,
+    tileX,
+    tileY,
+    SALT_OPEN_DITHER,
     /* ditherCoverage */ 25,
   );
 
@@ -433,4 +444,3 @@ function drawSparseSpecks(
     }
   }
 }
-

--- a/src/render/terrain-motifs.ts
+++ b/src/render/terrain-motifs.ts
@@ -37,12 +37,7 @@ export const GRASS_TUFT_SPRITE: MotifSprite = {
   // 1 = darker green base (root)
   // 2 = mid green (blade)
   // 3 = lighter green (tip highlight)
-  pixels: [
-    0, 0, 3, 0, 0,
-    0, 2, 2, 0, 3,
-    2, 2, 1, 2, 2,
-    0, 1, 1, 1, 0,
-  ],
+  pixels: [0, 0, 3, 0, 0, 0, 2, 2, 0, 3, 2, 2, 1, 2, 2, 0, 1, 1, 1, 0],
   colors: [0, 0x4f6b35, 0x6e8a3f, 0x9bb05a],
 };
 
@@ -50,11 +45,7 @@ export const GRASS_TUFT_SPRITE: MotifSprite = {
 export const DRY_GRASS_TUFT_SPRITE: MotifSprite = {
   width: 4,
   height: 3,
-  pixels: [
-    0, 2, 0, 2,
-    2, 1, 2, 1,
-    1, 1, 0, 1,
-  ],
+  pixels: [0, 2, 0, 2, 2, 1, 2, 1, 1, 1, 0, 1],
   colors: [0, 0x8a7838, 0xb09858],
 };
 
@@ -62,10 +53,7 @@ export const DRY_GRASS_TUFT_SPRITE: MotifSprite = {
 export const PEBBLE_SPRITE: MotifSprite = {
   width: 3,
   height: 2,
-  pixels: [
-    1, 2, 1,
-    2, 1, 2,
-  ],
+  pixels: [1, 2, 1, 2, 1, 2],
   colors: [0, 0x686058, 0x84776a],
 };
 
@@ -73,11 +61,7 @@ export const PEBBLE_SPRITE: MotifSprite = {
 export const SMALL_STONE_SPRITE: MotifSprite = {
   width: 4,
   height: 3,
-  pixels: [
-    0, 1, 1, 0,
-    1, 2, 1, 1,
-    1, 1, 1, 0,
-  ],
+  pixels: [0, 1, 1, 0, 1, 2, 1, 1, 1, 1, 1, 0],
   colors: [0, 0x4a443c, 0x6c6258],
 };
 
@@ -85,10 +69,7 @@ export const SMALL_STONE_SPRITE: MotifSprite = {
 export const TWIG_SPRITE: MotifSprite = {
   width: 5,
   height: 2,
-  pixels: [
-    1, 2, 1, 1, 1,
-    0, 0, 1, 0, 0,
-  ],
+  pixels: [1, 2, 1, 1, 1, 0, 0, 1, 0, 0],
   colors: [0, 0x4a3520, 0x6e4f30],
 };
 
@@ -96,11 +77,7 @@ export const TWIG_SPRITE: MotifSprite = {
 export const DEAD_LEAF_SPRITE: MotifSprite = {
   width: 4,
   height: 3,
-  pixels: [
-    0, 1, 2, 0,
-    1, 2, 2, 1,
-    0, 1, 2, 0,
-  ],
+  pixels: [0, 1, 2, 0, 1, 2, 2, 1, 0, 1, 2, 0],
   colors: [0, 0x6e4a25, 0x9c6a35],
 };
 
@@ -108,9 +85,7 @@ export const DEAD_LEAF_SPRITE: MotifSprite = {
 export const SEED_SPRITE: MotifSprite = {
   width: 2,
   height: 1,
-  pixels: [
-    1, 2,
-  ],
+  pixels: [1, 2],
   colors: [0, 0x3a2a18, 0x5a4028],
 };
 
@@ -122,10 +97,7 @@ export const SEED_SPRITE: MotifSprite = {
 export const ROCK_FLECK_SPRITE: MotifSprite = {
   width: 3,
   height: 2,
-  pixels: [
-    1, 0, 2,
-    0, 2, 1,
-  ],
+  pixels: [1, 0, 2, 0, 2, 1],
   colors: [0, 0x564030, 0x7a5b40],
 };
 
@@ -133,9 +105,7 @@ export const ROCK_FLECK_SPRITE: MotifSprite = {
 export const STRATA_LINE_SPRITE: MotifSprite = {
   width: 4,
   height: 1,
-  pixels: [
-    1, 2, 1, 2,
-  ],
+  pixels: [1, 2, 1, 2],
   colors: [0, 0x3e2d1d, 0x5c4530],
 };
 
@@ -143,10 +113,7 @@ export const STRATA_LINE_SPRITE: MotifSprite = {
 export const FLOOR_DUST_SPRITE: MotifSprite = {
   width: 2,
   height: 2,
-  pixels: [
-    0, 1,
-    1, 0,
-  ],
+  pixels: [0, 1, 1, 0],
   colors: [0, 0x35261c],
 };
 
@@ -215,37 +182,46 @@ const BOULDER_PALETTE = [0, 0x6b6258, 0x8b8278, 0x4a4338, 0x6e7c45] as const;
 // highlight on top-left and a wide dark crescent at the base sell weight.
 function buildBoulderRound(): ReadonlyArray<number> {
   const c = makeCanvas(64, 64);
-  paintOval(c, 64, 32, 38, 30, 24, 1);  // mid-grey body
-  paintOval(c, 64, 34, 56, 26,  7, 3);  // dark crescent at base
-  paintOval(c, 64, 28, 24, 18, 12, 2);  // light top-left highlight
+  paintOval(c, 64, 32, 38, 30, 24, 1); // mid-grey body
+  paintOval(c, 64, 34, 56, 26, 7, 3); // dark crescent at base
+  paintOval(c, 64, 28, 24, 18, 12, 2); // light top-left highlight
   return c;
 }
 
 function buildBoulderFlat(): ReadonlyArray<number> {
   const c = makeCanvas(64, 64);
-  paintOval(c, 64, 32, 44, 31, 18, 1);  // wider, lower body
-  paintOval(c, 64, 34, 58, 28,  5, 3);  // heavy bottom shadow
-  paintOval(c, 64, 30, 30, 22,  8, 2);  // long narrow top highlight
+  paintOval(c, 64, 32, 44, 31, 18, 1); // wider, lower body
+  paintOval(c, 64, 34, 58, 28, 5, 3); // heavy bottom shadow
+  paintOval(c, 64, 30, 30, 22, 8, 2); // long narrow top highlight
   return c;
 }
 
 function buildBoulderLichen(): ReadonlyArray<number> {
   const c = makeCanvas(64, 64);
   paintOval(c, 64, 32, 38, 30, 24, 1);
-  paintOval(c, 64, 34, 56, 26,  7, 3);
+  paintOval(c, 64, 34, 56, 26, 7, 3);
   paintOval(c, 64, 28, 24, 18, 12, 2);
-  paintFlecks(c, 64, 28, 12, 18, 52, 34, 4, 0x42);  // mossy green flecks across crown
+  paintFlecks(c, 64, 28, 12, 18, 52, 34, 4, 0x42); // mossy green flecks across crown
   return c;
 }
 
 export const LARGE_BOULDER_SPRITE: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: BOULDER_PALETTE, pixels: buildBoulderRound(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: BOULDER_PALETTE,
+  pixels: buildBoulderRound(),
 };
 export const LARGE_BOULDER_SPRITE_FLAT: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: BOULDER_PALETTE, pixels: buildBoulderFlat(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: BOULDER_PALETTE,
+  pixels: buildBoulderFlat(),
 };
 export const LARGE_BOULDER_SPRITE_LICHEN: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: BOULDER_PALETTE, pixels: buildBoulderLichen(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: BOULDER_PALETTE,
+  pixels: buildBoulderLichen(),
 };
 
 // ---------------------------------------------------------------------------
@@ -256,11 +232,11 @@ export const LARGE_BOULDER_SPRITE_LICHEN: LargeFeatureSprite = {
 
 const BUSH_PALETTE = [
   0,
-  0x4a6d2e,  // 1: dark green leaf base
-  0x6f9540,  // 2: mid green leaf body
-  0x9ab85a,  // 3: light green leaf tip / fleck
-  0xe8d97a,  // 4: pale yellow flower edge
-  0xf4eb9a,  // 5: bright yellow flower center
+  0x4a6d2e, // 1: dark green leaf base
+  0x6f9540, // 2: mid green leaf body
+  0x9ab85a, // 3: light green leaf tip / fleck
+  0xe8d97a, // 4: pale yellow flower edge
+  0xf4eb9a, // 5: bright yellow flower center
 ] as const;
 
 // 4×4 = 64×64 px.
@@ -270,12 +246,12 @@ function buildBushClover(): ReadonlyArray<number> {
   paintOval(c, 64, 20, 44, 16, 14, 1);
   paintOval(c, 64, 44, 40, 18, 16, 1);
   paintOval(c, 64, 32, 32, 15, 15, 1);
-  paintOval(c, 64, 14, 30, 10,  9, 1);
+  paintOval(c, 64, 14, 30, 10, 9, 1);
   // Mid-green highlights on top of each cluster.
-  paintOval(c, 64, 20, 38, 11,  7, 2);
-  paintOval(c, 64, 44, 32, 12,  8, 2);
-  paintOval(c, 64, 32, 26, 10,  6, 2);
-  paintOval(c, 64, 14, 26,  6,  4, 2);
+  paintOval(c, 64, 20, 38, 11, 7, 2);
+  paintOval(c, 64, 44, 32, 12, 8, 2);
+  paintOval(c, 64, 32, 26, 10, 6, 2);
+  paintOval(c, 64, 14, 26, 6, 4, 2);
   // Tip flecks for surface texture.
   paintFlecks(c, 64, 18, 12, 22, 50, 40, 3, 0x77);
   return c;
@@ -289,18 +265,18 @@ function buildBushFlower(): ReadonlyArray<number> {
   paintRect(c, 64, 40, 42, 42, 56, 1);
   paintRect(c, 64, 14, 46, 16, 56, 1);
   // Flower clusters at top of each stem.
-  paintOval(c, 64, 31, 32,  8, 6, 5);
-  paintOval(c, 64, 23, 38,  6, 5, 5);
-  paintOval(c, 64, 41, 38,  6, 5, 5);
-  paintOval(c, 64, 15, 42,  5, 4, 5);
-  paintOval(c, 64, 31, 30,  4, 2, 4);
-  paintOval(c, 64, 23, 36,  3, 2, 4);
-  paintOval(c, 64, 41, 36,  3, 2, 4);
-  paintOval(c, 64, 15, 41,  2, 1, 4);
+  paintOval(c, 64, 31, 32, 8, 6, 5);
+  paintOval(c, 64, 23, 38, 6, 5, 5);
+  paintOval(c, 64, 41, 38, 6, 5, 5);
+  paintOval(c, 64, 15, 42, 5, 4, 5);
+  paintOval(c, 64, 31, 30, 4, 2, 4);
+  paintOval(c, 64, 23, 36, 3, 2, 4);
+  paintOval(c, 64, 41, 36, 3, 2, 4);
+  paintOval(c, 64, 15, 41, 2, 1, 4);
   // Leaf base.
   paintOval(c, 64, 32, 56, 20, 5, 1);
-  paintOval(c, 64, 22, 56,  5, 3, 2);
-  paintOval(c, 64, 42, 56,  5, 3, 2);
+  paintOval(c, 64, 22, 56, 5, 3, 2);
+  paintOval(c, 64, 42, 56, 5, 3, 2);
   return c;
 }
 
@@ -319,13 +295,22 @@ function buildBushDense(): ReadonlyArray<number> {
 }
 
 export const LARGE_BUSH_SPRITE: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: BUSH_PALETTE, pixels: buildBushClover(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: BUSH_PALETTE,
+  pixels: buildBushClover(),
 };
 export const LARGE_BUSH_SPRITE_TALL: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: BUSH_PALETTE, pixels: buildBushFlower(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: BUSH_PALETTE,
+  pixels: buildBushFlower(),
 };
 export const LARGE_BUSH_SPRITE_DENSE: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: BUSH_PALETTE, pixels: buildBushDense(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: BUSH_PALETTE,
+  pixels: buildBushDense(),
 };
 
 // ---------------------------------------------------------------------------
@@ -337,10 +322,10 @@ export const LARGE_BUSH_SPRITE_DENSE: LargeFeatureSprite = {
 
 const GRASS_PALETTE = [
   0,
-  0x3f5a25,  // 1: dark green base
-  0x5d7a35,  // 2: mid green blade
-  0x8aa550,  // 3: light green tip
-  0xb3c87a,  // 4: pale tip highlight (rare)
+  0x3f5a25, // 1: dark green base
+  0x5d7a35, // 2: mid green blade
+  0x8aa550, // 3: light green tip
+  0xb3c87a, // 4: pale tip highlight (rare)
 ] as const;
 
 // 4×4 = 64×64 px. Vertical-bias blades that span most of the height.
@@ -348,11 +333,11 @@ function buildGrassDense(): ReadonlyArray<number> {
   const c = makeCanvas(64, 64);
   for (let i = 0; i < 18; i++) {
     const baseX = 4 + i * 3;
-    const tipX = baseX + (i % 3) - 1;     // slight per-blade lean
-    const tipY = 6 + ((i * 7) % 18);      // varying heights, mostly tall
+    const tipX = baseX + (i % 3) - 1; // slight per-blade lean
+    const tipY = 6 + ((i * 7) % 18); // varying heights, mostly tall
     paintGrassBlade(c, 64, baseX, 60, tipX, tipY, 1, 2, 3);
   }
-  paintFlecks(c, 64, 8, 5, 8, 56, 22, 4, 0x55);  // pale tip highlights
+  paintFlecks(c, 64, 8, 5, 8, 56, 22, 4, 0x55); // pale tip highlights
   return c;
 }
 
@@ -360,7 +345,7 @@ function buildGrassSparse(): ReadonlyArray<number> {
   const c = makeCanvas(64, 64);
   // Seven tall, well-spaced blades.
   const blades: ReadonlyArray<readonly [number, number, number]> = [
-    [10,  9, 4],
+    [10, 9, 4],
     [18, 16, 8],
     [27, 28, 3],
     [34, 33, 10],
@@ -387,13 +372,22 @@ function buildGrassTilted(): ReadonlyArray<number> {
 }
 
 export const LARGE_GRASS_CLUMP_SPRITE: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: GRASS_PALETTE, pixels: buildGrassDense(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: GRASS_PALETTE,
+  pixels: buildGrassDense(),
 };
 export const LARGE_GRASS_CLUMP_SPRITE_SPARSE: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: GRASS_PALETTE, pixels: buildGrassSparse(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: GRASS_PALETTE,
+  pixels: buildGrassSparse(),
 };
 export const LARGE_GRASS_CLUMP_SPRITE_TILTED: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: GRASS_PALETTE, pixels: buildGrassTilted(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: GRASS_PALETTE,
+  pixels: buildGrassTilted(),
 };
 
 // ---------------------------------------------------------------------------
@@ -404,11 +398,11 @@ export const LARGE_GRASS_CLUMP_SPRITE_TILTED: LargeFeatureSprite = {
 
 const TWIG_PALETTE = [
   0,
-  0x6b4a28,  // 1: mid brown body
-  0x8c6438,  // 2: light brown highlight
-  0x4a3018,  // 3: dark brown shadow
-  0xa07b48,  // 4: pale bark grain
-  0x3d2310,  // 5: deep shadow accent
+  0x6b4a28, // 1: mid brown body
+  0x8c6438, // 2: light brown highlight
+  0x4a3018, // 3: dark brown shadow
+  0xa07b48, // 4: pale bark grain
+  0x3d2310, // 5: deep shadow accent
 ] as const;
 
 // 6×3 = 96×48 px. Long horizontal log silhouette.
@@ -416,14 +410,14 @@ function buildTwigSmooth(): ReadonlyArray<number> {
   const c = makeCanvas(96, 48);
   // Cylindrical body with rounded end caps.
   paintRect(c, 96, 8, 18, 87, 30, 1);
-  paintOval(c, 96,  6, 24, 6, 7, 1);
+  paintOval(c, 96, 6, 24, 6, 7, 1);
   paintOval(c, 96, 90, 24, 6, 7, 1);
   // Top highlight strip and bottom shadow strip.
   paintRect(c, 96, 10, 16, 85, 18, 2);
   paintRect(c, 96, 10, 30, 85, 32, 3);
   paintRect(c, 96, 12, 33, 83, 33, 5);
   // Darker end caps.
-  paintOval(c, 96,  6, 24, 5, 8, 3);
+  paintOval(c, 96, 6, 24, 5, 8, 3);
   paintOval(c, 96, 90, 24, 5, 8, 3);
   // Bark grain flecks.
   paintFlecks(c, 96, 32, 16, 22, 84, 28, 4, 0x99);
@@ -443,10 +437,16 @@ function buildTwigBark(): ReadonlyArray<number> {
 }
 
 export const LARGE_TWIG_SPRITE: LargeFeatureSprite = {
-  tilesWide: 6, tilesTall: 3, colors: TWIG_PALETTE, pixels: buildTwigSmooth(),
+  tilesWide: 6,
+  tilesTall: 3,
+  colors: TWIG_PALETTE,
+  pixels: buildTwigSmooth(),
 };
 export const LARGE_TWIG_SPRITE_BARK: LargeFeatureSprite = {
-  tilesWide: 6, tilesTall: 3, colors: TWIG_PALETTE, pixels: buildTwigBark(),
+  tilesWide: 6,
+  tilesTall: 3,
+  colors: TWIG_PALETTE,
+  pixels: buildTwigBark(),
 };
 
 // ---------------------------------------------------------------------------
@@ -456,11 +456,11 @@ export const LARGE_TWIG_SPRITE_BARK: LargeFeatureSprite = {
 
 const LEAF_PALETTE = [
   0,
-  0x8a5a28,  // 1: mid brown leaf body
-  0xb07a40,  // 2: light brown highlight
-  0xc89358,  // 3: pale tan top edge
-  0x654020,  // 4: dark brown vein/edge
-  0x9a6c30,  // 5: mid-dark brown vein
+  0x8a5a28, // 1: mid brown leaf body
+  0xb07a40, // 2: light brown highlight
+  0xc89358, // 3: pale tan top edge
+  0x654020, // 4: dark brown vein/edge
+  0x9a6c30, // 5: mid-dark brown vein
 ] as const;
 
 // 4×4 = 64×64 px.
@@ -517,13 +517,22 @@ function buildLeafTorn(): ReadonlyArray<number> {
 }
 
 export const LARGE_LEAF_SPRITE: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: LEAF_PALETTE, pixels: buildLeafBroad(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: LEAF_PALETTE,
+  pixels: buildLeafBroad(),
 };
 export const LARGE_LEAF_SPRITE_CURLED: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: LEAF_PALETTE, pixels: buildLeafCurled(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: LEAF_PALETTE,
+  pixels: buildLeafCurled(),
 };
 export const LARGE_LEAF_SPRITE_TORN: LargeFeatureSprite = {
-  tilesWide: 4, tilesTall: 4, colors: LEAF_PALETTE, pixels: buildLeafTorn(),
+  tilesWide: 4,
+  tilesTall: 4,
+  colors: LEAF_PALETTE,
+  pixels: buildLeafTorn(),
 };
 
 // ---------------------------------------------------------------------------
@@ -532,14 +541,7 @@ export const LARGE_LEAF_SPRITE_TORN: LargeFeatureSprite = {
 // orientation. HardBlock.
 // ---------------------------------------------------------------------------
 
-const BIG_LEAF_PALETTE = [
-  0,
-  0x7a4818,
-  0xa8722c,
-  0xc89344,
-  0x523010,
-  0x8b5828,
-] as const;
+const BIG_LEAF_PALETTE = [0, 0x7a4818, 0xa8722c, 0xc89344, 0x523010, 0x8b5828] as const;
 
 // 5×6 = 80×96 px. Ant-scale "ship" canopy.
 function buildBigLeafBroad(): ReadonlyArray<number> {
@@ -549,14 +551,14 @@ function buildBigLeafBroad(): ReadonlyArray<number> {
   paintOval(c, 80, 38, 28, 28, 16, 2);
   paintOval(c, 80, 40, 22, 14, 7, 3);
   // Central vein from tip to base.
-  paintLine(c, 80, 40,  10, 40, 86, 4);
+  paintLine(c, 80, 40, 10, 40, 86, 4);
   // Side veins (7 pairs, fanning outward).
   for (let i = 0; i < 7; i++) {
     const y = 18 + i * 10;
     paintLine(c, 80, 40, y, 12 + i * 2, y + 10, 5);
     paintLine(c, 80, 40, y, 68 - i * 2, y + 10, 5);
   }
-  paintOval(c, 80, 40, 84, 28, 7, 4);  // base shadow
+  paintOval(c, 80, 40, 84, 28, 7, 4); // base shadow
   return c;
 }
 
@@ -584,12 +586,17 @@ function buildBigLeafTorn(): ReadonlyArray<number> {
 }
 
 export const LARGE_BIG_LEAF_SPRITE: LargeFeatureSprite = {
-  tilesWide: 5, tilesTall: 6, colors: BIG_LEAF_PALETTE, pixels: buildBigLeafBroad(),
+  tilesWide: 5,
+  tilesTall: 6,
+  colors: BIG_LEAF_PALETTE,
+  pixels: buildBigLeafBroad(),
 };
 export const LARGE_BIG_LEAF_SPRITE_TORN: LargeFeatureSprite = {
-  tilesWide: 5, tilesTall: 6, colors: BIG_LEAF_PALETTE, pixels: buildBigLeafTorn(),
+  tilesWide: 5,
+  tilesTall: 6,
+  colors: BIG_LEAF_PALETTE,
+  pixels: buildBigLeafTorn(),
 };
-
 
 // ---------------------------------------------------------------------------
 // SURFACE_FEATURE_SPRITES — kind→sprite[] map consumed by terrain-atlas.ts
@@ -614,13 +621,23 @@ import {
   type SurfaceFeatureKind as SurfaceFeatureKindType,
 } from '../sim/surface-features.js';
 
-export const SURFACE_FEATURE_SPRITES: Readonly<Record<SurfaceFeatureKindType, ReadonlyArray<LargeFeatureSprite>>> = {
-  [SurfaceFeatureKind.Boulder]:    [LARGE_BOULDER_SPRITE,    LARGE_BOULDER_SPRITE_FLAT,    LARGE_BOULDER_SPRITE_LICHEN],
-  [SurfaceFeatureKind.Bush]:       [LARGE_BUSH_SPRITE,       LARGE_BUSH_SPRITE_TALL,       LARGE_BUSH_SPRITE_DENSE],
-  [SurfaceFeatureKind.GrassClump]: [LARGE_GRASS_CLUMP_SPRITE, LARGE_GRASS_CLUMP_SPRITE_SPARSE, LARGE_GRASS_CLUMP_SPRITE_TILTED],
-  [SurfaceFeatureKind.Twig]:       [LARGE_TWIG_SPRITE,       LARGE_TWIG_SPRITE_BARK],
-  [SurfaceFeatureKind.Leaf]:       [LARGE_LEAF_SPRITE,       LARGE_LEAF_SPRITE_CURLED,     LARGE_LEAF_SPRITE_TORN],
-  [SurfaceFeatureKind.BigLeaf]:    [LARGE_BIG_LEAF_SPRITE,   LARGE_BIG_LEAF_SPRITE_TORN],
+export const SURFACE_FEATURE_SPRITES: Readonly<
+  Record<SurfaceFeatureKindType, ReadonlyArray<LargeFeatureSprite>>
+> = {
+  [SurfaceFeatureKind.Boulder]: [
+    LARGE_BOULDER_SPRITE,
+    LARGE_BOULDER_SPRITE_FLAT,
+    LARGE_BOULDER_SPRITE_LICHEN,
+  ],
+  [SurfaceFeatureKind.Bush]: [LARGE_BUSH_SPRITE, LARGE_BUSH_SPRITE_TALL, LARGE_BUSH_SPRITE_DENSE],
+  [SurfaceFeatureKind.GrassClump]: [
+    LARGE_GRASS_CLUMP_SPRITE,
+    LARGE_GRASS_CLUMP_SPRITE_SPARSE,
+    LARGE_GRASS_CLUMP_SPRITE_TILTED,
+  ],
+  [SurfaceFeatureKind.Twig]: [LARGE_TWIG_SPRITE, LARGE_TWIG_SPRITE_BARK],
+  [SurfaceFeatureKind.Leaf]: [LARGE_LEAF_SPRITE, LARGE_LEAF_SPRITE_CURLED, LARGE_LEAF_SPRITE_TORN],
+  [SurfaceFeatureKind.BigLeaf]: [LARGE_BIG_LEAF_SPRITE, LARGE_BIG_LEAF_SPRITE_TORN],
 };
 
 // Boot-time integrity check: each sprite array's length and footprint
@@ -637,7 +654,7 @@ for (const kindStr of Object.keys(SURFACE_FEATURE_SPRITES)) {
   if (sprites.length !== entry.variantCount) {
     throw new Error(
       `SURFACE_FEATURE_SPRITES[kind=${kind}]: ${sprites.length} sprites but ` +
-      `registry variantCount=${entry.variantCount}`,
+        `registry variantCount=${entry.variantCount}`,
     );
   }
   for (let i = 0; i < sprites.length; i++) {
@@ -645,8 +662,8 @@ for (const kindStr of Object.keys(SURFACE_FEATURE_SPRITES)) {
     if (s.tilesWide !== entry.footprintTilesWide || s.tilesTall !== entry.footprintTilesTall) {
       throw new Error(
         `SURFACE_FEATURE_SPRITES[kind=${kind}] variant[${i}]: ` +
-        `${s.tilesWide}×${s.tilesTall} but registry footprint=` +
-        `${entry.footprintTilesWide}×${entry.footprintTilesTall}`,
+          `${s.tilesWide}×${s.tilesTall} but registry footprint=` +
+          `${entry.footprintTilesWide}×${entry.footprintTilesTall}`,
       );
     }
   }

--- a/src/render/terrain-noise.test.ts
+++ b/src/render/terrain-noise.test.ts
@@ -5,13 +5,7 @@
 // readability of every tile, so a regression in either is worth catching.
 
 import { describe, expect, it } from 'vitest';
-import {
-  spatialHash,
-  pixelNoise,
-  bayer4,
-  bayer4Threshold,
-  motifOffset,
-} from './terrain-noise.js';
+import { spatialHash, pixelNoise, bayer4, bayer4Threshold, motifOffset } from './terrain-noise.js';
 import { TILE_SIZE_PX } from './sprites.js';
 
 describe('spatialHash', () => {

--- a/src/render/terrain-noise.ts
+++ b/src/render/terrain-noise.ts
@@ -42,12 +42,7 @@ export function pixelNoise(pixelX: number, pixelY: number, salt: number): number
  * stable cross-hatched dither that reads as a textured material rather than
  * either flat color or random noise.
  */
-const BAYER_4: ReadonlyArray<number> = [
-  0,  8,  2, 10,
-  12, 4, 14,  6,
-  3, 11,  1,  9,
-  15, 7, 13,  5,
-];
+const BAYER_4: ReadonlyArray<number> = [0, 8, 2, 10, 12, 4, 14, 6, 3, 11, 1, 9, 15, 7, 13, 5];
 
 export function bayer4(pixelX: number, pixelY: number): number {
   return BAYER_4[((pixelY & 3) << 2) | (pixelX & 3)]!;
@@ -71,11 +66,7 @@ export function bayer4Threshold(pixelX: number, pixelY: number): number {
  * Falls back to (0, 0) when the motif equals the tile size — rare but
  * defensive against zero-range modulos.
  */
-export function motifOffset(
-  hash: number,
-  width: number,
-  height: number,
-): { x: number; y: number } {
+export function motifOffset(hash: number, width: number, height: number): { x: number; y: number } {
   const xRange = TILE_SIZE_PX - width + 1;
   const yRange = TILE_SIZE_PX - height + 1;
   if (xRange <= 1 && yRange <= 1) return { x: 0, y: 0 };

--- a/src/render/triangle-widget.test.ts
+++ b/src/render/triangle-widget.test.ts
@@ -31,28 +31,37 @@ interface GfxCall {
 class MockGfx implements GfxLike {
   calls: GfxCall[] = [];
 
-  clear(): GfxLike { this.calls.push({ method: 'clear', args: [] }); return this; }
+  clear(): GfxLike {
+    this.calls.push({ method: 'clear', args: [] });
+    return this;
+  }
   fillStyle(color: number, alpha?: number): GfxLike {
-    this.calls.push({ method: 'fillStyle', args: [color, alpha] }); return this;
+    this.calls.push({ method: 'fillStyle', args: [color, alpha] });
+    return this;
   }
   lineStyle(width: number, color: number, alpha?: number): GfxLike {
-    this.calls.push({ method: 'lineStyle', args: [width, color, alpha] }); return this;
+    this.calls.push({ method: 'lineStyle', args: [width, color, alpha] });
+    return this;
   }
   fillRect(x: number, y: number, w: number, h: number): GfxLike {
-    this.calls.push({ method: 'fillRect', args: [x, y, w, h] }); return this;
+    this.calls.push({ method: 'fillRect', args: [x, y, w, h] });
+    return this;
   }
   fillCircle(x: number, y: number, r: number): GfxLike {
-    this.calls.push({ method: 'fillCircle', args: [x, y, r] }); return this;
+    this.calls.push({ method: 'fillCircle', args: [x, y, r] });
+    return this;
   }
   strokeCircle(x: number, y: number, r: number): GfxLike {
-    this.calls.push({ method: 'strokeCircle', args: [x, y, r] }); return this;
+    this.calls.push({ method: 'strokeCircle', args: [x, y, r] });
+    return this;
   }
   fillTriangle(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number): GfxLike {
-    this.calls.push({ method: 'fillTriangle', args: [x0, y0, x1, y1, x2, y2] }); return this;
+    this.calls.push({ method: 'fillTriangle', args: [x0, y0, x1, y1, x2, y2] });
+    return this;
   }
 
   callsOf(method: string): GfxCall[] {
-    return this.calls.filter(c => c.method === method);
+    return this.calls.filter((c) => c.method === method);
   }
 }
 
@@ -222,7 +231,11 @@ describe('drawSlider', () => {
     const gfx = new MockGfx();
     drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 10, fight: 0 });
     const allowedMethods = new Set([
-      'fillStyle', 'lineStyle', 'fillRect', 'fillCircle', 'strokeCircle',
+      'fillStyle',
+      'lineStyle',
+      'fillRect',
+      'fillCircle',
+      'strokeCircle',
     ]);
     for (const c of gfx.calls) {
       expect(allowedMethods.has(c.method)).toBe(true);
@@ -250,7 +263,10 @@ describe('drawSlider', () => {
     drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 10, fight: 0 });
     const firstFillRect = gfx.callsOf('fillRect')[0]!;
     expect(firstFillRect.args).toEqual([
-      HUD.TRIANGLE.x, HUD.TRIANGLE.y, HUD.TRIANGLE.w, HUD.TRIANGLE.h,
+      HUD.TRIANGLE.x,
+      HUD.TRIANGLE.y,
+      HUD.TRIANGLE.w,
+      HUD.TRIANGLE.h,
     ]);
   });
 
@@ -270,7 +286,7 @@ describe('drawSlider', () => {
     const gfx = new MockGfx();
     drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 0, fight: 10 });
     // Find the fillStyle call immediately preceding the fillCircle call.
-    const fillCircleIdx = gfx.calls.findIndex(c => c.method === 'fillCircle');
+    const fillCircleIdx = gfx.calls.findIndex((c) => c.method === 'fillCircle');
     expect(fillCircleIdx).toBeGreaterThan(0);
     // Walk backwards to the most recent fillStyle.
     let lastFillStyleColor: unknown = null;

--- a/src/render/triangle-widget.ts
+++ b/src/render/triangle-widget.ts
@@ -22,16 +22,16 @@ import type { GfxLike } from './draw-surface.js';
 // giving an 88-pixel-wide horizontal track. 4-pixel-thick rendered track.
 // ---------------------------------------------------------------------------
 
-const TRACK_LEFT  = HUD.TRIANGLE.x + 16;                  // 24
+const TRACK_LEFT = HUD.TRIANGLE.x + 16; // 24
 const TRACK_RIGHT = HUD.TRIANGLE.x + HUD.TRIANGLE.w - 16; // 112
-const TRACK_Y     = HUD.TRIANGLE.y + HUD.TRIANGLE.h / 2;  // 554
-const TRACK_LEN   = TRACK_RIGHT - TRACK_LEFT;             // 88
+const TRACK_Y = HUD.TRIANGLE.y + HUD.TRIANGLE.h / 2; // 554
+const TRACK_LEN = TRACK_RIGHT - TRACK_LEFT; // 88
 
 export const SLIDER_GEOMETRY = {
-  trackLeft:  TRACK_LEFT,
+  trackLeft: TRACK_LEFT,
   trackRight: TRACK_RIGHT,
-  trackY:     TRACK_Y,
-  trackLen:   TRACK_LEN,
+  trackY: TRACK_Y,
+  trackLen: TRACK_LEN,
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -39,7 +39,7 @@ export const SLIDER_GEOMETRY = {
 // ---------------------------------------------------------------------------
 
 export interface SliderDragState {
-  isDragging:  boolean;
+  isDragging: boolean;
   targetRatio: { forage: number; fight: number };
 }
 
@@ -65,10 +65,10 @@ export function screenToSliderRatio(px: number): { forage: number; fight: number
   // return `{forage: NaN, fight: NaN}`, corrupting colony.targetRatio. Fall
   // back to the safe default rather than poisoning state.
   if (TRACK_LEN <= 0) return { forage: 10, fight: 0 };
-  const t = (px - TRACK_LEFT) / TRACK_LEN;       // float in [0,1] (clamped below)
+  const t = (px - TRACK_LEFT) / TRACK_LEN; // float in [0,1] (clamped below)
   const tc = Math.max(0, Math.min(1, t));
   // 11 discrete steps: 0,1,...,10. fight gets `Math.round(tc * 10)`; forage = 10 - fight.
-  const fight  = Math.round(tc * 10);
+  const fight = Math.round(tc * 10);
   const forage = 10 - fight;
   return { forage, fight };
 }
@@ -80,7 +80,10 @@ export function screenToSliderRatio(px: number): { forage: number; fight: number
 // are zero (degenerate save-migration edge case), pins to the track center.
 // ---------------------------------------------------------------------------
 
-export function ratioToSliderPos(ratio: { forage: number; fight: number }): { x: number; y: number } {
+export function ratioToSliderPos(ratio: { forage: number; fight: number }): {
+  x: number;
+  y: number;
+} {
   const total = ratio.forage + ratio.fight;
   // Degenerate: pin to center if both are 0.
   const t = total === 0 ? 0.5 : ratio.fight / total;
@@ -117,9 +120,9 @@ export function isInsideSlider(px: number, py: number): boolean {
 // ---------------------------------------------------------------------------
 
 export function drawSlider(
-  gfx:          GfxLike,
+  gfx: GfxLike,
   currentRatio: { forage: number; fight: number },
-  targetRatio:  { forage: number; fight: number },
+  targetRatio: { forage: number; fight: number },
 ): void {
   // Zone background — semi-transparent dark fill behind the slider so labels
   // and markers stay readable against the surface beneath.

--- a/src/render/ui-scene-logic.ts
+++ b/src/render/ui-scene-logic.ts
@@ -24,11 +24,15 @@ export type QueenDeathCause =
  */
 export function formatOutcomeTitle(outcome: GameOutcome): { text: string; color: number } {
   switch (outcome) {
-    case GameOutcome.Victory:           return { text: 'VICTORY',           color: 0x00ff00 };
-    case GameOutcome.Defeat:            return { text: 'DEFEAT',             color: 0xff0000 };
-    case GameOutcome.MutualDestruction: return { text: 'MUTUAL DESTRUCTION', color: 0xffaa00 };
+    case GameOutcome.Victory:
+      return { text: 'VICTORY', color: 0x00ff00 };
+    case GameOutcome.Defeat:
+      return { text: 'DEFEAT', color: 0xff0000 };
+    case GameOutcome.MutualDestruction:
+      return { text: 'MUTUAL DESTRUCTION', color: 0xffaa00 };
     case GameOutcome.None:
-    default:                            return { text: '',                   color: 0x000000 };
+    default:
+      return { text: '', color: 0x000000 };
   }
 }
 
@@ -57,17 +61,25 @@ export function formatCauseSubtitle(outcome: GameOutcome, cause: QueenDeathCause
   switch (outcome) {
     case GameOutcome.Victory:
       switch (cause) {
-        case 'InvasionKill':  return 'Your fighters killed their queen';
-        case 'Starvation':    return 'Their queen starved';
-        case 'SpiderRampage': return 'Their queen was killed by a spider';
-        default:              return '';
+        case 'InvasionKill':
+          return 'Your fighters killed their queen';
+        case 'Starvation':
+          return 'Their queen starved';
+        case 'SpiderRampage':
+          return 'Their queen was killed by a spider';
+        default:
+          return '';
       }
     case GameOutcome.Defeat:
       switch (cause) {
-        case 'InvasionKill':  return 'Your queen was killed by the enemy';
-        case 'Starvation':    return 'Your queen starved';
-        case 'SpiderRampage': return 'Your queen was killed by a spider';
-        default:              return '';
+        case 'InvasionKill':
+          return 'Your queen was killed by the enemy';
+        case 'Starvation':
+          return 'Your queen starved';
+        case 'SpiderRampage':
+          return 'Your queen was killed by a spider';
+        default:
+          return '';
       }
     case GameOutcome.MutualDestruction:
       return 'Both queens died at the same time';

--- a/src/render/ui-scene.test.ts
+++ b/src/render/ui-scene.test.ts
@@ -9,7 +9,11 @@
 //   - formatCauseSubtitle(outcome, cause): string
 
 import { describe, it, expect } from 'vitest';
-import { formatOutcomeTitle, formatKillStatsSubtitle, formatCauseSubtitle } from './ui-scene-logic.js';
+import {
+  formatOutcomeTitle,
+  formatKillStatsSubtitle,
+  formatCauseSubtitle,
+} from './ui-scene-logic.js';
 import { GameOutcome } from '../sim/game-over.js';
 
 // ---------------------------------------------------------------------------
@@ -70,7 +74,9 @@ describe('formatKillStatsSubtitle', () => {
 
 describe('formatCauseSubtitle — Victory', () => {
   it('InvasionKill: your fighters killed their queen', () => {
-    expect(formatCauseSubtitle(GameOutcome.Victory, 'InvasionKill')).toBe('Your fighters killed their queen');
+    expect(formatCauseSubtitle(GameOutcome.Victory, 'InvasionKill')).toBe(
+      'Your fighters killed their queen',
+    );
   });
 
   it('Starvation: their queen starved', () => {
@@ -78,7 +84,9 @@ describe('formatCauseSubtitle — Victory', () => {
   });
 
   it('SpiderRampage: their queen killed by spider', () => {
-    expect(formatCauseSubtitle(GameOutcome.Victory, 'SpiderRampage')).toBe('Their queen was killed by a spider');
+    expect(formatCauseSubtitle(GameOutcome.Victory, 'SpiderRampage')).toBe(
+      'Their queen was killed by a spider',
+    );
   });
 
   it('null cause returns empty string', () => {
@@ -88,7 +96,9 @@ describe('formatCauseSubtitle — Victory', () => {
 
 describe('formatCauseSubtitle — Defeat', () => {
   it('InvasionKill: your queen killed by enemy', () => {
-    expect(formatCauseSubtitle(GameOutcome.Defeat, 'InvasionKill')).toBe('Your queen was killed by the enemy');
+    expect(formatCauseSubtitle(GameOutcome.Defeat, 'InvasionKill')).toBe(
+      'Your queen was killed by the enemy',
+    );
   });
 
   it('Starvation: your queen starved', () => {
@@ -96,7 +106,9 @@ describe('formatCauseSubtitle — Defeat', () => {
   });
 
   it('SpiderRampage: your queen killed by spider', () => {
-    expect(formatCauseSubtitle(GameOutcome.Defeat, 'SpiderRampage')).toBe('Your queen was killed by a spider');
+    expect(formatCauseSubtitle(GameOutcome.Defeat, 'SpiderRampage')).toBe(
+      'Your queen was killed by a spider',
+    );
   });
 
   it('null cause returns empty string', () => {
@@ -106,8 +118,12 @@ describe('formatCauseSubtitle — Defeat', () => {
 
 describe('formatCauseSubtitle — MutualDestruction', () => {
   it('always returns both-queens message regardless of cause', () => {
-    expect(formatCauseSubtitle(GameOutcome.MutualDestruction, 'MutualDestruction')).toBe('Both queens died at the same time');
-    expect(formatCauseSubtitle(GameOutcome.MutualDestruction, null)).toBe('Both queens died at the same time');
+    expect(formatCauseSubtitle(GameOutcome.MutualDestruction, 'MutualDestruction')).toBe(
+      'Both queens died at the same time',
+    );
+    expect(formatCauseSubtitle(GameOutcome.MutualDestruction, null)).toBe(
+      'Both queens died at the same time',
+    );
   });
 });
 

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -25,7 +25,12 @@ import { toggleView, toggleUndergroundColony } from './camera.js';
 import type { WorldState } from '../sim/types.js';
 import { HUD } from './sprites.js';
 import { GameOutcome } from '../sim/game-over.js';
-import { formatOutcomeTitle, formatKillStatsSubtitle, formatCauseSubtitle, type QueenDeathCause } from './ui-scene-logic.js';
+import {
+  formatOutcomeTitle,
+  formatKillStatsSubtitle,
+  formatCauseSubtitle,
+  type QueenDeathCause,
+} from './ui-scene-logic.js';
 import { PLAYER_COLONY_ID as _PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
 
 // Re-export pure helpers for Plan 07 and external consumers
@@ -97,11 +102,11 @@ export const SAVE_PROMPT_CONTINUE_RECT = { x: 300, y: 280, w: 120, h: 32 } as co
 /** Canvas-local rect for the SavePrompt "New Game" button. */
 export const SAVE_PROMPT_NEW_GAME_RECT = { x: 300, y: 320, w: 120, h: 32 } as const;
 /** Canvas-local rect for the GameOver "Restart" button. */
-export const GAME_OVER_RESTART_RECT    = { x: 300, y: 345, w: 120, h: 32 } as const;
+export const GAME_OVER_RESTART_RECT = { x: 300, y: 345, w: 120, h: 32 } as const;
 /** Canvas-local rects for the DifficultySelect buttons (Easy / Normal / Hard). */
-export const DIFFICULTY_EASY_RECT   = { x: 180, y: 260, w: 140, h: 40 } as const;
+export const DIFFICULTY_EASY_RECT = { x: 180, y: 260, w: 140, h: 40 } as const;
 export const DIFFICULTY_NORMAL_RECT = { x: 330, y: 260, w: 140, h: 40 } as const;
-export const DIFFICULTY_HARD_RECT   = { x: 480, y: 260, w: 140, h: 40 } as const;
+export const DIFFICULTY_HARD_RECT = { x: 480, y: 260, w: 140, h: 40 } as const;
 import {
   createSliderDragState,
   drawSlider,
@@ -203,12 +208,7 @@ import {
  *  noticed without slowing down a player who wants to chain Save → Continue. */
 const SAVE_FLASH_MS = 1500;
 import { loadSettings, saveSettings } from '../platform/settings.js';
-import {
-  hasSave,
-  hasIncompatibleSave,
-  getSaveInfo,
-  deleteSave,
-} from '../platform/save.js';
+import { hasSave, hasIncompatibleSave, getSaveInfo, deleteSave } from '../platform/save.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
 import type { SetBehaviorRatioCommand, PlaceChamberCommand } from '../sim/commands.js';
 
@@ -347,7 +347,9 @@ export class UIScene extends Phaser.Scene {
   private saveLoadDialogFlash: 'none' | 'saved' | 'failed' = 'none';
   private saveLoadDialogFlashTimer: Phaser.Time.TimerEvent | null = null;
 
-  constructor() { super({ key: 'UIScene' }); }
+  constructor() {
+    super({ key: 'UIScene' });
+  }
 
   init(data: {
     viewState: ViewState;
@@ -368,31 +370,28 @@ export class UIScene extends Phaser.Scene {
     // anchored). Row 2: queenLabelText (white, left) + queen health bar
     // (drawn in update() via gfx so its color can change per frame without
     // Text churn).
-    this.antsText = this.add.text(
-      STATS_TEXT_X,
-      STATS_ROW1_Y,
-      'Ants: 0',
-      { color: HUD_STATS_COLORS.antsTextCss, fontSize: '10px', fontFamily: 'monospace' },
-    );
+    this.antsText = this.add.text(STATS_TEXT_X, STATS_ROW1_Y, 'Ants: 0', {
+      color: HUD_STATS_COLORS.antsTextCss,
+      fontSize: '10px',
+      fontFamily: 'monospace',
+    });
     this.antsText.setScrollFactor(0);
 
-    this.foodText = this.add.text(
-      STATS_TEXT_X,
-      STATS_ROW1_Y,
-      'Food: 0/0',
-      { color: HUD_STATS_COLORS.foodTextCss, fontSize: '10px', fontFamily: 'monospace' },
-    );
+    this.foodText = this.add.text(STATS_TEXT_X, STATS_ROW1_Y, 'Food: 0/0', {
+      color: HUD_STATS_COLORS.foodTextCss,
+      fontSize: '10px',
+      fontFamily: 'monospace',
+    });
     this.foodText.setScrollFactor(0);
 
     // Queen label — "Queen" text sits on row 2 (09 HUD clarity pass).
     // Position is set in update() from queenLabelRect so layout constants
     // remain single-sourced in hud-stats.ts.
-    this.queenLabelText = this.add.text(
-      STATS_TEXT_X,
-      STATS_ROW2_Y,
-      formatQueenLabel(),
-      { color: HUD_STATS_COLORS.queenLabelCss, fontSize: '10px', fontFamily: 'monospace' },
-    );
+    this.queenLabelText = this.add.text(STATS_TEXT_X, STATS_ROW2_Y, formatQueenLabel(), {
+      color: HUD_STATS_COLORS.queenLabelCss,
+      fontSize: '10px',
+      fontFamily: 'monospace',
+    });
     this.queenLabelText.setScrollFactor(0);
 
     // Slider extreme labels — static text, created once. Phase 10 / D-01:
@@ -406,18 +405,14 @@ export class UIScene extends Phaser.Scene {
     // label sits flush at the top edge — trackY=554 - 22 = 532 = HUD.TRIANGLE.y,
     // and the 10px label text occupies y:[532,542], inside the zone.
     this.triangleLabels = [
-      this.add.text(
-        HUD.TRIANGLE.x + 4,
-        SLIDER_GEOMETRY.trackY - 22,
-        'Forage',
-        { color: '#ffffff', fontSize: '10px' },
-      ),
-      this.add.text(
-        HUD.TRIANGLE.x + HUD.TRIANGLE.w - 28,
-        SLIDER_GEOMETRY.trackY - 22,
-        'Fight',
-        { color: '#ffffff', fontSize: '10px' },
-      ),
+      this.add.text(HUD.TRIANGLE.x + 4, SLIDER_GEOMETRY.trackY - 22, 'Forage', {
+        color: '#ffffff',
+        fontSize: '10px',
+      }),
+      this.add.text(HUD.TRIANGLE.x + HUD.TRIANGLE.w - 28, SLIDER_GEOMETRY.trackY - 22, 'Fight', {
+        color: '#ffffff',
+        fontSize: '10px',
+      }),
     ];
     for (const label of this.triangleLabels) {
       label.setScrollFactor(0);
@@ -456,13 +451,12 @@ export class UIScene extends Phaser.Scene {
     // Context menu item labels — created once, positioned/shown per frame.
     // One Phaser.Text per ChamberType (Queen / Nursery / Food Storage) so the
     // player can actually read the choices instead of seeing unlabeled stripes.
-    this.contextMenuLabels = CONTEXT_MENU_ITEMS.map(item => {
-      const t = this.add.text(
-        0,
-        0,
-        item.label,
-        { color: '#ffffff', fontSize: '13px', fontFamily: 'monospace' },
-      );
+    this.contextMenuLabels = CONTEXT_MENU_ITEMS.map((item) => {
+      const t = this.add.text(0, 0, item.label, {
+        color: '#ffffff',
+        fontSize: '13px',
+        fontFamily: 'monospace',
+      });
       t.setScrollFactor(0);
       t.setVisible(false);
       t.setDepth(10); // draw above the gfx stripes
@@ -472,16 +466,11 @@ export class UIScene extends Phaser.Scene {
     // Ant-activity popup body — single multi-line Text widget anchored to the
     // top-left of ANT_ACTIVITY_PANEL. Created once, shown/hidden and retargeted
     // per frame in update() based on antActivityPanelState.visible.
-    this.antActivityText = this.add.text(
-      ANT_ACTIVITY_PANEL.x + 8,
-      ANT_ACTIVITY_PANEL.y + 8,
-      '',
-      {
-        color: ANT_ACTIVITY_PANEL_COLORS.textCss,
-        fontSize: '11px',
-        fontFamily: 'monospace',
-      },
-    );
+    this.antActivityText = this.add.text(ANT_ACTIVITY_PANEL.x + 8, ANT_ACTIVITY_PANEL.y + 8, '', {
+      color: ANT_ACTIVITY_PANEL_COLORS.textCss,
+      fontSize: '11px',
+      fontFamily: 'monospace',
+    });
     this.antActivityText.setScrollFactor(0);
     this.antActivityText.setVisible(false);
     this.antActivityText.setDepth(11);
@@ -583,14 +572,20 @@ export class UIScene extends Phaser.Scene {
       // menu from lingering after unrelated HUD interactions.
       if (contextMenuState.visible) {
         const items = this.contextMenuVisibleItems;
-        if (isInsideContextMenu(
-          pointer.x, pointer.y,
-          contextMenuState.screenX, contextMenuState.screenY,
-          items,
-        )) {
+        if (
+          isInsideContextMenu(
+            pointer.x,
+            pointer.y,
+            contextMenuState.screenX,
+            contextMenuState.screenY,
+            items,
+          )
+        ) {
           const choice = contextMenuItemAt(
-            pointer.x, pointer.y,
-            contextMenuState.screenX, contextMenuState.screenY,
+            pointer.x,
+            pointer.y,
+            contextMenuState.screenX,
+            contextMenuState.screenY,
             items,
           );
           const world = this.getWorld();
@@ -638,14 +633,14 @@ export class UIScene extends Phaser.Scene {
           return;
         }
         const overHud =
-             this.isInsideRect(pointer.x, pointer.y, HUD.TRIANGLE)
-          || this.isInsideRect(pointer.x, pointer.y, HUD.MINIMAP)
-          || this.isInsideRect(pointer.x, pointer.y, HUD.VIEW_TOGGLE)
+          this.isInsideRect(pointer.x, pointer.y, HUD.TRIANGLE) ||
+          this.isInsideRect(pointer.x, pointer.y, HUD.MINIMAP) ||
+          this.isInsideRect(pointer.x, pointer.y, HUD.VIEW_TOGGLE) ||
           // Issue #14 — colony-toggle button. Without this entry, a click
           // on the new toggle while the ant-activity panel is up would
           // be classified as "world click", dismissing the panel and
           // dropping the toggle dispatch.
-          || this.isInsideRect(pointer.x, pointer.y, HUD.UNDERGROUND_COLONY_TOGGLE);
+          this.isInsideRect(pointer.x, pointer.y, HUD.UNDERGROUND_COLONY_TOGGLE);
         if (!overHud) {
           // Click on the world — dismiss and consume. `return` prevents
           // any further UIScene handling; the deferred hide prevents the
@@ -773,7 +768,7 @@ export class UIScene extends Phaser.Scene {
       // small inset). Row 2: "Queen" left-anchored, queen health bar right-
       // anchored. Rows are disjoint so "Food: C/M" can grow without fighting
       // the queen label for horizontal budget.
-      const bar   = queenBarRect(HUD.STATS);
+      const bar = queenBarRect(HUD.STATS);
       const label = queenLabelRect(HUD.STATS);
       this.queenLabelText.setPosition(label.x, label.y);
       const FOOD_RIGHT_INSET = 6;
@@ -806,16 +801,21 @@ export class UIScene extends Phaser.Scene {
       // contradicting the actual (zero-on-axis) state. Fall back to the player's
       // intent (`targetRatio`) so the current marker overlays the target marker
       // rather than fabricating an extreme position.
-      const currentRatio = ff > 0
-        ? {
-            forage: Math.round(colony.taskCensus.forage * 100 / ff),
-            fight:  Math.round(colony.taskCensus.fight  * 100 / ff),
-          }
-        : { forage: colony.targetRatio.forage, fight: colony.targetRatio.fight };
+      const currentRatio =
+        ff > 0
+          ? {
+              forage: Math.round((colony.taskCensus.forage * 100) / ff),
+              fight: Math.round((colony.taskCensus.fight * 100) / ff),
+            }
+          : { forage: colony.targetRatio.forage, fight: colony.targetRatio.fight };
       const targetRatio = this.dragState.isDragging
         ? this.dragState.targetRatio
         : colony.targetRatio;
-      drawSlider(this.gfx as unknown as import('./draw-surface.js').GfxLike, currentRatio, targetRatio);
+      drawSlider(
+        this.gfx as unknown as import('./draw-surface.js').GfxLike,
+        currentRatio,
+        targetRatio,
+      );
     }
 
     // Minimap
@@ -835,9 +835,7 @@ export class UIScene extends Phaser.Scene {
     // string ('Your Colony' / 'Enemy Colony') so existing tests don't have
     // to know about the (X) hint affordance the button now renders.
     const undergroundLabel: ActiveUndergroundLabel =
-      this.viewState.activeUndergroundColonyId === ENEMY_COLONY_ID
-        ? 'Enemy Colony'
-        : 'Your Colony';
+      this.viewState.activeUndergroundColonyId === ENEMY_COLONY_ID ? 'Enemy Colony' : 'Your Colony';
     const undergroundShowing = this.viewState.activeView === 'underground';
     if (undergroundShowing) {
       // Draw the toggle background as a Graphics fill (matches VIEW_TOGGLE
@@ -952,9 +950,10 @@ export class UIScene extends Phaser.Scene {
 
     // S6: prefer narrativeSeed from summary-builder; fall back to formatCauseSubtitle
     // for pre-V22 saves or cases where buildPlaytraceSummary returns null.
-    const causeText = (narrativeSeed != null && narrativeSeed !== '')
-      ? narrativeSeed
-      : formatCauseSubtitle(outcome, cause);
+    const causeText =
+      narrativeSeed != null && narrativeSeed !== ''
+        ? narrativeSeed
+        : formatCauseSubtitle(outcome, cause);
     const causeLabel = this.add.text(W / 2, H / 2 - 25, causeText, {
       fontSize: '18px',
       fontFamily: 'monospace',
@@ -982,9 +981,12 @@ export class UIScene extends Phaser.Scene {
     // Restart button
     const btnR = GAME_OVER_RESTART_RECT;
     const btnBg = this.add.rectangle(
-      btnR.x + btnR.w / 2, btnR.y + btnR.h / 2,
-      btnR.w, btnR.h,
-      0x444444, 1,
+      btnR.x + btnR.w / 2,
+      btnR.y + btnR.h / 2,
+      btnR.w,
+      btnR.h,
+      0x444444,
+      1,
     );
     btnBg.setInteractive();
     btnBg.setDepth(21);
@@ -1032,7 +1034,9 @@ export class UIScene extends Phaser.Scene {
           duration: 400,
           delay: 800,
           ease: 'Linear',
-          onComplete: () => { captionText.destroy(); },
+          onComplete: () => {
+            captionText.destroy();
+          },
         });
       },
     });
@@ -1067,20 +1071,28 @@ export class UIScene extends Phaser.Scene {
     title.setOrigin(0.5);
     title.setDepth(21);
 
-    const subtitle = this.add.text(W / 2, H / 2 - 40, 'Found a previous session. Continue or start new?', {
-      fontSize: '14px',
-      fontFamily: 'monospace',
-      color: '#aaaaaa',
-    });
+    const subtitle = this.add.text(
+      W / 2,
+      H / 2 - 40,
+      'Found a previous session. Continue or start new?',
+      {
+        fontSize: '14px',
+        fontFamily: 'monospace',
+        color: '#aaaaaa',
+      },
+    );
     subtitle.setOrigin(0.5);
     subtitle.setDepth(21);
 
     // Continue button
     const contR = SAVE_PROMPT_CONTINUE_RECT;
     const contBg = this.add.rectangle(
-      contR.x + contR.w / 2, contR.y + contR.h / 2,
-      contR.w, contR.h,
-      0x226622, 1,
+      contR.x + contR.w / 2,
+      contR.y + contR.h / 2,
+      contR.w,
+      contR.h,
+      0x226622,
+      1,
     );
     contBg.setInteractive();
     contBg.setDepth(21);
@@ -1100,9 +1112,12 @@ export class UIScene extends Phaser.Scene {
     // New Game button
     const ngR = SAVE_PROMPT_NEW_GAME_RECT;
     const ngBg = this.add.rectangle(
-      ngR.x + ngR.w / 2, ngR.y + ngR.h / 2,
-      ngR.w, ngR.h,
-      0x662222, 1,
+      ngR.x + ngR.w / 2,
+      ngR.y + ngR.h / 2,
+      ngR.w,
+      ngR.h,
+      0x662222,
+      1,
     );
     ngBg.setInteractive();
     ngBg.setDepth(21);
@@ -1137,7 +1152,9 @@ export class UIScene extends Phaser.Scene {
   // button — the player must choose before the world is created.
   // ---------------------------------------------------------------------------
 
-  public showDifficultySelectOverlay(callbacks: { onSelect: (d: 'Easy' | 'Normal' | 'Hard') => void }): void {
+  public showDifficultySelectOverlay(callbacks: {
+    onSelect: (d: 'Easy' | 'Normal' | 'Hard') => void;
+  }): void {
     this.hideDifficultySelectOverlay();
 
     const W = 800;
@@ -1148,14 +1165,23 @@ export class UIScene extends Phaser.Scene {
     bg.setDepth(20);
 
     const title = this.add.text(W / 2, H / 2 - 100, 'Choose Difficulty', {
-      fontSize: '28px', fontFamily: 'monospace', color: '#ffffff',
+      fontSize: '28px',
+      fontFamily: 'monospace',
+      color: '#ffffff',
     });
     title.setOrigin(0.5);
     title.setDepth(21);
 
-    const subtitle = this.add.text(W / 2, H / 2 - 60, 'Affects the enemy colony\'s aggression and reproduction rate.', {
-      fontSize: '13px', fontFamily: 'monospace', color: '#aaaaaa',
-    });
+    const subtitle = this.add.text(
+      W / 2,
+      H / 2 - 60,
+      "Affects the enemy colony's aggression and reproduction rate.",
+      {
+        fontSize: '13px',
+        fontFamily: 'monospace',
+        color: '#aaaaaa',
+      },
+    );
     subtitle.setOrigin(0.5);
     subtitle.setDepth(21);
 
@@ -1167,8 +1193,12 @@ export class UIScene extends Phaser.Scene {
       difficulty: 'Easy' | 'Normal' | 'Hard',
     ): Phaser.GameObjects.GameObject[] => {
       const btnBg = this.add.rectangle(
-        rect.x + rect.w / 2, rect.y + rect.h / 2,
-        rect.w, rect.h, color, 1,
+        rect.x + rect.w / 2,
+        rect.y + rect.h / 2,
+        rect.w,
+        rect.h,
+        color,
+        1,
       );
       btnBg.setInteractive();
       btnBg.setDepth(21);
@@ -1178,13 +1208,17 @@ export class UIScene extends Phaser.Scene {
       });
 
       const btnLabel = this.add.text(rect.x + rect.w / 2, rect.y + 12, label, {
-        fontSize: '15px', fontFamily: 'monospace', color: '#ffffff',
+        fontSize: '15px',
+        fontFamily: 'monospace',
+        color: '#ffffff',
       });
       btnLabel.setOrigin(0.5, 0);
       btnLabel.setDepth(22);
 
       const btnDesc = this.add.text(rect.x + rect.w / 2, rect.y + 28, desc, {
-        fontSize: '10px', fontFamily: 'monospace', color: '#cccccc',
+        fontSize: '10px',
+        fontFamily: 'monospace',
+        color: '#cccccc',
         wordWrap: { width: rect.w - 8 },
       });
       btnDesc.setOrigin(0.5, 0);
@@ -1197,9 +1231,9 @@ export class UIScene extends Phaser.Scene {
     const normR = DIFFICULTY_NORMAL_RECT;
     const hardR = DIFFICULTY_HARD_RECT;
 
-    const easyObjs  = makeButton('Easy',   'Slower AI', easyR, 0x226622, 'Easy');
-    const normObjs  = makeButton('Normal', 'Balanced',  normR, 0x224466, 'Normal');
-    const hardObjs  = makeButton('Hard',   'Faster AI', hardR, 0x662222, 'Hard');
+    const easyObjs = makeButton('Easy', 'Slower AI', easyR, 0x226622, 'Easy');
+    const normObjs = makeButton('Normal', 'Balanced', normR, 0x224466, 'Normal');
+    const hardObjs = makeButton('Hard', 'Faster AI', hardR, 0x662222, 'Hard');
 
     this.difficultySelectGroup = [bg, title, subtitle, ...easyObjs, ...normObjs, ...hardObjs];
     this.recomputeActiveOverlay();
@@ -1329,24 +1363,16 @@ export class UIScene extends Phaser.Scene {
       const r = item.rect;
       const fillColor = item.enabled ? 0x333333 : 0x202020;
       const labelColor = item.enabled ? '#ffffff' : '#777777';
-      const btn = this.add.rectangle(
-        r.x + r.w / 2,
-        r.y + r.h / 2,
-        r.w,
-        r.h,
-        fillColor,
-        1,
-      );
+      const btn = this.add.rectangle(r.x + r.w / 2, r.y + r.h / 2, r.w, r.h, fillColor, 1);
       btn.setInteractive();
       btn.setDepth(21);
       this.pauseMenuGroup.push(btn);
 
-      const label = this.add.text(
-        r.x + r.w / 2,
-        r.y + r.h / 2,
-        item.label,
-        { fontSize: '16px', fontFamily: 'monospace', color: labelColor },
-      );
+      const label = this.add.text(r.x + r.w / 2, r.y + r.h / 2, item.label, {
+        fontSize: '16px',
+        fontFamily: 'monospace',
+        color: labelColor,
+      });
       label.setOrigin(0.5);
       label.setDepth(22);
       this.pauseMenuGroup.push(label);
@@ -1500,12 +1526,11 @@ export class UIScene extends Phaser.Scene {
     this.saveLoadDialogGroup.push(bg);
 
     // Title
-    const title = this.add.text(
-      PAUSE_MENU_CANVAS_W / 2,
-      DIALOG_TITLE_Y,
-      saveLoadDialogTitle(),
-      { fontSize: '28px', fontFamily: 'monospace', color: '#ffffff' },
-    );
+    const title = this.add.text(PAUSE_MENU_CANVAS_W / 2, DIALOG_TITLE_Y, saveLoadDialogTitle(), {
+      fontSize: '28px',
+      fontFamily: 'monospace',
+      color: '#ffffff',
+    });
     title.setOrigin(0.5);
     title.setDepth(31);
     this.saveLoadDialogGroup.push(title);
@@ -1528,12 +1553,11 @@ export class UIScene extends Phaser.Scene {
     if (this.saveLoadDialogFlash !== 'none') {
       const flashColor = this.saveLoadDialogFlash === 'saved' ? '#88ee88' : '#ff7766';
       const flashText = this.saveLoadDialogFlash === 'saved' ? 'Saved' : 'Save failed';
-      const flash = this.add.text(
-        PAUSE_MENU_CANVAS_W / 2,
-        DIALOG_INFO_Y + 18,
-        flashText,
-        { fontSize: '12px', fontFamily: 'monospace', color: flashColor },
-      );
+      const flash = this.add.text(PAUSE_MENU_CANVAS_W / 2, DIALOG_INFO_Y + 18, flashText, {
+        fontSize: '12px',
+        fontFamily: 'monospace',
+        color: flashColor,
+      });
       flash.setOrigin(0.5);
       flash.setDepth(31);
       this.saveLoadDialogGroup.push(flash);
@@ -1550,30 +1574,18 @@ export class UIScene extends Phaser.Scene {
     // is the sole entry point.
     for (const item of items) {
       const r = item.rect;
-      const fillColor = !item.enabled ? 0x202020
-        : item.confirming ? 0x884422
-        : 0x333333;
-      const labelColor = !item.enabled ? '#777777'
-        : item.confirming ? '#ffeecc'
-        : '#ffffff';
-      const btn = this.add.rectangle(
-        r.x + r.w / 2,
-        r.y + r.h / 2,
-        r.w,
-        r.h,
-        fillColor,
-        1,
-      );
+      const fillColor = !item.enabled ? 0x202020 : item.confirming ? 0x884422 : 0x333333;
+      const labelColor = !item.enabled ? '#777777' : item.confirming ? '#ffeecc' : '#ffffff';
+      const btn = this.add.rectangle(r.x + r.w / 2, r.y + r.h / 2, r.w, r.h, fillColor, 1);
       btn.setInteractive();
       btn.setDepth(31);
       this.saveLoadDialogGroup.push(btn);
 
-      const label = this.add.text(
-        r.x + r.w / 2,
-        r.y + r.h / 2,
-        item.label,
-        { fontSize: '14px', fontFamily: 'monospace', color: labelColor },
-      );
+      const label = this.add.text(r.x + r.w / 2, r.y + r.h / 2, item.label, {
+        fontSize: '14px',
+        fontFamily: 'monospace',
+        color: labelColor,
+      });
       label.setOrigin(0.5);
       label.setDepth(32);
       this.saveLoadDialogGroup.push(label);
@@ -1620,17 +1632,14 @@ export class UIScene extends Phaser.Scene {
         if (this.saveLoadDialogFlashTimer !== null) {
           this.saveLoadDialogFlashTimer.remove();
         }
-        this.saveLoadDialogFlashTimer = this.time.delayedCall(
-          SAVE_FLASH_MS,
-          () => {
-            this.saveLoadDialogFlashTimer = null;
-            this.saveLoadDialogFlash = 'none';
-            // Guard: dialog may have closed between Save Now and the timer
-            // firing (e.g. player clicked Continue or Back). Re-render only
-            // if the dialog is still on screen.
-            if (this.isSaveLoadDialogVisible()) this.renderSaveLoadDialog();
-          },
-        );
+        this.saveLoadDialogFlashTimer = this.time.delayedCall(SAVE_FLASH_MS, () => {
+          this.saveLoadDialogFlashTimer = null;
+          this.saveLoadDialogFlash = 'none';
+          // Guard: dialog may have closed between Save Now and the timer
+          // firing (e.g. player clicked Continue or Back). Re-render only
+          // if the dialog is still on screen.
+          if (this.isSaveLoadDialogVisible()) this.renderSaveLoadDialog();
+        });
         this.renderSaveLoadDialog();
         return;
       }
@@ -1693,7 +1702,8 @@ export class UIScene extends Phaser.Scene {
     else if (this.pauseMenuGroup.length > 0) setActiveOverlay('pause-menu');
     else if (this.gameOverGroup.length > 0) setActiveOverlay('game-over');
     else if (this.savePromptGroup.length > 0) setActiveOverlay('save-prompt');
-    else if (this.difficultySelectGroup.length > 0) setActiveOverlay('save-prompt'); // reuse 'save-prompt' HUD state
+    else if (this.difficultySelectGroup.length > 0)
+      setActiveOverlay('save-prompt'); // reuse 'save-prompt' HUD state
     else setActiveOverlay('none');
   }
 
@@ -1823,7 +1833,8 @@ export class UIScene extends Phaser.Scene {
     // For pause-menu-quit, show a generic "Quitting" heading.
     if (this.surveyState.quitFromPauseMenu) {
       const title = this.add.text(
-        SURVEY_CANVAS_W / 2, SURVEY_TITLE_Y,
+        SURVEY_CANVAS_W / 2,
+        SURVEY_TITLE_Y,
         'Quitting — tell us what you think',
         { fontSize: '22px', fontFamily: 'monospace', color: '#ffffff' },
       );
@@ -1831,23 +1842,25 @@ export class UIScene extends Phaser.Scene {
       title.setDepth(41);
       this.surveyGroup.push(title);
     } else {
-      const { text: outcomeText, color: outcomeColor } = formatOutcomeTitle(this.surveyState.outcome);
-      const outcomeLabel = this.add.text(
-        SURVEY_CANVAS_W / 2, SURVEY_TITLE_Y - 5,
-        outcomeText,
-        { fontSize: '28px', fontFamily: 'monospace', color: '#' + outcomeColor.toString(16).padStart(6, '0') },
+      const { text: outcomeText, color: outcomeColor } = formatOutcomeTitle(
+        this.surveyState.outcome,
       );
+      const outcomeLabel = this.add.text(SURVEY_CANVAS_W / 2, SURVEY_TITLE_Y - 5, outcomeText, {
+        fontSize: '28px',
+        fontFamily: 'monospace',
+        color: '#' + outcomeColor.toString(16).padStart(6, '0'),
+      });
       outcomeLabel.setOrigin(0.5, 0);
       outcomeLabel.setDepth(41);
       this.surveyGroup.push(outcomeLabel);
 
       const causeText = formatCauseSubtitle(this.surveyState.outcome, this.surveyState.cause);
       const secondLine = causeText !== '' ? causeText : 'Tell us what you think:';
-      const causeLabel = this.add.text(
-        SURVEY_CANVAS_W / 2, SURVEY_TITLE_Y + 33,
-        secondLine,
-        { fontSize: '16px', fontFamily: 'monospace', color: '#cccccc' },
-      );
+      const causeLabel = this.add.text(SURVEY_CANVAS_W / 2, SURVEY_TITLE_Y + 33, secondLine, {
+        fontSize: '16px',
+        fontFamily: 'monospace',
+        color: '#cccccc',
+      });
       causeLabel.setOrigin(0.5, 0);
       causeLabel.setDepth(41);
       this.surveyGroup.push(causeLabel);
@@ -1871,23 +1884,15 @@ export class UIScene extends Phaser.Scene {
       const selected = this.surveyState.rating === btn.rating;
       const fillColor = selected ? 0x22aa22 : 0x333333;
       const r = btn.rect;
-      const rect = this.add.rectangle(
-        r.x + r.w / 2,
-        r.y + r.h / 2,
-        r.w,
-        r.h,
-        fillColor,
-        1,
-      );
+      const rect = this.add.rectangle(r.x + r.w / 2, r.y + r.h / 2, r.w, r.h, fillColor, 1);
       rect.setInteractive();
       rect.setDepth(41);
       this.surveyGroup.push(rect);
-      const label = this.add.text(
-        r.x + r.w / 2,
-        r.y + r.h / 2,
-        String(btn.rating),
-        { fontSize: '20px', fontFamily: 'monospace', color: '#ffffff' },
-      );
+      const label = this.add.text(r.x + r.w / 2, r.y + r.h / 2, String(btn.rating), {
+        fontSize: '20px',
+        fontFamily: 'monospace',
+        color: '#ffffff',
+      });
       label.setOrigin(0.5);
       label.setDepth(42);
       this.surveyGroup.push(label);
@@ -1896,14 +1901,7 @@ export class UIScene extends Phaser.Scene {
     // Free-text rect background (the actual editable surface is a DOM
     // textarea positioned over the canvas below — see ensureSurveyTextarea).
     const ft = SURVEY_FREE_TEXT_RECT;
-    const ftBg = this.add.rectangle(
-      ft.x + ft.w / 2,
-      ft.y + ft.h / 2,
-      ft.w,
-      ft.h,
-      0x222222,
-      1,
-    );
+    const ftBg = this.add.rectangle(ft.x + ft.w / 2, ft.y + ft.h / 2, ft.w, ft.h, 0x222222, 1);
     ftBg.setDepth(41);
     this.surveyGroup.push(ftBg);
     this.ensureSurveyTextarea();
@@ -1965,12 +1963,11 @@ export class UIScene extends Phaser.Scene {
     const resultText = this.surveyState.confirmedSubmit
       ? 'Survey submitted — thanks for playing!'
       : 'Thanks for playing!';
-    const title = this.add.text(
-      SURVEY_CANVAS_W / 2,
-      SURVEY_CANVAS_H / 2 - 40,
-      resultText,
-      { fontSize: '22px', fontFamily: 'monospace', color: '#ffffff' },
-    );
+    const title = this.add.text(SURVEY_CANVAS_W / 2, SURVEY_CANVAS_H / 2 - 40, resultText, {
+      fontSize: '22px',
+      fontFamily: 'monospace',
+      color: '#ffffff',
+    });
     title.setOrigin(0.5);
     title.setDepth(41);
     this.surveyGroup.push(title);
@@ -1999,12 +1996,11 @@ export class UIScene extends Phaser.Scene {
     if (checked) {
       // Simple check mark — a Phaser-Text "✓" reads more cleanly than
       // drawing line segments at this resolution.
-      const tick = this.add.text(
-        rect.x + rect.w / 2,
-        rect.y + rect.h / 2,
-        '✓',
-        { fontSize: '16px', fontFamily: 'monospace', color: '#ffffff' },
-      );
+      const tick = this.add.text(rect.x + rect.w / 2, rect.y + rect.h / 2, '✓', {
+        fontSize: '16px',
+        fontFamily: 'monospace',
+        color: '#ffffff',
+      });
       tick.setOrigin(0.5);
       tick.setDepth(42);
       this.surveyGroup.push(tick);
@@ -2040,12 +2036,11 @@ export class UIScene extends Phaser.Scene {
     btn.setInteractive();
     btn.setDepth(41);
     this.surveyGroup.push(btn);
-    const text = this.add.text(
-      rect.x + rect.w / 2,
-      rect.y + rect.h / 2,
-      label,
-      { fontSize: '16px', fontFamily: 'monospace', color: labelColor },
-    );
+    const text = this.add.text(rect.x + rect.w / 2, rect.y + rect.h / 2, label, {
+      fontSize: '16px',
+      fontFamily: 'monospace',
+      color: labelColor,
+    });
     text.setOrigin(0.5);
     text.setDepth(42);
     this.surveyGroup.push(text);
@@ -2079,7 +2074,9 @@ export class UIScene extends Phaser.Scene {
       // preventDefault() for any key in its captures list — which includes
       // WASD and Space by default. stopPropagation prevents the keydown from
       // reaching Phaser so the textarea receives every character normally.
-      ta.addEventListener('keydown', (e) => { if (e.key !== 'Escape') e.stopPropagation(); });
+      ta.addEventListener('keydown', (e) => {
+        if (e.key !== 'Escape') e.stopPropagation();
+      });
       // Append to the canvas's parent so embedded-in-shadow-DOM hosts
       // (the library-mode embed on the website may eventually mount
       // inside a custom element) keep the textarea inside the same
@@ -2164,7 +2161,7 @@ export class UIScene extends Phaser.Scene {
       const cb = this.surveyCallbacks;
       this.hideSurveyOverlay();
       if (hit.kind === 'new-game') cb?.onNewGame();
-      else                        cb?.onRetry();
+      else cb?.onRetry();
       return;
     }
 

--- a/src/render/underground-autotile.test.ts
+++ b/src/render/underground-autotile.test.ts
@@ -28,12 +28,18 @@ void COLOR_QUEEN_OUTLINE; // silence unused — kept as a hook for future tests
 // pixel buffer.
 // ---------------------------------------------------------------------------
 
-interface GfxCall { method: string; args: unknown[]; }
+interface GfxCall {
+  method: string;
+  args: unknown[];
+}
 
 class PixelBuffer {
   // [y][x] → 'wall' | 'open' | undefined. Undefined = nothing painted yet.
   private grid: (NeighborKind | undefined)[][] = [];
-  constructor(public readonly w: number, public readonly h: number) {
+  constructor(
+    public readonly w: number,
+    public readonly h: number,
+  ) {
     for (let y = 0; y < h; y++) {
       const row: (NeighborKind | undefined)[] = new Array(w).fill(undefined);
       this.grid.push(row);
@@ -43,7 +49,9 @@ class PixelBuffer {
     if (x < 0 || y < 0 || x >= this.w || y >= this.h) return;
     this.grid[y]![x] = kind;
   }
-  get(x: number, y: number): NeighborKind | undefined { return this.grid[y]?.[x]; }
+  get(x: number, y: number): NeighborKind | undefined {
+    return this.grid[y]?.[x];
+  }
 }
 
 class MockGfx implements GfxLike {
@@ -51,21 +59,35 @@ class MockGfx implements GfxLike {
   private currentColor: number = 0;
   private currentAlpha: number = 1;
 
-  clear(): GfxLike { this.calls.push({ method: 'clear', args: [] }); return this; }
+  clear(): GfxLike {
+    this.calls.push({ method: 'clear', args: [] });
+    return this;
+  }
   fillStyle(color: number, alpha?: number): GfxLike {
     this.currentColor = color;
     this.currentAlpha = alpha ?? 1;
     this.calls.push({ method: 'fillStyle', args: [color, alpha] });
     return this;
   }
-  lineStyle(): GfxLike { return this; }
-  fillRect(x: number, y: number, w: number, h: number): GfxLike {
-    this.calls.push({ method: 'fillRect', args: [x, y, w, h, this.currentColor, this.currentAlpha] });
+  lineStyle(): GfxLike {
     return this;
   }
-  fillCircle(): GfxLike { return this; }
-  strokeCircle(): GfxLike { return this; }
-  fillTriangle(): GfxLike { return this; }
+  fillRect(x: number, y: number, w: number, h: number): GfxLike {
+    this.calls.push({
+      method: 'fillRect',
+      args: [x, y, w, h, this.currentColor, this.currentAlpha],
+    });
+    return this;
+  }
+  fillCircle(): GfxLike {
+    return this;
+  }
+  strokeCircle(): GfxLike {
+    return this;
+  }
+  fillTriangle(): GfxLike {
+    return this;
+  }
 
   /**
    * Replay calls into a single-tile pixel buffer. Pixels last-write-wins
@@ -78,7 +100,14 @@ class MockGfx implements GfxLike {
   paintBuffer(buf: PixelBuffer, screenX: number, screenY: number): void {
     for (const call of this.calls) {
       if (call.method !== 'fillRect') continue;
-      const [x, y, w, h, color, alpha] = call.args as [number, number, number, number, number, number];
+      const [x, y, w, h, color, alpha] = call.args as [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+      ];
       if (alpha !== 1) continue; // silhouette = opaque draws only
       const kind = classifyColor(color);
       if (kind === undefined) continue;
@@ -112,21 +141,18 @@ function classifyColor(color: number): NeighborKind | undefined {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeNeighbors(
-  c: NeighborKind,
-  spec: Partial<Neighbors3x3> = {},
-): Neighbors3x3 {
+function makeNeighbors(c: NeighborKind, spec: Partial<Neighbors3x3> = {}): Neighbors3x3 {
   // Default unspecified neighbors to 'wall' — this models a tile carved out
   // of an all-Solid grid, the most common test setup.
   return {
     nw: spec.nw ?? 'wall',
-    n:  spec.n  ?? 'wall',
+    n: spec.n ?? 'wall',
     ne: spec.ne ?? 'wall',
-    w:  spec.w  ?? 'wall',
+    w: spec.w ?? 'wall',
     c,
-    e:  spec.e  ?? 'wall',
+    e: spec.e ?? 'wall',
     sw: spec.sw ?? 'wall',
-    s:  spec.s  ?? 'wall',
+    s: spec.s ?? 'wall',
     se: spec.se ?? 'wall',
   };
 }
@@ -151,8 +177,8 @@ function countPixels(buf: PixelBuffer, kind: NeighborKind): number {
 
 function fillRectCalls(gfx: MockGfx): Array<[number, number, number, number, number, number]> {
   return gfx.calls
-    .filter(c => c.method === 'fillRect')
-    .map(c => c.args as [number, number, number, number, number, number]);
+    .filter((c) => c.method === 'fillRect')
+    .map((c) => c.args as [number, number, number, number, number, number]);
 }
 
 function rectOverlaps(
@@ -184,11 +210,18 @@ describe('drawAutotiledUndergroundTile — full quadrants', () => {
   });
 
   it('fully open tile (all 8 neighbors = open) leaves substrate intact — no opposite paint', () => {
-    const buf = renderTile(makeNeighbors('open', {
-      nw: 'open', n: 'open', ne: 'open',
-      w:  'open',             e: 'open',
-      sw: 'open', s: 'open', se: 'open',
-    }));
+    const buf = renderTile(
+      makeNeighbors('open', {
+        nw: 'open',
+        n: 'open',
+        ne: 'open',
+        w: 'open',
+        e: 'open',
+        sw: 'open',
+        s: 'open',
+        se: 'open',
+      }),
+    );
     // Substrate is all open; no opposite-kind paint should appear.
     expect(countPixels(buf, 'wall')).toBe(0);
   });
@@ -202,22 +235,36 @@ describe('drawAutotiledUndergroundTile — full quadrants', () => {
     // sameH=0, sameV=1 in NW, NE, SW, SE — every quadrant is v-edge.
     // No opposite-kind paint should appear; the substrate alone represents
     // the open floor between two vertical walls.
-    const buf = renderTile(makeNeighbors('open', {
-      nw: 'wall', n: 'open',  ne: 'wall',
-      w:  'wall',              e: 'wall',
-      sw: 'wall', s: 'open',  se: 'wall',
-    }));
+    const buf = renderTile(
+      makeNeighbors('open', {
+        nw: 'wall',
+        n: 'open',
+        ne: 'wall',
+        w: 'wall',
+        e: 'wall',
+        sw: 'wall',
+        s: 'open',
+        se: 'wall',
+      }),
+    );
     expect(countPixels(buf, 'wall')).toBe(0);
   });
 
   it('diagonal-only mismatch (all cardinals = open, NW diagonal = wall) leaves substrate intact', () => {
     // Issue #48: diagonal-only opposite-kind bites read as stray wrong-side
     // triangles. Only cardinal boundaries are allowed to change silhouette.
-    const buf = renderTile(makeNeighbors('open', {
-      nw: 'wall',  n: 'open', ne: 'open',
-      w:  'open',              e:  'open',
-      sw: 'open',  s: 'open', se: 'open',
-    }));
+    const buf = renderTile(
+      makeNeighbors('open', {
+        nw: 'wall',
+        n: 'open',
+        ne: 'open',
+        w: 'open',
+        e: 'open',
+        sw: 'open',
+        s: 'open',
+        se: 'open',
+      }),
+    );
     expect(countPixels(buf, 'wall')).toBe(0);
   });
 });
@@ -230,11 +277,18 @@ describe('drawAutotiledUndergroundTile — chamfer anchor pixels', () => {
     //   - SW NOT chamfer: h(W)=wall (sameH=0), so we need v(S)=open
     //     (sameV=1) to demote SW to v-edge.
     //   - SE NOT chamfer: h(E)=open, so SE is at most v-edge. Set S=open.
-    const buf = renderTile(makeNeighbors('open', {
-      nw: 'wall', n: 'wall',  ne: 'wall',  // NW chamfer fires; NE: h-edge
-      w:  'wall',              e:  'open',
-      sw: 'wall', s: 'open',  se: 'open',  // SW: v-edge; SE: full
-    }));
+    const buf = renderTile(
+      makeNeighbors('open', {
+        nw: 'wall',
+        n: 'wall',
+        ne: 'wall', // NW chamfer fires; NE: h-edge
+        w: 'wall',
+        e: 'open',
+        sw: 'wall',
+        s: 'open',
+        se: 'open', // SW: v-edge; SE: full
+      }),
+    );
     // The anchor pixels live on the BOUNDARY between quadrants. The NW
     // chamfer mask covers (lx + ly < 8) in the NW quadrant. So:
     //   - (8, 0) is in the NE quadrant → NOT painted by NW chamfer.
@@ -258,11 +312,18 @@ describe('drawAutotiledUndergroundTile — chamfer anchor pixels', () => {
     // and the cardinal between two open tiles is the OTHER OPEN tile).
     // So the shared boundary scanline is pure open substrate on both
     // sides — the autotile silhouette is silent there by design.
-    const interior = renderTile(makeNeighbors('open', {
-      nw: 'wall', n: 'wall',  ne: 'wall',
-      w:  'open',              e:  'open',  // both cardinals open: corridor
-      sw: 'wall', s: 'wall',  se: 'wall',
-    }));
+    const interior = renderTile(
+      makeNeighbors('open', {
+        nw: 'wall',
+        n: 'wall',
+        ne: 'wall',
+        w: 'open',
+        e: 'open', // both cardinals open: corridor
+        sw: 'wall',
+        s: 'wall',
+        se: 'wall',
+      }),
+    );
     // Left and right columns should be pure open substrate (no chamfer or
     // bite). The wall-side rim band (top / bottom, alpha < 1) does NOT
     // contribute to the silhouette buffer (paintBuffer filters alpha < 1).
@@ -278,18 +339,25 @@ describe('drawAutotiledUndergroundTile — stair-step diagonal corridor', () => 
     // Stair-step path: ..., (0,0)=O, (1,0)=O, (1,1)=O, (2,1)=O, ...
     // For tile (0,0) in this layout (relative to surrounding wall fill):
     //   N=W, S=W, E=O, W=W, NE=W, NW=W, SE=O, SW=W
-    const buf = renderTile(makeNeighbors('open', {
-      nw: 'wall', n: 'wall', ne: 'wall',
-      w:  'wall',             e: 'open',
-      sw: 'wall', s: 'wall', se: 'open',
-    }));
+    const buf = renderTile(
+      makeNeighbors('open', {
+        nw: 'wall',
+        n: 'wall',
+        ne: 'wall',
+        w: 'wall',
+        e: 'open',
+        sw: 'wall',
+        s: 'wall',
+        se: 'open',
+      }),
+    );
     // NW quadrant: h(W)=W, v(N)=W → chamfer. Wall pixels in NW corner
     // triangle.
     for (let i = 0; i < 8; i++) {
       // Row i, last wall pixel of NW chamfer is at x = 7 - i
       // (chamfer condition: x + y < 8).
-      expect(buf.get(0, i)).toBe('wall');           // first column of chamfer
-      expect(buf.get(7 - i, i)).toBe('wall');       // hypotenuse pixel
+      expect(buf.get(0, i)).toBe('wall'); // first column of chamfer
+      expect(buf.get(7 - i, i)).toBe('wall'); // hypotenuse pixel
       // Just past the hypotenuse → NOT wall (open substrate)
       // — except in row 0 where the NE chamfer also paints (x=8 wall).
       if (i > 0) {
@@ -308,11 +376,18 @@ describe('drawAutotiledUndergroundTile — stair-step diagonal corridor', () => 
   it('saddle case (cardinals all open, two opposing diagonals = wall) paints no diagonal-only bites', () => {
     // Diagonal-only mismatches do not represent a cardinal wall boundary, so
     // they should not paint isolated opposite-kind triangles.
-    const buf = renderTile(makeNeighbors('open', {
-      nw: 'wall',  n: 'open',  ne: 'open',
-      w:  'open',                e: 'open',
-      sw: 'open',  s: 'open',  se: 'wall',
-    }));
+    const buf = renderTile(
+      makeNeighbors('open', {
+        nw: 'wall',
+        n: 'open',
+        ne: 'open',
+        w: 'open',
+        e: 'open',
+        sw: 'open',
+        s: 'open',
+        se: 'wall',
+      }),
+    );
     expect(countPixels(buf, 'wall')).toBe(0);
   });
 });
@@ -320,9 +395,15 @@ describe('drawAutotiledUndergroundTile — stair-step diagonal corridor', () => 
 describe('drawAutotiledUndergroundTile — chip variants (Phase E)', () => {
   function makeNeighbors(c: NeighborKind, spec: Partial<Neighbors3x3> = {}): Neighbors3x3 {
     return {
-      nw: spec.nw ?? 'wall', n:  spec.n  ?? 'wall', ne: spec.ne ?? 'wall',
-      w:  spec.w  ?? 'wall', c,                       e:  spec.e  ?? 'wall',
-      sw: spec.sw ?? 'wall', s:  spec.s  ?? 'wall', se: spec.se ?? 'wall',
+      nw: spec.nw ?? 'wall',
+      n: spec.n ?? 'wall',
+      ne: spec.ne ?? 'wall',
+      w: spec.w ?? 'wall',
+      c,
+      e: spec.e ?? 'wall',
+      sw: spec.sw ?? 'wall',
+      s: spec.s ?? 'wall',
+      se: spec.se ?? 'wall',
     };
   }
 
@@ -336,9 +417,14 @@ describe('drawAutotiledUndergroundTile — chip variants (Phase E)', () => {
     //   - (0, 0) — the OUTER NW corner — is always wall (chip's lx, ly
     //     each ≥ 1, so chip never lands at (0, 0)).
     const singleNW = makeNeighbors('open', {
-      nw: 'wall', n: 'wall',  ne: 'wall',
-      w:  'wall',              e:  'open',
-      sw: 'wall', s: 'open',  se: 'open',
+      nw: 'wall',
+      n: 'wall',
+      ne: 'wall',
+      w: 'wall',
+      e: 'open',
+      sw: 'wall',
+      s: 'open',
+      se: 'open',
     });
     for (let tx = 0; tx < 32; tx++) {
       for (let ty = 0; ty < 32; ty++) {
@@ -349,7 +435,7 @@ describe('drawAutotiledUndergroundTile — chip variants (Phase E)', () => {
 
         expect(buf.get(8, 0)).not.toBe('wall'); // top-edge midpoint anchor
         expect(buf.get(0, 8)).not.toBe('wall'); // left-edge midpoint anchor
-        expect(buf.get(0, 0)).toBe('wall');     // outer NW corner — always wall
+        expect(buf.get(0, 0)).toBe('wall'); // outer NW corner — always wall
       }
     }
   });
@@ -406,13 +492,21 @@ describe('drawAutotiledUndergroundTile — determinism', () => {
 describe('drawUndergroundRim', () => {
   function makeNeighbors(c: NeighborKind, spec: Partial<Neighbors3x3> = {}): Neighbors3x3 {
     return {
-      nw: spec.nw ?? 'wall', n:  spec.n  ?? 'wall', ne: spec.ne ?? 'wall',
-      w:  spec.w  ?? 'wall', c,                       e:  spec.e  ?? 'wall',
-      sw: spec.sw ?? 'wall', s:  spec.s  ?? 'wall', se: spec.se ?? 'wall',
+      nw: spec.nw ?? 'wall',
+      n: spec.n ?? 'wall',
+      ne: spec.ne ?? 'wall',
+      w: spec.w ?? 'wall',
+      c,
+      e: spec.e ?? 'wall',
+      sw: spec.sw ?? 'wall',
+      s: spec.s ?? 'wall',
+      se: spec.se ?? 'wall',
     };
   }
 
-  function gfxCalls(): MockGfx { return new MockGfx(); }
+  function gfxCalls(): MockGfx {
+    return new MockGfx();
+  }
 
   it('does nothing on a wall tile (rim only fires on open tiles)', () => {
     const gfx = gfxCalls();
@@ -422,21 +516,48 @@ describe('drawUndergroundRim', () => {
 
   it('does nothing on an open tile with no wall neighbors', () => {
     const gfx = gfxCalls();
-    drawUndergroundRim(gfx, 0, 0, 0, 0, 'open', makeNeighbors('open', {
-      nw: 'open', n: 'open', ne: 'open',
-      w:  'open',             e: 'open',
-      sw: 'open', s: 'open', se: 'open',
-    }));
+    drawUndergroundRim(
+      gfx,
+      0,
+      0,
+      0,
+      0,
+      'open',
+      makeNeighbors('open', {
+        nw: 'open',
+        n: 'open',
+        ne: 'open',
+        w: 'open',
+        e: 'open',
+        sw: 'open',
+        s: 'open',
+        se: 'open',
+      }),
+    );
     expect(fillRectCalls(gfx)).toHaveLength(0);
   });
 
   it('emits 2 band fillRects + 1 chip per cardinal wall neighbor', () => {
     const gfx = gfxCalls();
     // Open tile with only N=wall (rest open).
-    drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
-      n: 'wall',
-      ne: 'open', e: 'open', se: 'open', s: 'open', sw: 'open', w: 'open', nw: 'open',
-    }));
+    drawUndergroundRim(
+      gfx,
+      0,
+      0,
+      5,
+      7,
+      'open',
+      makeNeighbors('open', {
+        n: 'wall',
+        ne: 'open',
+        e: 'open',
+        se: 'open',
+        s: 'open',
+        sw: 'open',
+        w: 'open',
+        nw: 'open',
+      }),
+    );
     // 1 heavy band + 1 light band + 1 chip = 3 fillRects.
     expect(fillRectCalls(gfx)).toHaveLength(3);
   });
@@ -449,11 +570,24 @@ describe('drawUndergroundRim', () => {
 
   it('clips rim bands away from chamfered corner halves — NW chamfer', () => {
     const gfx = gfxCalls();
-    drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
-      nw: 'wall', n: 'wall', ne: 'open',
-      w:  'wall',             e: 'open',
-      sw: 'open', s: 'open', se: 'open',
-    }));
+    drawUndergroundRim(
+      gfx,
+      0,
+      0,
+      5,
+      7,
+      'open',
+      makeNeighbors('open', {
+        nw: 'wall',
+        n: 'wall',
+        ne: 'open',
+        w: 'wall',
+        e: 'open',
+        sw: 'open',
+        s: 'open',
+        se: 'open',
+      }),
+    );
     const rects = fillRectCalls(gfx);
     // Heavy band (row 0): NW chamfer covers cols 0..7 → clipped.
     // Light band (row 1): NW chamfer covers cols 0..6 → cols 0..6 clipped.
@@ -464,78 +598,117 @@ describe('drawUndergroundRim', () => {
       expect(rectOverlaps(rect, 1, 0, 1, 7)).toBe(false); // clip light W col 1 rows 0..6
     }
     // Unclipped portions should be painted somewhere.
-    expect(rects.some(rect => rectOverlaps(rect, 8, 0, 8, 1))).toBe(true);  // heavy N E half
-    expect(rects.some(rect => rectOverlaps(rect, 7, 1, 9, 1))).toBe(true);  // light N from col 7
-    expect(rects.some(rect => rectOverlaps(rect, 0, 8, 1, 8))).toBe(true);  // heavy W S half
-    expect(rects.some(rect => rectOverlaps(rect, 1, 7, 1, 9))).toBe(true);  // light W from row 7
+    expect(rects.some((rect) => rectOverlaps(rect, 8, 0, 8, 1))).toBe(true); // heavy N E half
+    expect(rects.some((rect) => rectOverlaps(rect, 7, 1, 9, 1))).toBe(true); // light N from col 7
+    expect(rects.some((rect) => rectOverlaps(rect, 0, 8, 1, 8))).toBe(true); // heavy W S half
+    expect(rects.some((rect) => rectOverlaps(rect, 1, 7, 1, 9))).toBe(true); // light W from row 7
   });
 
   it('clips rim bands away from chamfered corner halves — NE chamfer', () => {
     const gfx = gfxCalls();
-    drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
-      nw: 'open', n: 'wall', ne: 'wall',
-      w:  'open',             e: 'wall',
-      sw: 'open', s: 'open', se: 'open',
-    }));
+    drawUndergroundRim(
+      gfx,
+      0,
+      0,
+      5,
+      7,
+      'open',
+      makeNeighbors('open', {
+        nw: 'open',
+        n: 'wall',
+        ne: 'wall',
+        w: 'open',
+        e: 'wall',
+        sw: 'open',
+        s: 'open',
+        se: 'open',
+      }),
+    );
     const rects = fillRectCalls(gfx);
     // NE chamfer at row R covers cols (8+R)..15. So heavy (row 0): cols
     // 8..15. Light (row 1): cols 9..15. NE on E edge col 15 row R covers
     // similarly mirrored.
     for (const rect of rects) {
-      expect(rectOverlaps(rect, 8, 0, 8, 1)).toBe(false);  // clip heavy N row 0 cols 8..15
-      expect(rectOverlaps(rect, 9, 1, 7, 1)).toBe(false);  // clip light N row 1 cols 9..15
+      expect(rectOverlaps(rect, 8, 0, 8, 1)).toBe(false); // clip heavy N row 0 cols 8..15
+      expect(rectOverlaps(rect, 9, 1, 7, 1)).toBe(false); // clip light N row 1 cols 9..15
       expect(rectOverlaps(rect, 15, 0, 1, 8)).toBe(false); // clip heavy E col 15 rows 0..7
       expect(rectOverlaps(rect, 14, 0, 1, 7)).toBe(false); // clip light E col 14 rows 0..6
     }
-    expect(rects.some(rect => rectOverlaps(rect, 0, 0, 8, 1))).toBe(true);  // heavy N W half
-    expect(rects.some(rect => rectOverlaps(rect, 0, 1, 9, 1))).toBe(true);  // light N up to col 8
-    expect(rects.some(rect => rectOverlaps(rect, 15, 8, 1, 8))).toBe(true); // heavy E S half
-    expect(rects.some(rect => rectOverlaps(rect, 14, 7, 1, 9))).toBe(true); // light E from row 7
+    expect(rects.some((rect) => rectOverlaps(rect, 0, 0, 8, 1))).toBe(true); // heavy N W half
+    expect(rects.some((rect) => rectOverlaps(rect, 0, 1, 9, 1))).toBe(true); // light N up to col 8
+    expect(rects.some((rect) => rectOverlaps(rect, 15, 8, 1, 8))).toBe(true); // heavy E S half
+    expect(rects.some((rect) => rectOverlaps(rect, 14, 7, 1, 9))).toBe(true); // light E from row 7
   });
 
   it('clips rim bands away from chamfered corner halves — SE chamfer', () => {
     const gfx = gfxCalls();
-    drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
-      nw: 'open', n: 'open', ne: 'open',
-      w:  'open',             e: 'wall',
-      sw: 'open', s: 'wall', se: 'wall',
-    }));
+    drawUndergroundRim(
+      gfx,
+      0,
+      0,
+      5,
+      7,
+      'open',
+      makeNeighbors('open', {
+        nw: 'open',
+        n: 'open',
+        ne: 'open',
+        w: 'open',
+        e: 'wall',
+        sw: 'open',
+        s: 'wall',
+        se: 'wall',
+      }),
+    );
     const rects = fillRectCalls(gfx);
     // SE chamfer at row R (R measured from south edge) covers cols
     // (8+R)..15. On the S edge: heavy (S row 15, rowFromEdge=0): cols
     // 8..15. Light (S row 14, rowFromEdge=1): cols 9..15.
     for (const rect of rects) {
-      expect(rectOverlaps(rect, 8, 15, 8, 1)).toBe(false);  // clip heavy S row 15 cols 8..15
-      expect(rectOverlaps(rect, 9, 14, 7, 1)).toBe(false);  // clip light S row 14 cols 9..15
-      expect(rectOverlaps(rect, 15, 8, 1, 8)).toBe(false);  // clip heavy E col 15 rows 8..15
-      expect(rectOverlaps(rect, 14, 9, 1, 7)).toBe(false);  // clip light E col 14 rows 9..15
+      expect(rectOverlaps(rect, 8, 15, 8, 1)).toBe(false); // clip heavy S row 15 cols 8..15
+      expect(rectOverlaps(rect, 9, 14, 7, 1)).toBe(false); // clip light S row 14 cols 9..15
+      expect(rectOverlaps(rect, 15, 8, 1, 8)).toBe(false); // clip heavy E col 15 rows 8..15
+      expect(rectOverlaps(rect, 14, 9, 1, 7)).toBe(false); // clip light E col 14 rows 9..15
     }
-    expect(rects.some(rect => rectOverlaps(rect, 0, 15, 8, 1))).toBe(true);  // heavy S W half
-    expect(rects.some(rect => rectOverlaps(rect, 0, 14, 9, 1))).toBe(true);  // light S up to col 8
-    expect(rects.some(rect => rectOverlaps(rect, 15, 0, 1, 8))).toBe(true);  // heavy E N half
-    expect(rects.some(rect => rectOverlaps(rect, 14, 0, 1, 9))).toBe(true);  // light E up to row 8
+    expect(rects.some((rect) => rectOverlaps(rect, 0, 15, 8, 1))).toBe(true); // heavy S W half
+    expect(rects.some((rect) => rectOverlaps(rect, 0, 14, 9, 1))).toBe(true); // light S up to col 8
+    expect(rects.some((rect) => rectOverlaps(rect, 15, 0, 1, 8))).toBe(true); // heavy E N half
+    expect(rects.some((rect) => rectOverlaps(rect, 14, 0, 1, 9))).toBe(true); // light E up to row 8
   });
 
   it('clips rim bands away from chamfered corner halves — SW chamfer', () => {
     const gfx = gfxCalls();
-    drawUndergroundRim(gfx, 0, 0, 5, 7, 'open', makeNeighbors('open', {
-      nw: 'open', n: 'open', ne: 'open',
-      w:  'wall',             e: 'open',
-      sw: 'wall', s: 'wall', se: 'open',
-    }));
+    drawUndergroundRim(
+      gfx,
+      0,
+      0,
+      5,
+      7,
+      'open',
+      makeNeighbors('open', {
+        nw: 'open',
+        n: 'open',
+        ne: 'open',
+        w: 'wall',
+        e: 'open',
+        sw: 'wall',
+        s: 'wall',
+        se: 'open',
+      }),
+    );
     const rects = fillRectCalls(gfx);
     // SW chamfer at row R (from south edge) covers cols 0..(7-R). Heavy
     // (S row 15): 0..7. Light (S row 14): 0..6. On the W edge, mirrored.
     for (const rect of rects) {
       expect(rectOverlaps(rect, 0, 15, 8, 1)).toBe(false); // clip heavy S row 15 cols 0..7
       expect(rectOverlaps(rect, 0, 14, 7, 1)).toBe(false); // clip light S row 14 cols 0..6
-      expect(rectOverlaps(rect, 0, 8, 1, 8)).toBe(false);  // clip heavy W col 0 rows 8..15
-      expect(rectOverlaps(rect, 1, 9, 1, 7)).toBe(false);  // clip light W col 1 rows 9..15
+      expect(rectOverlaps(rect, 0, 8, 1, 8)).toBe(false); // clip heavy W col 0 rows 8..15
+      expect(rectOverlaps(rect, 1, 9, 1, 7)).toBe(false); // clip light W col 1 rows 9..15
     }
-    expect(rects.some(rect => rectOverlaps(rect, 8, 15, 8, 1))).toBe(true); // heavy S E half
-    expect(rects.some(rect => rectOverlaps(rect, 7, 14, 9, 1))).toBe(true); // light S from col 7
-    expect(rects.some(rect => rectOverlaps(rect, 0, 0, 1, 8))).toBe(true);  // heavy W N half
-    expect(rects.some(rect => rectOverlaps(rect, 1, 0, 1, 9))).toBe(true);  // light W up to row 8
+    expect(rects.some((rect) => rectOverlaps(rect, 8, 15, 8, 1))).toBe(true); // heavy S E half
+    expect(rects.some((rect) => rectOverlaps(rect, 7, 14, 9, 1))).toBe(true); // light S from col 7
+    expect(rects.some((rect) => rectOverlaps(rect, 0, 0, 1, 8))).toBe(true); // heavy W N half
+    expect(rects.some((rect) => rectOverlaps(rect, 1, 0, 1, 9))).toBe(true); // light W up to row 8
   });
 
   it('all four cardinal walls — heavy bands fully clipped, light bands paint a 2-pixel center', () => {
@@ -549,16 +722,16 @@ describe('drawUndergroundRim', () => {
     const rects = fillRectCalls(gfx);
     // No heavy band at outermost rows/cols.
     for (const rect of rects) {
-      expect(rectOverlaps(rect, 0, 0, 16, 1)).toBe(false);  // heavy N
+      expect(rectOverlaps(rect, 0, 0, 16, 1)).toBe(false); // heavy N
       expect(rectOverlaps(rect, 0, 15, 16, 1)).toBe(false); // heavy S
-      expect(rectOverlaps(rect, 0, 0, 1, 16)).toBe(false);  // heavy W
+      expect(rectOverlaps(rect, 0, 0, 1, 16)).toBe(false); // heavy W
       expect(rectOverlaps(rect, 15, 0, 1, 16)).toBe(false); // heavy E
     }
     // Light bands present in the 2-pixel center segments.
-    expect(rects.some(rect => rectOverlaps(rect, 7, 1, 2, 1))).toBe(true);  // light N center
-    expect(rects.some(rect => rectOverlaps(rect, 7, 14, 2, 1))).toBe(true); // light S center
-    expect(rects.some(rect => rectOverlaps(rect, 1, 7, 1, 2))).toBe(true);  // light W center
-    expect(rects.some(rect => rectOverlaps(rect, 14, 7, 1, 2))).toBe(true); // light E center
+    expect(rects.some((rect) => rectOverlaps(rect, 7, 1, 2, 1))).toBe(true); // light N center
+    expect(rects.some((rect) => rectOverlaps(rect, 7, 14, 2, 1))).toBe(true); // light S center
+    expect(rects.some((rect) => rectOverlaps(rect, 1, 7, 1, 2))).toBe(true); // light W center
+    expect(rects.some((rect) => rectOverlaps(rect, 14, 7, 1, 2))).toBe(true); // light E center
   });
 });
 
@@ -566,16 +739,29 @@ describe('drawAutotiledUndergroundTile — draw-op budget', () => {
   it('worst-case open tile (4 chamfers) emits ≤ 80 fillRects', () => {
     const gfx = new MockGfx();
     drawAutotiledUndergroundTile(gfx, 0, 0, 0, 0, 'open', makeNeighbors('open'));
-    expect(gfx.calls.filter(c => c.method === 'fillRect').length).toBeLessThanOrEqual(80);
+    expect(gfx.calls.filter((c) => c.method === 'fillRect').length).toBeLessThanOrEqual(80);
   });
 
   it('worst-case wall tile (4 chamfers) emits ≤ 80 fillRects', () => {
     const gfx = new MockGfx();
-    drawAutotiledUndergroundTile(gfx, 0, 0, 0, 0, 'wall', makeNeighbors('wall', {
-      nw: 'open', n: 'open', ne: 'open',
-      w:  'open',             e:  'open',
-      sw: 'open', s: 'open', se: 'open',
-    }));
-    expect(gfx.calls.filter(c => c.method === 'fillRect').length).toBeLessThanOrEqual(80);
+    drawAutotiledUndergroundTile(
+      gfx,
+      0,
+      0,
+      0,
+      0,
+      'wall',
+      makeNeighbors('wall', {
+        nw: 'open',
+        n: 'open',
+        ne: 'open',
+        w: 'open',
+        e: 'open',
+        sw: 'open',
+        s: 'open',
+        se: 'open',
+      }),
+    );
+    expect(gfx.calls.filter((c) => c.method === 'fillRect').length).toBeLessThanOrEqual(80);
   });
 });

--- a/src/render/underground-autotile.ts
+++ b/src/render/underground-autotile.ts
@@ -105,10 +105,10 @@ function drawQuadrantMask(
   centerKind: NeighborKind,
   quadrant: Quadrant,
   horizKind: NeighborKind,
-  vertKind:  NeighborKind,
+  vertKind: NeighborKind,
 ): void {
   const sameH = horizKind === centerKind;
-  const sameV = vertKind  === centerKind;
+  const sameV = vertKind === centerKind;
 
   const oppositeColor = centerKind === 'wall' ? COLOR_FLOOR_BASE : COLOR_ROCK_BASE;
   if (!sameH && !sameV) {
@@ -147,12 +147,25 @@ function fillChamferTriangle(
   // one tile edge to the midpoint of the adjacent tile edge.
   for (let i = 0; i < HALF; i++) {
     const width = HALF - i;
-    let x = 0, y = 0;
+    let x = 0,
+      y = 0;
     switch (quadrant) {
-      case 'NW': x = 0;                        y = i;                              break;
-      case 'NE': x = HALF + i;                 y = i;                              break;
-      case 'SE': x = HALF + i;                 y = TILE_SIZE_PX - 1 - i;           break;
-      case 'SW': x = 0;                        y = TILE_SIZE_PX - 1 - i;           break;
+      case 'NW':
+        x = 0;
+        y = i;
+        break;
+      case 'NE':
+        x = HALF + i;
+        y = i;
+        break;
+      case 'SE':
+        x = HALF + i;
+        y = TILE_SIZE_PX - 1 - i;
+        break;
+      case 'SW':
+        x = 0;
+        y = TILE_SIZE_PX - 1 - i;
+        break;
     }
     gfx.fillRect(screenX + x, screenY + y, width, 1);
   }
@@ -184,25 +197,42 @@ function maybeAddChamferChip(
   quadrant: Quadrant,
   centerKind: NeighborKind,
 ): void {
-  const salt = quadrant === 'NW' ? SALT_CHIP_NW
-             : quadrant === 'NE' ? SALT_CHIP_NE
-             : quadrant === 'SE' ? SALT_CHIP_SE
-             :                     SALT_CHIP_SW;
+  const salt =
+    quadrant === 'NW'
+      ? SALT_CHIP_NW
+      : quadrant === 'NE'
+        ? SALT_CHIP_NE
+        : quadrant === 'SE'
+          ? SALT_CHIP_SE
+          : SALT_CHIP_SW;
   const h = spatialHash(tileX, tileY, salt);
   if ((h & 0xff) >= 154) return; // ~60% emission rate
 
   // Sample (lx, ly) inside the safe region. lx ∈ [1..5]; ly ∈ [1..(6 - lx)].
   // The constraint lx + ly ≤ 6 keeps the chip strictly interior.
-  const lx = 1 + ((h >>> 8) & 0xf) % 5;
-  const ly = 1 + ((h >>> 12) & 0xf) % (6 - lx);
+  const lx = 1 + (((h >>> 8) & 0xf) % 5);
+  const ly = 1 + (((h >>> 12) & 0xf) % (6 - lx));
 
   // Map quadrant-local (lx, ly) to tile-relative pixel.
-  let px = 0, py = 0;
+  let px = 0,
+    py = 0;
   switch (quadrant) {
-    case 'NW': px = lx;                          py = ly;                          break;
-    case 'NE': px = TILE_SIZE_PX - 1 - lx;       py = ly;                          break;
-    case 'SE': px = TILE_SIZE_PX - 1 - lx;       py = TILE_SIZE_PX - 1 - ly;       break;
-    case 'SW': px = lx;                          py = TILE_SIZE_PX - 1 - ly;       break;
+    case 'NW':
+      px = lx;
+      py = ly;
+      break;
+    case 'NE':
+      px = TILE_SIZE_PX - 1 - lx;
+      py = ly;
+      break;
+    case 'SE':
+      px = TILE_SIZE_PX - 1 - lx;
+      py = TILE_SIZE_PX - 1 - ly;
+      break;
+    case 'SW':
+      px = lx;
+      py = TILE_SIZE_PX - 1 - ly;
+      break;
   }
 
   // Chip color is the CENTER kind — i.e., a 1-pixel "cut" through the
@@ -266,17 +296,17 @@ export function drawUndergroundRim(
   //   - light band (1 inward): 1 → clip HALF-1 = 7 (chamfer row 1 covers
   //     0..6); the edge pixel at 7 stays visible.
   gfx.fillStyle(COLOR_ROCK_BASE_DARK, 0.55);
-  if (wallN) drawHorizontalRimBand(gfx, screenX, screenY,        0, wallW, wallE);
+  if (wallN) drawHorizontalRimBand(gfx, screenX, screenY, 0, wallW, wallE);
   if (wallS) drawHorizontalRimBand(gfx, screenX, screenY + last, 0, wallW, wallE);
-  if (wallW) drawVerticalRimBand(gfx,   screenX, screenY,        0, wallN, wallS);
-  if (wallE) drawVerticalRimBand(gfx,   screenX + last, screenY, 0, wallN, wallS);
+  if (wallW) drawVerticalRimBand(gfx, screenX, screenY, 0, wallN, wallS);
+  if (wallE) drawVerticalRimBand(gfx, screenX + last, screenY, 0, wallN, wallS);
 
   // Light band — 1 pixel inward, lighter alpha for the fade transition.
-  gfx.fillStyle(COLOR_ROCK_BASE_DARK, 0.30);
-  if (wallN) drawHorizontalRimBand(gfx, screenX, screenY + 1,        1, wallW, wallE);
+  gfx.fillStyle(COLOR_ROCK_BASE_DARK, 0.3);
+  if (wallN) drawHorizontalRimBand(gfx, screenX, screenY + 1, 1, wallW, wallE);
   if (wallS) drawHorizontalRimBand(gfx, screenX, screenY + last - 1, 1, wallW, wallE);
-  if (wallW) drawVerticalRimBand(gfx,   screenX + 1, screenY,        1, wallN, wallS);
-  if (wallE) drawVerticalRimBand(gfx,   screenX + last - 1, screenY, 1, wallN, wallS);
+  if (wallW) drawVerticalRimBand(gfx, screenX + 1, screenY, 1, wallN, wallS);
+  if (wallE) drawVerticalRimBand(gfx, screenX + last - 1, screenY, 1, wallN, wallS);
 
   // Per-tile rim chips — 1-pixel deterministic dark specks inside each
   // active rim band, breaking the rim's flat appearance. Same alpha as
@@ -285,7 +315,7 @@ export function drawUndergroundRim(
   const h = spatialHash(tileX, tileY, SALT_RIM_CHIP);
   gfx.fillStyle(COLOR_ROCK_BASE_DARK, 0.55);
   if (wallN) {
-    const x = (h >>> 0) & 0xf;        // 0..15
+    const x = (h >>> 0) & 0xf; // 0..15
     if (rimXVisible(x, 1, wallW, wallE)) gfx.fillRect(screenX + x, screenY + 1, 1, 1);
   }
   if (wallS) {
@@ -324,8 +354,8 @@ function drawHorizontalRimBand(
     gfx.fillRect(screenX, y, TILE_SIZE_PX, 1);
     return;
   }
-  const start  = clipWestHalf ? clipPx : 0;
-  const endExc = clipEastHalf ? (TILE_SIZE_PX - clipPx) : TILE_SIZE_PX;
+  const start = clipWestHalf ? clipPx : 0;
+  const endExc = clipEastHalf ? TILE_SIZE_PX - clipPx : TILE_SIZE_PX;
   if (endExc > start) {
     gfx.fillRect(screenX + start, y, endExc - start, 1);
   }
@@ -345,8 +375,8 @@ function drawVerticalRimBand(
     gfx.fillRect(x, screenY, 1, TILE_SIZE_PX);
     return;
   }
-  const start  = clipNorthHalf ? clipPx : 0;
-  const endExc = clipSouthHalf ? (TILE_SIZE_PX - clipPx) : TILE_SIZE_PX;
+  const start = clipNorthHalf ? clipPx : 0;
+  const endExc = clipSouthHalf ? TILE_SIZE_PX - clipPx : TILE_SIZE_PX;
   if (endExc > start) {
     gfx.fillRect(x, screenY + start, 1, endExc - start);
   }

--- a/src/render/underground-neighbors.test.ts
+++ b/src/render/underground-neighbors.test.ts
@@ -5,15 +5,8 @@
 // classification rules surfaces here rather than as a render-output diff.
 
 import { describe, expect, it } from 'vitest';
-import {
-  classifyUndergroundTile,
-  gatherUnderground3x3Neighbors,
-} from './underground-neighbors.js';
-import {
-  createUndergroundGrid,
-  ugSet,
-  UndergroundTileState,
-} from '../sim/terrain.js';
+import { classifyUndergroundTile, gatherUnderground3x3Neighbors } from './underground-neighbors.js';
+import { createUndergroundGrid, ugSet, UndergroundTileState } from '../sim/terrain.js';
 
 const NO_ENTRANCES: ReadonlySet<number> = new Set();
 
@@ -37,9 +30,9 @@ describe('classifyUndergroundTile', () => {
   it('classifies all out-of-bounds positions as wall', () => {
     const grid = createUndergroundGrid(4, 4);
     expect(classifyUndergroundTile(grid, -1, 0, NO_ENTRANCES)).toBe('wall');
-    expect(classifyUndergroundTile(grid,  0, -1, NO_ENTRANCES)).toBe('wall');
-    expect(classifyUndergroundTile(grid,  4, 0, NO_ENTRANCES)).toBe('wall');
-    expect(classifyUndergroundTile(grid,  0, 4, NO_ENTRANCES)).toBe('wall');
+    expect(classifyUndergroundTile(grid, 0, -1, NO_ENTRANCES)).toBe('wall');
+    expect(classifyUndergroundTile(grid, 4, 0, NO_ENTRANCES)).toBe('wall');
+    expect(classifyUndergroundTile(grid, 0, 4, NO_ENTRANCES)).toBe('wall');
     // Way out — same answer.
     expect(classifyUndergroundTile(grid, -100, -100, NO_ENTRANCES)).toBe('wall');
   });
@@ -82,9 +75,15 @@ describe('gatherUnderground3x3Neighbors', () => {
     // rule unless the entrance set says otherwise — verify both branches.
     const noEntrance = gatherUnderground3x3Neighbors(grid, 1, 1, NO_ENTRANCES);
     expect(noEntrance).toEqual({
-      nw: 'wall', n: 'wall', ne: 'wall',
-      w:  'open', c: 'open', e:  'open',
-      sw: 'wall', s: 'open', se: 'wall',
+      nw: 'wall',
+      n: 'wall',
+      ne: 'wall',
+      w: 'open',
+      c: 'open',
+      e: 'open',
+      sw: 'wall',
+      s: 'open',
+      se: 'wall',
     });
 
     const withEntrance = gatherUnderground3x3Neighbors(grid, 1, 1, new Set([1]));
@@ -108,9 +107,15 @@ describe('gatherUnderground3x3Neighbors', () => {
     // out-of-bounds or ceiling, so they're all wall.
     const n = gatherUnderground3x3Neighbors(grid, 0, 0, NO_ENTRANCES);
     expect(n).toEqual({
-      nw: 'wall', n: 'wall', ne: 'wall',
-      w:  'wall', c: 'wall', e:  'wall',
-      sw: 'wall', s: 'open', se: 'open',
+      nw: 'wall',
+      n: 'wall',
+      ne: 'wall',
+      w: 'wall',
+      c: 'wall',
+      e: 'wall',
+      sw: 'wall',
+      s: 'open',
+      se: 'open',
     });
   });
 
@@ -122,13 +127,19 @@ describe('gatherUnderground3x3Neighbors', () => {
     const grid = createUndergroundGrid(3, 3);
     ugSet(grid, 1, 1, UndergroundTileState.Open);
     const scratch: ReturnType<typeof gatherUnderground3x3Neighbors> = {
-      nw: 'wall', n: 'wall', ne: 'wall',
-      w:  'wall', c: 'wall', e:  'wall',
-      sw: 'wall', s: 'wall', se: 'wall',
+      nw: 'wall',
+      n: 'wall',
+      ne: 'wall',
+      w: 'wall',
+      c: 'wall',
+      e: 'wall',
+      sw: 'wall',
+      s: 'wall',
+      se: 'wall',
     };
     const result = gatherUnderground3x3Neighbors(grid, 1, 1, NO_ENTRANCES, scratch);
-    expect(result).toBe(scratch);          // same reference, not a copy
-    expect(scratch.c).toBe('open');        // mutated in place
+    expect(result).toBe(scratch); // same reference, not a copy
+    expect(scratch.c).toBe('open'); // mutated in place
   });
 
   it('is deterministic — same inputs produce the same output every call', () => {

--- a/src/render/underground-neighbors.ts
+++ b/src/render/underground-neighbors.ts
@@ -27,9 +27,15 @@ export type NeighborKind = 'wall' | 'open';
  * itself, included so callers can drive shape decisions off the same struct.
  */
 export interface Neighbors3x3 {
-  nw: NeighborKind; n: NeighborKind; ne: NeighborKind;
-  w:  NeighborKind; c: NeighborKind; e:  NeighborKind;
-  sw: NeighborKind; s: NeighborKind; se: NeighborKind;
+  nw: NeighborKind;
+  n: NeighborKind;
+  ne: NeighborKind;
+  w: NeighborKind;
+  c: NeighborKind;
+  e: NeighborKind;
+  sw: NeighborKind;
+  s: NeighborKind;
+  se: NeighborKind;
 }
 
 /**
@@ -71,18 +77,24 @@ export function gatherUnderground3x3Neighbors(
   out?: Neighbors3x3,
 ): Neighbors3x3 {
   const target = out ?? {
-    nw: 'wall', n: 'wall', ne: 'wall',
-    w:  'wall', c: 'wall', e:  'wall',
-    sw: 'wall', s: 'wall', se: 'wall',
+    nw: 'wall',
+    n: 'wall',
+    ne: 'wall',
+    w: 'wall',
+    c: 'wall',
+    e: 'wall',
+    sw: 'wall',
+    s: 'wall',
+    se: 'wall',
   };
   target.nw = classifyUndergroundTile(grid, tx - 1, ty - 1, entranceXSet);
-  target.n  = classifyUndergroundTile(grid, tx,     ty - 1, entranceXSet);
+  target.n = classifyUndergroundTile(grid, tx, ty - 1, entranceXSet);
   target.ne = classifyUndergroundTile(grid, tx + 1, ty - 1, entranceXSet);
-  target.w  = classifyUndergroundTile(grid, tx - 1, ty,     entranceXSet);
-  target.c  = classifyUndergroundTile(grid, tx,     ty,     entranceXSet);
-  target.e  = classifyUndergroundTile(grid, tx + 1, ty,     entranceXSet);
+  target.w = classifyUndergroundTile(grid, tx - 1, ty, entranceXSet);
+  target.c = classifyUndergroundTile(grid, tx, ty, entranceXSet);
+  target.e = classifyUndergroundTile(grid, tx + 1, ty, entranceXSet);
   target.sw = classifyUndergroundTile(grid, tx - 1, ty + 1, entranceXSet);
-  target.s  = classifyUndergroundTile(grid, tx,     ty + 1, entranceXSet);
+  target.s = classifyUndergroundTile(grid, tx, ty + 1, entranceXSet);
   target.se = classifyUndergroundTile(grid, tx + 1, ty + 1, entranceXSet);
   return target;
 }

--- a/src/sim/ai-state.test.ts
+++ b/src/sim/ai-state.test.ts
@@ -70,7 +70,12 @@ function makeMinimalWorld(): WorldState {
 }
 
 /** Spawn N alive fighters for a colony, starting at entity slot `startId`. */
-function spawnFighters(world: WorldState, colonyId: number, count: number, startId: number): number[] {
+function spawnFighters(
+  world: WorldState,
+  colonyId: number,
+  count: number,
+  startId: number,
+): number[] {
   const ids: number[] = [];
   for (let i = 0; i < count; i++) {
     const id = startId + i;
@@ -157,8 +162,9 @@ describe('advanceAIState — Peacetime → WarFooting (CF-P1-010)', () => {
     spawnFighters(world, ENEMY_COLONY_ID, minFighters, 10);
     // Set food: enough for 50% threshold
     const cap = aiFoodCapacity(world, ENEMY_COLONY_ID as ColonyId);
-    // eslint-disable-next-line no-restricted-syntax
-    world.colonies[ENEMY_COLONY_ID as ColonyId]!.foodStored = Math.ceil(cap * AI_WARFOOTING_FOOD_FRAC_PCT / 100);
+    world.colonies[ENEMY_COLONY_ID as ColonyId]!.foodStored = Math.ceil(
+      (cap * AI_WARFOOTING_FOOD_FRAC_PCT) / 100, // eslint-disable-line no-restricted-syntax
+    );
 
     // Player: low workers — NOT frontage ready
     world.colonies[PLAYER_COLONY_ID as ColonyId]!.workerCount = 2;
@@ -175,15 +181,16 @@ describe('advanceAIState — Peacetime → WarFooting (CF-P1-010)', () => {
     const minFighters = AI_WARFOOTING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX];
     spawnFighters(world, ENEMY_COLONY_ID, minFighters, 10);
     const cap = aiFoodCapacity(world, ENEMY_COLONY_ID as ColonyId);
-    // eslint-disable-next-line no-restricted-syntax
-    world.colonies[ENEMY_COLONY_ID as ColonyId]!.foodStored = Math.ceil(cap * AI_WARFOOTING_FOOD_FRAC_PCT / 100);
+    world.colonies[ENEMY_COLONY_ID as ColonyId]!.foodStored = Math.ceil(
+      (cap * AI_WARFOOTING_FOOD_FRAC_PCT) / 100, // eslint-disable-line no-restricted-syntax
+    );
 
     // Player: many workers, satisfying frontage hook
     const aiWorkers = world.colonies[ENEMY_COLONY_ID as ColonyId]!.workerCount;
     const playerNeeded = Math.max(
       AI_FRONTAGE_PLAYER_WORKERS_ABS,
       // eslint-disable-next-line no-restricted-syntax
-      Math.ceil(AI_FRONTAGE_PLAYER_WORKERS_RATIO_X100 * aiWorkers / 100),
+      Math.ceil((AI_FRONTAGE_PLAYER_WORKERS_RATIO_X100 * aiWorkers) / 100),
     );
     world.colonies[PLAYER_COLONY_ID as ColonyId]!.workerCount = playerNeeded;
 
@@ -199,8 +206,9 @@ describe('advanceAIState — Peacetime → WarFooting (CF-P1-010)', () => {
     const minFighters = AI_WARFOOTING_FIGHTER_THRESHOLD[NORMAL_TIER_INDEX];
     spawnFighters(world, ENEMY_COLONY_ID, minFighters - 1, 10); // one short
     const cap = aiFoodCapacity(world, ENEMY_COLONY_ID as ColonyId);
-    // eslint-disable-next-line no-restricted-syntax
-    world.colonies[ENEMY_COLONY_ID as ColonyId]!.foodStored = Math.ceil(cap * AI_WARFOOTING_FOOD_FRAC_PCT / 100);
+    world.colonies[ENEMY_COLONY_ID as ColonyId]!.foodStored = Math.ceil(
+      (cap * AI_WARFOOTING_FOOD_FRAC_PCT) / 100, // eslint-disable-line no-restricted-syntax
+    );
 
     // Player: large enough to trigger frontage
     world.colonies[PLAYER_COLONY_ID as ColonyId]!.workerCount = 100;
@@ -359,7 +367,14 @@ describe('setAIRallyOperation — probe cohort', () => {
     aiState.state = 'WarFooting';
 
     const eventsBefore = world.events.length;
-    setAIRallyOperation(world, ENEMY_COLONY_ID as ColonyId, 40, 64, [10, 11, 12, 13, 14], 'Invasion');
+    setAIRallyOperation(
+      world,
+      ENEMY_COLONY_ID as ColonyId,
+      40,
+      64,
+      [10, 11, 12, 13, 14],
+      'Invasion',
+    );
     const newEvents = world.events.slice(eventsBefore);
     const invasionEvent = newEvents.find((e) => e.type === 'invasion_start');
     expect(invasionEvent).toBeDefined();

--- a/src/sim/ai-state.ts
+++ b/src/sim/ai-state.ts
@@ -33,7 +33,6 @@ import {
   FOOD_CHAMBER_CAPACITY,
 } from './constants.js';
 
-
 // QC Pass 4 AR-P0-001: Normal-only tier index. Used for pre-V22 saves; V22+ uses tierIndex(world.difficulty).
 export const NORMAL_TIER_INDEX = 1 as const;
 
@@ -177,8 +176,8 @@ function allProbeFightersDone(world: WorldState, aiState: AIStateRecord): boolea
     if (ants.alive[id] !== 1) continue; // dead = done
     // "Done" = alive AND back in AI's underground grid AND task !== Fighting.
     // In-transit (alive but on surface or not yet returned) is NOT done.
-    const onAIGrid = ants.zone[id] === Zone.Underground &&
-      ants.currentGridColonyId[id] === aiState.colonyId;
+    const onAIGrid =
+      ants.zone[id] === Zone.Underground && ants.currentGridColonyId[id] === aiState.colonyId;
     const notFighting = ants.task[id] !== AntTask.Fighting;
     if (!(onAIGrid && notFighting)) return false; // still out
   }
@@ -345,7 +344,11 @@ function _checkProbingToWarFooting(
   if (allDead || allDone || timeout) {
     // Emit ClearRallyPoint before clearing rally tile so fighters re-route home.
     if (aiState.invasionRallyTileX !== -1) {
-      const clearCmd: ClearRallyPointCommand = { type: 'ClearRallyPoint', colonyId: aiColonyId, issuedAtTick: world.tick };
+      const clearCmd: ClearRallyPointCommand = {
+        type: 'ClearRallyPoint',
+        colonyId: aiColonyId,
+        issuedAtTick: world.tick,
+      };
       world.commandQueue.push(clearCmd);
     }
     aiState.state = 'WarFooting';
@@ -382,7 +385,8 @@ function _checkInvadingToRecovery(
       // ClearRallyPoint. advanceAIState still emits ai_state_transition after this returns.
       aiState.state = 'Recovery';
       aiState.enteredTick = world.tick;
-      aiState.recoveryEndTick = world.tick + AI_RECOVERY_DURATION_TICKS[tierIndex(world.difficulty)];
+      aiState.recoveryEndTick =
+        world.tick + AI_RECOVERY_DURATION_TICKS[tierIndex(world.difficulty)];
       aiState.invasionStartTick = 0;
       aiState.invasionRallyTileX = -1;
       aiState.invasionRallyTileY = -1;
@@ -437,7 +441,11 @@ function _endInvasion(
   });
 
   // Emit ClearRallyPoint so fighters stop routing to the invasion target and go home.
-  const clearCmd: ClearRallyPointCommand = { type: 'ClearRallyPoint', colonyId: aiColonyId, issuedAtTick: world.tick };
+  const clearCmd: ClearRallyPointCommand = {
+    type: 'ClearRallyPoint',
+    colonyId: aiColonyId,
+    issuedAtTick: world.tick,
+  };
   world.commandQueue.push(clearCmd);
   aiState.state = 'Recovery';
   aiState.enteredTick = world.tick;

--- a/src/sim/ant/ant-store.test.ts
+++ b/src/sim/ant/ant-store.test.ts
@@ -4,18 +4,9 @@
 // All tests run synchronously in < 10ms — no async, no allocations after setup.
 
 import { describe, it, expect } from 'vitest';
-import {
-  createAntComponents,
-  initAnt,
-  killAnt,
-  isAlive,
-} from './ant-store.js';
+import { createAntComponents, initAnt, killAnt, isAlive } from './ant-store.js';
 import { AntTask, ForagingSubState } from '../enums.js';
-import {
-  MAX_ENTITIES,
-  WORKER_BASE_SPEED,
-  WORKER_LIFESPAN_TICKS,
-} from '../constants.js';
+import { MAX_ENTITIES, WORKER_BASE_SPEED, WORKER_LIFESPAN_TICKS } from '../constants.js';
 
 describe('ant-store', () => {
   // ---------------------------------------------------------------------------
@@ -135,7 +126,7 @@ describe('ant-store', () => {
       speed: 64,
     });
 
-    expect(ants.task[id]).toBe(AntTask.Foraging);        // 1
+    expect(ants.task[id]).toBe(AntTask.Foraging); // 1
     expect(ants.subTask[id]).toBe(ForagingSubState.SearchingFood); // 0
     expect(ants.speed[id]).toBe(64);
     // alive still set to 1
@@ -203,9 +194,9 @@ describe('ant-store', () => {
     expect(ants.posX[id]).toBe(50);
     expect(ants.posY[id]).toBe(75);
     expect(ants.speed[id]).toBe(WORKER_BASE_SPEED); // back to default
-    expect(ants.age[id]).toBe(0);                   // reset by initAnt
-    expect(ants.foodCarrying[id]).toBe(0);           // reset by initAnt
-    expect(ants.alive[id]).toBe(1);                  // stays 1
+    expect(ants.age[id]).toBe(0); // reset by initAnt
+    expect(ants.foodCarrying[id]).toBe(0); // reset by initAnt
+    expect(ants.alive[id]).toBe(1); // stays 1
   });
 
   // ---------------------------------------------------------------------------
@@ -215,9 +206,23 @@ describe('ant-store', () => {
   it('createAntComponents(64) returns object with all 17 keys, each Int32Array of length 64', () => {
     const ants = createAntComponents(64);
     const fields: Array<keyof typeof ants> = [
-      'posX', 'posY', 'colonyId', 'task', 'subTask', 'speed',
-      'foodCarrying', 'starvationTimer', 'age', 'alive', 'lifespan',
-      'zone', 'digTileX', 'digTileY', 'digTicksRemaining', 'targetPosX', 'targetPosY',
+      'posX',
+      'posY',
+      'colonyId',
+      'task',
+      'subTask',
+      'speed',
+      'foodCarrying',
+      'starvationTimer',
+      'age',
+      'alive',
+      'lifespan',
+      'zone',
+      'digTileX',
+      'digTileY',
+      'digTicksRemaining',
+      'targetPosX',
+      'targetPosY',
     ];
     expect(fields.length).toBe(17);
     for (const field of fields) {
@@ -234,12 +239,12 @@ describe('ant-store', () => {
     const ants = createAntComponents(64);
     const indices = [0, 31, 63];
     for (const i of indices) {
-      expect(ants.zone[i],              `zone[${i}] should be 0 (Surface)`).toBe(0);
-      expect(ants.digTileX[i],          `digTileX[${i}] should be -1`).toBe(-1);
-      expect(ants.digTileY[i],          `digTileY[${i}] should be -1`).toBe(-1);
+      expect(ants.zone[i], `zone[${i}] should be 0 (Surface)`).toBe(0);
+      expect(ants.digTileX[i], `digTileX[${i}] should be -1`).toBe(-1);
+      expect(ants.digTileY[i], `digTileY[${i}] should be -1`).toBe(-1);
       expect(ants.digTicksRemaining[i], `digTicksRemaining[${i}] should be 0`).toBe(0);
-      expect(ants.targetPosX[i],        `targetPosX[${i}] should be -1`).toBe(-1);
-      expect(ants.targetPosY[i],        `targetPosY[${i}] should be -1`).toBe(-1);
+      expect(ants.targetPosX[i], `targetPosX[${i}] should be -1`).toBe(-1);
+      expect(ants.targetPosY[i], `targetPosY[${i}] should be -1`).toBe(-1);
     }
   });
 
@@ -252,12 +257,12 @@ describe('ant-store', () => {
     const id = 5;
     initAnt(ants, id, { colonyId: 1, posX: 100, posY: 200 });
 
-    expect(ants.zone[id]).toBe(0);              // Surface
-    expect(ants.digTileX[id]).toBe(-1);         // no claimed tile
-    expect(ants.digTileY[id]).toBe(-1);         // no claimed tile
+    expect(ants.zone[id]).toBe(0); // Surface
+    expect(ants.digTileX[id]).toBe(-1); // no claimed tile
+    expect(ants.digTileY[id]).toBe(-1); // no claimed tile
     expect(ants.digTicksRemaining[id]).toBe(0); // not digging
-    expect(ants.targetPosX[id]).toBe(-1);       // no target
-    expect(ants.targetPosY[id]).toBe(-1);       // no target
+    expect(ants.targetPosX[id]).toBe(-1); // no target
+    expect(ants.targetPosY[id]).toBe(-1); // no target
   });
 
   // ---------------------------------------------------------------------------
@@ -284,7 +289,7 @@ describe('ant-store', () => {
     // digTileX and posX start at -1 and 0 respectively (no initAnt needed)
     ants.zone[5] = 1;
     expect(ants.digTileX[5]).toBe(-1); // still sentinel
-    expect(ants.posX[5]).toBe(0);      // unchanged
+    expect(ants.posX[5]).toBe(0); // unchanged
   });
 
   // ---------------------------------------------------------------------------

--- a/src/sim/ant/ant-store.ts
+++ b/src/sim/ant/ant-store.ts
@@ -47,37 +47,37 @@ import {
 // ---------------------------------------------------------------------------
 
 export interface AntComponents {
-  readonly posX:            Int32Array;
-  readonly posY:            Int32Array;
-  readonly colonyId:        Int32Array;
-  readonly task:            Int32Array;
-  readonly subTask:         Int32Array;
-  readonly speed:           Int32Array;
-  readonly foodCarrying:    Int32Array;
+  readonly posX: Int32Array;
+  readonly posY: Int32Array;
+  readonly colonyId: Int32Array;
+  readonly task: Int32Array;
+  readonly subTask: Int32Array;
+  readonly speed: Int32Array;
+  readonly foodCarrying: Int32Array;
   readonly starvationTimer: Int32Array;
-  readonly age:             Int32Array;
-  readonly alive:           Int32Array;
-  readonly lifespan:        Int32Array;
+  readonly age: Int32Array;
+  readonly alive: Int32Array;
+  readonly lifespan: Int32Array;
   // Phase 7 additions:
   /** Zone the ant is currently in: 0 = Surface, 1 = Underground. */
-  readonly zone:              Int32Array;
+  readonly zone: Int32Array;
   /** X coordinate of the dig tile claimed by this ant (-1 = none). */
-  readonly digTileX:          Int32Array;
+  readonly digTileX: Int32Array;
   /** Y coordinate of the dig tile claimed by this ant (-1 = none). */
-  readonly digTileY:          Int32Array;
+  readonly digTileY: Int32Array;
   /** Ticks remaining to finish excavating the claimed tile (0 = not digging). */
   readonly digTicksRemaining: Int32Array;
   /** Forager priority target X in fixed-point units (-1 = no target). */
-  readonly targetPosX:        Int32Array;
+  readonly targetPosX: Int32Array;
   /** Forager priority target Y in fixed-point units (-1 = no target). */
-  readonly targetPosY:        Int32Array;
+  readonly targetPosY: Int32Array;
   /**
    * 09 SearchingFood leash wave index (0..SEARCH_LEASH_MAX_WAVE). Zero = base
    * radius. Incremented when a SearchingFood ant is demoted for exceeding the
    * current wave's radius; reset to 0 on a successful pickup. Per-ant state
    * (not colony-memory) per the 09 digger-reassignment memo.
    */
-  readonly searchWave:        Int32Array;
+  readonly searchWave: Int32Array;
   /**
    * 09 excursion-foraging memo — persistent outbound heading X component for a
    * SearchingFood forager. One of {-1, 0, 1}. Zero paired with searchHeadingY=0
@@ -86,9 +86,9 @@ export interface AntComponents {
    * this heading to produce a correlated outward walk instead of per-tick
    * random cardinals. Per-ant state — no colony-memory.
    */
-  readonly searchHeadingX:    Int32Array;
+  readonly searchHeadingX: Int32Array;
   /** Companion Y component to searchHeadingX. */
-  readonly searchHeadingY:    Int32Array;
+  readonly searchHeadingY: Int32Array;
   /**
    * 09 excursion-foraging memo — ticks remaining on the current heading before
    * the next turn check. Counts down each chooseExcursionDirection call; on
@@ -303,37 +303,37 @@ export function createAntComponents(maxEntities: number = MAX_ENTITIES): AntComp
   carriedBy.fill(-1);
 
   return {
-    posX:            new Int32Array(maxEntities),
-    posY:            new Int32Array(maxEntities),
-    colonyId:        new Int32Array(maxEntities),
-    task:            new Int32Array(maxEntities),
-    subTask:         new Int32Array(maxEntities),
-    speed:           new Int32Array(maxEntities),
-    foodCarrying:    new Int32Array(maxEntities),
+    posX: new Int32Array(maxEntities),
+    posY: new Int32Array(maxEntities),
+    colonyId: new Int32Array(maxEntities),
+    task: new Int32Array(maxEntities),
+    subTask: new Int32Array(maxEntities),
+    speed: new Int32Array(maxEntities),
+    foodCarrying: new Int32Array(maxEntities),
     starvationTimer: new Int32Array(maxEntities),
-    age:             new Int32Array(maxEntities),
-    alive:           new Int32Array(maxEntities),
-    lifespan:        new Int32Array(maxEntities),
+    age: new Int32Array(maxEntities),
+    alive: new Int32Array(maxEntities),
+    lifespan: new Int32Array(maxEntities),
     // Phase 7 fields:
-    zone:              new Int32Array(maxEntities), // zero = Surface (correct default)
+    zone: new Int32Array(maxEntities), // zero = Surface (correct default)
     digTileX,
     digTileY,
     digTicksRemaining: new Int32Array(maxEntities), // zero = not digging (correct default)
     targetPosX,
     targetPosY,
     // Phase 9 SearchingFood leash:
-    searchWave:        new Int32Array(maxEntities), // zero = base wave (correct default)
+    searchWave: new Int32Array(maxEntities), // zero = base wave (correct default)
     // Phase 9 excursion-foraging memo — correlated outward walk heading:
-    searchHeadingX:    new Int32Array(maxEntities), // zero = no heading yet
-    searchHeadingY:    new Int32Array(maxEntities), // zero = no heading yet
-    searchHeadingTicks:new Int32Array(maxEntities), // zero = re-roll heading now
+    searchHeadingX: new Int32Array(maxEntities), // zero = no heading yet
+    searchHeadingY: new Int32Array(maxEntities), // zero = no heading yet
+    searchHeadingTicks: new Int32Array(maxEntities), // zero = re-roll heading now
     // Phase 9 excursion-foraging follow-up — per-ant anti-backtrack prev tile:
     searchPrevTileX,
     searchPrevTileY,
     // Issue #34 — Bresenham accumulator. Zero-init = "no debt yet."
-    pathErr:           new Int32Array(maxEntities),
+    pathErr: new Int32Array(maxEntities),
     // Issue #35 — pause-while-searching counter. Zero-init = "not paused."
-    searchPauseTicks:  new Int32Array(maxEntities),
+    searchPauseTicks: new Int32Array(maxEntities),
     // Phase 09.1 Chunk 0 — grid-of-occupancy byte (Uint8Array). Zero-init is
     // correct: PLAYER_COLONY_ID is conventionally 0; initAnt overwrites with
     // spec.colonyId at spawn.
@@ -349,11 +349,15 @@ export function createAntComponents(maxEntities: number = MAX_ENTITIES): AntComp
     carriedBy,
     // S1 — combat fields. hp zero-init would be wrong (dead ants have hp=0);
     // initAnt sets hp=COMBAT_HP_BASE on spawn.
-    hp:               new Int32Array(maxEntities),
-    homeGroundBonusHp:new Int32Array(maxEntities),
-    attackCooldown:   new Int32Array(maxEntities),
+    hp: new Int32Array(maxEntities),
+    homeGroundBonusHp: new Int32Array(maxEntities),
+    attackCooldown: new Int32Array(maxEntities),
     // S1 — combat opponent tracking. -1 = not paired.
-    combatOpponentId: (() => { const a = new Int32Array(maxEntities); a.fill(-1); return a; })(),
+    combatOpponentId: (() => {
+      const a = new Int32Array(maxEntities);
+      a.fill(-1);
+      return a;
+    })(),
   };
 }
 
@@ -367,14 +371,14 @@ export function createAntComponents(maxEntities: number = MAX_ENTITIES): AntComp
  */
 export interface InitAntSpec {
   colonyId: number;
-  posX:     number;
-  posY:     number;
+  posX: number;
+  posY: number;
   /** Raw task discriminant. Defaults to AntTask.Idle (0). */
-  task?:    number;
+  task?: number;
   /** Raw sub-task discriminant. Defaults to 0. */
   subTask?: number;
   /** Fixed-point speed. Defaults to WORKER_BASE_SPEED (128 = 0.5 × FP_ONE). */
-  speed?:   number;
+  speed?: number;
   /** Fixed-point lifespan ticks. Defaults to WORKER_LIFESPAN_TICKS (INT32_MAX). */
   lifespan?: number;
   /**
@@ -397,57 +401,57 @@ export interface InitAntSpec {
  * Calling twice on the same id overwrites (no accumulation).
  */
 export function initAnt(ants: AntComponents, id: EntityId, spec: InitAntSpec): void {
-  ants.colonyId[id]        = spec.colonyId;
+  ants.colonyId[id] = spec.colonyId;
   // Phase 09.1 Chunk 0 — grid-of-occupancy matches owning colony at spawn.
   // Invariant: currentGridColonyId[id] === colonyId[id] for every ant,
   // until Chunks 3+4 land Fighter cross-grid invasion. See
   // 09.1-00-PLAN.md objective block.
   ants.currentGridColonyId[id] = spec.colonyId;
-  ants.posX[id]            = spec.posX;
-  ants.posY[id]            = spec.posY;
-  ants.task[id]            = spec.task     !== undefined ? spec.task     : AntTask.Idle;
-  ants.subTask[id]         = spec.subTask  !== undefined ? spec.subTask  : 0;
-  ants.speed[id]           = spec.speed    !== undefined ? spec.speed    : WORKER_BASE_SPEED;
-  ants.lifespan[id]        = spec.lifespan !== undefined ? spec.lifespan : WORKER_LIFESPAN_TICKS;
-  ants.alive[id]           = 1;
-  ants.age[id]             = 0;
-  ants.foodCarrying[id]    = 0;
+  ants.posX[id] = spec.posX;
+  ants.posY[id] = spec.posY;
+  ants.task[id] = spec.task !== undefined ? spec.task : AntTask.Idle;
+  ants.subTask[id] = spec.subTask !== undefined ? spec.subTask : 0;
+  ants.speed[id] = spec.speed !== undefined ? spec.speed : WORKER_BASE_SPEED;
+  ants.lifespan[id] = spec.lifespan !== undefined ? spec.lifespan : WORKER_LIFESPAN_TICKS;
+  ants.alive[id] = 1;
+  ants.age[id] = 0;
+  ants.foodCarrying[id] = 0;
   ants.starvationTimer[id] = 0;
   // Phase 7 fields:
-  ants.zone[id]              = spec.zone !== undefined ? spec.zone : 0;
-  ants.digTileX[id]          = -1;
-  ants.digTileY[id]          = -1;
+  ants.zone[id] = spec.zone !== undefined ? spec.zone : 0;
+  ants.digTileX[id] = -1;
+  ants.digTileY[id] = -1;
   ants.digTicksRemaining[id] = 0;
-  ants.targetPosX[id]        = -1;
-  ants.targetPosY[id]        = -1;
-  ants.searchWave[id]        = 0;
-  ants.searchHeadingX[id]    = 0;
-  ants.searchHeadingY[id]    = 0;
-  ants.searchHeadingTicks[id]= 0;
-  ants.searchPrevTileX[id]   = -1;
-  ants.searchPrevTileY[id]   = -1;
+  ants.targetPosX[id] = -1;
+  ants.targetPosY[id] = -1;
+  ants.searchWave[id] = 0;
+  ants.searchHeadingX[id] = 0;
+  ants.searchHeadingY[id] = 0;
+  ants.searchHeadingTicks[id] = 0;
+  ants.searchPrevTileX[id] = -1;
+  ants.searchPrevTileY[id] = -1;
   // Issue #34 — fresh ant has no path-error debt.
-  ants.pathErr[id]           = 0;
+  ants.pathErr[id] = 0;
   // Issue #35 — fresh ant is not paused.
-  ants.searchPauseTicks[id]  = 0;
+  ants.searchPauseTicks[id] = 0;
   // Issue #27 — fresh ant is never in wait state (must traverse a failed
   // deposit cycle to enter it).
-  ants.waitingDeposit[id]    = 0;
+  ants.waitingDeposit[id] = 0;
   // Issue #42 — fresh ant has no recent-tile history.
   const base = id * RECENT_TILES_LEN;
   for (let s = 0; s < RECENT_TILES_LEN; s++) {
     ants.recentTilesX[base + s] = RECENT_TILES_SENTINEL;
     ants.recentTilesY[base + s] = RECENT_TILES_SENTINEL;
   }
-  ants.recentTilesHead[id]   = 0;
+  ants.recentTilesHead[id] = 0;
   // Issue #17 Phase 1 — fresh ant is not carrying / not carried.
-  ants.carryingBroodId[id]   = -1;
-  ants.carriedBy[id]         = -1;
+  ants.carryingBroodId[id] = -1;
+  ants.carriedBy[id] = -1;
   // S1 — fresh ant starts at full base HP; home-ground bonus is set by
   // the combat resolver on first engagement on home ground.
-  ants.hp[id]               = spec.hp ?? COMBAT_HP_BASE;
-  ants.homeGroundBonusHp[id]= 0;
-  ants.attackCooldown[id]   = 0;
+  ants.hp[id] = spec.hp ?? COMBAT_HP_BASE;
+  ants.homeGroundBonusHp[id] = 0;
+  ants.attackCooldown[id] = 0;
   ants.combatOpponentId[id] = -1;
 }
 
@@ -462,14 +466,9 @@ export function initAnt(ants: AntComponents, id: EntityId, spec: InitAntSpec): v
  * Caller is responsible for gating: only call on actual movement (not on
  * pause ticks) and only when world.simVersion >= 6 + Surface SearchingFood.
  */
-export function pushRecentTile(
-  ants: AntComponents,
-  id: EntityId,
-  tx: number,
-  ty: number,
-): void {
+export function pushRecentTile(ants: AntComponents, id: EntityId, tx: number, ty: number): void {
   const slot = ants.recentTilesHead[id]!;
-  const idx  = id * RECENT_TILES_LEN + slot;
+  const idx = id * RECENT_TILES_LEN + slot;
   ants.recentTilesX[idx] = tx;
   ants.recentTilesY[idx] = ty;
   ants.recentTilesHead[id] = (slot + 1) % RECENT_TILES_LEN;
@@ -479,12 +478,7 @@ export function pushRecentTile(
  * True iff (tx, ty) appears anywhere in ant `id`'s recent-tiles ring buffer.
  * Cheap linear scan — RECENT_TILES_LEN is 4.
  */
-export function isRecentTile(
-  ants: AntComponents,
-  id: EntityId,
-  tx: number,
-  ty: number,
-): boolean {
+export function isRecentTile(ants: AntComponents, id: EntityId, tx: number, ty: number): boolean {
   const base = id * RECENT_TILES_LEN;
   for (let s = 0; s < RECENT_TILES_LEN; s++) {
     if (ants.recentTilesX[base + s] === tx && ants.recentTilesY[base + s] === ty) return true;

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -50,8 +50,20 @@ import {
 } from '../types.js';
 import { createColonyRecord } from '../colony/colony-store.js';
 import { initAnt, createAntComponents, RECENT_TILES_LEN, isRecentTile } from './ant-store.js';
-import { AntTask, ForagingSubState, DiggingSubState, NursingSubState, ChamberType, PheromoneType } from '../enums.js';
-import { createPheromoneGrid, phGet, phSet, pheromoneGridKey } from '../pheromone/pheromone-store.js';
+import {
+  AntTask,
+  ForagingSubState,
+  DiggingSubState,
+  NursingSubState,
+  ChamberType,
+  PheromoneType,
+} from '../enums.js';
+import {
+  createPheromoneGrid,
+  phGet,
+  phSet,
+  pheromoneGridKey,
+} from '../pheromone/pheromone-store.js';
 import { Rng } from '../rng.js';
 import {
   WORKER_CARRY_CAPACITY,
@@ -259,7 +271,7 @@ describe('antDepositFood', () => {
     // Full no-op: nothing changes
     expect(colony.foodStored).toBe(100);
     expect(world.ants.foodCarrying[antId]).toBe(0);
-    expect(world.ants.task[antId]).toBe(AntTask.Foraging);   // NOT flipped to Idle
+    expect(world.ants.task[antId]).toBe(AntTask.Foraging); // NOT flipped to Idle
     expect(world.ants.subTask[antId]).toBe(ForagingSubState.CarryingFood); // NOT cleared
   });
 
@@ -307,8 +319,13 @@ describe('antDepositFood', () => {
     world.ants.task[antId] = AntTask.Foraging;
     world.ants.subTask[antId] = ForagingSubState.CarryingFood;
     colony.chambers.push({
-      chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: 0,
-      posX: 0, posY: 0, width: 3, height: 3,
+      chamberId: 100,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 0,
+      posX: 0,
+      posY: 0,
+      width: 3,
+      height: 3,
     });
     // Pool is already at BASE; further pool deposits would be impossible. The
     // chamber-authoritative path lets the ant deposit anyway because the
@@ -333,9 +350,13 @@ describe('antDepositFood', () => {
     // Chamber at cap — antDepositFood must skip it (issue #15: full chambers
     // are not deposit targets).
     colony.chambers.push({
-      chamberId: 100, chamberType: ChamberType.FoodStorage,
+      chamberId: 100,
+      chamberType: ChamberType.FoodStorage,
       foodStored: FOOD_CHAMBER_CAPACITY,
-      posX: 0, posY: 0, width: 3, height: 3,
+      posX: 0,
+      posY: 0,
+      width: 3,
+      height: 3,
     });
     // Pool also at cap → no fallback room either.
     colony.foodStored = BASE_FOOD_STORAGE_CAPACITY;
@@ -476,20 +497,27 @@ describe('tickAntMovement', () => {
     // Key assertion: ant position changed from initial if exploit branch gives down direction
     // or explore branch gives any non-zero direction (which includes moving from posY=1024)
     // The speed (128) is added to position, so at least one dimension should change
-    const moved = (posYAfter !== posYBefore) || (world.ants.posX[antId]! !== (5 << FP_SHIFT));
+    const moved = posYAfter !== posYBefore || world.ants.posX[antId]! !== 5 << FP_SHIFT;
     expect(moved).toBe(true);
     // Also: posY should equal posYBefore + speed (moved toward strong pheromone)
     // Only true if exploit branch taken. Accept either posYBefore+speed OR any other valid movement.
     // With V7+ SoftCost, the ant may move at speed/2=64 instead of speed=128.
-    // eslint-disable-next-line no-restricted-syntax
-    expect([posYBefore + speed, posYBefore + speed/2, posYBefore, posYBefore - speed/2, posYBefore - speed]).toContain(posYAfter);
+    /* eslint-disable no-restricted-syntax */
+    expect([
+      posYBefore + speed,
+      posYBefore + speed / 2,
+      posYBefore,
+      posYBefore - speed / 2,
+      posYBefore - speed,
+    ]).toContain(posYAfter);
+    /* eslint-enable no-restricted-syntax */
   });
 
   it('12. non-forager stays put (getTaskDirection returns {0,0})', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances        = [];
-    colony.rallyPoint       = null;
+    colony.entrances = [];
+    colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
 
@@ -635,8 +663,8 @@ describe('getTaskDirection', () => {
   it('returns {dx:0, dy:0} for Idle and Fighting tasks (no pathfinding needed)', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances        = [];
-    colony.rallyPoint       = null;
+    colony.entrances = [];
+    colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
 
@@ -674,8 +702,8 @@ function setupWorldWithUnderground(
   const world = createWorldState(42, MAX_TEST_ENTITIES);
   const colonyId = COLONY_ID;
   const colony = createColonyRecord(colonyId, 0);
-  colony.entrances        = [];
-  colony.rallyPoint       = null;
+  colony.entrances = [];
+  colony.rallyPoint = null;
   colony.digFlowFieldDirty = false;
   world.colonies[colonyId] = colony;
 
@@ -725,8 +753,8 @@ describe('getTaskDirection — dig direction lookup (purity checks)', () => {
 
     // Purity: nothing mutated
     expect(ugGet(underground, 1, 0)).toBe(tileStateBefore); // tile unchanged
-    expect(world.ants.subTask[antId]).toBe(subTaskBefore);   // subTask unchanged
-    expect(colony.digFlowFieldDirty).toBe(dirtyBefore);      // dirty flag unchanged
+    expect(world.ants.subTask[antId]).toBe(subTaskBefore); // subTask unchanged
+    expect(colony.digFlowFieldDirty).toBe(dirtyBefore); // dirty flag unchanged
   });
 
   it('D-2. dig worker ON Marked tile (flow-field dir=-1) → returns {0,0}; tile still Marked (not claimed)', () => {
@@ -1039,8 +1067,8 @@ describe('tickDigExecution — state machine transitions', () => {
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX: 0,  // posX=0 → tileX=0
-      posY: 0,  // posY=0 → tileY=0
+      posX: 0, // posX=0 → tileX=0
+      posY: 0, // posY=0 → tileY=0
       task: AntTask.Digging,
       subTask: DiggingSubState.MovingToTile,
       zone: Zone.Underground,
@@ -1088,7 +1116,9 @@ describe('routeForagerPriority', () => {
   it('4. colony has no priorityFoodPileId → routeForagerPriority sets targetPosX/Y = -1', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     colony.priorityFoodPileId = null;
     world.colonies[COLONY_ID] = colony;
 
@@ -1111,10 +1141,12 @@ describe('routeForagerPriority', () => {
     expect(world.ants.targetPosY[antId]).toBe(-1);
   });
 
-  it('5. colony.priorityFoodPileId set → targetPosX/Y set to that pile\'s tile position', () => {
+  it("5. colony.priorityFoodPileId set → targetPosX/Y set to that pile's tile position", () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     colony.priorityFoodPileId = 1;
     world.colonies[COLONY_ID] = colony;
 
@@ -1144,7 +1176,9 @@ describe('routeForagerPriority', () => {
     // applies — a single priorityFoodPileId per colony is authoritative.
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     colony.priorityFoodPileId = 10;
     world.colonies[COLONY_ID] = colony;
 
@@ -1172,7 +1206,9 @@ describe('routeForagerPriority', () => {
   it('7. ant not in SearchingFood sub-state → targetPosX/Y unchanged', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     colony.priorityFoodPileId = 1;
     world.colonies[COLONY_ID] = colony;
 
@@ -1195,7 +1231,7 @@ describe('routeForagerPriority', () => {
     expect(world.ants.targetPosY[antId]).toBe(88);
   });
 
-  it('8. cross-colony isolation: colony A\'s priority pile does NOT redirect colony B\'s foragers', () => {
+  it("8. cross-colony isolation: colony A's priority pile does NOT redirect colony B's foragers", () => {
     // Regression for the Phase 9 bug where isMarkedPriority lived on the shared
     // FoodPile entity and enemy ants read it too. With per-colony priority, a
     // forager from a colony with no priority keeps targetPosX/Y at -1 even
@@ -1206,12 +1242,16 @@ describe('routeForagerPriority', () => {
     const COLONY_B = 2;
 
     const colonyA = createColonyRecord(COLONY_A, 0);
-    colonyA.entrances = []; colonyA.rallyPoint = null; colonyA.digFlowFieldDirty = false;
+    colonyA.entrances = [];
+    colonyA.rallyPoint = null;
+    colonyA.digFlowFieldDirty = false;
     colonyA.priorityFoodPileId = 1;
     world.colonies[COLONY_A] = colonyA;
 
     const colonyB = createColonyRecord(COLONY_B, 0);
-    colonyB.entrances = []; colonyB.rallyPoint = null; colonyB.digFlowFieldDirty = false;
+    colonyB.entrances = [];
+    colonyB.rallyPoint = null;
+    colonyB.digFlowFieldDirty = false;
     colonyB.priorityFoodPileId = null;
     world.colonies[COLONY_B] = colonyB;
 
@@ -1220,14 +1260,18 @@ describe('routeForagerPriority', () => {
     const antA = allocateEntityId(world);
     initAnt(world.ants, antA, {
       colonyId: COLONY_A,
-      posX: 0, posY: 0,
-      task: AntTask.Foraging, subTask: ForagingSubState.SearchingFood,
+      posX: 0,
+      posY: 0,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.SearchingFood,
     });
     const antB = allocateEntityId(world);
     initAnt(world.ants, antB, {
       colonyId: COLONY_B,
-      posX: 0, posY: 0,
-      task: AntTask.Foraging, subTask: ForagingSubState.SearchingFood,
+      posX: 0,
+      posY: 0,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.SearchingFood,
     });
 
     routeForagerPriority(world);
@@ -1246,7 +1290,9 @@ describe('routeForagerPriority', () => {
     // through to the pheromone gradient rather than chasing a ghost target.
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     colony.priorityFoodPileId = 999; // no such pile
     world.colonies[COLONY_ID] = colony;
 
@@ -1320,7 +1366,7 @@ describe('tickAntMovement — zone transitions', () => {
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
       posX: 8 << FP_SHIFT,
-      posY: 0,  // tileY=0 (already at top of underground)
+      posY: 0, // tileY=0 (already at top of underground)
       task: AntTask.Foraging,
       subTask: ForagingSubState.SearchingFood,
       zone: Zone.Underground,
@@ -1569,8 +1615,10 @@ describe('tickAntMovement — underground passability guard', () => {
       chamberId: 1,
       chamberType: ChamberType.Queen,
       foodStored: 0,
-      posX: 5 << FP_SHIFT, posY: 8 << FP_SHIFT,
-      width: 1, height: 1,
+      posX: 5 << FP_SHIFT,
+      posY: 8 << FP_SHIFT,
+      width: 1,
+      height: 1,
     });
 
     const nurseId = allocateEntityId(world);
@@ -1607,8 +1655,10 @@ describe('tickAntMovement — underground passability guard', () => {
       chamberId: 1,
       chamberType: ChamberType.Queen,
       foodStored: 0,
-      posX: 5 << FP_SHIFT, posY: 8 << FP_SHIFT,
-      width: 1, height: 1,
+      posX: 5 << FP_SHIFT,
+      posY: 8 << FP_SHIFT,
+      width: 1,
+      height: 1,
     });
 
     const nurseId = allocateEntityId(world);
@@ -1647,8 +1697,10 @@ describe('tickAntMovement — underground passability guard', () => {
       chamberId: 1,
       chamberType: ChamberType.FoodStorage,
       foodStored: 0,
-      posX: 8 << FP_SHIFT, posY: 4 << FP_SHIFT,
-      width: 2, height: 2,
+      posX: 8 << FP_SHIFT,
+      posY: 4 << FP_SHIFT,
+      width: 2,
+      height: 2,
     });
 
     const foragerId = allocateEntityId(world);
@@ -1727,7 +1779,8 @@ describe('tickAntMovement — underground passability guard', () => {
     const diggerId = allocateEntityId(world);
     initAnt(world.ants, diggerId, {
       colonyId: COLONY_ID,
-      posX: 0, posY: 0,
+      posX: 0,
+      posY: 0,
       task: AntTask.Digging,
       subTask: DiggingSubState.MovingToTile,
       zone: Zone.Underground,
@@ -1757,14 +1810,17 @@ describe('tickAntMovement — underground passability guard', () => {
       chamberId: 1,
       chamberType: ChamberType.Queen,
       foodStored: 0,
-      posX: 1 << FP_SHIFT, posY: 0,
-      width: 1, height: 1,
+      posX: 1 << FP_SHIFT,
+      posY: 0,
+      width: 1,
+      height: 1,
     });
 
     const nurseId = allocateEntityId(world);
     initAnt(world.ants, nurseId, {
       colonyId: COLONY_ID,
-      posX: 0, posY: 0,
+      posX: 0,
+      posY: 0,
       task: AntTask.Nursing,
       subTask: NursingSubState.MovingToBrood,
       zone: Zone.Underground,
@@ -1794,14 +1850,17 @@ describe('tickAntMovement — underground passability guard', () => {
         chamberId: 1,
         chamberType: ChamberType.Queen,
         foodStored: 0,
-        posX: 7 << FP_SHIFT, posY: 7 << FP_SHIFT,
-        width: 1, height: 1,
+        posX: 7 << FP_SHIFT,
+        posY: 7 << FP_SHIFT,
+        width: 1,
+        height: 1,
       });
 
       const id = allocateEntityId(world);
       initAnt(world.ants, id, {
         colonyId: COLONY_ID,
-        posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT,
+        posX: 5 << FP_SHIFT,
+        posY: 5 << FP_SHIFT,
         task: AntTask.Nursing,
         subTask: NursingSubState.MovingToBrood,
         zone: Zone.Underground,
@@ -1850,8 +1909,10 @@ describe('antDepositFood — chamber-authoritative deposit (issue #15)', () => {
   it('14. ant inside FoodStorage footprint → deposit writes ONLY chamber.foodStored; entrance pool untouched', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null;
-    colony.digFlowFieldDirty = false; colony.foodFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
+    colony.foodFlowFieldDirty = false;
     colony.chambers.push(makeFoodStorageChamber(1, 0, 0, 0));
     colony.foodStored = 0;
     world.colonies[COLONY_ID] = colony;
@@ -1859,7 +1920,8 @@ describe('antDepositFood — chamber-authoritative deposit (issue #15)', () => {
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX: 0, posY: 0,
+      posX: 0,
+      posY: 0,
       task: AntTask.Foraging,
       subTask: ForagingSubState.CarryingFood,
     });
@@ -1879,8 +1941,10 @@ describe('antDepositFood — chamber-authoritative deposit (issue #15)', () => {
   it('15. colony has no food storage chamber → deposit writes entrance pool up to BASE capacity', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null;
-    colony.digFlowFieldDirty = false; colony.foodFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
+    colony.foodFlowFieldDirty = false;
     // No chambers → capacity = BASE_FOOD_STORAGE_CAPACITY (entrance pool only).
     colony.foodStored = 0;
     world.colonies[COLONY_ID] = colony;
@@ -1888,7 +1952,8 @@ describe('antDepositFood — chamber-authoritative deposit (issue #15)', () => {
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX: 0, posY: 0,
+      posX: 0,
+      posY: 0,
       task: AntTask.Foraging,
       subTask: ForagingSubState.CarryingFood,
     });
@@ -1904,19 +1969,22 @@ describe('antDepositFood — chamber-authoritative deposit (issue #15)', () => {
   it('16. ant in chamber 0 fills it to cap → chamber.foodStored hits FOOD_CHAMBER_CAPACITY and foodFlowFieldDirty fires', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null;
-    colony.digFlowFieldDirty = false; colony.foodFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
+    colony.foodFlowFieldDirty = false;
     // Two chambers in different parts of the grid. Ant only stands in chamber[0].
     // chamber[0] starts with 1234 stored, so headroom = 5120-1234 = 3886.
-    colony.chambers.push(makeFoodStorageChamber(1, 1234, 0,  0));
-    colony.chambers.push(makeFoodStorageChamber(2,    0, 8,  8));
+    colony.chambers.push(makeFoodStorageChamber(1, 1234, 0, 0));
+    colony.chambers.push(makeFoodStorageChamber(2, 0, 8, 8));
     colony.foodStored = 0;
     world.colonies[COLONY_ID] = colony;
 
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX: 0, posY: 0,
+      posX: 0,
+      posY: 0,
       task: AntTask.Foraging,
       subTask: ForagingSubState.CarryingFood,
     });
@@ -1940,10 +2008,12 @@ describe('antDepositFood — chamber-authoritative deposit (issue #15)', () => {
   it('17. issue #15 regression — ant outside FoodStorage footprint does NOT cause distant chambers to fill', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null;
-    colony.digFlowFieldDirty = false; colony.foodFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
+    colony.foodFlowFieldDirty = false;
     // Two chambers, both far from the ant's tile.
-    colony.chambers.push(makeFoodStorageChamber(1, 0,  8, 8));
+    colony.chambers.push(makeFoodStorageChamber(1, 0, 8, 8));
     colony.chambers.push(makeFoodStorageChamber(2, 0, 16, 8));
     colony.foodStored = 0;
     world.colonies[COLONY_ID] = colony;
@@ -1951,7 +2021,8 @@ describe('antDepositFood — chamber-authoritative deposit (issue #15)', () => {
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX: 0, posY: 0, // outside both chamber footprints
+      posX: 0,
+      posY: 0, // outside both chamber footprints
       task: AntTask.Foraging,
       subTask: ForagingSubState.CarryingFood,
     });
@@ -1983,7 +2054,8 @@ describe('updateFightAntTargets', () => {
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX: 0, posY: 0,
+      posX: 0,
+      posY: 0,
       task: AntTask.Fighting,
       subTask: 0,
     });
@@ -2033,7 +2105,8 @@ describe('updateFightAntTargets', () => {
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX: 0, posY: 0,
+      posX: 0,
+      posY: 0,
       task: AntTask.Fighting,
       subTask: 0,
     });
@@ -2056,7 +2129,8 @@ describe('updateFightAntTargets', () => {
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX: 0, posY: 0,
+      posX: 0,
+      posY: 0,
       task: AntTask.Fighting,
       subTask: 0,
     });
@@ -2081,7 +2155,8 @@ describe('updateFightAntTargets', () => {
     const deadId = allocateEntityId(world);
     initAnt(world.ants, deadId, {
       colonyId: COLONY_ID,
-      posX: 0, posY: 0,
+      posX: 0,
+      posY: 0,
       task: AntTask.Fighting,
       subTask: 0,
     });
@@ -2093,7 +2168,8 @@ describe('updateFightAntTargets', () => {
     const unknownColonyAntId = allocateEntityId(world);
     initAnt(world.ants, unknownColonyAntId, {
       colonyId: 999 as typeof COLONY_ID,
-      posX: 0, posY: 0,
+      posX: 0,
+      posY: 0,
       task: AntTask.Fighting,
       subTask: 0,
     });
@@ -2260,8 +2336,11 @@ describe('updateFightAntTargets', () => {
 
     const fighter = allocateEntityId(world);
     initAnt(world.ants, fighter, {
-      colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
-      task: AntTask.Fighting, subTask: 0,
+      colonyId: COLONY_ID,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting,
+      subTask: 0,
     });
     world.ants.zone[fighter] = Zone.Surface;
 
@@ -2287,8 +2366,11 @@ describe('updateFightAntTargets', () => {
 
     const fighter = allocateEntityId(world);
     initAnt(world.ants, fighter, {
-      colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
-      task: AntTask.Fighting, subTask: 0,
+      colonyId: COLONY_ID,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting,
+      subTask: 0,
     });
     world.ants.zone[fighter] = Zone.Surface;
 
@@ -2301,8 +2383,11 @@ describe('updateFightAntTargets', () => {
     const enemyTileX = 11;
     const enemy = allocateEntityId(world);
     initAnt(world.ants, enemy, {
-      colonyId: COLONY_B, posX: (enemyTileX << FP_SHIFT) + (FP_ONE >> 1), posY: 10 << FP_SHIFT,
-      task: AntTask.Idle, subTask: 0,
+      colonyId: COLONY_B,
+      posX: (enemyTileX << FP_SHIFT) + (FP_ONE >> 1),
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Idle,
+      subTask: 0,
     });
     world.ants.zone[enemy] = Zone.Surface;
     colB.workers.push(enemy);
@@ -2330,8 +2415,11 @@ describe('updateFightAntTargets', () => {
 
     const fighter = allocateEntityId(world);
     initAnt(world.ants, fighter, {
-      colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
-      task: AntTask.Fighting, subTask: 0,
+      colonyId: COLONY_ID,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting,
+      subTask: 0,
     });
     world.ants.zone[fighter] = Zone.Surface;
 
@@ -2356,8 +2444,11 @@ describe('updateFightAntTargets', () => {
 
     const fighter = allocateEntityId(world);
     initAnt(world.ants, fighter, {
-      colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
-      task: AntTask.Fighting, subTask: 0,
+      colonyId: COLONY_ID,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting,
+      subTask: 0,
     });
     world.ants.zone[fighter] = Zone.Surface;
 
@@ -2383,8 +2474,11 @@ describe('updateFightAntTargets', () => {
 
     const fighter = allocateEntityId(world);
     initAnt(world.ants, fighter, {
-      colonyId: COLONY_ID, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
-      task: AntTask.Fighting, subTask: 0,
+      colonyId: COLONY_ID,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Fighting,
+      subTask: 0,
     });
     world.ants.zone[fighter] = Zone.Surface;
 
@@ -2406,10 +2500,18 @@ describe('tickForagerActions', () => {
   it('surface SearchingFood ant on a food pile tile → picks up, drains a charge, transitions to CarryingFood', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
 
-    world.foodPiles.push({ foodPileId: 1, tileX: 12, tileY: 8 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 12,
+      tileY: 8,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
 
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
@@ -2433,11 +2535,19 @@ describe('tickForagerActions', () => {
   it('issue #112 — final-charge pickup splices pile out and records depletion', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     colony.priorityFoodPileId = 1; // mark this pile as priority
     world.colonies[COLONY_ID] = colony;
 
-    world.foodPiles.push({ foodPileId: 1, tileX: 12, tileY: 8, pickupsRemaining: 1, pickupsInitial: 1 });
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 12,
+      tileY: 8,
+      pickupsRemaining: 1,
+      pickupsInitial: 1,
+    });
 
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
@@ -2466,10 +2576,18 @@ describe('tickForagerActions', () => {
   it('surface SearchingFood ant NOT on any food pile tile → no pickup', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
 
-    world.foodPiles.push({ foodPileId: 1, tileX: 12, tileY: 8 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 12,
+      tileY: 8,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
 
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
@@ -2491,21 +2609,25 @@ describe('tickForagerActions', () => {
   it('underground CarryingFood ant on a FoodStorage chamber tile → deposits to chamber.foodStored and flips to Idle', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null;
-    colony.digFlowFieldDirty = false; colony.foodFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
+    colony.foodFlowFieldDirty = false;
     colony.chambers.push({
       chamberId: 1,
       chamberType: ChamberType.FoodStorage,
       foodStored: 0,
-      posX: 0, posY: 0,
-      width: 4, height: 3,
+      posX: 0,
+      posY: 0,
+      width: 4,
+      height: 3,
     });
     world.colonies[COLONY_ID] = colony;
 
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX: 1 << FP_SHIFT,   // inside chamber footprint
+      posX: 1 << FP_SHIFT, // inside chamber footprint
       posY: 1 << FP_SHIFT,
       task: AntTask.Foraging,
       subTask: ForagingSubState.CarryingFood,
@@ -2526,7 +2648,8 @@ describe('tickForagerActions', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
     colony.entrances = [{ entranceId: 1, surfaceTileX: 7, surfaceTileY: 5, isOpen: true }];
-    colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     // No FoodStorage chamber — fallback path.
     world.colonies[COLONY_ID] = colony;
 
@@ -2534,7 +2657,7 @@ describe('tickForagerActions', () => {
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
       posX: 7 << FP_SHIFT,
-      posY: 0,            // underground top-of-shaft at entrance column
+      posY: 0, // underground top-of-shaft at entrance column
       task: AntTask.Foraging,
       subTask: ForagingSubState.CarryingFood,
     });
@@ -2552,7 +2675,8 @@ describe('tickForagerActions', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
     colony.entrances = [{ entranceId: 1, surfaceTileX: 7, surfaceTileY: 5, isOpen: true }];
-    colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
 
     const antId = allocateEntityId(world);
@@ -2569,7 +2693,7 @@ describe('tickForagerActions', () => {
     tickForagerActions(world);
 
     expect(colony.foodStored).toBe(0);
-    expect(world.ants.foodCarrying[antId]).toBe(300);      // still carrying
+    expect(world.ants.foodCarrying[antId]).toBe(300); // still carrying
     expect(world.ants.task[antId]).toBe(AntTask.Foraging); // not flipped
   });
 
@@ -2577,7 +2701,8 @@ describe('tickForagerActions', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
     colony.entrances = [{ entranceId: 1, surfaceTileX: 7, surfaceTileY: 5, isOpen: false }];
-    colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
 
     const antId = allocateEntityId(world);
@@ -2623,9 +2748,7 @@ describe('issue #27 — carrier WaitingToDeposit', () => {
   } {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = [
-      { entranceId: 1, surfaceTileX: 7, surfaceTileY: 5, isOpen: true },
-    ];
+    colony.entrances = [{ entranceId: 1, surfaceTileX: 7, surfaceTileY: 5, isOpen: true }];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     colony.foodFlowFieldDirty = false;
@@ -2633,7 +2756,10 @@ describe('issue #27 — carrier WaitingToDeposit', () => {
       chamberId: 1,
       chamberType: ChamberType.FoodStorage,
       foodStored: FOOD_CHAMBER_CAPACITY, // saturated
-      posX: 0, posY: 0, width: 3, height: 3,
+      posX: 0,
+      posY: 0,
+      width: 3,
+      height: 3,
     });
     world.colonies[COLONY_ID] = colony;
 
@@ -2641,7 +2767,7 @@ describe('issue #27 — carrier WaitingToDeposit', () => {
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
       posX: 7 << FP_SHIFT, // entrance column
-      posY: 0,             // top of shaft underground
+      posY: 0, // top of shaft underground
       task: AntTask.Foraging,
       subTask: ForagingSubState.CarryingFood,
     });
@@ -2660,7 +2786,7 @@ describe('issue #27 — carrier WaitingToDeposit', () => {
     antDepositFood(world, colony, antId);
 
     expect(world.ants.waitingDeposit[antId]).toBe(1);
-    expect(world.ants.foodCarrying[antId]).toBe(512);     // unchanged
+    expect(world.ants.foodCarrying[antId]).toBe(512); // unchanged
     expect(world.ants.task[antId]).toBe(AntTask.Foraging); // not Idle
     expect(world.ants.subTask[antId]).toBe(ForagingSubState.CarryingFood);
     // searchHeading cleared on entry so a future wake doesn't continue stale routing
@@ -2769,7 +2895,6 @@ describe('issue #27 — carrier WaitingToDeposit', () => {
     // current state on subsequent ticks.
     expect(world.ants.waitingDeposit[antId]).toBe(0);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -2785,12 +2910,14 @@ describe('chooseExcursionDirection', () => {
   ): { world: WorldState; antId: number } {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = [{
-      entranceId:   1,
-      surfaceTileX: entranceTileX,
-      surfaceTileY: entranceTileY,
-      isOpen:       true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: 1,
+        surfaceTileX: entranceTileX,
+        surfaceTileY: entranceTileY,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
@@ -2811,8 +2938,8 @@ describe('chooseExcursionDirection', () => {
     const { world, antId } = setupWorldWithEntrance(24, 64, 30, 70);
     for (let seed = 0; seed < 200; seed++) {
       // Reset heading so each seed starts from scratch.
-      world.ants.searchHeadingX[antId]     = 0;
-      world.ants.searchHeadingY[antId]     = 0;
+      world.ants.searchHeadingX[antId] = 0;
+      world.ants.searchHeadingY[antId] = 0;
       world.ants.searchHeadingTicks[antId] = 0;
       const rng = new Rng(seed);
       const dir = chooseExcursionDirection(world, antId, rng);
@@ -2824,11 +2951,11 @@ describe('chooseExcursionDirection', () => {
     const { world: w1, antId: a1 } = setupWorldWithEntrance(24, 64, 30, 70);
     const { world: w2, antId: a2 } = setupWorldWithEntrance(24, 64, 30, 70);
     for (let seed = 0; seed < 50; seed++) {
-      w1.ants.searchHeadingX[a1]     = 0;
-      w1.ants.searchHeadingY[a1]     = 0;
+      w1.ants.searchHeadingX[a1] = 0;
+      w1.ants.searchHeadingY[a1] = 0;
       w1.ants.searchHeadingTicks[a1] = 0;
-      w2.ants.searchHeadingX[a2]     = 0;
-      w2.ants.searchHeadingY[a2]     = 0;
+      w2.ants.searchHeadingX[a2] = 0;
+      w2.ants.searchHeadingY[a2] = 0;
       w2.ants.searchHeadingTicks[a2] = 0;
       const d1 = chooseExcursionDirection(w1, a1, new Rng(seed));
       const d2 = chooseExcursionDirection(w2, a2, new Rng(seed));
@@ -2842,8 +2969,8 @@ describe('chooseExcursionDirection', () => {
     // direction is deterministic regardless of RNG.
     const { world, antId } = setupWorldWithEntrance(24, 64, 28, 64);
     for (let seed = 0; seed < 20; seed++) {
-      world.ants.searchHeadingX[antId]     = 0;
-      world.ants.searchHeadingY[antId]     = 0;
+      world.ants.searchHeadingX[antId] = 0;
+      world.ants.searchHeadingY[antId] = 0;
       world.ants.searchHeadingTicks[antId] = 0;
       const dir = chooseExcursionDirection(world, antId, new Rng(seed));
       expect(dir.dx).toBe(1);
@@ -2890,8 +3017,8 @@ describe('chooseExcursionDirection', () => {
       subTask: ForagingSubState.SearchingFood,
     });
     for (let seed = 0; seed < 50; seed++) {
-      world.ants.searchHeadingX[antId]     = 0;
-      world.ants.searchHeadingY[antId]     = 0;
+      world.ants.searchHeadingX[antId] = 0;
+      world.ants.searchHeadingY[antId] = 0;
       world.ants.searchHeadingTicks[antId] = 0;
       const dir = chooseExcursionDirection(world, antId, new Rng(seed));
       expect(Math.abs(dir.dx) + Math.abs(dir.dy)).toBe(1);
@@ -2905,8 +3032,8 @@ describe('chooseExcursionDirection', () => {
     const { world, antId } = setupWorldWithEntrance(24, 64, 0, 64);
     // Manually seed a westward heading with active ticks so the bounce path
     // (rather than the initial-outward path) is exercised.
-    world.ants.searchHeadingX[antId]     = -1;
-    world.ants.searchHeadingY[antId]     = 0;
+    world.ants.searchHeadingX[antId] = -1;
+    world.ants.searchHeadingY[antId] = 0;
     world.ants.searchHeadingTicks[antId] = 10;
     const dir = chooseExcursionDirection(world, antId, new Rng(1));
     expect(dir.dx).toBeGreaterThanOrEqual(0);
@@ -2924,7 +3051,9 @@ describe('chooseExcursionDirection', () => {
     // We verify the post-call state matches a fresh Rng advanced 3x.
     const expectedAfter3 = (seed: number): number => {
       const r = new Rng(seed);
-      r.nextU32(); r.nextU32(); r.nextU32();
+      r.nextU32();
+      r.nextU32();
+      r.nextU32();
       return r.getState();
     };
 
@@ -2940,16 +3069,16 @@ describe('chooseExcursionDirection', () => {
       // Active-outward heading
       () => {
         const r = setupWorldWithEntrance(24, 64, 30, 70);
-        r.world.ants.searchHeadingX[r.antId]     = 1;
-        r.world.ants.searchHeadingY[r.antId]     = 0;
+        r.world.ants.searchHeadingX[r.antId] = 1;
+        r.world.ants.searchHeadingY[r.antId] = 0;
         r.world.ants.searchHeadingTicks[r.antId] = 5;
         return r;
       },
       // Active-inward (bounce) heading
       () => {
         const r = setupWorldWithEntrance(24, 64, 30, 70);
-        r.world.ants.searchHeadingX[r.antId]     = -1;
-        r.world.ants.searchHeadingY[r.antId]     = 0;
+        r.world.ants.searchHeadingX[r.antId] = -1;
+        r.world.ants.searchHeadingY[r.antId] = 0;
         r.world.ants.searchHeadingTicks[r.antId] = 10;
         return r;
       },
@@ -2982,12 +3111,14 @@ describe('tickExcursionBoundary', () => {
   ): { world: WorldState; colony: ColonyRecord; antId: number } {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = [{
-      entranceId:   allocateEntityId(world),
-      surfaceTileX: entranceX,
-      surfaceTileY: entranceY,
-      isOpen:       true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: allocateEntityId(world),
+        surfaceTileX: entranceX,
+        surfaceTileY: entranceY,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
@@ -3006,8 +3137,8 @@ describe('tickExcursionBoundary', () => {
   it('within base radius → no transition, heading preserved', () => {
     const base = SEARCH_LEASH_RADII[0]!;
     const { world, antId } = setupExcursionWorld(base, 0);
-    world.ants.searchHeadingX[antId]     = 1;
-    world.ants.searchHeadingY[antId]     = 0;
+    world.ants.searchHeadingX[antId] = 1;
+    world.ants.searchHeadingY[antId] = 0;
     world.ants.searchHeadingTicks[antId] = 5;
     tickExcursionBoundary(world);
     expect(world.ants.subTask[antId]).toBe(ForagingSubState.SearchingFood);
@@ -3018,8 +3149,8 @@ describe('tickExcursionBoundary', () => {
   it('past base radius → flips to ReturningToNest, heading cleared', () => {
     const base = SEARCH_LEASH_RADII[0]!;
     const { world, antId } = setupExcursionWorld(base + 1, 0);
-    world.ants.searchHeadingX[antId]     = 1;
-    world.ants.searchHeadingY[antId]     = 0;
+    world.ants.searchHeadingX[antId] = 1;
+    world.ants.searchHeadingY[antId] = 0;
     world.ants.searchHeadingTicks[antId] = 5;
     tickExcursionBoundary(world);
     expect(world.ants.subTask[antId]).toBe(ForagingSubState.ReturningToNest);
@@ -3080,12 +3211,14 @@ describe('tickExcursionBoundary — priority-aware (09 follow-up issue 1)', () =
   function baseSetup(antTileX: number, antTileY: number, wave = 0) {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = [{
-      entranceId: allocateEntityId(world),
-      surfaceTileX: 0,
-      surfaceTileY: 0,
-      isOpen: true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: allocateEntityId(world),
+        surfaceTileX: 0,
+        surfaceTileY: 0,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
@@ -3105,7 +3238,13 @@ describe('tickExcursionBoundary — priority-aware (09 follow-up issue 1)', () =
     const base = SEARCH_LEASH_RADII[0]!;
     const { world, colony, antId } = baseSetup(base + 2, 0);
     // Mark a priority pile; pile exists in foodPiles so colonyHasPriorityPile resolves true.
-    const pile = { foodPileId: 1, tileX: base + 20, tileY: 0 , pickupsRemaining: 50, pickupsInitial: 50} as FoodPile;
+    const pile = {
+      foodPileId: 1,
+      tileX: base + 20,
+      tileY: 0,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    } as FoodPile;
     world.foodPiles.push(pile);
     colony.priorityFoodPileId = pile.foodPileId;
     tickExcursionBoundary(world);
@@ -3116,7 +3255,13 @@ describe('tickExcursionBoundary — priority-aware (09 follow-up issue 1)', () =
     const base = SEARCH_LEASH_RADII[0]!;
     const { world, antId } = baseSetup(base + 2, 0);
     // Pile within FOOD_SCENT_RADIUS (=15) of the ant — scent lookup returns non-null.
-    world.foodPiles.push({ foodPileId: 1, tileX: base + 5, tileY: 0 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: base + 5,
+      tileY: 0,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     tickExcursionBoundary(world);
     expect(world.ants.subTask[antId]).toBe(ForagingSubState.SearchingFood);
   });
@@ -3147,7 +3292,13 @@ describe('tickExcursionBoundary — priority-aware (09 follow-up issue 1)', () =
     // hysteresis threshold (25 - 5 = 20).
     const { world, colony, antId } = baseSetup(5, 0);
     world.ants.subTask[antId] = ForagingSubState.ReturningToNest;
-    const pile = { foodPileId: 1, tileX: base + 20, tileY: 0 , pickupsRemaining: 50, pickupsInitial: 50} as FoodPile;
+    const pile = {
+      foodPileId: 1,
+      tileX: base + 20,
+      tileY: 0,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    } as FoodPile;
     world.foodPiles.push(pile);
     colony.priorityFoodPileId = pile.foodPileId;
     tickExcursionBoundary(world);
@@ -3160,7 +3311,13 @@ describe('tickExcursionBoundary — priority-aware (09 follow-up issue 1)', () =
   it('ReturningToNest + nearby scent pile → flips back to SearchingFood', () => {
     const { world, antId } = baseSetup(10, 10);
     world.ants.subTask[antId] = ForagingSubState.ReturningToNest;
-    world.foodPiles.push({ foodPileId: 1, tileX: 12, tileY: 10 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 12,
+      tileY: 10,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     tickExcursionBoundary(world);
     expect(world.ants.subTask[antId]).toBe(ForagingSubState.SearchingFood);
   });
@@ -3272,7 +3429,13 @@ describe('tickExcursionBoundary — priority-aware (09 follow-up issue 1)', () =
     const base = SEARCH_LEASH_RADII[0]!;
     const { world, colony, antId } = baseSetup(base + 2, 0);
     world.ants.subTask[antId] = ForagingSubState.ReturningToNest;
-    const pile = { foodPileId: 1, tileX: base + 20, tileY: 0 , pickupsRemaining: 50, pickupsInitial: 50} as FoodPile;
+    const pile = {
+      foodPileId: 1,
+      tileX: base + 20,
+      tileY: 0,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    } as FoodPile;
     world.foodPiles.push(pile);
     colony.priorityFoodPileId = pile.foodPileId;
     tickExcursionBoundary(world);
@@ -3292,20 +3455,17 @@ describe('tickExcursionBoundary — priority-aware (09 follow-up issue 1)', () =
 // ---------------------------------------------------------------------------
 
 describe('tickPheromoneDeposit — entrance suppression (09 follow-up issue 2)', () => {
-  function setupCarryingAnt(
-    antTileX: number,
-    antTileY: number,
-    entranceX = 0,
-    entranceY = 0,
-  ) {
+  function setupCarryingAnt(antTileX: number, antTileY: number, entranceX = 0, entranceY = 0) {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = [{
-      entranceId: allocateEntityId(world),
-      surfaceTileX: entranceX,
-      surfaceTileY: entranceY,
-      isOpen: true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: allocateEntityId(world),
+        surfaceTileX: entranceX,
+        surfaceTileY: entranceY,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
@@ -3391,12 +3551,14 @@ describe('tickPheromoneDeposit — entrance suppression (09 follow-up issue 2)',
     const colony = createColonyRecord(COLONY_ID, 0);
     const entranceX = 24;
     const entranceY = 64;
-    colony.entrances = [{
-      entranceId: allocateEntityId(world),
-      surfaceTileX: entranceX,
-      surfaceTileY: entranceY,
-      isOpen: true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: allocateEntityId(world),
+        surfaceTileX: entranceX,
+        surfaceTileY: entranceY,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
@@ -3407,7 +3569,10 @@ describe('tickPheromoneDeposit — entrance suppression (09 follow-up issue 2)',
     // two tiles). Pre-suppression, 50 ticks here would pin these cells at
     // PHEROMONE_CAP and create the two-tile trap.
     const carrierOffsets: Array<[number, number]> = [
-      [0, 0], [1, 0], [0, 1], [-1, 0],
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [-1, 0],
     ];
     for (const [dx, dy] of carrierOffsets) {
       const antId = allocateEntityId(world);
@@ -3555,12 +3720,14 @@ describe('tickSearchLeash (09 digger-reassignment memo)', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
     // PRD §2a extension contract: caller-side init for entrances / rallyPoint / digFlowFieldDirty.
-    colony.entrances = [{
-      entranceId:   allocateEntityId(world),
-      surfaceTileX: entranceX,
-      surfaceTileY: entranceY,
-      isOpen:       true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: allocateEntityId(world),
+        surfaceTileX: entranceX,
+        surfaceTileY: entranceY,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     // Seed the gate: the leash only fires when (a) more workers are foraging
@@ -3569,7 +3736,7 @@ describe('tickSearchLeash (09 digger-reassignment memo)', () => {
     // requested allocation no longer supports that role" — i.e. the triangle
     // is asking for dig/fight but foragers are stuck out searching.
     colony.computedAllocation.forage = 0;
-    colony.computedAllocation.dig    = 1;
+    colony.computedAllocation.dig = 1;
     colony.taskCensus.forage = 1;
     world.colonies[COLONY_ID] = colony;
 
@@ -3696,11 +3863,11 @@ describe('tickSearchLeash (09 digger-reassignment memo)', () => {
     // Over-foraged (census=5 > allocation.forage=4) but the only non-forage
     // demand is nurse — no dig/fight. Gate must stay closed.
     world.colonies[COLONY_ID]!.computedAllocation.forage = 4;
-    world.colonies[COLONY_ID]!.computedAllocation.dig    = 0;
-    world.colonies[COLONY_ID]!.computedAllocation.fight  = 0;
-    world.colonies[COLONY_ID]!.computedAllocation.nurse  = 1;
+    world.colonies[COLONY_ID]!.computedAllocation.dig = 0;
+    world.colonies[COLONY_ID]!.computedAllocation.fight = 0;
+    world.colonies[COLONY_ID]!.computedAllocation.nurse = 1;
     world.colonies[COLONY_ID]!.taskCensus.forage = 5;
-    world.colonies[COLONY_ID]!.taskCensus.nurse  = 0;
+    world.colonies[COLONY_ID]!.taskCensus.nurse = 0;
     tickSearchLeash(world);
     expect(world.ants.task[antId]).toBe(AntTask.Foraging);
     expect(world.ants.searchWave[antId]).toBe(0);
@@ -3711,7 +3878,7 @@ describe('tickSearchLeash (09 digger-reassignment memo)', () => {
     // gate must arm on either.
     const base = SEARCH_LEASH_RADII[0]!;
     const { world, antId } = setupLeashWorld(base + 1, 0);
-    world.colonies[COLONY_ID]!.computedAllocation.dig   = 0;
+    world.colonies[COLONY_ID]!.computedAllocation.dig = 0;
     world.colonies[COLONY_ID]!.computedAllocation.fight = 1;
     tickSearchLeash(world);
     expect(world.ants.task[antId]).toBe(AntTask.Idle);
@@ -3722,10 +3889,10 @@ describe('tickSearchLeash (09 digger-reassignment memo)', () => {
     const { world, colony, antId } = setupLeashWorld(30, 0, 100, 0);
     // Add a closer entrance — ant at (30,0) is 30 from (100,0) but 2 from (28,0).
     colony.entrances.push({
-      entranceId:   allocateEntityId(world),
+      entranceId: allocateEntityId(world),
       surfaceTileX: 28,
       surfaceTileY: 0,
-      isOpen:       true,
+      isOpen: true,
     });
     tickSearchLeash(world);
     // Closest is 2 ≤ 25 → not demoted.
@@ -3754,12 +3921,14 @@ describe('tickAntMovement — prev-tile tracking (09 follow-up issue 1)', () => 
     // about prev-tile recording semantics, not surface features.
     world.simVersion = SIM_VERSION_V5_CHAMBER_ON_MARKED;
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = [{
-      entranceId:   allocateEntityId(world),
-      surfaceTileX: 0,
-      surfaceTileY: antTileY,
-      isOpen:       true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: allocateEntityId(world),
+        surfaceTileX: 0,
+        surfaceTileY: antTileY,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
@@ -3879,12 +4048,14 @@ describe('tickExcursionBoundary — stale-trap recovery (09 follow-up issue 2)',
   function awayFromNestSetup(antTileX: number, antTileY: number) {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = [{
-      entranceId:   allocateEntityId(world),
-      surfaceTileX: 0,
-      surfaceTileY: 0,
-      isOpen:       true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: allocateEntityId(world),
+        surfaceTileX: 0,
+        surfaceTileY: 0,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
@@ -3951,8 +4122,8 @@ describe('tickExcursionBoundary — stale-trap recovery (09 follow-up issue 2)',
     const { world, grid, antId } = awayFromNestSetup(antTileX, antTileY);
     world.ants.searchPrevTileX[antId] = antTileX - 1;
     world.ants.searchPrevTileY[antId] = antTileY;
-    phSet(grid, antTileX - 1, antTileY, PHEROMONE_CAP);         // prev: ignored
-    phSet(grid, antTileX, antTileY + 2, FOOD_TRAIL_DEPOSIT);    // real signal
+    phSet(grid, antTileX - 1, antTileY, PHEROMONE_CAP); // prev: ignored
+    phSet(grid, antTileX, antTileY + 2, FOOD_TRAIL_DEPOSIT); // real signal
 
     tickExcursionBoundary(world);
 
@@ -3984,7 +4155,7 @@ describe('tickExcursionBoundary — stale-trap recovery (09 follow-up issue 2)',
     // lands on prev. The sampler rejects it and returns {0,0}; the leash
     // check must rule it out too, or the ant never flips home.
     const base = SEARCH_LEASH_RADII[0]!;
-    const antTileX = base + 2;         // 27
+    const antTileX = base + 2; // 27
     const antTileY = 0;
     const { world, grid, antId } = awayFromNestSetup(antTileX, antTileY);
     world.ants.searchPrevTileX[antId] = antTileX - 1; // 26
@@ -4002,7 +4173,7 @@ describe('tickExcursionBoundary — stale-trap recovery (09 follow-up issue 2)',
     // outer edge of SIGNAL_PHEROMONE_RADIUS. Major-axis step is still -X,
     // still lands on prev (26,0). Sampler rejects → leash must fire.
     const base = SEARCH_LEASH_RADII[0]!;
-    const antTileX = base + 2;         // 27
+    const antTileX = base + 2; // 27
     const antTileY = 0;
     const { world, grid, antId } = awayFromNestSetup(antTileX, antTileY);
     world.ants.searchPrevTileX[antId] = antTileX - 1; // 26
@@ -4019,7 +4190,7 @@ describe('tickExcursionBoundary — stale-trap recovery (09 follow-up issue 2)',
     // so major-axis step is +Y → target (27,1), NOT prev. Sampler would
     // accept this candidate, so the leash check must accept it too.
     const base = SEARCH_LEASH_RADII[0]!;
-    const antTileX = base + 2;         // 27
+    const antTileX = base + 2; // 27
     const antTileY = 0;
     const { world, grid, antId } = awayFromNestSetup(antTileX, antTileY);
     world.ants.searchPrevTileX[antId] = antTileX - 1;
@@ -4036,7 +4207,7 @@ describe('tickExcursionBoundary — stale-trap recovery (09 follow-up issue 2)',
     // prev axis. All three cells (prev, dist=2, dist=3) are candidates the
     // sampler will reject; none should keep the ant on SearchingFood.
     const base = SEARCH_LEASH_RADII[0]!;
-    const antTileX = base + 2;         // 27
+    const antTileX = base + 2; // 27
     const antTileY = 0;
     const { world, grid, antId } = awayFromNestSetup(antTileX, antTileY);
     world.ants.searchPrevTileX[antId] = antTileX - 1;
@@ -4085,30 +4256,32 @@ describe('tickNurseActions', () => {
     const colony = createColonyRecord(COLONY_ID, queenId);
     world.colonies[COLONY_ID] = colony;
     colony.chambers.push({
-      chamberId:   100,
+      chamberId: 100,
       chamberType: params.chamberType ?? ChamberType.Nursery,
-      foodStored:  0,
-      posX:        params.chamberTileX << FP_SHIFT,
-      posY:        params.chamberTileY << FP_SHIFT,
-      width:       params.chamberWidth  ?? 2,
-      height:      params.chamberHeight ?? 2,
+      foodStored: 0,
+      posX: params.chamberTileX << FP_SHIFT,
+      posY: params.chamberTileY << FP_SHIFT,
+      width: params.chamberWidth ?? 2,
+      height: params.chamberHeight ?? 2,
     });
 
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX:     params.antTileX << FP_SHIFT,
-      posY:     params.antTileY << FP_SHIFT,
-      task:     AntTask.Nursing,
-      subTask:  params.subTask ?? NursingSubState.MovingToBrood,
+      posX: params.antTileX << FP_SHIFT,
+      posY: params.antTileY << FP_SHIFT,
+      task: AntTask.Nursing,
+      subTask: params.subTask ?? NursingSubState.MovingToBrood,
     });
     return { world, antId, colony };
   }
 
   it('MovingToBrood on Nursery tile → Feeding (one-tick service begins)', () => {
     const { world, antId } = setupNursingAnt({
-      antTileX: 10, antTileY: 10,
-      chamberTileX: 10, chamberTileY: 10,
+      antTileX: 10,
+      antTileY: 10,
+      chamberTileX: 10,
+      chamberTileY: 10,
     });
 
     tickNurseActions(world);
@@ -4119,9 +4292,12 @@ describe('tickNurseActions', () => {
 
   it('MovingToBrood on Queen chamber tile → Feeding', () => {
     const { world, antId } = setupNursingAnt({
-      antTileX: 5, antTileY: 7,
-      chamberTileX: 4, chamberTileY: 6,
-      chamberWidth: 3, chamberHeight: 3,
+      antTileX: 5,
+      antTileY: 7,
+      chamberTileX: 4,
+      chamberTileY: 6,
+      chamberWidth: 3,
+      chamberHeight: 3,
       chamberType: ChamberType.Queen,
     });
 
@@ -4132,8 +4308,10 @@ describe('tickNurseActions', () => {
 
   it('Feeding → Idle (released for step 10a reassignment)', () => {
     const { world, antId } = setupNursingAnt({
-      antTileX: 10, antTileY: 10,
-      chamberTileX: 10, chamberTileY: 10,
+      antTileX: 10,
+      antTileY: 10,
+      chamberTileX: 10,
+      chamberTileY: 10,
       subTask: NursingSubState.Feeding,
     });
 
@@ -4145,8 +4323,10 @@ describe('tickNurseActions', () => {
 
   it('two-tick arc: MovingToBrood on tile → Feeding → Idle', () => {
     const { world, antId } = setupNursingAnt({
-      antTileX: 10, antTileY: 10,
-      chamberTileX: 10, chamberTileY: 10,
+      antTileX: 10,
+      antTileY: 10,
+      chamberTileX: 10,
+      chamberTileY: 10,
     });
 
     tickNurseActions(world);
@@ -4159,8 +4339,10 @@ describe('tickNurseActions', () => {
 
   it('dead ant: ignored', () => {
     const { world, antId } = setupNursingAnt({
-      antTileX: 10, antTileY: 10,
-      chamberTileX: 10, chamberTileY: 10,
+      antTileX: 10,
+      antTileY: 10,
+      chamberTileX: 10,
+      chamberTileY: 10,
     });
     world.ants.alive[antId] = 0;
 
@@ -4171,8 +4353,10 @@ describe('tickNurseActions', () => {
 
   it('non-nursing ant: ignored even on chamber tile', () => {
     const { world, antId } = setupNursingAnt({
-      antTileX: 10, antTileY: 10,
-      chamberTileX: 10, chamberTileY: 10,
+      antTileX: 10,
+      antTileY: 10,
+      chamberTileX: 10,
+      chamberTileY: 10,
     });
     world.ants.task[antId] = AntTask.Foraging;
     world.ants.subTask[antId] = ForagingSubState.SearchingFood;
@@ -4182,7 +4366,6 @@ describe('tickNurseActions', () => {
     expect(world.ants.task[antId]).toBe(AntTask.Foraging);
     expect(world.ants.subTask[antId]).toBe(ForagingSubState.SearchingFood);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -4373,8 +4556,13 @@ describe('chamber-flow nurseDeposit field (#17 phase 1)', () => {
       }
     }
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.Nursery, foodStored: 0,
-      posX: 6 << FP_SHIFT, posY: 6 << FP_SHIFT, width: 2, height: 2,
+      chamberId: 1,
+      chamberType: ChamberType.Nursery,
+      foodStored: 0,
+      posX: 6 << FP_SHIFT,
+      posY: 6 << FP_SHIFT,
+      width: 2,
+      height: 2,
     });
     // Queen chamber (2x2) at (10,3).
     for (let dy = 0; dy < 2; dy++) {
@@ -4383,8 +4571,13 @@ describe('chamber-flow nurseDeposit field (#17 phase 1)', () => {
       }
     }
     colony.chambers.push({
-      chamberId: 2, chamberType: ChamberType.Queen, foodStored: 0,
-      posX: 10 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 2, height: 2,
+      chamberId: 2,
+      chamberType: ChamberType.Queen,
+      foodStored: 0,
+      posX: 10 << FP_SHIFT,
+      posY: 3 << FP_SHIFT,
+      width: 2,
+      height: 2,
     });
     // Tunnel connecting them so BFS can reach Queen tiles.
     for (let y = 4; y <= 6; y++) ugSet(underground, 8, y, UndergroundTileState.Open);
@@ -4394,8 +4587,11 @@ describe('chamber-flow nurseDeposit field (#17 phase 1)', () => {
     const gridSize = underground.width * underground.height;
     const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
     computeChamberFlowField(
-      underground, colony.chambers, NURSERY_CHAMBER_TYPES,
-      bufs.nurseDeposit, bufs.queue,
+      underground,
+      colony.chambers,
+      NURSERY_CHAMBER_TYPES,
+      bufs.nurseDeposit,
+      bufs.queue,
     );
 
     const W = underground.width;
@@ -4406,7 +4602,12 @@ describe('chamber-flow nurseDeposit field (#17 phase 1)', () => {
     expect(bufs.nurseDeposit[7 * W + 7]).toBe(-1);
     // Queen footprint tiles are NOT sources — they're reachable, so they
     // carry a step direction (0..3), but never -1.
-    for (const [qx, qy] of [[10, 3], [11, 3], [10, 4], [11, 4]] as const) {
+    for (const [qx, qy] of [
+      [10, 3],
+      [11, 3],
+      [10, 4],
+      [11, 4],
+    ] as const) {
       const v = bufs.nurseDeposit[qy * W + qx]!;
       expect(v).not.toBe(-1);
       expect(v).toBeGreaterThanOrEqual(0);
@@ -4424,16 +4625,24 @@ describe('chamber-flow nurseDeposit field (#17 phase 1)', () => {
     }
     // Push a Queen chamber so we prove only the type filter matters.
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.Queen, foodStored: 0,
-      posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, width: 2, height: 2,
+      chamberId: 1,
+      chamberType: ChamberType.Queen,
+      foodStored: 0,
+      posX: 5 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      width: 2,
+      height: 2,
     });
 
     const cache = createChamberFlowFields();
     const gridSize = underground.width * underground.height;
     const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
     computeChamberFlowField(
-      underground, colony.chambers, NURSERY_CHAMBER_TYPES,
-      bufs.nurseDeposit, bufs.queue,
+      underground,
+      colony.chambers,
+      NURSERY_CHAMBER_TYPES,
+      bufs.nurseDeposit,
+      bufs.queue,
     );
 
     // No seeds → every tile stays at -2.
@@ -4470,8 +4679,13 @@ describe('chamber-flow nursing pickup field (#17 phase 1)', () => {
       }
     }
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.Queen, foodStored: 0,
-      posX: 30 << FP_SHIFT, posY: 8 << FP_SHIFT, width: 5, height: 3,
+      chamberId: 1,
+      chamberType: ChamberType.Queen,
+      foodStored: 0,
+      posX: 30 << FP_SHIFT,
+      posY: 8 << FP_SHIFT,
+      width: 5,
+      height: 3,
     });
     // Two eggs in only 2 of the 15 Queen tiles.
     const eggA = allocateEntityId(world);
@@ -4479,7 +4693,9 @@ describe('chamber-flow nursing pickup field (#17 phase 1)', () => {
       colonyId,
       posX: (33 << FP_SHIFT) + (FP_ONE >> 1),
       posY: (8 << FP_SHIFT) + (FP_ONE >> 1),
-      task: AntTask.Idle, speed: 0, zone: Zone.Underground,
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
     });
     colony.eggs.push(eggA);
     const eggB = allocateEntityId(world);
@@ -4487,7 +4703,9 @@ describe('chamber-flow nursing pickup field (#17 phase 1)', () => {
       colonyId,
       posX: (30 << FP_SHIFT) + (FP_ONE >> 1),
       posY: (9 << FP_SHIFT) + (FP_ONE >> 1),
-      task: AntTask.Idle, speed: 0, zone: Zone.Underground,
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
     });
     colony.eggs.push(eggB);
 
@@ -4495,9 +4713,13 @@ describe('chamber-flow nursing pickup field (#17 phase 1)', () => {
     const gridSize = underground.width * underground.height;
     const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
     computeNursingPickupField(
-      underground, colony.chambers, world.ants,
-      colony.eggs, colony.larvae,
-      bufs.nursing, bufs.queue,
+      underground,
+      colony.chambers,
+      world.ants,
+      colony.eggs,
+      colony.larvae,
+      bufs.nursing,
+      bufs.queue,
     );
 
     const W = underground.width;
@@ -4507,9 +4729,19 @@ describe('chamber-flow nursing pickup field (#17 phase 1)', () => {
     // Other Queen tiles are NOT sources — they carry a step direction
     // (0..3) routing them toward the nearest egg, never -1.
     const otherQueenTiles: Array<[number, number]> = [
-      [30, 8], [31, 8], [32, 8],         [34, 8], // row 8 minus eggA
-      [31, 9], [32, 9], [33, 9], [34, 9],         // row 9 minus eggB
-      [30, 10], [31, 10], [32, 10], [33, 10], [34, 10], // row 10
+      [30, 8],
+      [31, 8],
+      [32, 8],
+      [34, 8], // row 8 minus eggA
+      [31, 9],
+      [32, 9],
+      [33, 9],
+      [34, 9], // row 9 minus eggB
+      [30, 10],
+      [31, 10],
+      [32, 10],
+      [33, 10],
+      [34, 10], // row 10
     ];
     for (const [tx, ty] of otherQueenTiles) {
       const v = bufs.nursing[ty * W + tx]!;
@@ -4531,7 +4763,9 @@ describe('chamber-flow nursing pickup field (#17 phase 1)', () => {
       colonyId,
       posX: (5 << FP_SHIFT) + (FP_ONE >> 1),
       posY: (5 << FP_SHIFT) + (FP_ONE >> 1),
-      task: AntTask.Idle, speed: 0, zone: Zone.Underground,
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
     });
     colony.eggs.push(orphan);
 
@@ -4539,9 +4773,13 @@ describe('chamber-flow nursing pickup field (#17 phase 1)', () => {
     const gridSize = underground.width * underground.height;
     const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
     computeNursingPickupField(
-      underground, colony.chambers, world.ants,
-      colony.eggs, colony.larvae,
-      bufs.nursing, bufs.queue,
+      underground,
+      colony.chambers,
+      world.ants,
+      colony.eggs,
+      colony.larvae,
+      bufs.nursing,
+      bufs.queue,
     );
     expect(bufs.nursing[5 * underground.width + 5]).toBe(-1);
   });
@@ -4554,8 +4792,13 @@ describe('chamber-flow nursing pickup field (#17 phase 1)', () => {
     const { world, underground, colony, colonyId } = setupWorldWithUnderground(16, 16);
     void world;
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.Queen, foodStored: 0,
-      posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, width: 2, height: 2,
+      chamberId: 1,
+      chamberType: ChamberType.Queen,
+      foodStored: 0,
+      posX: 5 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      width: 2,
+      height: 2,
     });
     for (let dy = 0; dy < 2; dy++) {
       for (let dx = 0; dx < 2; dx++) {
@@ -4567,9 +4810,13 @@ describe('chamber-flow nursing pickup field (#17 phase 1)', () => {
     const gridSize = underground.width * underground.height;
     const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
     computeNursingPickupField(
-      underground, colony.chambers, world.ants,
-      colony.eggs, colony.larvae,
-      bufs.nursing, bufs.queue,
+      underground,
+      colony.chambers,
+      world.ants,
+      colony.eggs,
+      colony.larvae,
+      bufs.nursing,
+      bufs.queue,
     );
     const W = underground.width;
     // Queen tiles previously seeded as -1 by the dropped Seed (1) are
@@ -4595,7 +4842,12 @@ describe('tickAntMovement — underground chamber routing (tunnel-aware)', () =>
    *  from (10,10) westbound then northbound to (5,5). Direct-steering from
    *  (10,10) picks dx=-1 first → (9,10). Make (9,10) Solid so the old logic
    *  would freeze there. Flow-field instead routes via the tunnel. */
-  function buildChamberTunnelWorld(opts: { chamberType: 0 | 1 | 2; antTask: typeof AntTask.Foraging | typeof AntTask.Nursing; antSubTask: number; foodCarrying: number }) {
+  function buildChamberTunnelWorld(opts: {
+    chamberType: 0 | 1 | 2;
+    antTask: typeof AntTask.Foraging | typeof AntTask.Nursing;
+    antSubTask: number;
+    foodCarrying: number;
+  }) {
     const { world, colony, underground, colonyId } = setupWorldWithUnderground(16, 16);
     // Chamber tile at (5,5) — seeded tile for flow-field. 1x1 footprint.
     ugSet(underground, 5, 5, UndergroundTileState.Open);
@@ -4644,8 +4896,20 @@ describe('tickAntMovement — underground chamber routing (tunnel-aware)', () =>
     const cache = createChamberFlowFields();
     const gridSize = underground.width * underground.height;
     const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
-    computeChamberFlowField(underground, colony.chambers, FOOD_CHAMBER_TYPES, bufs.food, bufs.queue);
-    computeChamberFlowField(underground, colony.chambers, NURSING_CHAMBER_TYPES, bufs.nursing, bufs.queue);
+    computeChamberFlowField(
+      underground,
+      colony.chambers,
+      FOOD_CHAMBER_TYPES,
+      bufs.food,
+      bufs.queue,
+    );
+    computeChamberFlowField(
+      underground,
+      colony.chambers,
+      NURSING_CHAMBER_TYPES,
+      bufs.nursing,
+      bufs.queue,
+    );
     return cache;
   }
 
@@ -4961,8 +5225,20 @@ describe('tickAntMovement — v4 diagonal flow-field lift (issue #34)', () => {
     const cache = createChamberFlowFields();
     const gridSize = underground.width * underground.height;
     const bufs = ensureChamberFlowFields(cache, colonyId, gridSize);
-    computeChamberFlowField(underground, colony.chambers, FOOD_CHAMBER_TYPES, bufs.food, bufs.queue);
-    computeChamberFlowField(underground, colony.chambers, NURSING_CHAMBER_TYPES, bufs.nursing, bufs.queue);
+    computeChamberFlowField(
+      underground,
+      colony.chambers,
+      FOOD_CHAMBER_TYPES,
+      bufs.food,
+      bufs.queue,
+    );
+    computeChamberFlowField(
+      underground,
+      colony.chambers,
+      NURSING_CHAMBER_TYPES,
+      bufs.nursing,
+      bufs.queue,
+    );
     return cache;
   }
 
@@ -5222,7 +5498,7 @@ describe('tickAntMovement — Fighting rally movement', () => {
       updateFightAntTargets(world);
       tickAntMovement(world, rng, digFlowFields, entranceCache, chamberCache);
     }
-    const past = fighterIds.filter(id => (world.ants.posX[id]! >> FP_SHIFT) > 24).length;
+    const past = fighterIds.filter((id) => world.ants.posX[id]! >> FP_SHIFT > 24).length;
     expect(past).toBeGreaterThanOrEqual(2);
   });
 
@@ -5380,7 +5656,9 @@ describe('tickAntMovement — same-colony occupancy enforcement', () => {
   it('OCC-1. two same-colony workers target the same surface tile → lower-id keeps the tile, higher-id shifts to an adjacent tile', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
 
     // A at (5,5), B at (7,5). Both target (6,5). A is allocated first → lower id.
@@ -5449,9 +5727,13 @@ describe('tickAntMovement — same-colony occupancy enforcement', () => {
     // since they are from different colonies.
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colonyA = createColonyRecord(1, 0);
-    colonyA.entrances = []; colonyA.rallyPoint = null; colonyA.digFlowFieldDirty = false;
+    colonyA.entrances = [];
+    colonyA.rallyPoint = null;
+    colonyA.digFlowFieldDirty = false;
     const colonyB = createColonyRecord(2, 0);
-    colonyB.entrances = []; colonyB.rallyPoint = null; colonyB.digFlowFieldDirty = false;
+    colonyB.entrances = [];
+    colonyB.rallyPoint = null;
+    colonyB.digFlowFieldDirty = false;
     world.colonies[1] = colonyA;
     world.colonies[2] = colonyB;
 
@@ -5472,7 +5754,7 @@ describe('tickAntMovement — same-colony occupancy enforcement', () => {
     expect(world.ants.colonyId[aId]).not.toBe(world.ants.colonyId[bId]);
   });
 
-  it('OCC-4. lower-id ant moving into a higher-id stationary ant\'s tile → stationary keeps tile, mover shifts', () => {
+  it("OCC-4. lower-id ant moving into a higher-id stationary ant's tile → stationary keeps tile, mover shifts", () => {
     // Wait — spec says lower-id wins. Here A=lower, B=higher-stationary.
     // A walks into B's tile. In post-pass resolution, ants are processed in
     // entity-id order: A claims (6,5) first (it's a non-exempt tile and
@@ -5480,7 +5762,9 @@ describe('tickAntMovement — same-colony occupancy enforcement', () => {
     // (stationary), so B shifts to adjacent. Lower-id ALWAYS wins.
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
 
     // A first (lower id), will walk east.
@@ -5503,7 +5787,9 @@ describe('tickAntMovement — same-colony occupancy enforcement', () => {
     // duplicate: lower-id keeps, higher-id shifts to adjacent.
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
 
     const aId = spawnSurfaceHolding(world, COLONY_ID, 5, 5);
@@ -5596,7 +5882,9 @@ describe('tickAntMovement — same-colony occupancy enforcement', () => {
   it('OCC-8. four same-colony ants all converging on one tile end up on four distinct tiles', () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     const colony = createColonyRecord(COLONY_ID, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     world.colonies[COLONY_ID] = colony;
 
     const ids = [
@@ -5619,7 +5907,9 @@ describe('tickAntMovement — same-colony occupancy enforcement', () => {
     function run(): number[] {
       const world = createWorldState(42, MAX_TEST_ENTITIES);
       const colony = createColonyRecord(COLONY_ID, 0);
-      colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+      colony.entrances = [];
+      colony.rallyPoint = null;
+      colony.digFlowFieldDirty = false;
       world.colonies[COLONY_ID] = colony;
 
       const ids = [
@@ -5670,7 +5960,12 @@ describe('tickAntMovement — P1 queen relocation', () => {
     computeQueenField?: boolean;
     ugWidth?: number;
     ugHeight?: number;
-  }): { world: WorldState; colony: ColonyRecord; chamberFlowFields: ReturnType<typeof createChamberFlowFields>; queenId: number } {
+  }): {
+    world: WorldState;
+    colony: ColonyRecord;
+    chamberFlowFields: ReturnType<typeof createChamberFlowFields>;
+    queenId: number;
+  } {
     const ugWidth = params.ugWidth ?? 16;
     const ugHeight = params.ugHeight ?? 16;
     const world = createWorldState(42, MAX_TEST_ENTITIES);
@@ -5695,33 +5990,33 @@ describe('tickAntMovement — P1 queen relocation', () => {
       // Tile-aligned (no half-tile offset) so a single WORKER_BASE_SPEED step
       // (FP_ONE / 2) reliably crosses the tile boundary in tests that assert
       // tile-index deltas.
-      posX:     params.queenTileX << FP_SHIFT,
-      posY:     params.queenTileY << FP_SHIFT,
-      task:     AntTask.Idle,
-      subTask:  0,
-      speed:    WORKER_BASE_SPEED,
-      zone:     params.zone ?? Zone.Underground,
+      posX: params.queenTileX << FP_SHIFT,
+      posY: params.queenTileY << FP_SHIFT,
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: WORKER_BASE_SPEED,
+      zone: params.zone ?? Zone.Underground,
     });
     colony.queenEntityId = queenId;
 
     if (params.addQueenChamber) {
       colony.chambers.push({
-        chamberId:   500,
+        chamberId: 500,
         chamberType: ChamberType.Queen,
-        foodStored:  0,
-        posX:        (params.queenChamberTileX ?? 2) << FP_SHIFT,
-        posY:        (params.queenChamberTileY ?? 2) << FP_SHIFT,
-        width:       params.queenChamberWidth  ?? 2,
-        height:      params.queenChamberHeight ?? 2,
+        foodStored: 0,
+        posX: (params.queenChamberTileX ?? 2) << FP_SHIFT,
+        posY: (params.queenChamberTileY ?? 2) << FP_SHIFT,
+        width: params.queenChamberWidth ?? 2,
+        height: params.queenChamberHeight ?? 2,
       });
     }
 
     if (params.addEntrance) {
       colony.entrances.push({
-        entranceId:   1,
+        entranceId: 1,
         surfaceTileX: params.addEntrance.tileX,
         surfaceTileY: params.addEntrance.tileY,
-        isOpen:       params.addEntrance.isOpen,
+        isOpen: params.addEntrance.isOpen,
       });
     }
 
@@ -5742,7 +6037,8 @@ describe('tickAntMovement — P1 queen relocation', () => {
 
   it('Q-1. no Queen chamber → queen holds in place (any starting tile is home)', () => {
     const { world, queenId } = setupQueenWorld({
-      queenTileX: 5, queenTileY: 5,
+      queenTileX: 5,
+      queenTileY: 5,
       addQueenChamber: false,
     });
     const beforeX = world.ants.posX[queenId]!;
@@ -5764,10 +6060,13 @@ describe('tickAntMovement — P1 queen relocation', () => {
     // cadence; this case only asserts the bug fix's user-facing claim:
     // "she does not sit motionless on her arrival corner."
     const { world, chamberFlowFields, queenId } = setupQueenWorld({
-      queenTileX: 3, queenTileY: 3,            // inside chamber (2,2)-(3,3)
+      queenTileX: 3,
+      queenTileY: 3, // inside chamber (2,2)-(3,3)
       addQueenChamber: true,
-      queenChamberTileX: 2, queenChamberTileY: 2,
-      queenChamberWidth: 2, queenChamberHeight: 2,
+      queenChamberTileX: 2,
+      queenChamberTileY: 2,
+      queenChamberWidth: 2,
+      queenChamberHeight: 2,
       computeQueenField: true,
     });
     const beforeX = world.ants.posX[queenId]!;
@@ -5797,10 +6096,13 @@ describe('tickAntMovement — P1 queen relocation', () => {
     // (2,2), now drifts back toward (3,2). This pins the cadence contract:
     // the wander cycle is tied to the egg-laying interval.
     const { world, chamberFlowFields, queenId } = setupQueenWorld({
-      queenTileX: 2, queenTileY: 2,            // already at cycle-0 target
+      queenTileX: 2,
+      queenTileY: 2, // already at cycle-0 target
       addQueenChamber: true,
-      queenChamberTileX: 2, queenChamberTileY: 2,
-      queenChamberWidth: 2, queenChamberHeight: 2,
+      queenChamberTileX: 2,
+      queenChamberTileY: 2,
+      queenChamberWidth: 2,
+      queenChamberHeight: 2,
       computeQueenField: true,
     });
     const digFlowFields = createDigFlowFields();
@@ -5835,10 +6137,13 @@ describe('tickAntMovement — P1 queen relocation', () => {
     // openCount is computed as width*height including non-Open tiles) would
     // fail by leaving at least one tile unvisited.
     const { world, chamberFlowFields, queenId } = setupQueenWorld({
-      queenTileX: 2, queenTileY: 2,
+      queenTileX: 2,
+      queenTileY: 2,
       addQueenChamber: true,
-      queenChamberTileX: 2, queenChamberTileY: 2,
-      queenChamberWidth: 2, queenChamberHeight: 2,
+      queenChamberTileX: 2,
+      queenChamberTileY: 2,
+      queenChamberWidth: 2,
+      queenChamberHeight: 2,
       computeQueenField: true,
     });
     const digFlowFields = createDigFlowFields();
@@ -5872,10 +6177,13 @@ describe('tickAntMovement — P1 queen relocation', () => {
     // limitation (no diagonal routing) unrelated to the "count Open tiles"
     // contract under test here.
     const { world, chamberFlowFields, queenId } = setupQueenWorld({
-      queenTileX: 2, queenTileY: 2,
+      queenTileX: 2,
+      queenTileY: 2,
       addQueenChamber: true,
-      queenChamberTileX: 2, queenChamberTileY: 2,
-      queenChamberWidth: 3, queenChamberHeight: 3,
+      queenChamberTileX: 2,
+      queenChamberTileY: 2,
+      queenChamberWidth: 3,
+      queenChamberHeight: 3,
       computeQueenField: true,
     });
     const underground = world.undergroundGrids[COLONY_ID]!;
@@ -5892,17 +6200,20 @@ describe('tickAntMovement — P1 queen relocation', () => {
       visited.add(`${tx},${ty}`);
     }
     expect(visited.has('4,2')).toBe(false); // never on the Solid tile
-    const expectedOpen = ['2,2','3,2','2,3','3,3','4,3','2,4','3,4','4,4'];
+    const expectedOpen = ['2,2', '3,2', '2,3', '3,3', '4,3', '2,4', '3,4', '4,4'];
     for (const k of expectedOpen) expect(visited.has(k)).toBe(true);
     expect(visited.size).toBe(expectedOpen.length);
   });
 
   it('Q-3. underground queen routes toward Queen chamber (flow-field step)', () => {
     const { world, chamberFlowFields, queenId } = setupQueenWorld({
-      queenTileX: 5, queenTileY: 5,
+      queenTileX: 5,
+      queenTileY: 5,
       addQueenChamber: true,
-      queenChamberTileX: 2, queenChamberTileY: 2,
-      queenChamberWidth: 2, queenChamberHeight: 2,
+      queenChamberTileX: 2,
+      queenChamberTileY: 2,
+      queenChamberWidth: 2,
+      queenChamberHeight: 2,
       computeQueenField: true,
     });
     const beforeTileX = world.ants.posX[queenId]! >> FP_SHIFT;
@@ -5915,7 +6226,7 @@ describe('tickAntMovement — P1 queen relocation', () => {
     const afterTileX = world.ants.posX[queenId]! >> FP_SHIFT;
     const afterTileY = world.ants.posY[queenId]! >> FP_SHIFT;
     const beforeDist = Math.abs(beforeTileX - 2) + Math.abs(beforeTileY - 2);
-    const afterDist  = Math.abs(afterTileX  - 2) + Math.abs(afterTileY  - 2);
+    const afterDist = Math.abs(afterTileX - 2) + Math.abs(afterTileY - 2);
     expect(afterDist).toBeLessThan(beforeDist);
   });
 
@@ -5933,11 +6244,14 @@ describe('tickAntMovement — P1 queen relocation', () => {
     // when only Y intermediate is open). The expanded wall closes that
     // escape so the test still asserts "cannot cut through dirt".
     const { world, queenId } = setupQueenWorld({
-      queenTileX: 5, queenTileY: 5,
+      queenTileX: 5,
+      queenTileY: 5,
       addQueenChamber: true,
-      queenChamberTileX: 2, queenChamberTileY: 2,
-      queenChamberWidth: 2, queenChamberHeight: 2,
-      computeQueenField: false,   // force Manhattan-fallback path
+      queenChamberTileX: 2,
+      queenChamberTileY: 2,
+      queenChamberWidth: 2,
+      queenChamberHeight: 2,
+      computeQueenField: false, // force Manhattan-fallback path
     });
     const underground = world.undergroundGrids[COLONY_ID]!;
     for (let y = 0; y < underground.height; y++) {
@@ -5959,10 +6273,12 @@ describe('tickAntMovement — P1 queen relocation', () => {
 
   it('Q-5. surface queen steps toward nearest open entrance (Manhattan)', () => {
     const { world, queenId } = setupQueenWorld({
-      queenTileX: 10, queenTileY: 10,
+      queenTileX: 10,
+      queenTileY: 10,
       zone: Zone.Surface,
       addQueenChamber: true,
-      queenChamberTileX: 2, queenChamberTileY: 2,
+      queenChamberTileX: 2,
+      queenChamberTileY: 2,
       computeQueenField: true,
       addEntrance: { tileX: 5, tileY: 10, isOpen: true },
     });
@@ -5986,10 +6302,12 @@ describe('tickAntMovement — P1 queen relocation', () => {
     // Surface→Underground transition never ran — the queen sat on the
     // entrance forever with Gate 6 blocking egg production.
     const { world, chamberFlowFields, queenId } = setupQueenWorld({
-      queenTileX: 5, queenTileY: 5,
+      queenTileX: 5,
+      queenTileY: 5,
       zone: Zone.Surface,
       addQueenChamber: true,
-      queenChamberTileX: 2, queenChamberTileY: 2,
+      queenChamberTileX: 2,
+      queenChamberTileY: 2,
       computeQueenField: true,
       addEntrance: { tileX: 5, tileY: 5, isOpen: true },
     });
@@ -5999,8 +6317,8 @@ describe('tickAntMovement — P1 queen relocation', () => {
     tickAntMovement(world, rng, digFlowFields, undefined, chamberFlowFields);
 
     expect(world.ants.zone[queenId]).toBe(Zone.Underground);
-    expect(world.ants.posY[queenId]).toBe(0);                 // shaft top
-    expect(world.ants.posX[queenId]).toBe(5 << FP_SHIFT);     // column preserved
+    expect(world.ants.posY[queenId]).toBe(0); // shaft top
+    expect(world.ants.posX[queenId]).toBe(5 << FP_SHIFT); // column preserved
 
     // Second tick: queen flow-field should steer her toward the Queen
     // chamber at (2,2). Distance to (2,2) must strictly decrease.
@@ -6010,17 +6328,19 @@ describe('tickAntMovement — P1 queen relocation', () => {
     const afterTileX = world.ants.posX[queenId]! >> FP_SHIFT;
     const afterTileY = world.ants.posY[queenId]! >> FP_SHIFT;
     const beforeDist = Math.abs(beforeTileX - 2) + Math.abs(beforeTileY - 2);
-    const afterDist  = Math.abs(afterTileX  - 2) + Math.abs(afterTileY  - 2);
+    const afterDist = Math.abs(afterTileX - 2) + Math.abs(afterTileY - 2);
     expect(afterDist).toBeLessThan(beforeDist);
-    expect(world.ants.zone[queenId]).toBe(Zone.Underground);  // no surfacing back
+    expect(world.ants.zone[queenId]).toBe(Zone.Underground); // no surfacing back
   });
 
   it('Q-7. surface queen does NOT descend through a closed (designated) entrance', () => {
     const { world, queenId } = setupQueenWorld({
-      queenTileX: 5, queenTileY: 5,
+      queenTileX: 5,
+      queenTileY: 5,
       zone: Zone.Surface,
       addQueenChamber: true,
-      queenChamberTileX: 2, queenChamberTileY: 2,
+      queenChamberTileX: 2,
+      queenChamberTileY: 2,
       computeQueenField: true,
       addEntrance: { tileX: 5, tileY: 5, isOpen: false },
     });
@@ -6034,7 +6354,6 @@ describe('tickAntMovement — P1 queen relocation', () => {
     expect(world.ants.zone[queenId]).toBe(Zone.Surface);
   });
 });
-
 
 // ---------------------------------------------------------------------------
 // Issue #34 — pickCardinalStep
@@ -6101,9 +6420,18 @@ describe('pickCardinalStep (issue #34) — v4 8-connected diagonal', () => {
 
   it('pure cardinals are unchanged in v4 (single-axis targets behave identically)', () => {
     const ants = emptyAnts();
-    expect(step(pickCardinalStep(ants, 0, 5, 0, SIM_VERSION_V4_DIAGONAL_MOTION))).toEqual({ dx: 1, dy: 0 });
-    expect(step(pickCardinalStep(ants, 0, 0, -3, SIM_VERSION_V4_DIAGONAL_MOTION))).toEqual({ dx: 0, dy: -1 });
-    expect(step(pickCardinalStep(ants, 0, 0, 0, SIM_VERSION_V4_DIAGONAL_MOTION))).toEqual({ dx: 0, dy: 0 });
+    expect(step(pickCardinalStep(ants, 0, 5, 0, SIM_VERSION_V4_DIAGONAL_MOTION))).toEqual({
+      dx: 1,
+      dy: 0,
+    });
+    expect(step(pickCardinalStep(ants, 0, 0, -3, SIM_VERSION_V4_DIAGONAL_MOTION))).toEqual({
+      dx: 0,
+      dy: -1,
+    });
+    expect(step(pickCardinalStep(ants, 0, 0, 0, SIM_VERSION_V4_DIAGONAL_MOTION))).toEqual({
+      dx: 0,
+      dy: 0,
+    });
   });
 
   it('45° target (3,3) reaches the target in 3 diagonal steps — no zig-zag', () => {
@@ -6206,7 +6534,8 @@ describe('SearchingFood pause cadence (issue #35)', () => {
     const posY = 64 << FP_SHIFT;
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX, posY,
+      posX,
+      posY,
       task: AntTask.Foraging,
       subTask: ForagingSubState.SearchingFood,
     });
@@ -6316,7 +6645,9 @@ describe('SearchingFood pause cadence (issue #35)', () => {
     expect(observedTotalPauses.size).toBeGreaterThan(0);
     for (const totalPause of observedTotalPauses) {
       expect(totalPause).toBeGreaterThanOrEqual(SEARCH_PAUSE_BASE_TICKS);
-      expect(totalPause).toBeLessThanOrEqual(SEARCH_PAUSE_BASE_TICKS + SEARCH_PAUSE_JITTER_TICKS - 1);
+      expect(totalPause).toBeLessThanOrEqual(
+        SEARCH_PAUSE_BASE_TICKS + SEARCH_PAUSE_JITTER_TICKS - 1,
+      );
     }
   });
 
@@ -6336,7 +6667,10 @@ describe('SearchingFood pause cadence (issue #35)', () => {
       tickAntMovement(world, new Rng(t * 17 + 11), digFlowFields);
       // Counts ticks where the ant was paused (didn't move because of #35).
       const after = world.ants.searchPauseTicks[antId]!;
-      if (after > 0 || (before === 0 && world.ants.posX[antId] === posX && world.ants.posY[antId] === posY)) {
+      if (
+        after > 0 ||
+        (before === 0 && world.ants.posX[antId] === posX && world.ants.posY[antId] === posY)
+      ) {
         pausedTickCount += 1;
       }
     }
@@ -6392,7 +6726,6 @@ describe('issue #42 — partial-deposit wait gate (v6)', () => {
     expect(world.ants.foodCarrying[antId]).toBe(400);
     expect(world.ants.waitingDeposit[antId]).toBe(1);
   });
-
 });
 
 describe('issue #42 — demote SearchingFood when no deposit target (v6)', () => {
@@ -6411,7 +6744,7 @@ describe('issue #42 — demote SearchingFood when no deposit target (v6)', () =>
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
       colonyId: COLONY_ID,
-      posX: 5 << FP_SHIFT,           // 5 tiles from entrance — well within wave 0 radius (25)
+      posX: 5 << FP_SHIFT, // 5 tiles from entrance — well within wave 0 radius (25)
       posY: 0,
       task: AntTask.Foraging,
       subTask: ForagingSubState.SearchingFood,
@@ -6439,7 +6772,10 @@ describe('issue #42 — demote SearchingFood when no deposit target (v6)', () =>
       chamberId: 1,
       chamberType: ChamberType.FoodStorage,
       foodStored: 0,
-      posX: 0, posY: 0, width: 3, height: 3,
+      posX: 0,
+      posY: 0,
+      width: 3,
+      height: 3,
     });
     world.colonies[COLONY_ID] = colony;
 
@@ -6577,10 +6913,14 @@ describe('issue #42 — surface SearchingFood no-revisit rule (v6)', () => {
     world.ants.posY[antId] = 0;
     // Mark E, SE, S, SW as recent — covers 4 of 5 in-bounds neighbors
     // at y=0. Only W remains as a valid in-bounds alternate.
-    world.ants.recentTilesX[antId * RECENT_TILES_LEN + 0] = 51; world.ants.recentTilesY[antId * RECENT_TILES_LEN + 0] = 0; // E
-    world.ants.recentTilesX[antId * RECENT_TILES_LEN + 1] = 51; world.ants.recentTilesY[antId * RECENT_TILES_LEN + 1] = 1; // SE
-    world.ants.recentTilesX[antId * RECENT_TILES_LEN + 2] = 50; world.ants.recentTilesY[antId * RECENT_TILES_LEN + 2] = 1; // S
-    world.ants.recentTilesX[antId * RECENT_TILES_LEN + 3] = 49; world.ants.recentTilesY[antId * RECENT_TILES_LEN + 3] = 1; // SW
+    world.ants.recentTilesX[antId * RECENT_TILES_LEN + 0] = 51;
+    world.ants.recentTilesY[antId * RECENT_TILES_LEN + 0] = 0; // E
+    world.ants.recentTilesX[antId * RECENT_TILES_LEN + 1] = 51;
+    world.ants.recentTilesY[antId * RECENT_TILES_LEN + 1] = 1; // SE
+    world.ants.recentTilesX[antId * RECENT_TILES_LEN + 2] = 50;
+    world.ants.recentTilesY[antId * RECENT_TILES_LEN + 2] = 1; // S
+    world.ants.recentTilesX[antId * RECENT_TILES_LEN + 3] = 49;
+    world.ants.recentTilesY[antId * RECENT_TILES_LEN + 3] = 1; // SW
     world.ants.recentTilesHead[antId] = 0;
 
     const visitedTiles = new Set<string>();
@@ -6602,7 +6942,6 @@ describe('issue #42 — surface SearchingFood no-revisit rule (v6)', () => {
     // (50, 0) by repeatedly choosing OOB directions.
     expect(visitedTiles.size).toBeGreaterThan(1);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -6615,9 +6954,12 @@ describe('issue #42 — surface SearchingFood no-revisit rule (v6)', () => {
 // ---------------------------------------------------------------------------
 
 describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
-  function setupV10NurseAndBroodOnTile(opts: {
-    sameTile: boolean;
-  }): { world: WorldState; nurseId: number; broodId: number; colony: ColonyRecord } {
+  function setupV10NurseAndBroodOnTile(opts: { sameTile: boolean }): {
+    world: WorldState;
+    nurseId: number;
+    broodId: number;
+    colony: ColonyRecord;
+  } {
     const world = createWorldState(42, 64);
     // LATEST already includes v10; pin explicitly so the test name describes
     // what's under test even when LATEST advances.
@@ -6628,25 +6970,35 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     world.colonies[COLONY_ID] = colony;
     // Queen chamber so the brood is in a "natural" location.
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.Queen, foodStored: 0,
-      posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, width: 2, height: 2,
+      chamberId: 1,
+      chamberType: ChamberType.Queen,
+      foodStored: 0,
+      posX: 5 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      width: 2,
+      height: 2,
     });
     // Nursery chamber — required for v10 pickup gate. Empty space (no
     // Open tiles needed for these unit tests; the gate just requires
     // hasCompletedChamber to return true).
     colony.chambers.push({
-      chamberId: 2, chamberType: ChamberType.Nursery, foodStored: 0,
-      posX: 12 << FP_SHIFT, posY: 12 << FP_SHIFT, width: 2, height: 2,
+      chamberId: 2,
+      chamberType: ChamberType.Nursery,
+      foodStored: 0,
+      posX: 12 << FP_SHIFT,
+      posY: 12 << FP_SHIFT,
+      width: 2,
+      height: 2,
     });
     // Brood entity (egg) at tile (5, 5).
     const broodId = allocateEntityId(world);
     initAnt(world.ants, broodId, {
       colonyId: COLONY_ID,
-      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Idle,
-      speed:    0,
-      zone:     Zone.Underground,
+      posX: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
     });
     colony.eggs.push(broodId);
     // Nurse — same tile as brood, OR offset depending on sameTile flag.
@@ -6655,11 +7007,11 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     const nurseId = allocateEntityId(world);
     initAnt(world.ants, nurseId, {
       colonyId: COLONY_ID,
-      posX:     (nurseTileX << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (nurseTileY << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Nursing,
-      subTask:  NursingSubState.MovingToBrood,
-      zone:     Zone.Underground,
+      posX: (nurseTileX << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (nurseTileY << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Nursing,
+      subTask: NursingSubState.MovingToBrood,
+      zone: Zone.Underground,
     });
     return { world, nurseId, broodId, colony };
   }
@@ -6687,11 +7039,11 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     const nurse2 = allocateEntityId(world);
     initAnt(world.ants, nurse2, {
       colonyId: COLONY_ID,
-      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Nursing,
-      subTask:  NursingSubState.MovingToBrood,
-      zone:     Zone.Underground,
+      posX: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Nursing,
+      subTask: NursingSubState.MovingToBrood,
+      zone: Zone.Underground,
     });
     expect(nurse2).toBeGreaterThan(nurseId); // entity ids are monotonic
     tickNurseActions(world);
@@ -6714,7 +7066,10 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     // claim through if the carrier weren't alive.
     const otherCarrier = allocateEntityId(world);
     initAnt(world.ants, otherCarrier, {
-      colonyId: COLONY_ID, posX: 0, posY: 0, task: AntTask.Nursing,
+      colonyId: COLONY_ID,
+      posX: 0,
+      posY: 0,
+      task: AntTask.Nursing,
     });
     world.ants.carriedBy[broodId] = otherCarrier;
     tickNurseActions(world);
@@ -6761,7 +7116,10 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     // can't claim, so findUncarriedBroodOnTile returns -1.
     const otherCarrier = allocateEntityId(world);
     initAnt(world.ants, otherCarrier, {
-      colonyId: COLONY_ID, posX: 0, posY: 0, task: AntTask.Nursing,
+      colonyId: COLONY_ID,
+      posX: 0,
+      posY: 0,
+      task: AntTask.Nursing,
     });
     world.ants.carriedBy[broodId] = otherCarrier;
     // Tick 1: MovingToBrood → Feeding (release-pending, no carry).
@@ -6838,7 +7196,10 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     // Mark the brood as orphaned (carriedBy points at a dead nurse).
     const deadCarrier = allocateEntityId(world);
     initAnt(world.ants, deadCarrier, {
-      colonyId: COLONY_ID, posX: 0, posY: 0, task: AntTask.Nursing,
+      colonyId: COLONY_ID,
+      posX: 0,
+      posY: 0,
+      task: AntTask.Nursing,
     });
     world.ants.alive[deadCarrier] = 0;
     world.ants.carriedBy[broodId] = deadCarrier;
@@ -6869,7 +7230,6 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
     tickNurseActions(world);
     expect(world.ants.task[nurseId]).toBe(AntTask.Idle);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -6884,13 +7244,18 @@ describe('tickNurseActions — v10+ pickup (#17 phase 1.3)', () => {
 
 describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
   function setupV10CarryWorld(opts: {
-    nurseTileX: number; nurseTileY: number;
-    broodTileX: number; broodTileY: number;
-    nurseryTileX: number; nurseryTileY: number;
-    nurseryWidth?: number; nurseryHeight?: number;
+    nurseTileX: number;
+    nurseTileY: number;
+    broodTileX: number;
+    broodTileY: number;
+    nurseryTileX: number;
+    nurseryTileY: number;
+    nurseryWidth?: number;
+    nurseryHeight?: number;
     omitNursery?: boolean;
   }): { world: WorldState; nurseId: number; broodId: number; colony: ColonyRecord } {
-    const ugWidth = 16, ugHeight = 16;
+    const ugWidth = 16,
+      ugHeight = 16;
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     world.simVersion = SIM_VERSION_V10_VISIBLE_BROOD_CARRY;
     const queenId = allocateEntityId(world);
@@ -6916,36 +7281,46 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     // pickup-source tile detection (isInsideQueenChamber). 2×2 anchored at
     // (broodTileX, broodTileY) so the brood always sits inside.
     colony.chambers.push({
-      chamberId: 0, chamberType: ChamberType.Queen, foodStored: 0,
-      posX: opts.broodTileX << FP_SHIFT, posY: opts.broodTileY << FP_SHIFT,
-      width: 2, height: 2,
+      chamberId: 0,
+      chamberType: ChamberType.Queen,
+      foodStored: 0,
+      posX: opts.broodTileX << FP_SHIFT,
+      posY: opts.broodTileY << FP_SHIFT,
+      width: 2,
+      height: 2,
     });
 
     if (!opts.omitNursery) {
       colony.chambers.push({
-        chamberId: 1, chamberType: ChamberType.Nursery, foodStored: 0,
-        posX: opts.nurseryTileX << FP_SHIFT, posY: opts.nurseryTileY << FP_SHIFT,
-        width: opts.nurseryWidth ?? 2, height: opts.nurseryHeight ?? 2,
+        chamberId: 1,
+        chamberType: ChamberType.Nursery,
+        foodStored: 0,
+        posX: opts.nurseryTileX << FP_SHIFT,
+        posY: opts.nurseryTileY << FP_SHIFT,
+        width: opts.nurseryWidth ?? 2,
+        height: opts.nurseryHeight ?? 2,
       });
     }
 
     const broodId = allocateEntityId(world);
     initAnt(world.ants, broodId, {
       colonyId: COLONY_ID,
-      posX:     (opts.broodTileX << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (opts.broodTileY << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Idle, speed: 0, zone: Zone.Underground,
+      posX: (opts.broodTileX << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (opts.broodTileY << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
     });
     colony.eggs.push(broodId);
 
     const nurseId = allocateEntityId(world);
     initAnt(world.ants, nurseId, {
       colonyId: COLONY_ID,
-      posX:     (opts.nurseTileX << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (opts.nurseTileY << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Nursing,
-      subTask:  NursingSubState.MovingToBrood,
-      zone:     Zone.Underground,
+      posX: (opts.nurseTileX << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (opts.nurseTileY << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Nursing,
+      subTask: NursingSubState.MovingToBrood,
+      zone: Zone.Underground,
     });
     return { world, nurseId, broodId, colony };
   }
@@ -6955,9 +7330,12 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     // after the tick, brood position equals carrier position; nurse is
     // still in Feeding (not yet at Nursery) and not back to Idle.
     const { world, nurseId, broodId } = setupV10CarryWorld({
-      nurseTileX: 5, nurseTileY: 5,
-      broodTileX: 5, broodTileY: 5,
-      nurseryTileX: 12, nurseryTileY: 12,
+      nurseTileX: 5,
+      nurseTileY: 5,
+      broodTileX: 5,
+      broodTileY: 5,
+      nurseryTileX: 12,
+      nurseryTileY: 12,
     });
     tickNurseActions(world);
     // Sub-state flipped to Feeding (claim succeeded), brood follows carrier.
@@ -6982,9 +7360,12 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     // we then pre-position the carrier on a Nursery tile and run a
     // second tick to trigger the deposit branch.
     const { world, nurseId, broodId } = setupV10CarryWorld({
-      nurseTileX: 5, nurseTileY: 5,
-      broodTileX: 5, broodTileY: 5,
-      nurseryTileX: 12, nurseryTileY: 12,
+      nurseTileX: 5,
+      nurseTileY: 5,
+      broodTileX: 5,
+      broodTileY: 5,
+      nurseryTileX: 12,
+      nurseryTileY: 12,
     });
     // Tick 1 — claim.
     tickNurseActions(world);
@@ -7013,28 +7394,33 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     // Two carriers each holding a different brood, both arriving at Nursery
     // on the same tick. broodId differs → spread index differs → tiles differ.
     const { world, nurseId, broodId } = setupV10CarryWorld({
-      nurseTileX: 5, nurseTileY: 5,
-      broodTileX: 5, broodTileY: 5,
-      nurseryTileX: 12, nurseryTileY: 12,
+      nurseTileX: 5,
+      nurseTileY: 5,
+      broodTileX: 5,
+      broodTileY: 5,
+      nurseryTileX: 12,
+      nurseryTileY: 12,
     });
     // Add a second brood + nurse pair at a second non-Nursery tile.
     const colony = world.colonies[COLONY_ID]!;
     const brood2 = allocateEntityId(world);
     initAnt(world.ants, brood2, {
       colonyId: COLONY_ID,
-      posX:     (6 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Idle, speed: 0, zone: Zone.Underground,
+      posX: (6 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
     });
     colony.eggs.push(brood2);
     const nurse2 = allocateEntityId(world);
     initAnt(world.ants, nurse2, {
       colonyId: COLONY_ID,
-      posX:     (6 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Nursing,
-      subTask:  NursingSubState.MovingToBrood,
-      zone:     Zone.Underground,
+      posX: (6 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Nursing,
+      subTask: NursingSubState.MovingToBrood,
+      zone: Zone.Underground,
     });
     // Tick 1 — both nurses claim their respective brood.
     tickNurseActions(world);
@@ -7042,8 +7428,8 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     // branches converge in the same tick).
     world.ants.posX[nurseId] = (12 << FP_SHIFT) + (FP_ONE >> 1);
     world.ants.posY[nurseId] = (12 << FP_SHIFT) + (FP_ONE >> 1);
-    world.ants.posX[nurse2]  = (12 << FP_SHIFT) + (FP_ONE >> 1);
-    world.ants.posY[nurse2]  = (12 << FP_SHIFT) + (FP_ONE >> 1);
+    world.ants.posX[nurse2] = (12 << FP_SHIFT) + (FP_ONE >> 1);
+    world.ants.posY[nurse2] = (12 << FP_SHIFT) + (FP_ONE >> 1);
     // Tick 2 — both deposit.
     tickNurseActions(world);
     const allBroodIds = colony.eggs.slice();
@@ -7073,9 +7459,12 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     // unconditionally; Nursery is omitted via `omitNursery: true`. The
     // nurse stands on the Queen tile, so onSourceTile=true → release.
     const { world, nurseId, broodId } = setupV10CarryWorld({
-      nurseTileX: 5, nurseTileY: 5,
-      broodTileX: 5, broodTileY: 5,
-      nurseryTileX: 0, nurseryTileY: 0, // ignored
+      nurseTileX: 5,
+      nurseTileY: 5,
+      broodTileX: 5,
+      broodTileY: 5,
+      nurseryTileX: 0,
+      nurseryTileY: 0, // ignored
       omitNursery: true,
     });
     tickNurseActions(world); // tick 1 — release-pending
@@ -7092,9 +7481,12 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     // continue walking — she may reach the source on a future tick and
     // THEN release.
     const { world, nurseId } = setupV10CarryWorld({
-      nurseTileX: 0, nurseTileY: 0, // far from any chamber
-      broodTileX: 5, broodTileY: 5,
-      nurseryTileX: 0, nurseryTileY: 0, // ignored
+      nurseTileX: 0,
+      nurseTileY: 0, // far from any chamber
+      broodTileX: 5,
+      broodTileY: 5,
+      nurseryTileX: 0,
+      nurseryTileY: 0, // ignored
       omitNursery: true,
     });
     tickNurseActions(world);
@@ -7105,10 +7497,14 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
 
   it('1×1 Nursery: deposit collapses to the single Open tile (broodId % 1 === 0)', () => {
     const { world, nurseId, broodId } = setupV10CarryWorld({
-      nurseTileX: 5, nurseTileY: 5,
-      broodTileX: 5, broodTileY: 5,
-      nurseryTileX: 14, nurseryTileY: 14,
-      nurseryWidth: 1, nurseryHeight: 1,
+      nurseTileX: 5,
+      nurseTileY: 5,
+      broodTileX: 5,
+      broodTileY: 5,
+      nurseryTileX: 14,
+      nurseryTileY: 14,
+      nurseryWidth: 1,
+      nurseryHeight: 1,
     });
     tickNurseActions(world); // claim at (5, 5)
     // Move carrier onto the 1×1 Nursery tile.
@@ -7129,9 +7525,12 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     // this skip, the brood would be re-picked-up and re-shuffled via
     // broodId%openCount on the next deposit, visible as a brood teleport.
     const { world, nurseId, broodId } = setupV10CarryWorld({
-      nurseTileX: 12, nurseTileY: 12, // Inside the Nursery 2x2 at (12,12).
-      broodTileX: 12, broodTileY: 12, // Brood already deposited there.
-      nurseryTileX: 12, nurseryTileY: 12,
+      nurseTileX: 12,
+      nurseTileY: 12, // Inside the Nursery 2x2 at (12,12).
+      broodTileX: 12,
+      broodTileY: 12, // Brood already deposited there.
+      nurseryTileX: 12,
+      nurseryTileY: 12,
     });
     tickNurseActions(world);
     // No claim — brood-inside-Nursery is excluded from pickup selection.
@@ -7155,9 +7554,12 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     // The carry-aware exemption skips both ends of the carry pointer so
     // the resolver never contests the shared tile.
     const { world, nurseId, broodId } = setupV10CarryWorld({
-      nurseTileX: 5, nurseTileY: 5,
-      broodTileX: 5, broodTileY: 5,
-      nurseryTileX: 12, nurseryTileY: 12,
+      nurseTileX: 5,
+      nurseTileY: 5,
+      broodTileX: 5,
+      broodTileY: 5,
+      nurseryTileX: 12,
+      nurseryTileY: 12,
     });
     tickNurseActions(world); // claim — both at (5, 5), broodId carriedBy nurseId
     expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
@@ -7179,9 +7581,12 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
 
   it('carrier dies mid-carry: brood stays at carrier last-synced tile and is reclaimable', () => {
     const { world, nurseId, broodId, colony } = setupV10CarryWorld({
-      nurseTileX: 5, nurseTileY: 5,
-      broodTileX: 5, broodTileY: 5,
-      nurseryTileX: 12, nurseryTileY: 12,
+      nurseTileX: 5,
+      nurseTileY: 5,
+      broodTileX: 5,
+      broodTileY: 5,
+      nurseryTileX: 12,
+      nurseryTileY: 12,
     });
     tickNurseActions(world); // claim
     expect(world.ants.subTask[nurseId]).toBe(NursingSubState.Feeding);
@@ -7195,10 +7600,11 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
     const nurse2 = allocateEntityId(world);
     initAnt(world.ants, nurse2, {
       colonyId: COLONY_ID,
-      posX:     (8 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (8 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Nursing, subTask: NursingSubState.MovingToBrood,
-      zone:     Zone.Underground,
+      posX: (8 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (8 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Nursing,
+      subTask: NursingSubState.MovingToBrood,
+      zone: Zone.Underground,
     });
     void colony;
     tickNurseActions(world);
@@ -7210,9 +7616,12 @@ describe('tickNurseActions — v10+ carry + deposit (#17 phase 1.4)', () => {
 
   it('brood dies mid-carry: carrier drops the carry and returns to Idle', () => {
     const { world, nurseId, broodId } = setupV10CarryWorld({
-      nurseTileX: 5, nurseTileY: 5,
-      broodTileX: 5, broodTileY: 5,
-      nurseryTileX: 12, nurseryTileY: 12,
+      nurseTileX: 5,
+      nurseTileY: 5,
+      broodTileX: 5,
+      broodTileY: 5,
+      nurseryTileX: 12,
+      nurseryTileY: 12,
     });
     tickNurseActions(world); // claim
     expect(world.ants.carryingBroodId[nurseId]).toBe(broodId);
@@ -7244,8 +7653,13 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
     const colony = createColonyRecord(COLONY_ID, queenId);
     world.colonies[COLONY_ID] = colony;
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.Nursery, foodStored: 0,
-      posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT, width: 2, height: 2,
+      chamberId: 1,
+      chamberType: ChamberType.Nursery,
+      foodStored: 0,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      width: 2,
+      height: 2,
     });
 
     // Larva at age = LARVA_MATURE_TICKS - 1 so a single tick promotes it.
@@ -7253,9 +7667,11 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
     const larvaId = allocateEntityId(world);
     initAnt(world.ants, larvaId, {
       colonyId: COLONY_ID,
-      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Idle, speed: 0, zone: Zone.Underground,
+      posX: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
     });
     world.ants.age[larvaId] = LARVA_MATURE_TICKS - 1;
     colony.larvae.push(larvaId);
@@ -7269,13 +7685,14 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
     const nurseId = allocateEntityId(world);
     initAnt(world.ants, nurseId, {
       colonyId: COLONY_ID,
-      posX:     (8 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (7 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Nursing, subTask: NursingSubState.Feeding,
-      zone:     Zone.Underground,
+      posX: (8 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (7 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Nursing,
+      subTask: NursingSubState.Feeding,
+      zone: Zone.Underground,
     });
     world.ants.carryingBroodId[nurseId] = larvaId;
-    world.ants.carriedBy[larvaId]       = nurseId;
+    world.ants.carriedBy[larvaId] = nurseId;
     // Manually pre-sync the larva's position to the carrier (mirrors what
     // tickNurseActions Feeding branch does each tick).
     world.ants.posX[larvaId] = world.ants.posX[nurseId]!;
@@ -7308,15 +7725,22 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
     const colony = createColonyRecord(COLONY_ID, queenId);
     world.colonies[COLONY_ID] = colony;
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.Nursery, foodStored: 0,
-      posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT, width: 2, height: 2,
+      chamberId: 1,
+      chamberType: ChamberType.Nursery,
+      foodStored: 0,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      width: 2,
+      height: 2,
     });
     const eggId = allocateEntityId(world);
     initAnt(world.ants, eggId, {
       colonyId: COLONY_ID,
-      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Idle, speed: 0, zone: Zone.Underground,
+      posX: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
     });
     world.ants.age[eggId] = EGG_HATCH_TICKS - 1;
     colony.eggs.push(eggId);
@@ -7324,13 +7748,14 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
     const nurseId = allocateEntityId(world);
     initAnt(world.ants, nurseId, {
       colonyId: COLONY_ID,
-      posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Nursing, subTask: NursingSubState.Feeding,
-      zone:     Zone.Underground,
+      posX: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (5 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Nursing,
+      subTask: NursingSubState.Feeding,
+      zone: Zone.Underground,
     });
     world.ants.carryingBroodId[nurseId] = eggId;
-    world.ants.carriedBy[eggId]         = nurseId;
+    world.ants.carriedBy[eggId] = nurseId;
 
     tickLifecycleTransitions(world, colony);
     // Promoted to larva; carry preserved.
@@ -7352,7 +7777,7 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
 // invariant holds.
 // ---------------------------------------------------------------------------
 describe('Issue #106 — ascent uses currentGridColonyId (V13+)', () => {
-  it('V13+ ascent looks up GRID colony\'s entrances, not the ant\'s OWN colony', () => {
+  it("V13+ ascent looks up GRID colony's entrances, not the ant's OWN colony", () => {
     const world = createWorldState(42, MAX_TEST_ENTITIES);
     world.simVersion = 13;
     // Two colonies. Player owns colony 1; enemy is colony 2.
@@ -7547,7 +7972,10 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
    * at (antX, antY) on an open tile. The grid is 8×8 with all tiles Solid by
    * default; callers open specific tiles.
    */
-  function setupUndergroundCarryingAnt(antX: number, antY: number): {
+  function setupUndergroundCarryingAnt(
+    antX: number,
+    antY: number,
+  ): {
     world: WorldState;
     antId: number;
     underground: ReturnType<typeof createUndergroundGrid>;
@@ -7557,12 +7985,14 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
     const { world, colony, underground, colonyId } = setupWorldWithUnderground(8, 8);
     world.simVersion = SIM_VERSION_V14_PHEROMONE_AND_MOVEMENT_FIX;
 
-    colony.entrances = [{
-      entranceId: 1,
-      surfaceTileX: 0,
-      surfaceTileY: 64,
-      isOpen: true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: 1,
+        surfaceTileX: 0,
+        surfaceTileY: 64,
+        isOpen: true,
+      },
+    ];
 
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
@@ -7585,7 +8015,8 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
     // Place ant at (3, 3); open tile to East (4, 3) and South (3, 4).
     // With no flow field, the ant explores; after a tile crossing, the previous
     // tile should appear in the ring buffer.
-    const { world, antId, underground, chamberFlowFields, digFlowFields } = setupUndergroundCarryingAnt(3, 3);
+    const { world, antId, underground, chamberFlowFields, digFlowFields } =
+      setupUndergroundCarryingAnt(3, 3);
     ugSet(underground, 3, 3, UndergroundTileState.Open);
     ugSet(underground, 4, 3, UndergroundTileState.Open);
     ugSet(underground, 3, 4, UndergroundTileState.Open);
@@ -7607,7 +8038,10 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
         if (
           world.ants.recentTilesX[antId * RECENT_TILES_LEN + s] === 3 &&
           world.ants.recentTilesY[antId * RECENT_TILES_LEN + s] === 3
-        ) { found = true; break; }
+        ) {
+          found = true;
+          break;
+        }
       }
       expect(found).toBe(true);
     }
@@ -7619,10 +8053,11 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
     // Ant at (3, 3). FoodStorage chamber at (4, 3) → flow field points East.
     // Poison East with a recent tile so the guard fires.
     // South (3, 4) is open → guard redirects South.
-    const { world, antId, underground, chamberFlowFields, digFlowFields } = setupUndergroundCarryingAnt(3, 3);
+    const { world, antId, underground, chamberFlowFields, digFlowFields } =
+      setupUndergroundCarryingAnt(3, 3);
     ugSet(underground, 3, 3, UndergroundTileState.Open);
-    ugSet(underground, 4, 3, UndergroundTileState.Open);  // East — proposed direction
-    ugSet(underground, 3, 4, UndergroundTileState.Open);  // South — alternate
+    ugSet(underground, 4, 3, UndergroundTileState.Open); // East — proposed direction
+    ugSet(underground, 3, 4, UndergroundTileState.Open); // South — alternate
     // (2,3) and (3,2) remain Solid — no other alternates
 
     const colonyId = world.ants.colonyId[antId]! as number;
@@ -7639,7 +8074,13 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
     });
     const gridSize = underground.width * underground.height;
     const bufs = ensureChamberFlowFields(chamberFlowFields, colonyId, gridSize);
-    computeChamberFlowField(underground, colony.chambers, FOOD_CHAMBER_TYPES, bufs.food, bufs.queue);
+    computeChamberFlowField(
+      underground,
+      colony.chambers,
+      FOOD_CHAMBER_TYPES,
+      bufs.food,
+      bufs.queue,
+    );
 
     // Poison East tile (4, 3) as a recent tile.
     world.ants.recentTilesX[antId * RECENT_TILES_LEN + 0] = 4;
@@ -7662,7 +8103,8 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
     // All other neighbors are Solid — no alternate escape. Guard must NOT hold
     // (holding deadlocks permanently since ring buffer only advances on crossings).
     // The ant should proceed East into the recent tile.
-    const { world, antId, underground, chamberFlowFields, digFlowFields } = setupUndergroundCarryingAnt(3, 3);
+    const { world, antId, underground, chamberFlowFields, digFlowFields } =
+      setupUndergroundCarryingAnt(3, 3);
     ugSet(underground, 3, 3, UndergroundTileState.Open);
     ugSet(underground, 4, 3, UndergroundTileState.Open); // East — will be poisoned
     // (2,3), (3,2), (3,4) remain Solid
@@ -7680,7 +8122,13 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
     });
     const gridSize = underground.width * underground.height;
     const bufs = ensureChamberFlowFields(chamberFlowFields, colonyId, gridSize);
-    computeChamberFlowField(underground, colony.chambers, FOOD_CHAMBER_TYPES, bufs.food, bufs.queue);
+    computeChamberFlowField(
+      underground,
+      colony.chambers,
+      FOOD_CHAMBER_TYPES,
+      bufs.food,
+      bufs.queue,
+    );
 
     // Poison East as recent. No other open tiles exist — no valid alternate.
     world.ants.recentTilesX[antId * RECENT_TILES_LEN + 0] = 4;
@@ -7732,7 +8180,6 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
     expect(isRecentTile(world.ants, antId, 3, 3)).toBe(false);
     expect(isRecentTile(world.ants, antId, 4, 4)).toBe(false);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -7852,9 +8299,11 @@ describe('Nursery brood deposit — capacity-aware spread, real pipeline (#173, 
   const PICKUP_Y = 5;
 
   function mkWorld(simVersion: number): {
-    world: WorldState; colony: ColonyRecord;
+    world: WorldState;
+    colony: ColonyRecord;
     underground: ReturnType<typeof createUndergroundGrid>;
-    A: ChamberRecord; B: ChamberRecord;
+    A: ChamberRecord;
+    B: ChamberRecord;
   } {
     const world = createWorldState(42, 256);
     world.simVersion = simVersion;
@@ -7869,12 +8318,22 @@ describe('Nursery brood deposit — capacity-aware spread, real pipeline (#173, 
       for (let x = 5; x <= 40; x++) ugSet(underground, x, y, UndergroundTileState.Open);
     }
     const A: ChamberRecord = {
-      chamberId: 10, chamberType: ChamberType.Nursery, foodStored: 0,
-      posX: 10 << FP_SHIFT, posY: 4 << FP_SHIFT, width: 4, height: 3,
+      chamberId: 10,
+      chamberType: ChamberType.Nursery,
+      foodStored: 0,
+      posX: 10 << FP_SHIFT,
+      posY: 4 << FP_SHIFT,
+      width: 4,
+      height: 3,
     };
     const B: ChamberRecord = {
-      chamberId: 11, chamberType: ChamberType.Nursery, foodStored: 0,
-      posX: 30 << FP_SHIFT, posY: 4 << FP_SHIFT, width: 4, height: 3,
+      chamberId: 11,
+      chamberType: ChamberType.Nursery,
+      foodStored: 0,
+      posX: 30 << FP_SHIFT,
+      posY: 4 << FP_SHIFT,
+      width: 4,
+      height: 3,
     };
     colony.chambers.push(A, B);
     return { world, colony, underground, A, B };
@@ -7899,8 +8358,12 @@ describe('Nursery brood deposit — capacity-aware spread, real pipeline (#173, 
   function placeResident(world: WorldState, colony: ColonyRecord, tx: number, ty: number): void {
     const id = allocateEntityId(world);
     initAnt(world.ants, id, {
-      colonyId: COLONY_ID, posX: (tx << FP_SHIFT) + (FP_ONE >> 1),
-      posY: (ty << FP_SHIFT) + (FP_ONE >> 1), task: AntTask.Idle, speed: 0, zone: Zone.Underground,
+      colonyId: COLONY_ID,
+      posX: (tx << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (ty << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
     });
     colony.eggs.push(id);
   }
@@ -7916,7 +8379,11 @@ describe('Nursery brood deposit — capacity-aware spread, real pipeline (#173, 
   // Persistent real-pipeline driver: one step = recompute field, move ants,
   // run nurse actions. Spawns carriers sequentially so arrival timing matches
   // real play (a fresh carrier picks up only after the previous deposited).
-  function makeDriver(world: WorldState, colony: ColonyRecord, underground: ReturnType<typeof createUndergroundGrid>) {
+  function makeDriver(
+    world: WorldState,
+    colony: ColonyRecord,
+    underground: ReturnType<typeof createUndergroundGrid>,
+  ) {
     const rng = new Rng(7);
     const dig = createDigFlowFields();
     const ent = createEntranceFlowFields();
@@ -7925,9 +8392,23 @@ describe('Nursery brood deposit — capacity-aware spread, real pipeline (#173, 
     function step(): void {
       const bufs = ensureChamberFlowFields(cff, COLONY_ID, gs);
       if (world.simVersion >= SIM_VERSION_V24_NURSERY_CAPACITY) {
-        computeNurseryDepositField(underground, colony.chambers, world.ants, colony.eggs, colony.larvae, bufs.nurseDeposit, bufs.queue);
+        computeNurseryDepositField(
+          underground,
+          colony.chambers,
+          world.ants,
+          colony.eggs,
+          colony.larvae,
+          bufs.nurseDeposit,
+          bufs.queue,
+        );
       } else {
-        computeChamberFlowField(underground, colony.chambers, NURSERY_CHAMBER_TYPES, bufs.nurseDeposit, bufs.queue);
+        computeChamberFlowField(
+          underground,
+          colony.chambers,
+          NURSERY_CHAMBER_TYPES,
+          bufs.nurseDeposit,
+          bufs.queue,
+        );
       }
       tickAntMovement(world, rng, dig, ent, cff);
       tickNurseActions(world, cff);
@@ -7937,15 +8418,22 @@ describe('Nursery brood deposit — capacity-aware spread, real pipeline (#173, 
     function carryOne(maxTicks: number): number {
       const broodId = allocateEntityId(world);
       initAnt(world.ants, broodId, {
-        colonyId: COLONY_ID, posX: (PICKUP_X << FP_SHIFT) + (FP_ONE >> 1),
-        posY: (PICKUP_Y << FP_SHIFT) + (FP_ONE >> 1), task: AntTask.Idle, speed: 0, zone: Zone.Underground,
+        colonyId: COLONY_ID,
+        posX: (PICKUP_X << FP_SHIFT) + (FP_ONE >> 1),
+        posY: (PICKUP_Y << FP_SHIFT) + (FP_ONE >> 1),
+        task: AntTask.Idle,
+        speed: 0,
+        zone: Zone.Underground,
       });
       colony.eggs.push(broodId);
       const nurseId = allocateEntityId(world);
       initAnt(world.ants, nurseId, {
-        colonyId: COLONY_ID, posX: (PICKUP_X << FP_SHIFT) + (FP_ONE >> 1),
+        colonyId: COLONY_ID,
+        posX: (PICKUP_X << FP_SHIFT) + (FP_ONE >> 1),
         posY: (PICKUP_Y << FP_SHIFT) + (FP_ONE >> 1),
-        task: AntTask.Nursing, subTask: NursingSubState.Feeding, zone: Zone.Underground,
+        task: AntTask.Nursing,
+        subTask: NursingSubState.Feeding,
+        zone: Zone.Underground,
       });
       world.ants.carryingBroodId[nurseId] = broodId;
       world.ants.carriedBy[broodId] = nurseId;
@@ -7985,7 +8473,7 @@ describe('Nursery brood deposit — capacity-aware spread, real pipeline (#173, 
     const inB = broodCountIn(world, colony, B);
     expect(inA + inB).toBe(13);
     expect(inA).toBeGreaterThan(0);
-    expect(inB).toBeGreaterThan(0);      // far Nursery is no longer dead space — bug fixed
+    expect(inB).toBeGreaterThan(0); // far Nursery is no longer dead space — bug fixed
     expect(inA).toBeLessThanOrEqual(12); // never stacked past capacity
     expect(inB).toBeLessThanOrEqual(12);
   });
@@ -7995,7 +8483,7 @@ describe('Nursery brood deposit — capacity-aware spread, real pipeline (#173, 
     const driver = makeDriver(world, colony, underground);
     for (let n = 0; n < 13; n++) driver.carryOne(400);
     expect(broodCountIn(world, colony, A)).toBe(13); // all funneled to nearest (stacked)
-    expect(broodCountIn(world, colony, B)).toBe(0);  // far Nursery never used
+    expect(broodCountIn(world, colony, B)).toBe(0); // far Nursery never used
   });
 
   it('V24 saturation: when EVERY Nursery is full, a carrier overflow-deposits (stacks) rather than piling up forever', () => {

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -48,8 +48,19 @@ import {
 import type { AntComponents } from './ant-store.js';
 import { isRecentTile, pushRecentTile, clearRecentTiles, isBroodReclaimable } from './ant-store.js';
 import type { ColonyRecord, ChamberRecord } from '../colony/colony-store.js';
-import { hasCompletedChamber, isFoodChamberDepositable, colonyFoodTotal } from '../colony/colony-system.js';
-import { AntTask, ForagingSubState, DiggingSubState, NursingSubState, ChamberType, PheromoneType } from '../enums.js';
+import {
+  hasCompletedChamber,
+  isFoodChamberDepositable,
+  colonyFoodTotal,
+} from '../colony/colony-system.js';
+import {
+  AntTask,
+  ForagingSubState,
+  DiggingSubState,
+  NursingSubState,
+  ChamberType,
+  PheromoneType,
+} from '../enums.js';
 import {
   WORKER_CARRY_CAPACITY,
   FOOD_PICKUP_AMOUNT,
@@ -92,8 +103,8 @@ import { Zone, UndergroundTileState, ugGet, ugSet, type UndergroundGrid } from '
 // Direction tables for dig flow-field to dx/dy conversion
 // Flow-field direction encoding: 0=N, 1=E, 2=S, 3=W
 // ---------------------------------------------------------------------------
-const DIR_DX = [0, 1, 0, -1] as const;  // N, E, S, W
-const DIR_DY = [-1, 0, 1, 0] as const;  // N, E, S, W
+const DIR_DX = [0, 1, 0, -1] as const; // N, E, S, W
+const DIR_DY = [-1, 0, 1, 0] as const; // N, E, S, W
 
 // Issue #42 fix #3 — 8-connected alternate-step ordering, clockwise from N.
 // Used by the surface SearchingFood no-revisit filter when the proposed step
@@ -276,7 +287,10 @@ export function antPickupFood(
 // pickCardinalStep call.
 // ---------------------------------------------------------------------------
 
-export interface CardinalStep { dx: number; dy: number }
+export interface CardinalStep {
+  dx: number;
+  dy: number;
+}
 
 /**
  * Issue #69 — return a primitive packed int instead of a shared scratch
@@ -302,12 +316,14 @@ export function pickCardinalStep(
   rawDy: number,
   _simVersion?: number,
 ): number {
-  void ants; void id; void _simVersion;
+  void ants;
+  void id;
+  void _simVersion;
   const absDx = rawDx < 0 ? -rawDx : rawDx;
   const absDy = rawDy < 0 ? -rawDy : rawDy;
   if (absDx === 0 && absDy === 0) return packStep(0, 0);
-  if (absDx === 0)                return packStep(0, rawDy > 0 ? 1 : -1);
-  if (absDy === 0)                return packStep(rawDx > 0 ? 1 : -1, 0);
+  if (absDx === 0) return packStep(0, rawDy > 0 ? 1 : -1);
+  if (absDy === 0) return packStep(rawDx > 0 ? 1 : -1, 0);
 
   // Both axes non-zero — 8-connected diagonal step.
   return packStep(rawDx > 0 ? 1 : -1, rawDy > 0 ? 1 : -1);
@@ -511,10 +527,7 @@ export function antDepositFood(world: WorldState, colony: ColonyRecord, antId: n
     if (!isFoodChamberDepositable(ch)) continue;
     const baseX = ch.posX >> FP_SHIFT;
     const baseY = ch.posY >> FP_SHIFT;
-    if (
-      tileX >= baseX && tileX < baseX + ch.width &&
-      tileY >= baseY && tileY < baseY + ch.height
-    ) {
+    if (tileX >= baseX && tileX < baseX + ch.width && tileY >= baseY && tileY < baseY + ch.height) {
       chamber = ch;
       break;
     }
@@ -550,7 +563,7 @@ export function antDepositFood(world: WorldState, colony: ColonyRecord, antId: n
   if (remaining > 0) {
     // Fallback — entrance-shaft / chamberless pool. Cap at BASE.
     const space = BASE_FOOD_STORAGE_CAPACITY - colony.foodStored;
-    const toPool = remaining < space ? remaining : (space > 0 ? space : 0);
+    const toPool = remaining < space ? remaining : space > 0 ? space : 0;
     colony.foodStored += toPool;
     remaining -= toPool;
 
@@ -587,9 +600,9 @@ export function antDepositFood(world: WorldState, colony: ColonyRecord, antId: n
         world.ants.waitingDeposit[antId] = 1;
         // Clear the outward heading so a future wake-up rebuilds routing fresh
         // rather than continuing a stale return-to-entrance bearing.
-        world.ants.searchHeadingX[antId]    = 0;
-        world.ants.searchHeadingY[antId]    = 0;
-        world.ants.searchHeadingTicks[antId]= 0;
+        world.ants.searchHeadingX[antId] = 0;
+        world.ants.searchHeadingY[antId] = 0;
+        world.ants.searchHeadingTicks[antId] = 0;
       }
     }
   }
@@ -677,8 +690,7 @@ export function tickForagerActions(world: WorldState): void {
 
     if (
       zone === Zone.Surface &&
-      (subTask === ForagingSubState.SearchingFood ||
-       subTask === ForagingSubState.ReturningToNest)
+      (subTask === ForagingSubState.SearchingFood || subTask === ForagingSubState.ReturningToNest)
     ) {
       // Pickup path — ant must be exactly on a food pile tile.
       // ReturningToNest is included per the 09 excursion-foraging memo: a
@@ -695,7 +707,7 @@ export function tickForagerActions(world: WorldState): void {
         // drains a pickup-charge; we splice the pile + record the depletion
         // here when its charges hit zero so the spawn step (16d) can avoid
         // re-placing on the same neighbourhood while pheromones decay.
-        antPickupFood(ants, id, pile);    // may transition subTask to CarryingFood
+        antPickupFood(ants, id, pile); // may transition subTask to CarryingFood
         if (pile.pickupsRemaining <= 0) {
           recordFoodPileDepletion(world, p);
           // Splice (not swap-pop) so the tile-key uniqueness invariant on
@@ -774,8 +786,10 @@ export function tickForagerActions(world: WorldState): void {
         const baseX = chamber.posX >> FP_SHIFT;
         const baseY = chamber.posY >> FP_SHIFT;
         if (
-          tileX >= baseX && tileX < baseX + chamber.width &&
-          tileY >= baseY && tileY < baseY + chamber.height
+          tileX >= baseX &&
+          tileX < baseX + chamber.width &&
+          tileY >= baseY &&
+          tileY < baseY + chamber.height
         ) {
           depositSite = true;
           break;
@@ -884,7 +898,7 @@ export function tickNurseActions(world: WorldState, chamberFlowFields?: ChamberF
         // under normal v10 flow (pickup always sets the slot). If we
         // hit it (state corruption, manual mutation), release back to
         // Idle so the nurse doesn't strand.
-        ants.task[id]    = AntTask.Idle;
+        ants.task[id] = AntTask.Idle;
         ants.subTask[id] = 0;
         continue;
       }
@@ -892,12 +906,12 @@ export function tickNurseActions(world: WorldState, chamberFlowFields?: ChamberF
       // and return to Idle. The dead brood will be swap-removed from
       // colony.eggs/larvae at step 5 (tickDeathCleanup) on the next tick.
       if (ants.alive[broodId] !== 1) {
-        ants.carryingBroodId[id]    = -1;
+        ants.carryingBroodId[id] = -1;
         // carriedBy[broodId] is left as-is — the brood is dead and will
         // be swap-removed from colony.eggs/larvae at the next step 5
         // tickDeathCleanup. Entity ids are not recycled (PRD §3), so
         // the stale carriedBy is harmless.
-        ants.task[id]    = AntTask.Idle;
+        ants.task[id] = AntTask.Idle;
         ants.subTask[id] = 0;
         continue;
       }
@@ -927,7 +941,8 @@ export function tickNurseActions(world: WorldState, chamberFlowFields?: ChamberF
         const field = chamberFlowFields.nurseDeposit[colonyId];
         const underground = world.undergroundGrids[colonyId];
         shouldDeposit =
-          field !== undefined && underground !== undefined &&
+          field !== undefined &&
+          underground !== undefined &&
           field[tileY * underground.width + tileX] === -1;
       } else {
         shouldDeposit = isInsideNursery(colony, tileX, tileY);
@@ -949,12 +964,12 @@ export function tickNurseActions(world: WorldState, chamberFlowFields?: ChamberF
     // so no per-tick brood check is needed here.
     if (subTask === NursingSubState.Attending) {
       const colonyId = ants.colonyId[id]!;
-      const colony   = world.colonies[colonyId];
+      const colony = world.colonies[colonyId];
       const starving = colony !== undefined && colonyFoodTotal(colony) === 0;
       ants.searchPauseTicks[id] = ants.searchPauseTicks[id]! + 1;
       if (starving || ants.searchPauseTicks[id]! >= NURSE_ATTEND_DWELL_TICKS) {
-        ants.task[id]             = AntTask.Idle;
-        ants.subTask[id]          = 0;
+        ants.task[id] = AntTask.Idle;
+        ants.subTask[id] = 0;
         ants.searchPauseTicks[id] = 0;
       }
       continue;
@@ -992,8 +1007,7 @@ export function tickNurseActions(world: WorldState, chamberFlowFields?: ChamberF
     // a source tile (i.e., she has actually arrived). An in-transit
     // off-source nurse keeps walking — she'll reach a brood tile.
     const onSourceTile =
-      isInsideQueenChamber(colony, tileX, tileY) ||
-      isInsideNursery(colony, tileX, tileY);
+      isInsideQueenChamber(colony, tileX, tileY) || isInsideNursery(colony, tileX, tileY);
 
     // Case 2: no completed Nursery → no destination for the carry.
     // Symmetric with the pre-v10 transport gate. Defensive — allocator
@@ -1029,9 +1043,9 @@ export function tickNurseActions(world: WorldState, chamberFlowFields?: ChamberF
     }
 
     // Claim the brood. Set both ends of the carry pointer atomically.
-    ants.carryingBroodId[id]    = broodId;
-    ants.carriedBy[broodId]     = id;
-    ants.subTask[id]            = NursingSubState.Feeding;
+    ants.carryingBroodId[id] = broodId;
+    ants.carriedBy[broodId] = id;
+    ants.subTask[id] = NursingSubState.Feeding;
     // Carried brood is no longer a pickup seed — the next per-tick
     // recompute of the `nursing` field in tick.ts step 9 will exclude
     // it because `carriedBy[broodId] !== -1`. No dirty flag needed.
@@ -1067,10 +1081,7 @@ export function tickNurseActions(world: WorldState, chamberFlowFields?: ChamberF
  * brood on a Solid/Marked tile (theoretically impossible — defensive
  * only) would be counted as claimable but never seeded → strand.
  */
-function colonyHasClaimableBrood(
-  world: WorldState,
-  colony: ColonyRecord,
-): boolean {
+function colonyHasClaimableBrood(world: WorldState, colony: ColonyRecord): boolean {
   const ants = world.ants;
   const underground = world.undergroundGrids[colony.colonyId];
   for (let i = 0; i < colony.eggs.length; i++) {
@@ -1100,7 +1111,8 @@ function isReclaimableBroodSeedable(
   if (underground !== undefined) {
     if (tx < 0 || tx >= underground.width || ty < 0 || ty >= underground.height) return false;
     const state = ugGet(underground, tx, ty);
-    if (state !== UndergroundTileState.Open && state !== UndergroundTileState.BeingDug) return false;
+    if (state !== UndergroundTileState.Open && state !== UndergroundTileState.BeingDug)
+      return false;
   }
   return true;
 }
@@ -1162,7 +1174,7 @@ function computeDepositPositionInChamber(
   let openCount = 0;
   for (let ty = 0; ty < chamber.height; ty++) {
     for (let tx = 0; tx < chamber.width; tx++) {
-    if (ugGet(underground, bx + tx, by + ty) === UndergroundTileState.Open) openCount++;
+      if (ugGet(underground, bx + tx, by + ty) === UndergroundTileState.Open) openCount++;
     }
   }
   if (openCount === 0) return null;
@@ -1195,13 +1207,13 @@ function computeDepositPositionInChamber(
   let cursor = 0;
   for (let ty = 0; ty < chamber.height; ty++) {
     for (let tx = 0; tx < chamber.width; tx++) {
-    const cx = bx + tx;
-    const cy = by + ty;
-    if (ugGet(underground, cx, cy) !== UndergroundTileState.Open) continue;
-    if (cursor === targetIndex) {
+      const cx = bx + tx;
+      const cy = by + ty;
+      if (ugGet(underground, cx, cy) !== UndergroundTileState.Open) continue;
+      if (cursor === targetIndex) {
         return { x: (cx << FP_SHIFT) + (FP_ONE >> 1), y: (cy << FP_SHIFT) + (FP_ONE >> 1) };
-    }
-    cursor++;
+      }
+      cursor++;
     }
   }
   return null;
@@ -1230,10 +1242,8 @@ function tileHasResidentBrood(
       const bid = broodIds[i]!;
       if (bid === excludeBroodId) continue;
       if (!isBroodReclaimable(ants, bid)) continue;
-      if (
-        (ants.posX[bid]! >> FP_SHIFT) === tileX &&
-        (ants.posY[bid]! >> FP_SHIFT) === tileY
-      ) return true;
+      if (ants.posX[bid]! >> FP_SHIFT === tileX && ants.posY[bid]! >> FP_SHIFT === tileY)
+        return true;
     }
   }
   return false;
@@ -1261,9 +1271,9 @@ function computeNurseryDepositPosition(
     const bx = ch.posX >> FP_SHIFT;
     const by = ch.posY >> FP_SHIFT;
     for (let ty = 0; ty < ch.height; ty++) {
-    for (let tx = 0; tx < ch.width; tx++) {
+      for (let tx = 0; tx < ch.width; tx++) {
         if (ugGet(underground, bx + tx, by + ty) === UndergroundTileState.Open) openCount++;
-    }
+      }
     }
   }
   if (openCount === 0) return null;
@@ -1278,7 +1288,7 @@ function computeNurseryDepositPosition(
     const bx = ch.posX >> FP_SHIFT;
     const by = ch.posY >> FP_SHIFT;
     for (let ty = 0; ty < ch.height; ty++) {
-    for (let tx = 0; tx < ch.width; tx++) {
+      for (let tx = 0; tx < ch.width; tx++) {
         const cx = bx + tx;
         const cy = by + ty;
         if (ugGet(underground, cx, cy) !== UndergroundTileState.Open) continue;
@@ -1289,7 +1299,7 @@ function computeNurseryDepositPosition(
           };
         }
         cursor++;
-    }
+      }
     }
   }
   return null;
@@ -1331,15 +1341,20 @@ function depositCarriedBrood(
     if (ch.chamberType !== ChamberType.Nursery) continue;
     const bx = ch.posX >> FP_SHIFT;
     const by = ch.posY >> FP_SHIFT;
-    if (nurseTileX >= bx && nurseTileX < bx + ch.width &&
-        nurseTileY >= by && nurseTileY < by + ch.height) {
-    nurseChamber = ch;
-    break;
+    if (
+      nurseTileX >= bx &&
+      nurseTileX < bx + ch.width &&
+      nurseTileY >= by &&
+      nurseTileY < by + ch.height
+    ) {
+      nurseChamber = ch;
+      break;
     }
   }
-  pos = nurseChamber !== null
-    ? computeDepositPositionInChamber(world, colony, broodId, nurseChamber)
-    : computeNurseryDepositPosition(world, colony, broodId); // fallback (pathological)
+  pos =
+    nurseChamber !== null
+      ? computeDepositPositionInChamber(world, colony, broodId, nurseChamber)
+      : computeNurseryDepositPosition(world, colony, broodId); // fallback (pathological)
   // Issue #173 (V24+): computeDepositPositionInChamber returns null when the
   // carrier's target Nursery has no unoccupied Open tile — e.g. several carriers
   // reach the same Nursery in one tick and an earlier one consumed the last free
@@ -1365,12 +1380,14 @@ function depositCarriedBrood(
     // flood lets the disconnected case fall through to overflow like the
     // all-full case, while still deferring in the legitimate mid-tick race
     // (a reachable non-full Nursery was filled by an earlier carrier this tick).
-    const visited = chamberFlowFields !== undefined && colonyId !== undefined
-      ? chamberFlowFields.depositReachVisited[colonyId]
-      : undefined;
-    const floodQueue = chamberFlowFields !== undefined && colonyId !== undefined
-      ? chamberFlowFields.queues[colonyId]
-      : undefined;
+    const visited =
+      chamberFlowFields !== undefined && colonyId !== undefined
+        ? chamberFlowFields.depositReachVisited[colonyId]
+        : undefined;
+    const floodQueue =
+      chamberFlowFields !== undefined && colonyId !== undefined
+        ? chamberFlowFields.queues[colonyId]
+        : undefined;
     const canRerouteElsewhere =
       underground !== undefined &&
       visited !== undefined &&
@@ -1399,7 +1416,7 @@ function depositCarriedBrood(
   ants.currentGridColonyId[broodId] = colony.colonyId;
   // Clear both ends of the carry pointer.
   ants.carryingBroodId[nurseId] = -1;
-  ants.carriedBy[broodId]       = -1;
+  ants.carriedBy[broodId] = -1;
   // S4 V21+: nurse enters Attending substate and dwells at the Nursery tile
   // for NURSE_ATTEND_DWELL_TICKS, accelerating adjacent larvae. Pre-V21:
   // carrier returns to Idle immediately; step 10a re-allocates next tick.
@@ -1412,16 +1429,15 @@ function depositCarriedBrood(
   // receives zero maturation benefit, so transport must come first.
   // This check runs once per deposit (not per tick), keeping it cheap.
   if (colonyHasClaimableBrood(world, colony)) {
-    ants.task[nurseId]             = AntTask.Idle;
-    ants.subTask[nurseId]          = 0;
+    ants.task[nurseId] = AntTask.Idle;
+    ants.subTask[nurseId] = 0;
     ants.searchPauseTicks[nurseId] = 0;
   } else {
-    ants.subTask[nurseId]          = NursingSubState.Attending;
+    ants.subTask[nurseId] = NursingSubState.Attending;
     ants.searchPauseTicks[nurseId] = 0;
     // task remains AntTask.Nursing — Attending is a Nursing substate
   }
 }
-
 
 function isInsideNursery(colony: ColonyRecord, tileX: number, tileY: number): boolean {
   for (let c = 0; c < colony.chambers.length; c++) {
@@ -1542,8 +1558,7 @@ export function getTaskDirection(
     // re-seeds to Queen tiles + uncarried-brood tiles outside Nursery.
     if (chamberFlowFields !== undefined) {
       const v10Carrying =
-        ants.subTask[antId] === NursingSubState.Feeding &&
-        ants.carryingBroodId[antId] !== -1;
+        ants.subTask[antId] === NursingSubState.Feeding && ants.carryingBroodId[antId] !== -1;
       const flowField = v10Carrying
         ? chamberFlowFields.nurseDeposit[colonyId]
         : chamberFlowFields.nursing[colonyId];
@@ -1586,7 +1601,8 @@ export function getTaskDirection(
     for (let i = 0; i < colony.chambers.length; i++) {
       const chamber = colony.chambers[i]!;
       const ct = chamber.chamberType;
-      if (ct !== (0 as typeof ChamberType.Queen) && ct !== (1 as typeof ChamberType.Nursery)) continue;
+      if (ct !== (0 as typeof ChamberType.Queen) && ct !== (1 as typeof ChamberType.Nursery))
+        continue;
 
       const chamberTileX = chamber.posX >> FP_SHIFT;
       const chamberTileY = chamber.posY >> FP_SHIFT;
@@ -1604,7 +1620,8 @@ export function getTaskDirection(
     // once per tick, regardless of how many chambers were considered.
     if (bestDist >= 0) {
       const step = pickCardinalStep(
-        ants, antId,
+        ants,
+        antId,
         bestChamberTileX - antTileX,
         bestChamberTileY - antTileY,
       );
@@ -1695,8 +1712,7 @@ export function tickSearchLeash(world: WorldState): void {
   for (const key in world.colonies) {
     if (!Object.hasOwn(world.colonies, key)) continue;
     const colony = world.colonies[key as unknown as number]!;
-    const overForage =
-      colony.taskCensus.forage > colony.computedAllocation.forage;
+    const overForage = colony.taskCensus.forage > colony.computedAllocation.forage;
     const nonForageDemand =
       colony.computedAllocation.dig > 0 || colony.computedAllocation.fight > 0;
     rebalanceNeeded[colony.colonyId] = overForage && nonForageDemand;
@@ -1787,9 +1803,7 @@ export function tickSearchLeash(world: WorldState): void {
     // at the same radius once a deposit target opens up.
     if (overLeashed) {
       const nextWave = wave + 1;
-      ants.searchWave[id] = nextWave > SEARCH_LEASH_MAX_WAVE
-        ? SEARCH_LEASH_MAX_WAVE
-        : nextWave;
+      ants.searchWave[id] = nextWave > SEARCH_LEASH_MAX_WAVE ? SEARCH_LEASH_MAX_WAVE : nextWave;
     }
   }
 }
@@ -1831,10 +1845,7 @@ export function tickSearchLeash(world: WorldState): void {
  * @param world          WorldState (reads/writes ants, undergroundGrids, colonies).
  * @param digFlowFields  Per-colony flow-field cache (reads fields for direction lookup).
  */
-export function tickDigExecution(
-  world: WorldState,
-  digFlowFields: DigFlowFields,
-): void {
+export function tickDigExecution(world: WorldState, digFlowFields: DigFlowFields): void {
   const ants = world.ants;
 
   for (let id = 0; id < world.nextEntityId; id++) {
@@ -1908,7 +1919,6 @@ export function tickDigExecution(
         ants.subTask[id] = DiggingSubState.Excavating;
       }
       // Otherwise: no-op (ant will move toward Marked tile in step 16 movement)
-
     } else if (subTask === DiggingSubState.Excavating) {
       // Decrement countdown
       const remaining = ants.digTicksRemaining[id]!;
@@ -1982,14 +1992,19 @@ export function tickDigExecution(
  *      already checks `hasEntrances` before calling.
  */
 function pickFighterTargetEntrance(
-  entrances: ReadonlyArray<{ entranceId: number; surfaceTileX: number; surfaceTileY: number; isOpen: boolean }>,
+  entrances: ReadonlyArray<{
+    entranceId: number;
+    surfaceTileX: number;
+    surfaceTileY: number;
+    isOpen: boolean;
+  }>,
   antTileX: number,
   antTileY: number,
 ): { entranceId: number; surfaceTileX: number; surfaceTileY: number; isOpen: boolean } | null {
-  let bestOpen: typeof entrances[number] | null = null;
+  let bestOpen: (typeof entrances)[number] | null = null;
   let bestOpenDist = Infinity;
   let bestOpenId = Infinity;
-  let bestClosed: typeof entrances[number] | null = null;
+  let bestClosed: (typeof entrances)[number] | null = null;
   let bestClosedDist = Infinity;
   let bestClosedId = Infinity;
   for (let e = 0; e < entrances.length; e++) {
@@ -2043,9 +2058,7 @@ export function updateFightAntTargets(world: WorldState): void {
       if (!other || !other.entrances) continue;
       for (let e = 0; e < other.entrances.length; e++) {
         const ent = other.entrances[e]!;
-        if (ent.isOpen
-            && ent.surfaceTileX === rp.tileX
-            && ent.surfaceTileY === rp.tileY) {
+        if (ent.isOpen && ent.surfaceTileX === rp.tileX && ent.surfaceTileY === rp.tileY) {
           hit = true;
           break;
         }
@@ -2061,7 +2074,12 @@ export function updateFightAntTargets(world: WorldState): void {
   for (const cidKey in world.colonies) {
     if (!Object.hasOwn(world.colonies, cidKey)) continue;
     const col = world.colonies[cidKey as unknown as keyof typeof world.colonies];
-    if (col) aggroEnemyColonies.push({ cid: Number(cidKey), workers: col.workers, queenEntityId: col.queenEntityId });
+    if (col)
+      aggroEnemyColonies.push({
+        cid: Number(cidKey),
+        workers: col.workers,
+        queenEntityId: col.queenEntityId,
+      });
   }
 
   for (let id = 0; id < ants.alive.length; id++) {
@@ -2099,7 +2117,11 @@ export function updateFightAntTargets(world: WorldState): void {
         // Issue #62 (v12+) — pick nearest open entrance, fallback to nearest
         // closed if none open (fighters stack near soon-to-open shafts).
         // Pre-v12 always used entrances[0] regardless of isOpen.
-        const e = pickFighterTargetEntrance(entrances, ants.posX[id]! >> FP_SHIFT, ants.posY[id]! >> FP_SHIFT);
+        const e = pickFighterTargetEntrance(
+          entrances,
+          ants.posX[id]! >> FP_SHIFT,
+          ants.posY[id]! >> FP_SHIFT,
+        );
         if (e !== null) {
           ants.targetPosX[id] = (e.surfaceTileX << FP_SHIFT) + (FP_ONE >> 1);
           ants.targetPosY[id] = (e.surfaceTileY << FP_SHIFT) + (FP_ONE >> 1);
@@ -2117,7 +2139,11 @@ export function updateFightAntTargets(world: WorldState): void {
     // Zone promotion happens inside tickAntMovement when the ant crosses the shaft;
     // this pass only writes the fixed-point target coord.
     if (ants.zone[id] === 1 /* Underground */ && hasEntrances) {
-      const e = pickFighterTargetEntrance(entrances, ants.posX[id]! >> FP_SHIFT, ants.posY[id]! >> FP_SHIFT);
+      const e = pickFighterTargetEntrance(
+        entrances,
+        ants.posX[id]! >> FP_SHIFT,
+        ants.posY[id]! >> FP_SHIFT,
+      );
       if (e !== null) {
         ants.targetPosX[id] = (e.surfaceTileX << FP_SHIFT) + (FP_ONE >> 1);
         ants.targetPosY[id] = (e.surfaceTileY << FP_SHIFT) + (FP_ONE >> 1);
@@ -2137,8 +2163,7 @@ export function updateFightAntTargets(world: WorldState): void {
     // enemy) — rallyOnEntrance is colony-agnostic (see precompute above): fighters
     // must walk to the exact tile so the descent trigger fires, whether it's an
     // invasion into an enemy grid or a defensive descent into their own grid.
-    if (ants.zone[id] === Zone.Surface
-        && !rallyOnEntrance[colony.colonyId]) {
+    if (ants.zone[id] === Zone.Surface && !rallyOnEntrance[colony.colonyId]) {
       const aggroZone = ants.zone[id];
       const aggroTileX = ants.posX[id]! >> FP_SHIFT;
       const aggroTileY = ants.posY[id]! >> FP_SHIFT;
@@ -2151,19 +2176,33 @@ export function updateFightAntTargets(world: WorldState): void {
           if (ants.alive[eid] !== 1) continue;
           if (ants.zone[eid] !== aggroZone) continue;
           // Underground grids are disjoint spaces — reject candidates in a different grid.
-          if (aggroZone === Zone.Underground && ants.currentGridColonyId[eid] !== currentGridColonyId) continue;
+          if (
+            aggroZone === Zone.Underground &&
+            ants.currentGridColonyId[eid] !== currentGridColonyId
+          )
+            continue;
           const eTileX = ants.posX[eid]! >> FP_SHIFT;
           const eTileY = ants.posY[eid]! >> FP_SHIFT;
           const dist = Math.abs(eTileX - aggroTileX) + Math.abs(eTileY - aggroTileY);
-          if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) { nearestEnemyDist = dist; nearestEnemy = eid; }
+          if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) {
+            nearestEnemyDist = dist;
+            nearestEnemy = eid;
+          }
         }
         const qid = ec.queenEntityId;
-        if (qid >= 0 && ants.alive[qid] === 1 && ants.zone[qid] === aggroZone
-            && (aggroZone !== Zone.Underground || ants.currentGridColonyId[qid] === currentGridColonyId)) {
+        if (
+          qid >= 0 &&
+          ants.alive[qid] === 1 &&
+          ants.zone[qid] === aggroZone &&
+          (aggroZone !== Zone.Underground || ants.currentGridColonyId[qid] === currentGridColonyId)
+        ) {
           const qTileX = ants.posX[qid]! >> FP_SHIFT;
           const qTileY = ants.posY[qid]! >> FP_SHIFT;
           const dist = Math.abs(qTileX - aggroTileX) + Math.abs(qTileY - aggroTileY);
-          if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) { nearestEnemyDist = dist; nearestEnemy = qid; }
+          if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) {
+            nearestEnemyDist = dist;
+            nearestEnemy = qid;
+          }
         }
       }
       // V23 (#147): the spider is one more candidate in the same nearest-hostile scan
@@ -2177,7 +2216,10 @@ export function updateFightAntTargets(world: WorldState): void {
         const spTileX = world.spider.posX >> FP_SHIFT;
         const spTileY = world.spider.posY >> FP_SHIFT;
         const dist = Math.abs(spTileX - aggroTileX) + Math.abs(spTileY - aggroTileY);
-        if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) { nearestEnemyDist = dist; nearestIsSpider = true; }
+        if (dist <= FIGHT_AGGRO_RADIUS && dist < nearestEnemyDist) {
+          nearestEnemyDist = dist;
+          nearestIsSpider = true;
+        }
       }
       if (nearestIsSpider) {
         ants.targetPosX[id] = world.spider!.posX;
@@ -2273,7 +2315,10 @@ export function routeForagerPriority(world: WorldState): void {
         // so a v11 snapshot loaded by v12 code would write tile-center
         // where the saved bytes had tile-corner — breaking SCEN-06
         // byte-identity for any save with priority foragers active.
-        priorityTargets[colony.colonyId] = { targetX: (pile.tileX << FP_SHIFT) + (FP_ONE >> 1), targetY: (pile.tileY << FP_SHIFT) + (FP_ONE >> 1) };
+        priorityTargets[colony.colonyId] = {
+          targetX: (pile.tileX << FP_SHIFT) + (FP_ONE >> 1),
+          targetY: (pile.tileY << FP_SHIFT) + (FP_ONE >> 1),
+        };
         break;
       }
     }
@@ -2396,10 +2441,22 @@ export function chooseExcursionDirection(
       // an initial cardinal by antId so colony members fan out to four
       // different compass directions rather than all piling the same way.
       switch (antId & 3) {
-        case 0:  hx =  1; hy =  0; break;
-        case 1:  hx = -1; hy =  0; break;
-        case 2:  hx =  0; hy =  1; break;
-        default: hx =  0; hy = -1; break;
+        case 0:
+          hx = 1;
+          hy = 0;
+          break;
+        case 1:
+          hx = -1;
+          hy = 0;
+          break;
+        case 2:
+          hx = 0;
+          hy = 1;
+          break;
+        default:
+          hx = 0;
+          hy = -1;
+          break;
       }
     } else {
       const absX = outX < 0 ? -outX : outX;
@@ -2434,13 +2491,13 @@ export function chooseExcursionDirection(
     if (turnRoll < EXCURSION_TURN_PERCENT) {
       // Rotate 90° — left: (hx,hy) → (hy, -hx); right: (hx,hy) → (-hy, hx).
       if (turnDir === 0) {
-        const nhx =  hy;
+        const nhx = hy;
         const nhy = -hx;
         hx = nhx;
         hy = nhy;
       } else {
         const nhx = -hy;
-        const nhy =  hx;
+        const nhy = hx;
         hx = nhx;
         hy = nhy;
       }
@@ -2448,8 +2505,8 @@ export function chooseExcursionDirection(
     } else if (turnRoll >= 100 - EXCURSION_WOBBLE_PERCENT) {
       // Lateral wobble — one-tick perpendicular step, heading preserved.
       // Perpendicular of (hx,hy) is (hy,-hx) (left) or (-hy,hx) (right).
-      const lhx = turnDir === 0 ?  hy : -hy;
-      const lhy = turnDir === 0 ? -hx :  hx;
+      const lhx = turnDir === 0 ? hy : -hy;
+      const lhy = turnDir === 0 ? -hx : hx;
       const nx = tileX + lhx;
       const ny = tileY + lhy;
       if (nx >= 0 && nx < SURFACE_GRID_WIDTH && ny >= 0 && ny < SURFACE_GRID_HEIGHT) {
@@ -2479,7 +2536,7 @@ export function chooseExcursionDirection(
     const ny = tileY + hy;
     if (nx >= 0 && nx < SURFACE_GRID_WIDTH && ny >= 0 && ny < SURFACE_GRID_HEIGHT) break;
     const nhx = -hy;
-    const nhy =  hx;
+    const nhy = hx;
     hx = nhx;
     hy = nhy;
   }
@@ -2580,7 +2637,7 @@ function hasNearbyPheromoneSignal(
       if (hasPrev) {
         const absX = dx < 0 ? -dx : dx;
         const stepX = absX >= absY ? (dx > 0 ? 1 : dx < 0 ? -1 : 0) : 0;
-        const stepY = absX >= absY ? 0 : (dy > 0 ? 1 : dy < 0 ? -1 : 0);
+        const stepY = absX >= absY ? 0 : dy > 0 ? 1 : dy < 0 ? -1 : 0;
         if (tileX + stepX === prevTileX && tileY + stepY === prevTileY) continue;
       }
       if (phGet(grid, sx, sy) > 0) return true;
@@ -2652,7 +2709,8 @@ export function tickExcursionBoundary(world: WorldState): void {
     if (ants.task[id] !== AntTask.Foraging) continue;
     if (ants.zone[id] !== Zone.Surface) continue;
     const sub = ants.subTask[id]!;
-    if (sub !== ForagingSubState.SearchingFood && sub !== ForagingSubState.ReturningToNest) continue;
+    if (sub !== ForagingSubState.SearchingFood && sub !== ForagingSubState.ReturningToNest)
+      continue;
 
     const colonyId = ants.colonyId[id]!;
     const colony = world.colonies[colonyId];
@@ -2971,11 +3029,7 @@ export function canEnterUndergroundTile(
 // tickAntMovement, moveQueens, and resolveSameColonyOccupancy.
 // ---------------------------------------------------------------------------
 
-export function canEnterSurfaceTile(
-  world: WorldState,
-  tileX: number,
-  tileY: number,
-): boolean {
+export function canEnterSurfaceTile(world: WorldState, tileX: number, tileY: number): boolean {
   if (tileX < 0 || tileY < 0 || tileX >= SURFACE_GRID_WIDTH || tileY >= SURFACE_GRID_HEIGHT) {
     return false;
   }
@@ -3018,8 +3072,8 @@ export function canEnterSurfaceTile(
 // Direction-agnostic — same set probed regardless of caller's intended
 // direction. Order doubles as the deterministic tie-break: at equal
 // Manhattan distance to target, earlier compass direction wins.
-const PROBE_COMPASS_DX = [ 0,  1,  1,  1,  0, -1, -1, -1] as const;
-const PROBE_COMPASS_DY = [-1, -1,  0,  1,  1,  1,  0, -1] as const;
+const PROBE_COMPASS_DX = [0, 1, 1, 1, 0, -1, -1, -1] as const;
+const PROBE_COMPASS_DY = [-1, -1, 0, 1, 1, 1, 0, -1] as const;
 
 // Module-scratch result object for `pickSurfaceDetour` — reused across
 // every call to avoid per-call literal allocation (AGENTS.md "Hot-loop
@@ -3121,15 +3175,18 @@ export function pickSurfaceDetour(
     //     escapes them in one detour cycle. Don't penalize.
     const aheadX = cx + pdx;
     const aheadY = cy + pdy;
-    const aheadInBounds = aheadX >= 0 && aheadY >= 0
-      && aheadX < SURFACE_GRID_WIDTH && aheadY < SURFACE_GRID_HEIGHT;
+    const aheadInBounds =
+      aheadX >= 0 && aheadY >= 0 && aheadX < SURFACE_GRID_WIDTH && aheadY < SURFACE_GRID_HEIGHT;
     // Only penalize when (ahead in-bounds AND blocked) AND (ahead2 in-bounds AND blocked).
     // This isolates the multi-tile-feature pocket case from OOB + shallow dead-ends.
     if (aheadInBounds && !canEnterSurfaceTile(world, aheadX, aheadY)) {
       const ahead2X = aheadX + pdx;
       const ahead2Y = aheadY + pdy;
-      const ahead2InBounds = ahead2X >= 0 && ahead2Y >= 0
-        && ahead2X < SURFACE_GRID_WIDTH && ahead2Y < SURFACE_GRID_HEIGHT;
+      const ahead2InBounds =
+        ahead2X >= 0 &&
+        ahead2Y >= 0 &&
+        ahead2X < SURFACE_GRID_WIDTH &&
+        ahead2Y < SURFACE_GRID_HEIGHT;
       if (ahead2InBounds && !canEnterSurfaceTile(world, ahead2X, ahead2Y)) {
         // Real pocket: dominate Manhattan differences in this 128x128 grid.
         score += 1000;
@@ -3164,10 +3221,7 @@ export function pickSurfaceDetour(
   // eventually rotating the original blocker out and re-enabling
   // forward progress. Pre-v8 keeps the original "(0, 0) hold on
   // exhaustion" behaviour for byte-identical replay (SCEN-06).
-  if (
-    bestScore < 0 &&
-    bestRecentScore >= 0
-  ) {
+  if (bestScore < 0 && bestRecentScore >= 0) {
     bestDx = bestRecentDx;
     bestDy = bestRecentDy;
   }
@@ -3342,7 +3396,10 @@ export function pickInvaderUndergroundStep(
     const cx = qx[head]!;
     const cy = qy[head]!;
     head++;
-    if (cx === tileX && cy === tileY) { reached = true; break; }
+    if (cx === tileX && cy === tileY) {
+      reached = true;
+      break;
+    }
     const nextDist = dist[cy * width + cx]! + 1;
     for (let i = 0; i < DIR_DX.length; i++) {
       const nx = cx + DIR_DX[i]!;
@@ -3665,9 +3722,15 @@ function moveQueens(
             // the corner-cut check passes. Queens use AntTask.Idle for
             // passability rules — no Marked-tile traversal.
             diagonalizeFlowStep(
-              underground, flowField, tileX, tileY,
-              DIR_DX[dir]!, DIR_DY[dir]!,
-              AntTask.Idle, world.simVersion, cardinalStepScratch,
+              underground,
+              flowField,
+              tileX,
+              tileY,
+              DIR_DX[dir]!,
+              DIR_DY[dir]!,
+              AntTask.Idle,
+              world.simVersion,
+              cardinalStepScratch,
             );
             dx = cardinalStepScratch.dx;
             dy = cardinalStepScratch.dy;
@@ -3720,9 +3783,10 @@ function moveQueens(
     // to direct compute when called from a test harness without a cache.
     let speed = baseSpeed;
     if (zone === Zone.Surface) {
-      const movement = surfaceMoveCache !== undefined
-        ? surfaceMovementAtCached(world, tileX, tileY, surfaceMoveCache)
-        : surfaceMovementAt(world, tileX, tileY);
+      const movement =
+        surfaceMoveCache !== undefined
+          ? surfaceMovementAtCached(world, tileX, tileY, surfaceMoveCache)
+          : surfaceMovementAt(world, tileX, tileY);
       if (movement === SurfaceMovementEffect.SoftCost) {
         const halved = baseSpeed >> 1;
         speed = halved < 1 ? 1 : halved;
@@ -3747,7 +3811,12 @@ function moveQueens(
         const yCrossed = newTileY !== tileY;
         if (xCrossed && yCrossed) {
           // Diagonal tile crossing (issue #34 v4) — corner-cut prevention.
-          const destPassable = canEnterUndergroundTile(underground, newTileX, newTileY, AntTask.Idle);
+          const destPassable = canEnterUndergroundTile(
+            underground,
+            newTileX,
+            newTileY,
+            AntTask.Idle,
+          );
           const passXOnly = canEnterUndergroundTile(underground, newTileX, tileY, AntTask.Idle);
           const passYOnly = canEnterUndergroundTile(underground, tileX, newTileY, AntTask.Idle);
           if (destPassable && (passXOnly || passYOnly)) {
@@ -3773,10 +3842,7 @@ function moveQueens(
     }
 
     // Surface passability guard + detour.
-    if (
-      zone === Zone.Surface &&
-      (dx !== 0 || dy !== 0)
-    ) {
+    if (zone === Zone.Surface && (dx !== 0 || dy !== 0)) {
       const newTileX = posX >> FP_SHIFT;
       const newTileY = posY >> FP_SHIFT;
       const xCrossed = newTileX !== tileX;
@@ -3784,8 +3850,8 @@ function moveQueens(
       let blocked = false;
       if (xCrossed && yCrossed) {
         const destPassable = canEnterSurfaceTile(world, newTileX, newTileY);
-        const passXOnly    = canEnterSurfaceTile(world, newTileX, tileY);
-        const passYOnly    = canEnterSurfaceTile(world, tileX, newTileY);
+        const passXOnly = canEnterSurfaceTile(world, newTileX, tileY);
+        const passYOnly = canEnterSurfaceTile(world, tileX, newTileY);
         if (destPassable && (passXOnly || passYOnly)) {
           // Diagonal allowed.
         } else if (passXOnly) {
@@ -3822,11 +3888,15 @@ function moveQueens(
 
     // Clamp to zone bounds
     if (zone === Zone.Underground) {
-      if (posX < 0) posX = 0; else if (posX > undergroundMaxX) posX = undergroundMaxX;
-      if (posY < 0) posY = 0; else if (posY > undergroundMaxY) posY = undergroundMaxY;
+      if (posX < 0) posX = 0;
+      else if (posX > undergroundMaxX) posX = undergroundMaxX;
+      if (posY < 0) posY = 0;
+      else if (posY > undergroundMaxY) posY = undergroundMaxY;
     } else {
-      if (posX < 0) posX = 0; else if (posX > surfaceMaxX) posX = surfaceMaxX;
-      if (posY < 0) posY = 0; else if (posY > surfaceMaxY) posY = surfaceMaxY;
+      if (posX < 0) posX = 0;
+      else if (posX > surfaceMaxX) posX = surfaceMaxX;
+      if (posY < 0) posY = 0;
+      else if (posY > surfaceMaxY) posY = surfaceMaxY;
     }
 
     ants.posX[qId] = posX;
@@ -3839,7 +3909,11 @@ function moveQueens(
       const newTileY = posY >> FP_SHIFT;
       for (let e = 0; e < colony.entrances.length; e++) {
         const entrance = colony.entrances[e]!;
-        if (entrance.isOpen && entrance.surfaceTileX === newTileX && entrance.surfaceTileY === newTileY) {
+        if (
+          entrance.isOpen &&
+          entrance.surfaceTileX === newTileX &&
+          entrance.surfaceTileY === newTileY
+        ) {
           ants.zone[qId] = Zone.Underground;
           // Plan 09.1-00: every Surface→Underground transition must update
           // currentGridColonyId so the descending queen resolves to its own
@@ -3918,8 +3992,8 @@ function isDescentBlocked(
       queenId >= 0 &&
       ants.alive[queenId] === 1 &&
       ants.zone[queenId] === Zone.Surface &&
-      (ants.posX[queenId]! >> FP_SHIFT) === entranceTileX &&
-      (ants.posY[queenId]! >> FP_SHIFT) === entranceTileY
+      ants.posX[queenId]! >> FP_SHIFT === entranceTileX &&
+      ants.posY[queenId]! >> FP_SHIFT === entranceTileY
     ) {
       return true;
     }
@@ -4040,11 +4114,7 @@ export function tickAntMovement(
     // then row-major tile iteration — stable across ticks given stable inputs.
     let chamberTargetX = -1;
     let chamberTargetY = -1;
-    if (
-      zone === Zone.Underground &&
-      task === AntTask.Foraging &&
-      foodCarrying > 0
-    ) {
+    if (zone === Zone.Underground && task === AntTask.Foraging && foodCarrying > 0) {
       // colonyId keys the OWN-colony record (carriers deposit into their own
       // FoodStorage chambers — foragers never invade). gridColonyId keys the
       // underground grid the ant currently occupies (Phase 09.1 Chunk 0);
@@ -4111,8 +4181,7 @@ export function tickAntMovement(
           task === AntTask.Digging ||
           task === AntTask.Nursing ||
           (task === AntTask.Foraging && foodCarrying > 0) ||
-          (task === AntTask.Foraging &&
-           ants.subTask[id] === ForagingSubState.ReturningToNest);
+          (task === AntTask.Foraging && ants.subTask[id] === ForagingSubState.ReturningToNest);
       } else {
         // Zone.Underground — underground carriers compute an entrance target
         // whether or not a FoodStorage chamber exists, so the chamber-flow
@@ -4147,13 +4216,8 @@ export function tickAntMovement(
             const ent = colony.entrances[e]!;
             if (!ent.isOpen && !allowClosedEntrance) continue;
             const entDistY = zone === Zone.Surface ? ent.surfaceTileY : 0;
-            const dist =
-              Math.abs(ent.surfaceTileX - antTileX) + Math.abs(entDistY - antTileY);
-            if (
-              bestDist < 0 ||
-              dist < bestDist ||
-              (dist === bestDist && ent.entranceId < bestId)
-            ) {
+            const dist = Math.abs(ent.surfaceTileX - antTileX) + Math.abs(entDistY - antTileY);
+            if (bestDist < 0 || dist < bestDist || (dist === bestDist && ent.entranceId < bestId)) {
               bestDist = dist;
               bestId = ent.entranceId;
               entranceTargetX = ent.surfaceTileX << FP_SHIFT;
@@ -4219,9 +4283,15 @@ export function tickAntMovement(
             // corner-cut check passes. Foragers use their actual task for
             // passability (AntTask.Foraging blocks Marked tiles).
             diagonalizeFlowStep(
-              underground, flowField, tileX, tileY,
-              DIR_DX[dir]!, DIR_DY[dir]!,
-              task as AntTask, world.simVersion, cardinalStepScratch,
+              underground,
+              flowField,
+              tileX,
+              tileY,
+              DIR_DX[dir]!,
+              DIR_DY[dir]!,
+              task as AntTask,
+              world.simVersion,
+              cardinalStepScratch,
             );
             dx = cardinalStepScratch.dx;
             dy = cardinalStepScratch.dy;
@@ -4243,7 +4313,8 @@ export function tickAntMovement(
         // FP-era debt that dwarfs tile-era comparisons, producing long
         // one-axis stair-steps when an ant transitions between tasks.
         const step = pickCardinalStep(
-          ants, id,
+          ants,
+          id,
           (chamberTargetX >> FP_SHIFT) - (posX >> FP_SHIFT),
           (chamberTargetY >> FP_SHIFT) - (posY >> FP_SHIFT),
         );
@@ -4286,9 +4357,15 @@ export function tickAntMovement(
             // tile's flow direction is perpendicular and the corner-cut
             // check passes. Uses the ant's actual task for passability.
             diagonalizeFlowStep(
-              underground, flowField, tileX, tileY,
-              DIR_DX[dir]!, DIR_DY[dir]!,
-              task as AntTask, world.simVersion, cardinalStepScratch,
+              underground,
+              flowField,
+              tileX,
+              tileY,
+              DIR_DX[dir]!,
+              DIR_DY[dir]!,
+              task as AntTask,
+              world.simVersion,
+              cardinalStepScratch,
             );
             dx = cardinalStepScratch.dx;
             dy = cardinalStepScratch.dy;
@@ -4326,18 +4403,24 @@ export function tickAntMovement(
       const isHomeBoundForager =
         task === AntTask.Foraging &&
         (subTaskHere === ForagingSubState.CarryingFood ||
-         subTaskHere === ForagingSubState.ReturningToNest);
-      if (!stepped
-        && zone === Zone.Surface
-        && isHomeBoundForager
-        && entranceFlowFields !== undefined
+          subTaskHere === ForagingSubState.ReturningToNest);
+      if (
+        !stepped &&
+        zone === Zone.Surface &&
+        isHomeBoundForager &&
+        entranceFlowFields !== undefined
       ) {
         const colonyId = ants.colonyId[id]!;
         const surfaceField = entranceFlowFields.surface[colonyId];
         if (surfaceField) {
           const tileX = posX >> FP_SHIFT;
           const tileY = posY >> FP_SHIFT;
-          if (tileX >= 0 && tileX < SURFACE_GRID_WIDTH && tileY >= 0 && tileY < SURFACE_GRID_HEIGHT) {
+          if (
+            tileX >= 0 &&
+            tileX < SURFACE_GRID_WIDTH &&
+            tileY >= 0 &&
+            tileY < SURFACE_GRID_HEIGHT
+          ) {
             const sIdx = tileY * SURFACE_GRID_WIDTH + tileX;
             const sDir = surfaceField[sIdx]!;
             if (sDir === -1) {
@@ -4362,7 +4445,8 @@ export function tickAntMovement(
         // Issue #34 + codex coord-scale fix: tile-space deltas (see the
         // chamber-target site above for rationale).
         const step = pickCardinalStep(
-          ants, id,
+          ants,
+          id,
           (entranceTargetX >> FP_SHIFT) - (posX >> FP_SHIFT),
           (entranceTargetY >> FP_SHIFT) - (posY >> FP_SHIFT),
         );
@@ -4393,10 +4477,7 @@ export function tickAntMovement(
       // Throughput impact (v4 only): ~12% of search time paused with the
       // default constants (probability 1/50, duration 5-9 ticks). Tuned to
       // stay inside the ±15% throughput band acceptance criterion.
-      if (
-        ants.subTask[id] === ForagingSubState.SearchingFood &&
-        zone === Zone.Surface
-      ) {
+      if (ants.subTask[id] === ForagingSubState.SearchingFood && zone === Zone.Surface) {
         if (ants.searchPauseTicks[id]! > 0) {
           ants.searchPauseTicks[id] = ants.searchPauseTicks[id]! - 1;
           continue;
@@ -4410,7 +4491,7 @@ export function tickAntMovement(
           // 1 so total paused ticks (this trigger tick + next N decrements)
           // equals the (base + jitter) value the constants advertise.
           const jitter = rng.nextU32() % SEARCH_PAUSE_JITTER_TICKS;
-          ants.searchPauseTicks[id] = (SEARCH_PAUSE_BASE_TICKS + jitter) - 1;
+          ants.searchPauseTicks[id] = SEARCH_PAUSE_BASE_TICKS + jitter - 1;
           continue;
         }
       }
@@ -4424,7 +4505,8 @@ export function tickAntMovement(
         const posY = ants.posY[id]!;
         // Issue #34 + codex coord-scale fix: tile-space deltas.
         const step = pickCardinalStep(
-          ants, id,
+          ants,
+          id,
           (targetX >> FP_SHIFT) - (posX >> FP_SHIFT),
           (targetY >> FP_SHIFT) - (posY >> FP_SHIFT),
         );
@@ -4505,8 +4587,7 @@ export function tickAntMovement(
 
       const gridColonyId = ants.currentGridColonyId[id]!;
       const ownColonyId = ants.colonyId[id]!;
-      const isForeignGridUnderground =
-        zone === Zone.Underground && gridColonyId !== ownColonyId;
+      const isForeignGridUnderground = zone === Zone.Underground && gridColonyId !== ownColonyId;
 
       let rawDx = 0;
       let rawDy = 0;
@@ -4516,8 +4597,8 @@ export function tickAntMovement(
         const ownColony = world.colonies[ownColonyId];
         // null colony is treated as NOT recalled (matches isRecallingFromForeign guard
         // in skipAscent) — missing colony record is a defensive fallback, not a recall.
-        const isRecalling = ownColony != null
-          && (ownColony.targetRatio.fight === 0 || ownColony.rallyPoint == null);
+        const isRecalling =
+          ownColony != null && (ownColony.targetRatio.fight === 0 || ownColony.rallyPoint == null);
 
         if (isRecalling) {
           // Recalled invader: navigate toward the nearest foreign entrance exit
@@ -4534,9 +4615,14 @@ export function tickAntMovement(
             for (let ei = 1; ei < fEnts.length; ei++) {
               const candidate = fEnts[ei]!;
               const dist = Math.abs(candidate.surfaceTileX - antTileX) + antTileY;
-              const improves = candidate.isOpen && !bestIsOpen
-                || (candidate.isOpen === bestIsOpen && dist < bestDist);
-              if (improves) { bestEnt = candidate; bestDist = dist; bestIsOpen = candidate.isOpen; }
+              const improves =
+                (candidate.isOpen && !bestIsOpen) ||
+                (candidate.isOpen === bestIsOpen && dist < bestDist);
+              if (improves) {
+                bestEnt = candidate;
+                bestDist = dist;
+                bestIsOpen = candidate.isOpen;
+              }
             }
             rawDx = (bestEnt.surfaceTileX << FP_SHIFT) - posX;
             rawDy = -posY; // target underground Y=0 (entrance row)
@@ -4639,10 +4725,8 @@ export function tickAntMovement(
           // Bounds check — out-of-grid alternates clamp to a no-op step
           // and would stall the ant at the map edge. Reject before they
           // can be picked.
-          if (
-            candX < 0 || candX >= SURFACE_GRID_WIDTH ||
-            candY < 0 || candY >= SURFACE_GRID_HEIGHT
-          ) continue;
+          if (candX < 0 || candX >= SURFACE_GRID_WIDTH || candY < 0 || candY >= SURFACE_GRID_HEIGHT)
+            continue;
           if (isRecentTile(ants, id, candX, candY)) continue;
           dx = ax;
           dy = ay;
@@ -4686,9 +4770,12 @@ export function tickAntMovement(
             const candX = tileX + ax;
             const candY = tileY + ay;
             if (
-              candX < 0 || candX >= UNDERGROUND_GRID_WIDTH ||
-              candY < 0 || candY >= UNDERGROUND_GRID_HEIGHT
-            ) continue;
+              candX < 0 ||
+              candX >= UNDERGROUND_GRID_WIDTH ||
+              candY < 0 ||
+              candY >= UNDERGROUND_GRID_HEIGHT
+            )
+              continue;
             if (!canEnterUndergroundTile(underground, candX, candY, task as AntTask)) continue;
             if (isRecentTile(ants, id, candX, candY)) continue;
             dx = ax;
@@ -4713,7 +4800,10 @@ export function tickAntMovement(
     if (zone === Zone.Surface) {
       const tileX = prevPosX >> FP_SHIFT;
       const tileY = prevPosY >> FP_SHIFT;
-      if (surfaceMovementAtCached(world, tileX, tileY, surfaceMoveCache) === SurfaceMovementEffect.SoftCost) {
+      if (
+        surfaceMovementAtCached(world, tileX, tileY, surfaceMoveCache) ===
+        SurfaceMovementEffect.SoftCost
+      ) {
         const halved = baseSpeed >> 1;
         speed = halved < 1 ? 1 : halved;
       }
@@ -4748,9 +4838,24 @@ export function tickAntMovement(
           // BOTH intermediate cardinal tiles are blocked (squeezing through
           // a wall corner). When only one intermediate is open, drop the
           // other axis so the ant hugs that side.
-          const destPassable = canEnterUndergroundTile(underground, newTileX, newTileY, taskAsAntTask);
-          const passXOnly = canEnterUndergroundTile(underground, newTileX, prevTileY, taskAsAntTask);
-          const passYOnly = canEnterUndergroundTile(underground, prevTileX, newTileY, taskAsAntTask);
+          const destPassable = canEnterUndergroundTile(
+            underground,
+            newTileX,
+            newTileY,
+            taskAsAntTask,
+          );
+          const passXOnly = canEnterUndergroundTile(
+            underground,
+            newTileX,
+            prevTileY,
+            taskAsAntTask,
+          );
+          const passYOnly = canEnterUndergroundTile(
+            underground,
+            prevTileX,
+            newTileY,
+            taskAsAntTask,
+          );
           if (destPassable && (passXOnly || passYOnly)) {
             // Diagonal allowed — keep both axis updates.
           } else if (passXOnly) {
@@ -4784,10 +4889,7 @@ export function tickAntMovement(
     // twigs, leaves, big leaves) reject the step; pickSurfaceDetour finds
     // the best walkable adjacent tile. Pre-v6 saves replay with no surface
     // passability — same coordinate-only motion they recorded.
-    if (
-      zone === Zone.Surface &&
-      (dx !== 0 || dy !== 0)
-    ) {
+    if (zone === Zone.Surface && (dx !== 0 || dy !== 0)) {
       const prevTileX = prevPosX >> FP_SHIFT;
       const prevTileY = prevPosY >> FP_SHIFT;
       const newTileX = posX >> FP_SHIFT;
@@ -4804,10 +4906,12 @@ export function tickAntMovement(
         // when wedged against an obstacle (UAT round 2 stuck-ant repro,
         // ant 17 in seed 1790811502).
         const destPassable = canEnterSurfaceTile(world, newTileX, newTileY);
-        const passXOnly    = canEnterSurfaceTile(world, newTileX, prevTileY) &&
-                             !isRecentTile(ants, id, newTileX, prevTileY);
-        const passYOnly    = canEnterSurfaceTile(world, prevTileX, newTileY) &&
-                             !isRecentTile(ants, id, prevTileX, newTileY);
+        const passXOnly =
+          canEnterSurfaceTile(world, newTileX, prevTileY) &&
+          !isRecentTile(ants, id, newTileX, prevTileY);
+        const passYOnly =
+          canEnterSurfaceTile(world, prevTileX, newTileY) &&
+          !isRecentTile(ants, id, prevTileX, newTileY);
         if (destPassable && (passXOnly || passYOnly)) {
           // Diagonal allowed.
         } else if (passXOnly) {
@@ -4872,10 +4976,7 @@ export function tickAntMovement(
     // reversing onto the just-vacated cell (anti-backtrack). Only the
     // SearchingFood state needs this — CarryingFood/ReturningToNest paths
     // navigate by scent/target/entrance, not by scalar gradient.
-    if (
-      zone === Zone.Surface &&
-      task === AntTask.Foraging
-    ) {
+    if (zone === Zone.Surface && task === AntTask.Foraging) {
       // Issue #44 UAT round 2 fix: extended from SearchingFood-only to
       // ALL surface Foraging ants (CarryingFood, ReturningToNest too).
       // The recent-tiles ring buffer is now consulted by
@@ -4935,10 +5036,7 @@ export function tickAntMovement(
       // surface, flips back to SearchingFood, bumps its wave counter (capped
       // at SEARCH_LEASH_MAX_WAVE), and clears the heading so the next
       // excursion re-derives an outward direction from the entrance.
-      if (
-        task === AntTask.Foraging &&
-        ants.subTask[id] === ForagingSubState.ReturningToNest
-      ) {
+      if (task === AntTask.Foraging && ants.subTask[id] === ForagingSubState.ReturningToNest) {
         const tileXR = posX >> FP_SHIFT;
         const tileYR = posY >> FP_SHIFT;
         const colonyIdR = ants.colonyId[id]!;
@@ -4950,9 +5048,8 @@ export function tickAntMovement(
               ants.subTask[id] = ForagingSubState.SearchingFood;
               const curWave = ants.searchWave[id]!;
               const nextWave = curWave + 1;
-              ants.searchWave[id] = nextWave > SEARCH_LEASH_MAX_WAVE
-                ? SEARCH_LEASH_MAX_WAVE
-                : nextWave;
+              ants.searchWave[id] =
+                nextWave > SEARCH_LEASH_MAX_WAVE ? SEARCH_LEASH_MAX_WAVE : nextWave;
               ants.searchHeadingX[id] = 0;
               ants.searchHeadingY[id] = 0;
               ants.searchHeadingTicks[id] = 0;
@@ -5099,9 +5196,10 @@ export function tickAntMovement(
           // Recalled invaders (fight ratio zeroed or rally cleared) must be able to
           // exit the enemy underground, so skipAscent is cleared for them.
           const ownColonyForAscent = world.colonies[ants.colonyId[id]!];
-          const isRecallingFromForeign = !inOwnGrid
-            && ownColonyForAscent != null
-            && (ownColonyForAscent.targetRatio.fight === 0 || ownColonyForAscent.rallyPoint == null);
+          const isRecallingFromForeign =
+            !inOwnGrid &&
+            ownColonyForAscent != null &&
+            (ownColonyForAscent.targetRatio.fight === 0 || ownColonyForAscent.rallyPoint == null);
           const skipAscent = task === AntTask.Fighting && !inOwnGrid && !isRecallingFromForeign;
           if (!skipAscent) {
             const lookupColonyId = ants.currentGridColonyId[id]!;
@@ -5126,7 +5224,6 @@ export function tickAntMovement(
         }
       }
     }
-
   }
 
   // POST-PASS: resolve same-colony occupancy after every ant has moved and
@@ -5295,10 +5392,7 @@ function isOccupancyExempt(
     const chamber = colony.chambers[c]!;
     const bx = chamber.posX >> FP_SHIFT;
     const by = chamber.posY >> FP_SHIFT;
-    if (
-      tileX >= bx && tileX < bx + chamber.width &&
-      tileY >= by && tileY < by + chamber.height
-    ) {
+    if (tileX >= bx && tileX < bx + chamber.width && tileY >= by && tileY < by + chamber.height) {
       return true;
     }
   }

--- a/src/sim/ant/surface-passability.test.ts
+++ b/src/sim/ant/surface-passability.test.ts
@@ -21,11 +21,7 @@ import {
   SIM_VERSION_V7_SURFACE_PASSABILITY,
 } from '../types.js';
 import { initAnt, pushRecentTile } from './ant-store.js';
-import {
-  canEnterSurfaceTile,
-  pickSurfaceDetour,
-  tickAntMovement,
-} from './ant-system.js';
+import { canEnterSurfaceTile, pickSurfaceDetour, tickAntMovement } from './ant-system.js';
 import { surfaceFeatureAt, SurfaceMovementEffect } from '../surface-features.js';
 import { AntTask, ForagingSubState } from '../enums.js';
 import { Zone } from '../terrain.js';
@@ -135,19 +131,18 @@ describe('pickSurfaceDetour', () => {
     // corner; the returned step must NOT be a diagonal whose two
     // intermediate cardinals are both blocked.
     let foundCorner = false;
-    seedLoop:
-    for (let seed = 1; seed < 50; seed++) {
+    seedLoop: for (let seed = 1; seed < 50; seed++) {
       const world = createWorldState(seed);
       for (let y = 5; y < 80; y++) {
         for (let x = 5; x < 80; x++) {
           // Try all 4 diagonal directions for the squeeze geometry.
           for (let s = 0; s < 4; s++) {
-            const ddx = s === 0 || s === 1 ?  1 : -1;
-            const ddy = s === 0 || s === 2 ?  1 : -1;
-            const here       = canEnterSurfaceTile(world, x, y);
-            const diag       = canEnterSurfaceTile(world, x + ddx, y + ddy);
-            const interX     = canEnterSurfaceTile(world, x + ddx, y);
-            const interY     = canEnterSurfaceTile(world, x, y + ddy);
+            const ddx = s === 0 || s === 1 ? 1 : -1;
+            const ddy = s === 0 || s === 2 ? 1 : -1;
+            const here = canEnterSurfaceTile(world, x, y);
+            const diag = canEnterSurfaceTile(world, x + ddx, y + ddy);
+            const interX = canEnterSurfaceTile(world, x + ddx, y);
+            const interY = canEnterSurfaceTile(world, x, y + ddy);
             if (here && diag && !interX && !interY) {
               foundCorner = true;
               // Call the detour with intent EXACTLY toward the diagonal.
@@ -192,19 +187,18 @@ describe('pickSurfaceDetour', () => {
     // east-of-here target. Pre-fix the picker would never return that
     // diagonal; post-fix it does.
     let foundCase = false;
-    seedLoop:
-    for (let seed = 1; seed < 50; seed++) {
+    seedLoop: for (let seed = 1; seed < 50; seed++) {
       const world = createWorldState(seed);
       for (let y = 5; y < 60; y++) {
         for (let x = 5; x < 60; x++) {
           const here = canEnterSurfaceTile(world, x, y);
           if (!here) continue;
           // Intent: east. East tile blocked, NE walkable.
-          const east  = canEnterSurfaceTile(world, x + 1, y);
-          const ne    = canEnterSurfaceTile(world, x + 1, y - 1);
+          const east = canEnterSurfaceTile(world, x + 1, y);
+          const ne = canEnterSurfaceTile(world, x + 1, y - 1);
           const north = canEnterSurfaceTile(world, x, y - 1);
-          if (east) continue;            // east must be the blocker
-          if (!ne)  continue;            // NE must be a candidate
+          if (east) continue; // east must be the blocker
+          if (!ne) continue; // NE must be a candidate
           // For the diagonal NE corner-cut check to pass, intermediate
           // cardinals (E or N) must include at least one walkable.
           // E is blocked here; require N walkable so corner-cut allows.
@@ -220,7 +214,7 @@ describe('pickSurfaceDetour', () => {
           const det = pickSurfaceDetour(world, x, y, 1, 0);
           const detTargetX = x + 1;
           const detTargetY = y;
-          const score = Math.abs((x + det.dx) - detTargetX) + Math.abs((y + det.dy) - detTargetY);
+          const score = Math.abs(x + det.dx - detTargetX) + Math.abs(y + det.dy - detTargetY);
           expect(score).toBeLessThanOrEqual(1);
           break seedLoop;
         }
@@ -257,7 +251,7 @@ describe('pickSurfaceDetour', () => {
       if (
         canEnterSurfaceTile(w, ANT_X + 1, ANT_Y) &&
         canEnterSurfaceTile(w, ANT_X + 1, ANT_Y + 1) &&
-        canEnterSurfaceTile(w, ANT_X,     ANT_Y + 1)
+        canEnterSurfaceTile(w, ANT_X, ANT_Y + 1)
       ) {
         world = w;
         break;
@@ -276,9 +270,9 @@ describe('pickSurfaceDetour', () => {
     // Push all THREE walkable neighbors into the recent buffer. Since
     // RECENT_TILES_LEN is 4, the ring isn't even full — every walkable
     // candidate is guaranteed to be recent.
-    pushRecentTile(w.ants, antId, ANT_X + 1, ANT_Y);     // E
+    pushRecentTile(w.ants, antId, ANT_X + 1, ANT_Y); // E
     pushRecentTile(w.ants, antId, ANT_X + 1, ANT_Y + 1); // SE
-    pushRecentTile(w.ants, antId, ANT_X,     ANT_Y + 1); // S
+    pushRecentTile(w.ants, antId, ANT_X, ANT_Y + 1); // S
 
     // Intent east. With all walkable neighbors recent, pre-fix returns
     // (0, 0) and the ant deadlocks; post-fix falls back to the best
@@ -297,7 +291,6 @@ describe('pickSurfaceDetour', () => {
       (det.dx === 0 && det.dy === 1);
     expect(isOneOfRecent).toBe(true);
   });
-
 
   it('prefers cardinal slip on intended axis as the first probe', () => {
     // Construct a synthetic test by checking the well-defined order:
@@ -358,7 +351,8 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
         const east = surfaceFeatureAt(world, x + 1, y);
         if (
           (open === null || open.movement !== SurfaceMovementEffect.HardBlock) &&
-          east !== null && east.movement === SurfaceMovementEffect.HardBlock
+          east !== null &&
+          east.movement === SurfaceMovementEffect.HardBlock
         ) {
           pair = { open: { x, y }, blocked: { x: x + 1, y } };
           break;
@@ -370,12 +364,14 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
     // Install a colony with an entrance far east of the obstacle so the
     // ant routes that direction.
     const colony = createColonyRecord(1, 0);
-    colony.entrances = [{
-      entranceId: 0,
-      surfaceTileX: pair!.blocked.x + 10,
-      surfaceTileY: pair!.blocked.y,
-      isOpen: true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: 0,
+        surfaceTileX: pair!.blocked.x + 10,
+        surfaceTileY: pair!.blocked.y,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[1] = colony;
@@ -393,7 +389,8 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
     const endTileX = world.ants.posX[id]! >> FP_SHIFT;
     const endTileY = world.ants.posY[id]! >> FP_SHIFT;
     expect(endTileX === blockedTileX && endTileY === blockedTileY).toBe(false);
-    void startTileX; void startTileY;
+    void startTileX;
+    void startTileY;
   });
 
   it('under v7 — ant on a SoftCost (grass/bush) tile moves exactly half its base speed (issue #44 step 5)', () => {
@@ -419,7 +416,8 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
         const cur = surfaceFeatureAt(world, x, y);
         const east = surfaceFeatureAt(world, x + 1, y);
         if (
-          cur !== null && cur.movement === SurfaceMovementEffect.SoftCost &&
+          cur !== null &&
+          cur.movement === SurfaceMovementEffect.SoftCost &&
           (east === null || east.movement !== SurfaceMovementEffect.HardBlock)
         ) {
           soft = { x, y };
@@ -430,12 +428,14 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
     expect(soft).not.toBeNull();
 
     const colony = createColonyRecord(1, 0);
-    colony.entrances = [{
-      entranceId: 0,
-      surfaceTileX: soft!.x + 30,
-      surfaceTileY: soft!.y,
-      isOpen: true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: 0,
+        surfaceTileX: soft!.x + 30,
+        surfaceTileY: soft!.y,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[1] = colony;
@@ -456,7 +456,7 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
     // above filtered out HardBlock east-neighbors, so the step is
     // accepted in full.
     const totalDelta = Math.abs(deltaX) + Math.abs(deltaY);
-    expect(totalDelta).toBe(FP_ONE >> 1);  // exactly 128 — half speed
+    expect(totalDelta).toBe(FP_ONE >> 1); // exactly 128 — half speed
   });
 
   it('under v7 — ant on a Cosmetic tile moves exactly its base speed (sanity, complements the SoftCost test)', () => {
@@ -476,12 +476,14 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
     expect(open).not.toBeNull();
 
     const colony = createColonyRecord(1, 0);
-    colony.entrances = [{
-      entranceId: 0,
-      surfaceTileX: open!.x + 30,
-      surfaceTileY: open!.y,
-      isOpen: true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: 0,
+        surfaceTileX: open!.x + 30,
+        surfaceTileY: open!.y,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[1] = colony;
@@ -496,7 +498,7 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
 
     // Full speed: cardinal step at FP_ONE = 256 sub-pixels.
     const totalDelta = Math.abs(deltaX) + Math.abs(deltaY);
-    expect(totalDelta).toBe(FP_ONE);  // exactly 256 — full speed
+    expect(totalDelta).toBe(FP_ONE); // exactly 256 — full speed
   });
 
   it('detour: ant blocked from preferred east step ends at a deterministic alternate tile (issue #44 step 6)', () => {
@@ -516,7 +518,8 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
           const east = surfaceFeatureAt(world, x + 1, y);
           if (
             (open === null || open.movement !== SurfaceMovementEffect.HardBlock) &&
-            east !== null && east.movement === SurfaceMovementEffect.HardBlock
+            east !== null &&
+            east.movement === SurfaceMovementEffect.HardBlock
           ) {
             pair = { open: { x, y }, blocked: { x: x + 1, y } };
             break;
@@ -526,12 +529,14 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
       if (pair === null) throw new Error('no test pair found for seed');
 
       const colony = createColonyRecord(1, 0);
-      colony.entrances = [{
-        entranceId: 0,
-        surfaceTileX: pair.blocked.x + 10,
-        surfaceTileY: pair.blocked.y,
-        isOpen: true,
-      }];
+      colony.entrances = [
+        {
+          entranceId: 0,
+          surfaceTileX: pair.blocked.x + 10,
+          surfaceTileY: pair.blocked.y,
+          isOpen: true,
+        },
+      ];
       colony.rallyPoint = null;
       colony.digFlowFieldDirty = false;
       world.colonies[1] = colony;
@@ -563,16 +568,16 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
     let pickedT: { x: number; y: number } | null = null;
     for (let y = 5; y < 80 && pickedT === null; y++) {
       for (let x = 5; x < 80; x++) {
-        const here  = surfaceFeatureAt(world, x, y);
+        const here = surfaceFeatureAt(world, x, y);
         const north = surfaceFeatureAt(world, x, y - 1);
-        const east  = surfaceFeatureAt(world, x + 1, y);
+        const east = surfaceFeatureAt(world, x + 1, y);
         const south = surfaceFeatureAt(world, x, y + 1);
-        const west  = surfaceFeatureAt(world, x - 1, y);
-        const hereOk  = here === null || here.movement !== SurfaceMovementEffect.HardBlock;
+        const west = surfaceFeatureAt(world, x - 1, y);
+        const hereOk = here === null || here.movement !== SurfaceMovementEffect.HardBlock;
         const northBlock = north !== null && north.movement === SurfaceMovementEffect.HardBlock;
-        const eastOk  = east === null || east.movement !== SurfaceMovementEffect.HardBlock;
+        const eastOk = east === null || east.movement !== SurfaceMovementEffect.HardBlock;
         const southOk = south === null || south.movement !== SurfaceMovementEffect.HardBlock;
-        const westOk  = west === null || west.movement !== SurfaceMovementEffect.HardBlock;
+        const westOk = west === null || west.movement !== SurfaceMovementEffect.HardBlock;
         if (hereOk && northBlock && eastOk && southOk && westOk) {
           pickedT = { x, y };
           break;
@@ -582,7 +587,9 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
     expect(pickedT).not.toBeNull();
 
     const colony = createColonyRecord(1, 0);
-    colony.entrances = []; colony.rallyPoint = null; colony.digFlowFieldDirty = false;
+    colony.entrances = [];
+    colony.rallyPoint = null;
+    colony.digFlowFieldDirty = false;
     world.colonies[1] = colony;
 
     // Spawn two stationary ants at T. Both have no movement → both end at T
@@ -615,8 +622,7 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
     expect(bX === pickedT!.x && bY === pickedT!.y - 1).toBe(false);
   });
 
-
-  it('SoftCost slowdown clamps to min 1 (speed=1 stays at 1, doesn\'t go to 0)', () => {
+  it("SoftCost slowdown clamps to min 1 (speed=1 stays at 1, doesn't go to 0)", () => {
     // Edge case: an ant with the absolute minimum nonzero speed (1) on a
     // SoftCost tile. Half of 1 is 0; the clamp must keep it at 1 so the
     // ant isn't permanently stuck. Verify by reading effective speed via
@@ -635,12 +641,14 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
     expect(soft).not.toBeNull();
 
     const colony = createColonyRecord(1, 0);
-    colony.entrances = [{
-      entranceId: 0,
-      surfaceTileX: soft!.x + 30,
-      surfaceTileY: soft!.y,
-      isOpen: true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: 0,
+        surfaceTileX: soft!.x + 30,
+        surfaceTileY: soft!.y,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
     world.colonies[1] = colony;
@@ -656,5 +664,4 @@ describe('tickAntMovement surface passability — gated on simVersion', () => {
     // 1 sub-pixel per tick (the minimum quantum). NOT stuck.
     expect(endPosX).not.toBe(startPosX);
   });
-
 });

--- a/src/sim/behavior/allocation-system.test.ts
+++ b/src/sim/behavior/allocation-system.test.ts
@@ -61,10 +61,22 @@ describe('computeNurseCount — ceil(w/4) cap table', () => {
   // Fixed high brood (1000) so cap is always the binding constraint.
   const HIGH_BROOD = 1000;
   const table: Array<[number, number]> = [
-    [0, 0], [1, 1], [2, 1], [3, 1], [4, 1],
-    [5, 2], [6, 2], [7, 2], [8, 2],
-    [9, 3], [10, 3], [11, 3], [12, 3],
-    [13, 4], [16, 4], [17, 5],
+    [0, 0],
+    [1, 1],
+    [2, 1],
+    [3, 1],
+    [4, 1],
+    [5, 2],
+    [6, 2],
+    [7, 2],
+    [8, 2],
+    [9, 3],
+    [10, 3],
+    [11, 3],
+    [12, 3],
+    [13, 4],
+    [16, 4],
+    [17, 5],
   ];
   for (const [workers, expectedCap] of table) {
     it(`workers=${workers} → max nurses=${expectedCap}`, () => {
@@ -77,7 +89,7 @@ describe('computeNurseCount — ceil(w/4) cap table', () => {
 // allocateWorkers — PRD §8b' scenarios (Phase 10 two-role amendment)
 // ---------------------------------------------------------------------------
 
-describe('allocateWorkers — PRD §8b\' scenarios', () => {
+describe("allocateWorkers — PRD §8b' scenarios", () => {
   it('5. Nurse Carveout at High Brood: workerCount=3, broodCount=30, forage-only, hasNursery', () => {
     // floor(30/3)=10, cap ceil(3/4)=1 → nurse=1; available=2 → forage=2
     const result = allocateWorkers(3, 30, { forage: 10, fight: 0 }, true);
@@ -153,16 +165,16 @@ describe('allocateWorkers — edge cases', () => {
 describe('allocateWorkers — Phase 10 dig contract', () => {
   it('returned `dig` is 0 across many shape combinations (auto-dig owns the live value)', () => {
     const inputs: Array<[number, number, { forage: number; fight: number }, boolean]> = [
-      [10,  0,  { forage: 10, fight: 0 }, true],
-      [10,  0,  { forage: 0,  fight: 10 }, true],
-      [10,  0,  { forage: 1,  fight: 1 },  true],
-      [11,  0,  { forage: 1,  fight: 1 },  true],
-      [3,   30, { forage: 10, fight: 0 }, true],
-      [10,  3,  { forage: 10, fight: 0 }, true],
-      [10,  30, { forage: 1,  fight: 1 },  false],
-      [50,  0,  { forage: 10, fight: 5 },  true],
-      [0,   0,  { forage: 10, fight: 0 }, true],
-      [5,   0,  { forage: 0,  fight: 0 },  true],
+      [10, 0, { forage: 10, fight: 0 }, true],
+      [10, 0, { forage: 0, fight: 10 }, true],
+      [10, 0, { forage: 1, fight: 1 }, true],
+      [11, 0, { forage: 1, fight: 1 }, true],
+      [3, 30, { forage: 10, fight: 0 }, true],
+      [10, 3, { forage: 10, fight: 0 }, true],
+      [10, 30, { forage: 1, fight: 1 }, false],
+      [50, 0, { forage: 10, fight: 5 }, true],
+      [0, 0, { forage: 10, fight: 0 }, true],
+      [5, 0, { forage: 0, fight: 0 }, true],
     ];
     for (const [workers, brood, ratio, hasNursery] of inputs) {
       const result = allocateWorkers(workers, brood, ratio, hasNursery);
@@ -194,7 +206,7 @@ describe('allocateWorkers — 09 memo: hasNursery=false gate', () => {
   });
 
   it('no nursery + zero brood: identical to hasNursery=true (nurse=0 both ways)', () => {
-    const noNursery  = allocateWorkers(10, 0, { forage: 3, fight: 1 }, false);
+    const noNursery = allocateWorkers(10, 0, { forage: 3, fight: 1 }, false);
     const yesNursery = allocateWorkers(10, 0, { forage: 3, fight: 1 }, true);
     expect(noNursery).toEqual(yesNursery);
   });
@@ -236,26 +248,26 @@ describe('allocateWorkers — CTRL-04 immediate allocation', () => {
 
 describe('allocateWorkers — sum invariant', () => {
   const cases: Array<[number, number, { forage: number; fight: number }]> = [
-    [10,  5,  { forage: 3,  fight: 1 }],
-    [100, 50, { forage: 1,  fight: 1 }],
-    [1,   0,  { forage: 1,  fight: 0 }],
-    [50,  0,  { forage: 10, fight: 5 }],
-    [0,   0,  { forage: 10, fight: 0 }],
-    [20,  3,  { forage: 7,  fight: 1 }],
-    [15,  15, { forage: 1,  fight: 1 }],
-    [30,  90, { forage: 10, fight: 0 }],
-    [7,   6,  { forage: 2,  fight: 2 }],
-    [8,   0,  { forage: 3,  fight: 3 }],
-    [12,  9,  { forage: 5,  fight: 2 }],
-    [25,  0,  { forage: 10, fight: 0 }],
-    [5,   5,  { forage: 10, fight: 5 }],
-    [3,   3,  { forage: 1,  fight: 0 }],
-    [99,  0,  { forage: 4,  fight: 3 }],
-    [10,  30, { forage: 1,  fight: 0 }],
-    [6,   6,  { forage: 0,  fight: 10 }],
-    [40,  12, { forage: 6,  fight: 2 }],
-    [11,  0,  { forage: 1,  fight: 1 }],
-    [100, 0,  { forage: 10, fight: 0 }],
+    [10, 5, { forage: 3, fight: 1 }],
+    [100, 50, { forage: 1, fight: 1 }],
+    [1, 0, { forage: 1, fight: 0 }],
+    [50, 0, { forage: 10, fight: 5 }],
+    [0, 0, { forage: 10, fight: 0 }],
+    [20, 3, { forage: 7, fight: 1 }],
+    [15, 15, { forage: 1, fight: 1 }],
+    [30, 90, { forage: 10, fight: 0 }],
+    [7, 6, { forage: 2, fight: 2 }],
+    [8, 0, { forage: 3, fight: 3 }],
+    [12, 9, { forage: 5, fight: 2 }],
+    [25, 0, { forage: 10, fight: 0 }],
+    [5, 5, { forage: 10, fight: 5 }],
+    [3, 3, { forage: 1, fight: 0 }],
+    [99, 0, { forage: 4, fight: 3 }],
+    [10, 30, { forage: 1, fight: 0 }],
+    [6, 6, { forage: 0, fight: 10 }],
+    [40, 12, { forage: 6, fight: 2 }],
+    [11, 0, { forage: 1, fight: 1 }],
+    [100, 0, { forage: 10, fight: 0 }],
   ];
 
   it('15a. nurse + forage + fight === workerCount — hasNursery=true (Phase 10: dig is 0)', () => {

--- a/src/sim/behavior/allocation-system.ts
+++ b/src/sim/behavior/allocation-system.ts
@@ -105,7 +105,7 @@ export function allocateWorkers(
   // floors negatives to 0 so `(available * ratio.forage / total) | 0` cannot
   // produce a negative integer (which would yield a nonsense allocation).
   const forageWeight = Math.max(0, ratio.forage | 0);
-  const fightWeight  = Math.max(0, ratio.fight  | 0);
+  const fightWeight = Math.max(0, ratio.fight | 0);
 
   const total = forageWeight + fightWeight;
   if (total === 0 || available === 0) {
@@ -115,14 +115,14 @@ export function allocateWorkers(
   // eslint-disable-next-line no-restricted-syntax -- PRD §7b integer ratio, not float math
   const forage = ((available * forageWeight) / total) | 0;
   // eslint-disable-next-line no-restricted-syntax -- PRD §7b integer ratio, not float math
-  const fight  = ((available * fightWeight)  / total) | 0;
+  const fight = ((available * fightWeight) / total) | 0;
   const remainder = available - forage - fight;
 
   return {
-    nurse:  nurseCount,
+    nurse: nurseCount,
     forage: forage + (remainder > 0 ? 1 : 0),
-    dig:    0,
-    fight:  fight,
+    dig: 0,
+    fight: fight,
   };
 }
 
@@ -203,10 +203,26 @@ export function computeDigDemand(
     // mid-excavation would falsely report unreachable for one tick of
     // the dig cycle, briefly suppressing demand and causing the
     // forage-carve to wobble.
-    if (x > 0     && (data[i - 1] === UndergroundTileState.Open || data[i - 1] === UndergroundTileState.BeingDug)) return 1;
-    if (x < w - 1 && (data[i + 1] === UndergroundTileState.Open || data[i + 1] === UndergroundTileState.BeingDug)) return 1;
-    if (y > 0     && (data[i - w] === UndergroundTileState.Open || data[i - w] === UndergroundTileState.BeingDug)) return 1;
-    if (y < h - 1 && (data[i + w] === UndergroundTileState.Open || data[i + w] === UndergroundTileState.BeingDug)) return 1;
+    if (
+      x > 0 &&
+      (data[i - 1] === UndergroundTileState.Open || data[i - 1] === UndergroundTileState.BeingDug)
+    )
+      return 1;
+    if (
+      x < w - 1 &&
+      (data[i + 1] === UndergroundTileState.Open || data[i + 1] === UndergroundTileState.BeingDug)
+    )
+      return 1;
+    if (
+      y > 0 &&
+      (data[i - w] === UndergroundTileState.Open || data[i - w] === UndergroundTileState.BeingDug)
+    )
+      return 1;
+    if (
+      y < h - 1 &&
+      (data[i + w] === UndergroundTileState.Open || data[i + w] === UndergroundTileState.BeingDug)
+    )
+      return 1;
   }
   return 0;
 }

--- a/src/sim/bfs-flow-field.ts
+++ b/src/sim/bfs-flow-field.ts
@@ -73,10 +73,7 @@ export function bfsExpandSeededField(
       if (out[nIdx] !== -2) continue;
 
       const tileState = data[nIdx]!;
-      if (
-        tileState !== UndergroundTileState.Open &&
-        tileState !== UndergroundTileState.BeingDug
-      ) {
+      if (tileState !== UndergroundTileState.Open && tileState !== UndergroundTileState.BeingDug) {
         continue;
       }
 

--- a/src/sim/chamber-flow.test.ts
+++ b/src/sim/chamber-flow.test.ts
@@ -55,24 +55,49 @@ function setup(): Setup {
     for (let x = 5; x <= 40; x++) ugSet(underground, x, y, UndergroundTileState.Open);
   }
   const A: ChamberRecord = {
-    chamberId: 10, chamberType: ChamberType.Nursery, foodStored: 0,
-    posX: 10 << FP_SHIFT, posY: 4 << FP_SHIFT, width: 4, height: 3,
+    chamberId: 10,
+    chamberType: ChamberType.Nursery,
+    foodStored: 0,
+    posX: 10 << FP_SHIFT,
+    posY: 4 << FP_SHIFT,
+    width: 4,
+    height: 3,
   };
   const B: ChamberRecord = {
-    chamberId: 11, chamberType: ChamberType.Nursery, foodStored: 0,
-    posX: 30 << FP_SHIFT, posY: 4 << FP_SHIFT, width: 4, height: 3,
+    chamberId: 11,
+    chamberType: ChamberType.Nursery,
+    foodStored: 0,
+    posX: 30 << FP_SHIFT,
+    posY: 4 << FP_SHIFT,
+    width: 4,
+    height: 3,
   };
   colony.chambers.push(A, B);
-  return { world, colony, underground, A, B, field: new Int32Array(W * H), queue: new Int32Array(W * H) };
+  return {
+    world,
+    colony,
+    underground,
+    A,
+    B,
+    field: new Int32Array(W * H),
+    queue: new Int32Array(W * H),
+  };
 }
 
-function addResidentBrood(world: WorldState, colony: ColonyRecord, tileX: number, tileY: number): void {
+function addResidentBrood(
+  world: WorldState,
+  colony: ColonyRecord,
+  tileX: number,
+  tileY: number,
+): void {
   const id = allocateEntityId(world);
   initAnt(world.ants, id, {
     colonyId: COLONY_ID,
     posX: (tileX << FP_SHIFT) + (FP_ONE >> 1),
     posY: (tileY << FP_SHIFT) + (FP_ONE >> 1),
-    task: AntTask.Idle, speed: 0, zone: Zone.Underground,
+    task: AntTask.Idle,
+    speed: 0,
+    zone: Zone.Underground,
   });
   colony.eggs.push(id);
 }
@@ -113,13 +138,19 @@ describe('computeNurseryDepositField — capacity-aware routing (#173, V24)', ()
     fillNursery(world, colony, A); // A at capacity (12/12); B empty
 
     computeNurseryDepositField(
-      underground, colony.chambers, world.ants, colony.eggs, colony.larvae, field, queue,
+      underground,
+      colony.chambers,
+      world.ants,
+      colony.eggs,
+      colony.larvae,
+      field,
+      queue,
     );
 
     // B advertises (its Open tiles are sources); A does NOT (excluded — its
     // tiles are reachable toward B but are not sources).
-    expect(field[4 * W + 30]).toBe(-1);      // B corner (30,4) is a source
-    expect(field[4 * W + 10]).not.toBe(-1);  // A corner (10,4) is excluded
+    expect(field[4 * W + 30]).toBe(-1); // B corner (30,4) is a source
+    expect(field[4 * W + 10]).not.toBe(-1); // A corner (10,4) is excluded
 
     // A tile just east of A routes to B, not back into the full A.
     const term = followToSource(field, 14, 5);
@@ -145,7 +176,13 @@ describe('computeNurseryDepositField — capacity-aware routing (#173, V24)', ()
     fillNursery(world, colony, B);
 
     computeNurseryDepositField(
-      underground, colony.chambers, world.ants, colony.eggs, colony.larvae, field, queue,
+      underground,
+      colony.chambers,
+      world.ants,
+      colony.eggs,
+      colony.larvae,
+      field,
+      queue,
     );
 
     // Fallback seeds all Nurseries, so the pickup tile still routes to a target

--- a/src/sim/chamber-flow.ts
+++ b/src/sim/chamber-flow.ts
@@ -77,7 +77,14 @@ export interface ChamberFlowFields {
 }
 
 export function createChamberFlowFields(): ChamberFlowFields {
-  return { food: {}, nursing: {}, queen: {}, nurseDeposit: {}, queues: {}, depositReachVisited: {} };
+  return {
+    food: {},
+    nursing: {},
+    queen: {},
+    nurseDeposit: {},
+    queues: {},
+    depositReachVisited: {},
+  };
 }
 
 /**
@@ -91,19 +98,27 @@ export function ensureChamberFlowFields(
   cache: ChamberFlowFields,
   colonyId: ColonyId,
   gridSize: number,
-): { food: Int32Array; nursing: Int32Array; queen: Int32Array; nurseDeposit: Int32Array; queue: Int32Array; depositReachVisited: Int32Array } {
-  if (!(colonyId in cache.food))         cache.food[colonyId]         = new Int32Array(gridSize);
-  if (!(colonyId in cache.nursing))      cache.nursing[colonyId]      = new Int32Array(gridSize);
-  if (!(colonyId in cache.queen))        cache.queen[colonyId]        = new Int32Array(gridSize);
+): {
+  food: Int32Array;
+  nursing: Int32Array;
+  queen: Int32Array;
+  nurseDeposit: Int32Array;
+  queue: Int32Array;
+  depositReachVisited: Int32Array;
+} {
+  if (!(colonyId in cache.food)) cache.food[colonyId] = new Int32Array(gridSize);
+  if (!(colonyId in cache.nursing)) cache.nursing[colonyId] = new Int32Array(gridSize);
+  if (!(colonyId in cache.queen)) cache.queen[colonyId] = new Int32Array(gridSize);
   if (!(colonyId in cache.nurseDeposit)) cache.nurseDeposit[colonyId] = new Int32Array(gridSize);
-  if (!(colonyId in cache.queues))       cache.queues[colonyId]       = new Int32Array(gridSize);
-  if (!(colonyId in cache.depositReachVisited)) cache.depositReachVisited[colonyId] = new Int32Array(gridSize);
+  if (!(colonyId in cache.queues)) cache.queues[colonyId] = new Int32Array(gridSize);
+  if (!(colonyId in cache.depositReachVisited))
+    cache.depositReachVisited[colonyId] = new Int32Array(gridSize);
   return {
-    food:                cache.food[colonyId]!,
-    nursing:             cache.nursing[colonyId]!,
-    queen:               cache.queen[colonyId]!,
-    nurseDeposit:        cache.nurseDeposit[colonyId]!,
-    queue:               cache.queues[colonyId]!,
+    food: cache.food[colonyId]!,
+    nursing: cache.nursing[colonyId]!,
+    queen: cache.queen[colonyId]!,
+    nurseDeposit: cache.nurseDeposit[colonyId]!,
+    queue: cache.queues[colonyId]!,
     depositReachVisited: cache.depositReachVisited[colonyId]!,
   };
 }
@@ -152,7 +167,10 @@ export function computeChamberFlowField(
     const chamber = chambers[c]!;
     let matches = false;
     for (let t = 0; t < chamberTypes.length; t++) {
-      if (chamber.chamberType === chamberTypes[t]!) { matches = true; break; }
+      if (chamber.chamberType === chamberTypes[t]!) {
+        matches = true;
+        break;
+      }
     }
     if (!matches) continue;
     if (chamberFilter !== undefined && !chamberFilter(chamber)) continue;
@@ -221,10 +239,7 @@ function residentBroodInChamber(
       if (!isBroodReclaimable(ants, bid)) continue;
       const tx = ants.posX[bid]! >> FP_SHIFT;
       const ty = ants.posY[bid]! >> FP_SHIFT;
-      if (
-        tx >= bx && tx < bx + chamber.width &&
-        ty >= by && ty < by + chamber.height
-      ) count++;
+      if (tx >= bx && tx < bx + chamber.width && ty >= by && ty < by + chamber.height) count++;
     }
   }
   return count;
@@ -383,10 +398,7 @@ export function hasReachableNonFullNursery(
   queue: Int32Array,
 ): boolean {
   const { data, width, height } = underground;
-  if (
-    carrierTileX < 0 || carrierTileX >= width ||
-    carrierTileY < 0 || carrierTileY >= height
-  ) {
+  if (carrierTileX < 0 || carrierTileX >= width || carrierTileY < 0 || carrierTileY >= height) {
     return false;
   }
 
@@ -414,10 +426,7 @@ export function hasReachableNonFullNursery(
       const nIdx = nRow * width + nCol;
       if (visited[nIdx] === 1) continue;
       const tileState = data[nIdx]!;
-      if (
-        tileState !== UndergroundTileState.Open &&
-        tileState !== UndergroundTileState.BeingDug
-      ) {
+      if (tileState !== UndergroundTileState.Open && tileState !== UndergroundTileState.BeingDug) {
         continue;
       }
       visited[nIdx] = 1;
@@ -497,11 +506,11 @@ export const NURSERY_CHAMBER_TYPES: ReadonlyArray<ChamberType> = [ChamberType.Nu
 export function computeNursingPickupField(
   underground: UndergroundGrid,
   chambers: ReadonlyArray<ChamberRecord>,
-  ants:      AntComponents,
-  eggIds:    ReadonlyArray<number>,
+  ants: AntComponents,
+  eggIds: ReadonlyArray<number>,
   larvaeIds: ReadonlyArray<number>,
-  out:       Int32Array,
-  queue:     Int32Array,
+  out: Int32Array,
+  queue: Int32Array,
 ): void {
   const { data, width, height } = underground;
 
@@ -545,10 +554,7 @@ export function computeNursingPickupField(
         if (chamber.chamberType !== ChamberType.Nursery) continue;
         const bx = chamber.posX >> FP_SHIFT;
         const by = chamber.posY >> FP_SHIFT;
-        if (
-          tx >= bx && tx < bx + chamber.width &&
-          ty >= by && ty < by + chamber.height
-        ) {
+        if (tx >= bx && tx < bx + chamber.width && ty >= by && ty < by + chamber.height) {
           insideNursery = true;
           break;
         }
@@ -566,10 +572,8 @@ export function computeNursingPickupField(
       // ant-system.ts applies the same Open-or-BeingDug filter so the
       // field-seed-set and the release predicate agree exactly.
       const tileState = data[idx]!;
-      if (
-        tileState !== UndergroundTileState.Open &&
-        tileState !== UndergroundTileState.BeingDug
-      ) continue;
+      if (tileState !== UndergroundTileState.Open && tileState !== UndergroundTileState.BeingDug)
+        continue;
       if (out[idx] !== -2) continue;
       out[idx] = -1;
       queue[tail++] = idx;

--- a/src/sim/clny-08-guard.test.ts
+++ b/src/sim/clny-08-guard.test.ts
@@ -21,7 +21,7 @@ import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const HERE = fileURLToPath(new URL('.', import.meta.url));  // .../code/src/sim/
+const HERE = fileURLToPath(new URL('.', import.meta.url)); // .../code/src/sim/
 
 function listSimProductionFiles(root: string): string[] {
   const out: string[] = [];
@@ -30,11 +30,7 @@ function listSimProductionFiles(root: string): string[] {
     const stat = statSync(p);
     if (stat.isDirectory()) {
       out.push(...listSimProductionFiles(p));
-    } else if (
-      entry.endsWith('.ts') &&
-      !entry.endsWith('.test.ts') &&
-      !entry.endsWith('.d.ts')
-    ) {
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts') && !entry.endsWith('.d.ts')) {
       out.push(p);
     }
   }
@@ -42,32 +38,34 @@ function listSimProductionFiles(root: string): string[] {
 }
 
 function stripCommentsAndImports(source: string): string {
-  return source
-    // line comments
-    .replace(/\/\/.*$/gm, '')
-    // block comments (non-greedy, multiline)
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    // import statements (whole line) — keyed access inside imports is irrelevant
-    .replace(/^\s*import\s[^;]*;\s*$/gm, '');
+  return (
+    source
+      // line comments
+      .replace(/\/\/.*$/gm, '')
+      // block comments (non-greedy, multiline)
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      // import statements (whole line) — keyed access inside imports is irrelevant
+      .replace(/^\s*import\s[^;]*;\s*$/gm, '')
+  );
 }
 
 // Branching regexes. Each must match a branching USE, not a keyed access or call argument.
 const BRANCHING_PATTERNS: Array<{ name: string; re: RegExp }> = [
-  { name: '=== PLAYER_COLONY_ID',  re: /===\s*PLAYER_COLONY_ID\b/ },
-  { name: '!== PLAYER_COLONY_ID',  re: /!==\s*PLAYER_COLONY_ID\b/ },
-  { name: 'PLAYER_COLONY_ID ===',  re: /\bPLAYER_COLONY_ID\s*===/ },
-  { name: 'PLAYER_COLONY_ID !==',  re: /\bPLAYER_COLONY_ID\s*!==/ },
-  { name: '=== ENEMY_COLONY_ID',   re: /===\s*ENEMY_COLONY_ID\b/ },
-  { name: '!== ENEMY_COLONY_ID',   re: /!==\s*ENEMY_COLONY_ID\b/ },
-  { name: 'ENEMY_COLONY_ID ===',   re: /\bENEMY_COLONY_ID\s*===/ },
-  { name: 'ENEMY_COLONY_ID !==',   re: /\bENEMY_COLONY_ID\s*!==/ },
-  { name: 'isPlayer identifier',   re: /\bisPlayer\b/ },
-  { name: 'isEnemy identifier',    re: /\bisEnemy\b/ },
+  { name: '=== PLAYER_COLONY_ID', re: /===\s*PLAYER_COLONY_ID\b/ },
+  { name: '!== PLAYER_COLONY_ID', re: /!==\s*PLAYER_COLONY_ID\b/ },
+  { name: 'PLAYER_COLONY_ID ===', re: /\bPLAYER_COLONY_ID\s*===/ },
+  { name: 'PLAYER_COLONY_ID !==', re: /\bPLAYER_COLONY_ID\s*!==/ },
+  { name: '=== ENEMY_COLONY_ID', re: /===\s*ENEMY_COLONY_ID\b/ },
+  { name: '!== ENEMY_COLONY_ID', re: /!==\s*ENEMY_COLONY_ID\b/ },
+  { name: 'ENEMY_COLONY_ID ===', re: /\bENEMY_COLONY_ID\s*===/ },
+  { name: 'ENEMY_COLONY_ID !==', re: /\bENEMY_COLONY_ID\s*!==/ },
+  { name: 'isPlayer identifier', re: /\bisPlayer\b/ },
+  { name: 'isEnemy identifier', re: /\bisEnemy\b/ },
 ];
 
 // Carve-outs — file paths (relative to src/sim/) that are exempt from the scan.
 const CARVE_OUTS = new Set<string>([
-  'constants.ts',  // the definition site — exporting the symbols is not branching
+  'constants.ts', // the definition site — exporting the symbols is not branching
 ]);
 
 describe('CLNY-08 / SC 7 static branching guard', () => {

--- a/src/sim/colony/chamber.test.ts
+++ b/src/sim/colony/chamber.test.ts
@@ -39,12 +39,12 @@ describe('CHAMBER_DIMENSIONS', () => {
 describe('PendingChamber interface', () => {
   it('can be constructed with anchorTileX and anchorTileY (no chamberId field)', () => {
     const pending: PendingChamber = {
-      colonyId:    1,
+      colonyId: 1,
       chamberType: ChamberType.Queen,
       anchorTileX: 60,
       anchorTileY: 30,
-      width:       CHAMBER_DIMENSIONS[ChamberType.Queen].width,
-      height:      CHAMBER_DIMENSIONS[ChamberType.Queen].height,
+      width: CHAMBER_DIMENSIONS[ChamberType.Queen].width,
+      height: CHAMBER_DIMENSIONS[ChamberType.Queen].height,
     };
     expect(pending.anchorTileX).toBe(60);
     expect(pending.anchorTileY).toBe(30);
@@ -54,12 +54,12 @@ describe('PendingChamber interface', () => {
 
   it('PendingChamber has no chamberId field', () => {
     const pending: PendingChamber = {
-      colonyId:    1,
+      colonyId: 1,
       chamberType: ChamberType.Nursery,
       anchorTileX: 50,
       anchorTileY: 20,
-      width:       4,
-      height:      3,
+      width: 4,
+      height: 3,
     };
     // chamberId must not exist on the object
     expect('chamberId' in pending).toBe(false);
@@ -67,12 +67,12 @@ describe('PendingChamber interface', () => {
 
   it('can construct PendingChamber for FoodStorage', () => {
     const pending: PendingChamber = {
-      colonyId:    2,
+      colonyId: 2,
       chamberType: ChamberType.FoodStorage,
       anchorTileX: 100,
       anchorTileY: 50,
-      width:       CHAMBER_DIMENSIONS[ChamberType.FoodStorage].width,
-      height:      CHAMBER_DIMENSIONS[ChamberType.FoodStorage].height,
+      width: CHAMBER_DIMENSIONS[ChamberType.FoodStorage].width,
+      height: CHAMBER_DIMENSIONS[ChamberType.FoodStorage].height,
     };
     expect(pending.chamberType).toBe(ChamberType.FoodStorage);
     expect(pending.width).toBe(4);

--- a/src/sim/colony/chamber.ts
+++ b/src/sim/colony/chamber.ts
@@ -20,12 +20,12 @@ import type { ColonyId } from './colony-store.js';
 // ---------------------------------------------------------------------------
 
 export interface PendingChamber {
-  colonyId:     ColonyId;
-  chamberType:  ChamberType;
-  anchorTileX:  number;   // top-left tile X in underground grid
-  anchorTileY:  number;   // top-left tile Y in underground grid
-  width:        number;
-  height:       number;
+  colonyId: ColonyId;
+  chamberType: ChamberType;
+  anchorTileX: number; // top-left tile X in underground grid
+  anchorTileY: number; // top-left tile Y in underground grid
+  width: number;
+  height: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -35,7 +35,7 @@ export interface PendingChamber {
 // ---------------------------------------------------------------------------
 
 export const CHAMBER_DIMENSIONS: Record<ChamberType, { width: number; height: number }> = {
-  [0]: { width: 5, height: 3 },  // Queen:       5×3
-  [1]: { width: 4, height: 3 },  // Nursery:     4×3
-  [2]: { width: 4, height: 3 },  // FoodStorage: 4×3
+  [0]: { width: 5, height: 3 }, // Queen:       5×3
+  [1]: { width: 4, height: 3 }, // Nursery:     4×3
+  [2]: { width: 4, height: 3 }, // FoodStorage: 4×3
 };

--- a/src/sim/colony/colony-store.test.ts
+++ b/src/sim/colony/colony-store.test.ts
@@ -21,11 +21,7 @@
 import { describe, it, expect } from 'vitest';
 import { ChamberType } from '../enums.js';
 import { STARVATION_GRACE_TICKS, RECONCILE_INTERVAL_TICKS } from '../constants.js';
-import {
-  createColonyRecord,
-  createColonyStore,
-  type ChamberRecord,
-} from './colony-store.js';
+import { createColonyRecord, createColonyStore, type ChamberRecord } from './colony-store.js';
 
 describe('createColonyRecord', () => {
   it('(1) initial values match PRD §2 factory defaults', () => {
@@ -78,7 +74,7 @@ describe('createColonyRecord', () => {
     expect(b.taskCensus.forage).toBe(0);
   });
 
-  it('(5) DEFAULT_BEHAVIOR_RATIO shape: forage=10, fight=0 (Phase 10 amendment, CTRL-01\')', () => {
+  it("(5) DEFAULT_BEHAVIOR_RATIO shape: forage=10, fight=0 (Phase 10 amendment, CTRL-01')", () => {
     const r = createColonyRecord(1, 0);
     expect(r.targetRatio.forage).toBe(10);
     expect(r.targetRatio.fight).toBe(0);
@@ -160,7 +156,15 @@ describe('Phase 3 PRD §2a caller-side init contract', () => {
     a.workers.push(300);
     expect(b.workers.length).toBe(0);
 
-    a.chambers.push({ chamberId: 1, chamberType: 0, foodStored: 0, posX: 0, posY: 0, width: 5, height: 3 });
+    a.chambers.push({
+      chamberId: 1,
+      chamberType: 0,
+      foodStored: 0,
+      posX: 0,
+      posY: 0,
+      width: 5,
+      height: 3,
+    });
     expect(b.chambers.length).toBe(0);
 
     // targetRatio, computedAllocation, taskCensus must be independent objects
@@ -193,13 +197,13 @@ describe('createColonyStore', () => {
 describe('ChamberRecord', () => {
   it('(8) all fields are numeric (type-check-via-runtime — shape drift guard)', () => {
     const chamber: ChamberRecord = {
-      chamberId:   1,
+      chamberId: 1,
       chamberType: ChamberType.FoodStorage,
-      foodStored:  0,
-      posX:        512,
-      posY:        256,
-      width:       3,
-      height:      3,
+      foodStored: 0,
+      posX: 512,
+      posY: 256,
+      width: 3,
+      height: 3,
     };
     expect(typeof chamber.chamberId).toBe('number');
     expect(typeof chamber.chamberType).toBe('number');

--- a/src/sim/colony/colony-store.ts
+++ b/src/sim/colony/colony-store.ts
@@ -41,10 +41,10 @@ export type ColonyId = number;
 // ---------------------------------------------------------------------------
 
 export interface WorkerAllocation {
-  nurse:  number;
+  nurse: number;
   forage: number;
-  dig:    number;
-  fight:  number;
+  dig: number;
+  fight: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -59,7 +59,7 @@ export interface WorkerAllocation {
 
 export interface BehaviorRatio {
   forage: number;
-  fight:  number;
+  fight: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,13 +70,13 @@ export interface BehaviorRatio {
 // ---------------------------------------------------------------------------
 
 export interface ChamberRecord {
-  chamberId:   EntityId;
+  chamberId: EntityId;
   chamberType: ChamberType;
-  foodStored:  number;
-  posX:        number;
-  posY:        number;
-  width:       number;
-  height:      number;
+  foodStored: number;
+  posX: number;
+  posY: number;
+  width: number;
+  height: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -97,29 +97,29 @@ export interface ChamberRecord {
 // ---------------------------------------------------------------------------
 
 export interface ColonyRecord {
-  colonyId:              ColonyId;
-  queenEntityId:         EntityId;
-  queenStarvationTimer:  number;
-  foodStored:            number;
-  workerCount:           number;
-  eggCount:              number;
-  larvaeCount:           number;
-  nurseCount:            number;
-  eggs:                  EntityId[];
-  larvae:                EntityId[];
-  workers:               EntityId[];
-  chambers:              ChamberRecord[];
-  targetRatio:           BehaviorRatio;
-  computedAllocation:    WorkerAllocation;
+  colonyId: ColonyId;
+  queenEntityId: EntityId;
+  queenStarvationTimer: number;
+  foodStored: number;
+  workerCount: number;
+  eggCount: number;
+  larvaeCount: number;
+  nurseCount: number;
+  eggs: EntityId[];
+  larvae: EntityId[];
+  workers: EntityId[];
+  chambers: ChamberRecord[];
+  targetRatio: BehaviorRatio;
+  computedAllocation: WorkerAllocation;
   /**
    * Per-task worker counts written at the end of PRD §8a step 9 (Plan 10). Invariants:
    *   (1) Every field is non-negative: `taskCensus.{nurse,forage,dig,fight} >= 0`.
    *   (2) Sum is bounded by workerCount: `nurse + forage + dig + fight === workerCount - (ants whose task is AntTask.Idle post-step-9)`. In Phase 6 steady state step 9 reassigns every idle-checkpoint ant, so the sum equals `workerCount` once all eligible idle ants have been rehomed.
    * Step 9 writes this field after reconciling actual-per-task counters against `computedAllocation`; see Plan 10 Test 14b for the regression guard.
    */
-  taskCensus:            WorkerAllocation;
-  defeated:              boolean;
-  reconcileCountdown:    number;
+  taskCensus: WorkerAllocation;
+  defeated: boolean;
+  reconcileCountdown: number;
 
   /** Phase 3 PRD §2 — nest entrances (max MAX_ENTRANCES_PER_COLONY = 4). Assigned caller-side (PRD §2a extension contract); the Phase 2 factory body does not initialize this field. */
   entrances: NestEntrance[];
@@ -203,29 +203,29 @@ export function createColonyRecord(colonyId: ColonyId, queenEntityId: EntityId):
   // (see createScenario in Plan 07, and the new-colony fallback in copyWorldState
   // in Task 2 below). The `as unknown as ColonyRecord` assertion reflects that the
   // object is complete only after the caller assigns the Phase 3 defaults.
-  return ({
+  return {
     colonyId,
     queenEntityId,
-    queenStarvationTimer:  STARVATION_GRACE_TICKS,
-    foodStored:            0,
-    workerCount:           0,
-    eggCount:              0,
-    larvaeCount:           0,
-    nurseCount:            0,
-    eggs:                  [],
-    larvae:                [],
-    workers:               [],
-    chambers:              [],
-    targetRatio:           { ...DEFAULT_BEHAVIOR_RATIO },
-    computedAllocation:    { nurse: 0, forage: 0, dig: 0, fight: 0 },
-    taskCensus:            { nurse: 0, forage: 0, dig: 0, fight: 0 },
-    defeated:              false,
-    reconcileCountdown:    RECONCILE_INTERVAL_TICKS,
-    killCount:             0,
-    priorityFoodPileId:    null,
-    queenLastEggTick:      -QUEEN_EGG_INTERVAL_BASE_TICKS,
-    eggIntervalNumerator:  4, // Normal = identity (set per-colony in createScenario for difficulty tiers)
-  }) as unknown as ColonyRecord;
+    queenStarvationTimer: STARVATION_GRACE_TICKS,
+    foodStored: 0,
+    workerCount: 0,
+    eggCount: 0,
+    larvaeCount: 0,
+    nurseCount: 0,
+    eggs: [],
+    larvae: [],
+    workers: [],
+    chambers: [],
+    targetRatio: { ...DEFAULT_BEHAVIOR_RATIO },
+    computedAllocation: { nurse: 0, forage: 0, dig: 0, fight: 0 },
+    taskCensus: { nurse: 0, forage: 0, dig: 0, fight: 0 },
+    defeated: false,
+    reconcileCountdown: RECONCILE_INTERVAL_TICKS,
+    killCount: 0,
+    priorityFoodPileId: null,
+    queenLastEggTick: -QUEEN_EGG_INTERVAL_BASE_TICKS,
+    eggIntervalNumerator: 4, // Normal = identity (set per-colony in createScenario for difficulty tiers)
+  } as unknown as ColonyRecord;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sim/colony/colony-system.test.ts
+++ b/src/sim/colony/colony-system.test.ts
@@ -173,25 +173,35 @@ describe('withdrawFood', () => {
   it('drains chambers before the entrance pool (issue #15)', () => {
     const { colony } = setupWorldWithQueen(100);
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: 200,
-      posX: 0, posY: 0, width: 1, height: 1,
+      chamberId: 1,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 200,
+      posX: 0,
+      posY: 0,
+      width: 1,
+      height: 1,
     });
     const result = withdrawFood(colony, 50, LATEST_SIM_VERSION);
     expect(result).toBe(true);
     expect(colony.chambers[0]!.foodStored).toBe(150); // chamber drained
-    expect(colony.foodStored).toBe(100);              // pool untouched
+    expect(colony.foodStored).toBe(100); // pool untouched
   });
 
   it('drains the entrance pool only after every chamber is empty (issue #15)', () => {
     const { colony } = setupWorldWithQueen(100);
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: 30,
-      posX: 0, posY: 0, width: 1, height: 1,
+      chamberId: 1,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 30,
+      posX: 0,
+      posY: 0,
+      width: 1,
+      height: 1,
     });
     const result = withdrawFood(colony, 50, LATEST_SIM_VERSION);
     expect(result).toBe(true);
-    expect(colony.chambers[0]!.foodStored).toBe(0);   // chamber drained first
-    expect(colony.foodStored).toBe(80);               // remaining 20 from pool
+    expect(colony.chambers[0]!.foodStored).toBe(0); // chamber drained first
+    expect(colony.foodStored).toBe(80); // remaining 20 from pool
   });
 
   it('sets foodFlowFieldDirty only on saturated→depositable transitions (issue #15 follow-up)', () => {
@@ -206,14 +216,24 @@ describe('withdrawFood', () => {
     // Chamber 0: full → still saturated after small drains until we reach
     // the depositable threshold (free space >= HYST).
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: FOOD_CHAMBER_CAPACITY,
-      posX: 0, posY: 0, width: 1, height: 1,
+      chamberId: 1,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: FOOD_CHAMBER_CAPACITY,
+      posX: 0,
+      posY: 0,
+      width: 1,
+      height: 1,
     });
     // Chamber 1: starts depositable (free space > HYST) — drains within the
     // depositable band must NOT fire dirty.
     colony.chambers.push({
-      chamberId: 2, chamberType: ChamberType.FoodStorage, foodStored: 100,
-      posX: 0, posY: 0, width: 1, height: 1,
+      chamberId: 2,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 100,
+      posX: 0,
+      posY: 0,
+      width: 1,
+      height: 1,
     });
     colony.foodFlowFieldDirty = false;
 
@@ -269,12 +289,22 @@ describe('colonyFoodTotal — issue #15', () => {
   it('includes FoodStorage chamber food in the total', () => {
     const { colony } = setupWorldWithQueen(0);
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: 200,
-      posX: 0, posY: 0, width: 1, height: 1,
+      chamberId: 1,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 200,
+      posX: 0,
+      posY: 0,
+      width: 1,
+      height: 1,
     });
     colony.chambers.push({
-      chamberId: 2, chamberType: ChamberType.FoodStorage, foodStored: 50,
-      posX: 0, posY: 0, width: 1, height: 1,
+      chamberId: 2,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 50,
+      posX: 0,
+      posY: 0,
+      width: 1,
+      height: 1,
     });
     expect(colonyFoodTotal(colony)).toBe(250);
   });
@@ -282,8 +312,13 @@ describe('colonyFoodTotal — issue #15', () => {
   it('sums entrance pool + every FoodStorage chamber', () => {
     const { colony } = setupWorldWithQueen(100);
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: 200,
-      posX: 0, posY: 0, width: 1, height: 1,
+      chamberId: 1,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 200,
+      posX: 0,
+      posY: 0,
+      width: 1,
+      height: 1,
     });
     expect(colonyFoodTotal(colony)).toBe(300);
   });
@@ -292,12 +327,22 @@ describe('colonyFoodTotal — issue #15', () => {
     const { colony } = setupWorldWithQueen(100);
     // A non-FoodStorage chamber's foodStored is meaningless — must not contribute.
     colony.chambers.push({
-      chamberId: 1, chamberType: ChamberType.Queen, foodStored: 999,
-      posX: 0, posY: 0, width: 1, height: 1,
+      chamberId: 1,
+      chamberType: ChamberType.Queen,
+      foodStored: 999,
+      posX: 0,
+      posY: 0,
+      width: 1,
+      height: 1,
     });
     colony.chambers.push({
-      chamberId: 2, chamberType: ChamberType.Nursery, foodStored: 999,
-      posX: 0, posY: 0, width: 1, height: 1,
+      chamberId: 2,
+      chamberType: ChamberType.Nursery,
+      foodStored: 999,
+      posX: 0,
+      posY: 0,
+      width: 1,
+      height: 1,
     });
     expect(colonyFoodTotal(colony)).toBe(100);
   });
@@ -479,8 +524,8 @@ describe('tickDeathCleanup', () => {
 
     expect(colony.workers).toHaveLength(2);
     expect(colony.workers).not.toContain(id2); // removed
-    expect(colony.workers).toContain(id1);     // still present
-    expect(colony.workers).toContain(id3);     // still present
+    expect(colony.workers).toContain(id1); // still present
+    expect(colony.workers).toContain(id3); // still present
     expect(colony.workerCount).toBe(2);
   });
 
@@ -499,17 +544,17 @@ describe('tickDeathCleanup', () => {
     const { world, colony } = setupWorldWithQueen();
 
     // Add entities to all three buckets
-    const egg1  = addEgg(world, colony);
-    const egg2  = addEgg(world, colony);
-    const lar1  = addLarva(world, colony);
-    const lar2  = addLarva(world, colony);
-    const wrk1  = addWorker(world, colony);
-    const wrk2  = addWorker(world, colony);
+    const egg1 = addEgg(world, colony);
+    const egg2 = addEgg(world, colony);
+    const lar1 = addLarva(world, colony);
+    const lar2 = addLarva(world, colony);
+    const wrk1 = addWorker(world, colony);
+    const wrk2 = addWorker(world, colony);
 
     // Kill one from each bucket
-    world.ants.alive[egg1]  = 0;
-    world.ants.alive[lar1]  = 0;
-    world.ants.alive[wrk1]  = 0;
+    world.ants.alive[egg1] = 0;
+    world.ants.alive[lar1] = 0;
+    world.ants.alive[wrk1] = 0;
 
     tickDeathCleanup(world, colony);
 
@@ -543,17 +588,39 @@ describe('colonyFoodCapacity', () => {
 
   it('base + 1× FoodStorage chamber → BASE + 1 × FOOD_CHAMBER_CAPACITY', () => {
     const { colony } = setupWorldWithQueen();
-    colony.chambers.push(
-      { chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: 0, posX: 0, posY: 0, width: 3, height: 3 },
-    );
+    colony.chambers.push({
+      chamberId: 100,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 0,
+      posX: 0,
+      posY: 0,
+      width: 3,
+      height: 3,
+    });
     expect(colonyFoodCapacity(colony)).toBe(BASE_FOOD_STORAGE_CAPACITY + FOOD_CHAMBER_CAPACITY);
   });
 
   it('base + 2× FoodStorage chamber → BASE + 2 × FOOD_CHAMBER_CAPACITY', () => {
     const { colony } = setupWorldWithQueen();
     colony.chambers.push(
-      { chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: 0, posX: 0, posY: 0, width: 3, height: 3 },
-      { chamberId: 101, chamberType: ChamberType.FoodStorage, foodStored: 0, posX: 4, posY: 0, width: 3, height: 3 },
+      {
+        chamberId: 100,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 0,
+        posX: 0,
+        posY: 0,
+        width: 3,
+        height: 3,
+      },
+      {
+        chamberId: 101,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 0,
+        posX: 4,
+        posY: 0,
+        width: 3,
+        height: 3,
+      },
     );
     expect(colonyFoodCapacity(colony)).toBe(BASE_FOOD_STORAGE_CAPACITY + 2 * FOOD_CHAMBER_CAPACITY);
   });
@@ -561,8 +628,24 @@ describe('colonyFoodCapacity', () => {
   it('Queen / Nursery chambers do NOT contribute to capacity', () => {
     const { colony } = setupWorldWithQueen();
     colony.chambers.push(
-      { chamberId: 100, chamberType: ChamberType.Queen,   foodStored: 0, posX: 0, posY: 0, width: 5, height: 3 },
-      { chamberId: 101, chamberType: ChamberType.Nursery, foodStored: 0, posX: 8, posY: 0, width: 4, height: 3 },
+      {
+        chamberId: 100,
+        chamberType: ChamberType.Queen,
+        foodStored: 0,
+        posX: 0,
+        posY: 0,
+        width: 5,
+        height: 3,
+      },
+      {
+        chamberId: 101,
+        chamberType: ChamberType.Nursery,
+        foodStored: 0,
+        posX: 8,
+        posY: 0,
+        width: 4,
+        height: 3,
+      },
     );
     expect(colonyFoodCapacity(colony)).toBe(BASE_FOOD_STORAGE_CAPACITY);
   });
@@ -645,8 +728,11 @@ describe('tickReconcile', () => {
     tickReconcile(world, colony);
 
     // Allocation must now reflect actual worker/brood counts
-    const total = colony.computedAllocation.nurse + colony.computedAllocation.forage
-                + colony.computedAllocation.dig + colony.computedAllocation.fight;
+    const total =
+      colony.computedAllocation.nurse +
+      colony.computedAllocation.forage +
+      colony.computedAllocation.dig +
+      colony.computedAllocation.fight;
     expect(total).toBe(colony.workerCount);
     expect(colony.nurseCount).toBe(colony.computedAllocation.nurse);
   });
@@ -672,9 +758,15 @@ describe('tickReconcile', () => {
     // Issue #15: chamber.foodStored is per-chamber authoritative; the entrance
     // pool (`colony.foodStored`) caps at BASE alone — chambers are NOT a
     // capacity extension of the pool. Reconcile defensively clamps each side.
-    colony.chambers.push(
-      { chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: FOOD_CHAMBER_CAPACITY + 200, posX: 0, posY: 0, width: 3, height: 3 },
-    );
+    colony.chambers.push({
+      chamberId: 100,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: FOOD_CHAMBER_CAPACITY + 200,
+      posX: 0,
+      posY: 0,
+      width: 3,
+      height: 3,
+    });
     colony.foodStored = BASE_FOOD_STORAGE_CAPACITY + 1000; // pool overshoot
     colony.reconcileCountdown = 1;
     tickReconcile(world, colony);
@@ -706,9 +798,33 @@ describe('tickReconcile', () => {
     // footprint. Reconcile is forbidden from moving food across boundaries.
     const { world, colony } = setupWorldWithQueen(8000);
     colony.chambers.push(
-      { chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: 0, posX: 0, posY: 0, width: 3, height: 3 },
-      { chamberId: 101, chamberType: ChamberType.Nursery,     foodStored: 0, posX: 4, posY: 0, width: 3, height: 3 },
-      { chamberId: 102, chamberType: ChamberType.FoodStorage, foodStored: 0, posX: 8, posY: 0, width: 3, height: 3 },
+      {
+        chamberId: 100,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 0,
+        posX: 0,
+        posY: 0,
+        width: 3,
+        height: 3,
+      },
+      {
+        chamberId: 101,
+        chamberType: ChamberType.Nursery,
+        foodStored: 0,
+        posX: 4,
+        posY: 0,
+        width: 3,
+        height: 3,
+      },
+      {
+        chamberId: 102,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 0,
+        posX: 8,
+        posY: 0,
+        width: 3,
+        height: 3,
+      },
     );
 
     colony.reconcileCountdown = 1;
@@ -726,11 +842,15 @@ describe('tickReconcile', () => {
     // The deposit + withdraw paths cap at source, but reconcile is the safety
     // net for any drift. Direct chamber overshoot is clamped here.
     const { world, colony } = setupWorldWithQueen(0);
-    colony.chambers.push(
-      { chamberId: 100, chamberType: ChamberType.FoodStorage,
-        foodStored: FOOD_CHAMBER_CAPACITY + 12345, // simulated drift
-        posX: 0, posY: 0, width: 3, height: 3 },
-    );
+    colony.chambers.push({
+      chamberId: 100,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: FOOD_CHAMBER_CAPACITY + 12345, // simulated drift
+      posX: 0,
+      posY: 0,
+      width: 3,
+      height: 3,
+    });
 
     colony.reconcileCountdown = 1;
     tickReconcile(world, colony);
@@ -777,7 +897,10 @@ describe('CLNY-07 cached fields — integration', () => {
  * Assigns Phase 3 defaults (entrances, rallyPoint, digFlowFieldDirty) per PRD §2a.
  * Returns world, colony, and the colonyId used.
  */
-function setupWorldWithColonyAndUnderground(gridW = 20, gridH = 20): {
+function setupWorldWithColonyAndUnderground(
+  gridW = 20,
+  gridH = 20,
+): {
   world: WorldState;
   colony: ColonyRecord;
   colonyId: number;
@@ -791,8 +914,8 @@ function setupWorldWithColonyAndUnderground(gridW = 20, gridH = 20): {
 
   const colony = createColonyRecord(colonyId, queenId);
   // Phase 3 caller-side init contract (PRD §2a):
-  colony.entrances         = [];
-  colony.rallyPoint        = null;
+  colony.entrances = [];
+  colony.rallyPoint = null;
   colony.digFlowFieldDirty = false;
 
   world.colonies[colonyId] = colony;
@@ -821,8 +944,8 @@ describe('checkPendingChambers', () => {
       chamberType: ChamberType.Nursery,
       anchorTileX: 3,
       anchorTileY: 4,
-      width:       2,
-      height:      2,
+      width: 2,
+      height: 2,
     };
 
     const entityIdBefore = world.nextEntityId;
@@ -858,8 +981,8 @@ describe('checkPendingChambers', () => {
       chamberType: ChamberType.FoodStorage,
       anchorTileX: 3,
       anchorTileY: 4,
-      width:       2,
-      height:      2,
+      width: 2,
+      height: 2,
     };
 
     checkPendingChambers(world);
@@ -883,8 +1006,8 @@ describe('checkPendingChambers', () => {
       chamberType: ChamberType.Nursery,
       anchorTileX: 3,
       anchorTileY: 4,
-      width:       2,
-      height:      2,
+      width: 2,
+      height: 2,
     };
 
     checkPendingChambers(world);
@@ -901,21 +1024,29 @@ describe('checkPendingChambers', () => {
     ugSet(ug, 2, 2, UndergroundTileState.Open);
     const keyA = `${colonyId}:2:2`;
     world.pendingChambers[keyA] = {
-      colonyId, chamberType: ChamberType.Nursery,
-      anchorTileX: 2, anchorTileY: 2, width: 1, height: 1,
+      colonyId,
+      chamberType: ChamberType.Nursery,
+      anchorTileX: 2,
+      anchorTileY: 2,
+      width: 1,
+      height: 1,
     };
 
     // Chamber B (1×1 at 5,5) — still Solid
     const keyB = `${colonyId}:5:5`;
     world.pendingChambers[keyB] = {
-      colonyId, chamberType: ChamberType.FoodStorage,
-      anchorTileX: 5, anchorTileY: 5, width: 1, height: 1,
+      colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: 5,
+      anchorTileY: 5,
+      width: 1,
+      height: 1,
     };
 
     checkPendingChambers(world);
 
     expect(world.pendingChambers[keyA]).toBeUndefined(); // completed — deleted
-    expect(world.pendingChambers[keyB]).toBeDefined();   // incomplete — remains
+    expect(world.pendingChambers[keyB]).toBeDefined(); // incomplete — remains
     expect(colony.chambers).toHaveLength(1);
     expect(colony.chambers[0]!.chamberType).toBe(ChamberType.Nursery);
   });
@@ -933,8 +1064,12 @@ describe('checkPendingChambers', () => {
 
     const key = `${colonyId}:1:2`;
     world.pendingChambers[key] = {
-      colonyId, chamberType: ChamberType.FoodStorage,
-      anchorTileX: 1, anchorTileY: 2, width: 3, height: 2,
+      colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: 1,
+      anchorTileY: 2,
+      width: 3,
+      height: 2,
     };
 
     checkPendingChambers(world);
@@ -961,10 +1096,10 @@ describe('checkEntranceCompletion', () => {
     ugSet(ug, 5, 1, UndergroundTileState.Open);
 
     colony.entrances.push({
-      entranceId:   1,
+      entranceId: 1,
       surfaceTileX: 5,
       surfaceTileY: 0,
-      isOpen:       false,
+      isOpen: false,
     });
 
     checkEntranceCompletion(world);
@@ -980,10 +1115,10 @@ describe('checkEntranceCompletion', () => {
     // (5,1) stays Solid
 
     colony.entrances.push({
-      entranceId:   1,
+      entranceId: 1,
       surfaceTileX: 5,
       surfaceTileY: 0,
-      isOpen:       false,
+      isOpen: false,
     });
 
     checkEntranceCompletion(world);
@@ -998,10 +1133,10 @@ describe('checkEntranceCompletion', () => {
     // Shaft tiles remain Solid (normally would keep entrance closed)
     // but entrance is already marked open
     colony.entrances.push({
-      entranceId:   1,
+      entranceId: 1,
       surfaceTileX: 5,
       surfaceTileY: 0,
-      isOpen:       true, // already open
+      isOpen: true, // already open
     });
 
     // Confirm ug tiles are Solid (default)
@@ -1032,7 +1167,7 @@ describe('checkEntranceCompletion', () => {
 
     checkEntranceCompletion(world);
 
-    expect(colony.entrances[0]!.isOpen).toBe(true);  // entrance A opened
+    expect(colony.entrances[0]!.isOpen).toBe(true); // entrance A opened
     expect(colony.entrances[1]!.isOpen).toBe(false); // entrance B still closed
   });
 });

--- a/src/sim/colony/colony-system.ts
+++ b/src/sim/colony/colony-system.ts
@@ -132,11 +132,7 @@ export function isFoodChamberDepositable(chamber: ChamberRecord): boolean {
  * the oscillation cycle described in the FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP
  * constant docs.
  */
-export function withdrawFood(
-  colony: ColonyRecord,
-  amount: number,
-  simVersion: number,
-): boolean {
+export function withdrawFood(colony: ColonyRecord, amount: number, simVersion: number): boolean {
   if (colonyFoodTotal(colony) < amount) return false;
 
   let remaining = amount;
@@ -245,10 +241,7 @@ export function colonyFoodCapacity(colony: ColonyRecord): number {
  * unlocks only trigger once excavation finishes and checkPendingChambers
  * promotes the pending record into colony.chambers.
  */
-export function hasCompletedChamber(
-  colony: ColonyRecord,
-  chamberType: ChamberType,
-): boolean {
+export function hasCompletedChamber(colony: ColonyRecord, chamberType: ChamberType): boolean {
   for (let i = 0; i < colony.chambers.length; i++) {
     if (colony.chambers[i]!.chamberType === chamberType) return true;
   }
@@ -499,10 +492,10 @@ export function tickReconcile(world: WorldState, colony: ColonyRecord): void {
   const brood = colony.eggCount + colony.larvaeCount;
   const hasNursery = hasCompletedChamber(colony, ChamberType.Nursery);
   const alloc = allocateWorkers(colony.workerCount, brood, colony.targetRatio, hasNursery);
-  colony.computedAllocation.nurse  = alloc.nurse;
+  colony.computedAllocation.nurse = alloc.nurse;
   colony.computedAllocation.forage = alloc.forage;
-  colony.computedAllocation.dig    = alloc.dig;
-  colony.computedAllocation.fight  = alloc.fight;
+  colony.computedAllocation.dig = alloc.dig;
+  colony.computedAllocation.fight = alloc.fight;
   colony.nurseCount = alloc.nurse;
 
   colony.reconcileCountdown = RECONCILE_INTERVAL_TICKS;
@@ -542,7 +535,9 @@ export function checkPendingChambers(world: WorldState): void {
     let allOpen = true;
     for (let dy = 0; dy < pc.height && allOpen; dy++) {
       for (let dx = 0; dx < pc.width && allOpen; dx++) {
-        if (ugGet(underground, pc.anchorTileX + dx, pc.anchorTileY + dy) !== UndergroundTileState.Open) {
+        if (
+          ugGet(underground, pc.anchorTileX + dx, pc.anchorTileY + dy) !== UndergroundTileState.Open
+        ) {
           allOpen = false;
         }
       }
@@ -567,11 +562,11 @@ export function checkPendingChambers(world: WorldState): void {
       colony.chambers.push({
         chamberId,
         chamberType: pc.chamberType,
-        foodStored:  0,
-        posX:        pc.anchorTileX << FP_SHIFT,
-        posY:        pc.anchorTileY << FP_SHIFT,
-        width:       pc.width,
-        height:      pc.height,
+        foodStored: 0,
+        posX: pc.anchorTileX << FP_SHIFT,
+        posY: pc.anchorTileY << FP_SHIFT,
+        width: pc.width,
+        height: pc.height,
       });
 
       // Remove PendingChamber by key (safe during for-in iteration — delete is allowed)
@@ -655,7 +650,7 @@ export function tickDeadDiggerCleanup(world: WorldState): void {
     if (!ug) continue;
     if (ugGet(ug, dtx, dty) === UndergroundTileState.BeingDug) {
       ugSet(ug, dtx, dty, UndergroundTileState.Marked);
-      world.colonies[cid]!.digFlowFieldDirty = true;   // typed field (Plan 03 Task 1)
+      world.colonies[cid]!.digFlowFieldDirty = true; // typed field (Plan 03 Task 1)
     }
     // Clear the dead ant's dig claim
     world.ants.digTileX[id] = -1;

--- a/src/sim/colony/entrance.test.ts
+++ b/src/sim/colony/entrance.test.ts
@@ -8,10 +8,10 @@ import type { NestEntrance, NestEntranceId } from './entrance.js';
 describe('NestEntrance interface', () => {
   it('can be constructed with isOpen=false (default closed state)', () => {
     const entrance: NestEntrance = {
-      entranceId:   1 as NestEntranceId,
+      entranceId: 1 as NestEntranceId,
       surfaceTileX: 64,
       surfaceTileY: 64,
-      isOpen:       false,
+      isOpen: false,
     };
     expect(entrance.entranceId).toBe(1);
     expect(entrance.surfaceTileX).toBe(64);
@@ -21,10 +21,10 @@ describe('NestEntrance interface', () => {
 
   it('isOpen can be set to true', () => {
     const entrance: NestEntrance = {
-      entranceId:   2 as NestEntranceId,
+      entranceId: 2 as NestEntranceId,
       surfaceTileX: 24,
       surfaceTileY: 24,
-      isOpen:       true,
+      isOpen: true,
     };
     expect(entrance.isOpen).toBe(true);
   });

--- a/src/sim/colony/entrance.ts
+++ b/src/sim/colony/entrance.ts
@@ -20,8 +20,8 @@ export type NestEntranceId = number;
 // ---------------------------------------------------------------------------
 
 export interface NestEntrance {
-  entranceId:   NestEntranceId;
+  entranceId: NestEntranceId;
   surfaceTileX: number;
   surfaceTileY: number;
-  isOpen:       boolean;   // true once shaft tiles (y=0, y=1) are both Open
+  isOpen: boolean; // true once shaft tiles (y=0, y=1) are both Open
 }

--- a/src/sim/colony/larva-maturation.ts
+++ b/src/sim/colony/larva-maturation.ts
@@ -66,7 +66,7 @@ import { MAX_ENTITIES } from '../constants.js';
 
 const nurseScratch = {
   /** Per-nurse stamp: nurseScratch.usedStamp[nurseId] === currentStamp means used this tick. */
-  usedStamp:    new Uint32Array(MAX_ENTITIES),
+  usedStamp: new Uint32Array(MAX_ENTITIES),
   /** Incremented once per tick before the acceleration pass. Uint32 wrap is safe. */
   currentStamp: 0,
 };
@@ -82,7 +82,6 @@ const nurseScratch = {
  * No-op if the colony has no completed Nursery chamber.
  */
 export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): void {
-
   // Brood frozen = no completed Nursery. Nurses can't exist without a Nursery
   // (behavior allocator gates on hasNursery), so there's nothing to accelerate.
   if (!hasCompletedChamber(colony, ChamberType.Nursery)) return;
@@ -93,7 +92,7 @@ export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): vo
   // Advance the stamp. Skip 0: usedStamp[] is zero-initialized, so stamp===0
   // would falsely treat every nurse as "used this tick" after a full Uint32
   // wrap (~4 billion ticks). `|| 1` bumps the one collision tick to 1.
-  nurseScratch.currentStamp = ((nurseScratch.currentStamp + 1) >>> 0) || 1;
+  nurseScratch.currentStamp = (nurseScratch.currentStamp + 1) >>> 0 || 1;
   const stamp = nurseScratch.currentStamp;
 
   let slotsRemaining = cap;
@@ -142,10 +141,10 @@ export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): vo
       colony.larvae[i] = colony.larvae[colony.larvae.length - 1]!;
       colony.larvae.pop();
       colony.larvaeCount -= 1;
-      ants.age[larvaId]             = 0;
+      ants.age[larvaId] = 0;
       ants.starvationTimer[larvaId] = STARVATION_GRACE_TICKS;
-      ants.task[larvaId]            = AntTask.Idle;
-      ants.speed[larvaId]           = WORKER_BASE_SPEED;
+      ants.task[larvaId] = AntTask.Idle;
+      ants.speed[larvaId] = WORKER_BASE_SPEED;
       colony.workers.push(larvaId);
       colony.workerCount += 1;
       // If a nurse was carrying this larva (Feeding state), drop the carry.
@@ -153,9 +152,9 @@ export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): vo
       const carrierId = ants.carriedBy[larvaId]!;
       if (carrierId !== -1) {
         if (ants.alive[carrierId] === 1 && ants.carryingBroodId[carrierId] === larvaId) {
-          ants.carryingBroodId[carrierId]  = -1;
-          ants.task[carrierId]             = AntTask.Idle;
-          ants.subTask[carrierId]          = 0;
+          ants.carryingBroodId[carrierId] = -1;
+          ants.task[carrierId] = AntTask.Idle;
+          ants.subTask[carrierId] = 0;
           // Clear the Attending dwell counter so the future Forager search-pause
           // logic (which decrements searchPauseTicks > 0) doesn't see a stale
           // non-zero value from the mid-dwell abort.
@@ -186,13 +185,13 @@ export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): vo
  * Returns -1 if no eligible nurse is found.
  */
 function findAdjacentAttendingNurse(
-  ants:         AntComponents,
-  entityCount:  number,
-  colonyId:     number,
-  larvaTileX:   number,
-  larvaTileY:   number,
-  usedStamp:    Uint32Array,
-  stamp:        number,
+  ants: AntComponents,
+  entityCount: number,
+  colonyId: number,
+  larvaTileX: number,
+  larvaTileY: number,
+  usedStamp: Uint32Array,
+  stamp: number,
 ): number {
   let bestId = -1;
   for (let j = 0; j < entityCount; j++) {

--- a/src/sim/colony/lifecycle-system.test.ts
+++ b/src/sim/colony/lifecycle-system.test.ts
@@ -57,10 +57,10 @@ function setupWorldWithQueen(
 
   initAnt(world.ants, queenId, {
     colonyId: COLONY_ID,
-    posX:     queenX,
-    posY:     queenY,
-    task:     AntTask.Idle,
-    speed:    0,
+    posX: queenX,
+    posY: queenY,
+    task: AntTask.Idle,
+    speed: 0,
   });
 
   const colony = createColonyRecord(COLONY_ID, queenId);
@@ -77,13 +77,13 @@ function setupWorldWithQueen(
   for (let i = 0; i < chambers.length; i++) {
     const isQueen = chambers[i]!.chamberType === ChamberType.Queen;
     colony.chambers.push({
-      chamberId:   1000 + i,
+      chamberId: 1000 + i,
       chamberType: chambers[i]!.chamberType,
-      foodStored:  0,
-      posX:        isQueen ? (queenTileX << FP_SHIFT) : 0,
-      posY:        isQueen ? (queenTileY << FP_SHIFT) : 0,
-      width:       2,
-      height:      2,
+      foodStored: 0,
+      posX: isQueen ? queenTileX << FP_SHIFT : 0,
+      posY: isQueen ? queenTileY << FP_SHIFT : 0,
+      width: 2,
+      height: 2,
     });
   }
   world.colonies[COLONY_ID] = colony;
@@ -184,10 +184,9 @@ describe('tickQueenEggProduction — 09 reproduction-gate memo', () => {
   });
 
   it('6b. does NOT produce an egg with only a Queen chamber (Nursery missing)', () => {
-    const { world, colony } = setupWorldWithQueen(
-      10_000, 1024, 512,
-      [{ chamberType: ChamberType.Queen }],
-    );
+    const { world, colony } = setupWorldWithQueen(10_000, 1024, 512, [
+      { chamberType: ChamberType.Queen },
+    ]);
     world.tick = 0;
 
     tickQueenEggProduction(world, colony);
@@ -197,10 +196,9 @@ describe('tickQueenEggProduction — 09 reproduction-gate memo', () => {
   });
 
   it('6c. does NOT produce an egg with only a Nursery chamber (Queen missing)', () => {
-    const { world, colony } = setupWorldWithQueen(
-      10_000, 1024, 512,
-      [{ chamberType: ChamberType.Nursery }],
-    );
+    const { world, colony } = setupWorldWithQueen(10_000, 1024, 512, [
+      { chamberType: ChamberType.Nursery },
+    ]);
     world.tick = 0;
 
     tickQueenEggProduction(world, colony);
@@ -210,10 +208,10 @@ describe('tickQueenEggProduction — 09 reproduction-gate memo', () => {
   });
 
   it('6d. produces an egg once both Queen and Nursery are present', () => {
-    const { world, colony } = setupWorldWithQueen(
-      10_000, 1024, 512,
-      [{ chamberType: ChamberType.Queen }, { chamberType: ChamberType.Nursery }],
-    );
+    const { world, colony } = setupWorldWithQueen(10_000, 1024, 512, [
+      { chamberType: ChamberType.Queen },
+      { chamberType: ChamberType.Nursery },
+    ]);
     world.tick = 0;
 
     tickQueenEggProduction(world, colony);
@@ -223,10 +221,9 @@ describe('tickQueenEggProduction — 09 reproduction-gate memo', () => {
   });
 
   it('6e. FoodStorage alone does not satisfy either gate', () => {
-    const { world, colony } = setupWorldWithQueen(
-      10_000, 1024, 512,
-      [{ chamberType: ChamberType.FoodStorage }],
-    );
+    const { world, colony } = setupWorldWithQueen(10_000, 1024, 512, [
+      { chamberType: ChamberType.FoodStorage },
+    ]);
     world.tick = 0;
 
     tickQueenEggProduction(world, colony);
@@ -378,7 +375,7 @@ describe('tickQueenEggProduction — Gate 6 queen-in-chamber', () => {
     // Shrink the Queen chamber footprint to 1×1 around the queen tile.
     for (const ch of colony.chambers) {
       if (ch.chamberType === ChamberType.Queen) {
-        ch.width  = 1;
+        ch.width = 1;
         ch.height = 1;
       }
     }
@@ -515,7 +512,7 @@ describe('tickLifecycleTransitions — CLNY-03 larva mature', () => {
     expect(colony.larvaeCount).toBe(0);
     expect(colony.workers.length).toBe(1);
     expect(colony.workerCount).toBe(1);
-    expect(world.ants.age[larvaId]).toBe(0);               // age reset on transition
+    expect(world.ants.age[larvaId]).toBe(0); // age reset on transition
     expect(world.ants.task[larvaId]).toBe(AntTask.Idle);
     expect(world.ants.speed[larvaId]).toBe(WORKER_BASE_SPEED);
   });
@@ -648,10 +645,9 @@ describe('tickLifecycleTransitions — brood-aging gate (09 reproduction-gate me
   });
 
   it('19. Queen chamber alone (Nursery missing) still freezes brood', () => {
-    const { world, colony } = setupWorldWithQueen(
-      10_000, 1024, 512,
-      [{ chamberType: ChamberType.Queen }],
-    );
+    const { world, colony } = setupWorldWithQueen(10_000, 1024, 512, [
+      { chamberType: ChamberType.Queen },
+    ]);
 
     const eggId = world.nextEntityId++;
     initAnt(world.ants, eggId, { colonyId: COLONY_ID, posX: 0, posY: 0 });
@@ -701,10 +697,10 @@ describe('tickLifecycleTransitions — brood-aging gate (09 reproduction-gate me
     const workerId = world.nextEntityId++;
     initAnt(world.ants, workerId, {
       colonyId: COLONY_ID,
-      posX:     0,
-      posY:     0,
-      task:     AntTask.Idle,
-      speed:    WORKER_BASE_SPEED,
+      posX: 0,
+      posY: 0,
+      task: AntTask.Idle,
+      speed: WORKER_BASE_SPEED,
     });
     world.ants.age[workerId] = 0;
     colony.workers.push(workerId);
@@ -735,13 +731,13 @@ describe('tickLifecycleTransitions — brood-aging gate (09 reproduction-gate me
 
     // Complete a Nursery — brood unfreezes.
     colony.chambers.push({
-      chamberId:   2001,
+      chamberId: 2001,
       chamberType: ChamberType.Nursery,
-      foodStored:  0,
-      posX:        0,
-      posY:        0,
-      width:       2,
-      height:      2,
+      foodStored: 0,
+      posX: 0,
+      posY: 0,
+      width: 2,
+      height: 2,
     });
 
     for (let t = 0; t < EGG_HATCH_TICKS; t++) tickLifecycleTransitions(world, colony);

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -97,12 +97,12 @@ function eggIntervalForColony(colony: ColonyRecord): number {
   const foodTotal = colonyFoodTotal(colony);
   if (foodTotal < QUEEN_EGG_FOOD_THRESHOLD) return QUEEN_EGG_INTERVAL_DISABLED;
   const mouthsRaw = colony.workerCount + colony.larvaeCount + colony.eggCount + 1; // +1 queen
-  const mouths    = Math.max(mouthsRaw, COLONY_SIZE_FLOOR);
-  const denom     = mouths * FOOD_PER_ANT_BASELINE;
-  const food10    = foodTotal * 10; // multiply once; no division, no | 0 truncation
+  const mouths = Math.max(mouthsRaw, COLONY_SIZE_FLOOR);
+  const denom = mouths * FOOD_PER_ANT_BASELINE;
+  const food10 = foodTotal * 10; // multiply once; no division, no | 0 truncation
   if (food10 >= 100 * denom) return QUEEN_EGG_INTERVAL_FLOOR_TICKS;
-  if (food10 >=  50 * denom) return QUEEN_EGG_INTERVAL_FAST_TICKS;
-  if (food10 >=  30 * denom) return QUEEN_EGG_INTERVAL_MEDIUM_TICKS;
+  if (food10 >= 50 * denom) return QUEEN_EGG_INTERVAL_FAST_TICKS;
+  if (food10 >= 30 * denom) return QUEEN_EGG_INTERVAL_MEDIUM_TICKS;
   return QUEEN_EGG_INTERVAL_BASE_TICKS;
 }
 
@@ -129,7 +129,7 @@ export function tickQueenEggProduction(world: WorldState, colony: ColonyRecord):
 
   // Gate 4/5 (09 reproduction-gate memo): require completed Queen + Nursery
   // chambers before the queen starts laying. Either missing → no eggs.
-  if (!hasCompletedChamber(colony, ChamberType.Queen))   return;
+  if (!hasCompletedChamber(colony, ChamberType.Queen)) return;
   if (!hasCompletedChamber(colony, ChamberType.Nursery)) return;
 
   // Gate 6 (seed936214196-tick2401 fix): queen must be inside the Queen
@@ -147,8 +147,10 @@ export function tickQueenEggProduction(world: WorldState, colony: ColonyRecord):
     const bx = ch.posX >> FP_SHIFT;
     const by = ch.posY >> FP_SHIFT;
     if (
-      queenTileX >= bx && queenTileX < bx + ch.width &&
-      queenTileY >= by && queenTileY < by + ch.height
+      queenTileX >= bx &&
+      queenTileX < bx + ch.width &&
+      queenTileY >= by &&
+      queenTileY < by + ch.height
     ) {
       queenHome = true;
       break;
@@ -233,13 +235,13 @@ export function tickQueenEggProduction(world: WorldState, colony: ColonyRecord):
   // Init the already-allocated egg entity.
   initAnt(world.ants, eggId, {
     colonyId: colony.colonyId,
-    posX:     eggPosX,
-    posY:     eggPosY,
-    task:     AntTask.Idle,
-    subTask:  0,
-    speed:    0,                  // eggs don't move
+    posX: eggPosX,
+    posY: eggPosY,
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0, // eggs don't move
     lifespan: WORKER_LIFESPAN_TICKS,
-    zone:     Zone.Underground,   // Gate 6 guarantees queen is Underground
+    zone: Zone.Underground, // Gate 6 guarantees queen is Underground
   });
 
   colony.eggs.push(eggId);
@@ -269,8 +271,8 @@ export function tickLifecycleTransitions(world: WorldState, colony: ColonyRecord
   // Snapshot bucket lengths before each phase so newly-promoted entities are
   // not processed in the same tick they are promoted (PRD §4b: one phase-step
   // per tick per bucket; newly pushed IDs start participating next tick).
-  const eggSnapLen     = colony.eggs.length;
-  const larvaeSnapLen  = colony.larvae.length;
+  const eggSnapLen = colony.eggs.length;
+  const larvaeSnapLen = colony.larvae.length;
   const workersSnapLen = colony.workers.length;
 
   // 09 reproduction-gate memo — brood-aging gate. Egg production is already
@@ -313,7 +315,7 @@ export function tickLifecycleTransitions(world: WorldState, colony: ColonyRecord
       colony.eggs[i] = colony.eggs[colony.eggs.length - 1]!;
       colony.eggs.pop();
       colony.eggCount -= 1;
-      ants.age[id] = 0;         // reset age for larva phase
+      ants.age[id] = 0; // reset age for larva phase
       ants.starvationTimer[id] = STARVATION_GRACE_TICKS;
       colony.larvae.push(id);
       colony.larvaeCount += 1;
@@ -346,7 +348,7 @@ export function tickLifecycleTransitions(world: WorldState, colony: ColonyRecord
       colony.larvae[i] = colony.larvae[colony.larvae.length - 1]!;
       colony.larvae.pop();
       colony.larvaeCount -= 1;
-      ants.age[id] = 0;         // reset age for worker phase
+      ants.age[id] = 0; // reset age for worker phase
       ants.starvationTimer[id] = STARVATION_GRACE_TICKS;
       ants.task[id] = AntTask.Idle;
       ants.speed[id] = WORKER_BASE_SPEED;
@@ -364,7 +366,7 @@ export function tickLifecycleTransitions(world: WorldState, colony: ColonyRecord
           // (e.g. carrier already started carrying a different brood).
           if (ants.alive[carrierId] === 1 && ants.carryingBroodId[carrierId] === id) {
             ants.carryingBroodId[carrierId] = -1;
-            ants.task[carrierId]    = AntTask.Idle;
+            ants.task[carrierId] = AntTask.Idle;
             ants.subTask[carrierId] = 0;
           }
           // Always clear the matured worker's `carriedBy` so the new

--- a/src/sim/colony/reproduction.test.ts
+++ b/src/sim/colony/reproduction.test.ts
@@ -11,7 +11,12 @@
 import { describe, it, expect } from 'vitest';
 import { tickQueenEggProduction, tickLifecycleTransitions } from './lifecycle-system.js';
 import { tickLarvaMaturation } from './larva-maturation.js';
-import { createWorldState, SIM_VERSION_V20_SPIDER, SIM_VERSION_V21_REPRODUCTION, SIM_VERSION_V22_DIFFICULTY } from '../types.js';
+import {
+  createWorldState,
+  SIM_VERSION_V20_SPIDER,
+  SIM_VERSION_V21_REPRODUCTION,
+  SIM_VERSION_V22_DIFFICULTY,
+} from '../types.js';
 import { createColonyRecord } from './colony-store.js';
 import { initAnt } from '../ant/ant-store.js';
 import { AntTask, ChamberType, NursingSubState } from '../enums.js';
@@ -32,7 +37,6 @@ import {
 } from '../constants.js';
 import type { WorldState } from '../types.js';
 import type { ColonyRecord, ColonyId } from './colony-store.js';
-
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -63,7 +67,8 @@ function setupColony(
 
   initAnt(world.ants, queenId, {
     colonyId: COLONY_ID,
-    posX, posY,
+    posX,
+    posY,
     task: AntTask.Idle,
     speed: 0,
   });
@@ -79,7 +84,8 @@ function setupColony(
     foodStored: 0,
     posX: QUEEN_TILE_X << FP_SHIFT,
     posY: QUEEN_TILE_Y << FP_SHIFT,
-    width: 2, height: 2,
+    width: 2,
+    height: 2,
   });
   // Nursery chamber of 12 tiles (4×3) so the reproduction gates pass.
   colony.chambers.push({
@@ -88,7 +94,8 @@ function setupColony(
     foodStored: 0,
     posX: 0,
     posY: 0,
-    width: 4, height: 3,
+    width: 4,
+    height: 3,
   });
 
   // Underground grid so deposit logic can run.
@@ -104,18 +111,14 @@ function setupColony(
 /**
  * Add a larva at (larvaTileX, larvaTileY) to the colony. Returns the entity ID.
  */
-function addLarva(
-  world: WorldState,
-  colony: ColonyRecord,
-  larvaTileX = 1,
-  larvaTileY = 1,
-): number {
+function addLarva(world: WorldState, colony: ColonyRecord, larvaTileX = 1, larvaTileY = 1): number {
   const id = world.nextEntityId++;
   const posX = (larvaTileX << FP_SHIFT) + (FP_ONE >> 1);
   const posY = (larvaTileY << FP_SHIFT) + (FP_ONE >> 1);
   initAnt(world.ants, id, {
     colonyId: COLONY_ID,
-    posX, posY,
+    posX,
+    posY,
     task: AntTask.Idle,
     speed: 0,
   });
@@ -139,11 +142,12 @@ function addAttendingNurse(
   const posY = (nurseTileY << FP_SHIFT) + (FP_ONE >> 1);
   initAnt(world.ants, id, {
     colonyId: COLONY_ID,
-    posX, posY,
+    posX,
+    posY,
     task: AntTask.Nursing,
     speed: 0,
   });
-  world.ants.zone[id]    = Zone.Underground;
+  world.ants.zone[id] = Zone.Underground;
   world.ants.subTask[id] = NursingSubState.Attending;
   world.ants.searchPauseTicks[id] = 0;
   colony.workers.push(id);
@@ -204,7 +208,8 @@ describe('eggIntervalForColony — V21 surplus thresholds', () => {
     // 300 is also a multiple of nothing we expect — actually 300 % 250 = 50 ≠ 0
     // so confirm no second egg at 300.
     // Reset colony eggs for clean count.
-    colony.eggs.length = 0; colony.eggCount = 0;
+    colony.eggs.length = 0;
+    colony.eggCount = 0;
     world.tick = QUEEN_EGG_INTERVAL_BASE_TICKS; // 300 — not a multiple of 250
     tickQueenEggProduction(world, colony);
     expect(colony.eggCount).toBe(0);
@@ -218,7 +223,8 @@ describe('eggIntervalForColony — V21 surplus thresholds', () => {
     tickQueenEggProduction(world, colony);
     expect(colony.eggCount).toBe(1);
 
-    colony.eggs.length = 0; colony.eggCount = 0;
+    colony.eggs.length = 0;
+    colony.eggCount = 0;
     world.tick = QUEEN_EGG_INTERVAL_MEDIUM_TICKS; // 250 — not a multiple of 200
     tickQueenEggProduction(world, colony);
     expect(colony.eggCount).toBe(0);
@@ -232,7 +238,8 @@ describe('eggIntervalForColony — V21 surplus thresholds', () => {
     tickQueenEggProduction(world, colony);
     expect(colony.eggCount).toBe(1);
 
-    colony.eggs.length = 0; colony.eggCount = 0;
+    colony.eggs.length = 0;
+    colony.eggCount = 0;
     world.tick = QUEEN_EGG_INTERVAL_FAST_TICKS; // 200 — not a multiple of 150
     tickQueenEggProduction(world, colony);
     expect(colony.eggCount).toBe(0);
@@ -303,7 +310,7 @@ describe('tickLarvaMaturation — throughput cap (nurse-side binds)', () => {
     for (let i = 0; i < 3; i++) addAttendingNurse(world, colony, 1, 1);
 
     // Record ages before.
-    const agesBefore = larvaIds.map(id => world.ants.age[id]!);
+    const agesBefore = larvaIds.map((id) => world.ants.age[id]!);
 
     // Baseline tick: each larva gets +1.
     tickLifecycleTransitions(world, colony);
@@ -330,8 +337,8 @@ describe('tickLarvaMaturation — throughput cap (cap binds)', () => {
     const { colony } = setupColony(world);
 
     // Replace the default 4×3 Nursery (cap=12) with a 2×2 (cap=4).
-    const nurseryIdx = colony.chambers.findIndex(c => c.chamberType === ChamberType.Nursery);
-    colony.chambers[nurseryIdx]!.width  = 2;
+    const nurseryIdx = colony.chambers.findIndex((c) => c.chamberType === ChamberType.Nursery);
+    colony.chambers[nurseryIdx]!.width = 2;
     colony.chambers[nurseryIdx]!.height = 2;
 
     // Add 6 larvae at tile (1,1).
@@ -341,7 +348,7 @@ describe('tickLarvaMaturation — throughput cap (cap binds)', () => {
     // Add 10 nurses at tile (1,1).
     for (let i = 0; i < 10; i++) addAttendingNurse(world, colony, 1, 1);
 
-    const agesBefore = larvaIds.map(id => world.ants.age[id]!);
+    const agesBefore = larvaIds.map((id) => world.ants.age[id]!);
 
     tickLifecycleTransitions(world, colony);
     tickLarvaMaturation(world, colony);
@@ -399,68 +406,65 @@ describe('D-29 WarFooting — reproduction speed advantage', () => {
     return { world, colony };
   }
 
-  it(
-    '10× surplus colony reaches workerCount=10 ≥120 ticks before lean colony',
-    () => {
-      const MAX_TICKS = 8400;
-      const MIN_TICK_DELTA = 120;
+  it('10× surplus colony reaches workerCount=10 ≥120 ticks before lean colony', () => {
+    const MAX_TICKS = 8400;
+    const MIN_TICK_DELTA = 120;
 
-      // With 9 workers + queen (mouths = max(10, COLONY_SIZE_FLOOR=8) = 10):
-      //   denom = 10 × FOOD_PER_ANT_BASELINE (60) = 600
-      //   Lean: food=768  → sX10 = floor(768×10/600) = 12 → BASE interval (300)
-      //   Rich: food=6000 → sX10 = floor(6000×10/600) = 100 → FLOOR interval (150)
-      const LEAN_FOOD = QUEEN_EGG_FOOD_THRESHOLD; // 768
-      // foodForSX10(100) = 4800 with 8 mouths (COLONY_SIZE_FLOOR), but with 10 mouths
-      // (9 workers + queen) the threshold for FLOOR interval needs food ≥ 6000.
-      const RICH_FOOD_10X = 6000; // sX10 = floor(6000×10/600) = 100 → FLOOR (150)
+    // With 9 workers + queen (mouths = max(10, COLONY_SIZE_FLOOR=8) = 10):
+    //   denom = 10 × FOOD_PER_ANT_BASELINE (60) = 600
+    //   Lean: food=768  → sX10 = floor(768×10/600) = 12 → BASE interval (300)
+    //   Rich: food=6000 → sX10 = floor(6000×10/600) = 100 → FLOOR interval (150)
+    const LEAN_FOOD = QUEEN_EGG_FOOD_THRESHOLD; // 768
+    // foodForSX10(100) = 4800 with 8 mouths (COLONY_SIZE_FLOOR), but with 10 mouths
+    // (9 workers + queen) the threshold for FLOOR interval needs food ≥ 6000.
+    const RICH_FOOD_10X = 6000; // sX10 = floor(6000×10/600) = 100 → FLOOR (150)
 
-      const { world: worldA, colony: colonyA } = makeD29World(LEAN_FOOD);
-      const { world: worldB, colony: colonyB } = makeD29World(RICH_FOOD_10X);
+    const { world: worldA, colony: colonyA } = makeD29World(LEAN_FOOD);
+    const { world: worldB, colony: colonyB } = makeD29World(RICH_FOOD_10X);
 
-      // Reset queenLastEggTick so neither world lays at t=1 (default=-300 would
-      // give elapsed=301>=300, firing both worlds at the same tick and masking the
-      // interval difference). Setting to 0 means lean lays at t=300, rich at t=150.
-      colonyA.queenLastEggTick = 0;
-      colonyB.queenLastEggTick = 0;
+    // Reset queenLastEggTick so neither world lays at t=1 (default=-300 would
+    // give elapsed=301>=300, firing both worlds at the same tick and masking the
+    // interval difference). Setting to 0 means lean lays at t=300, rich at t=150.
+    colonyA.queenLastEggTick = 0;
+    colonyB.queenLastEggTick = 0;
 
-      let reachTickA = -1;
-      let reachTickB = -1;
+    let reachTickA = -1;
+    let reachTickB = -1;
 
-      for (let t = 1; t < MAX_TICKS; t++) {
-        // Pin food so the surplus tier stays constant across the run.
-        colonyA.foodStored = LEAN_FOOD;
-        colonyB.foodStored = RICH_FOOD_10X;
+    for (let t = 1; t < MAX_TICKS; t++) {
+      // Pin food so the surplus tier stays constant across the run.
+      colonyA.foodStored = LEAN_FOOD;
+      colonyB.foodStored = RICH_FOOD_10X;
 
-        worldA.tick = t;
-        worldB.tick = t;
+      worldA.tick = t;
+      worldB.tick = t;
 
-        tickQueenEggProduction(worldA, colonyA);
-        tickLifecycleTransitions(worldA, colonyA);
-        tickLarvaMaturation(worldA, colonyA);
+      tickQueenEggProduction(worldA, colonyA);
+      tickLifecycleTransitions(worldA, colonyA);
+      tickLarvaMaturation(worldA, colonyA);
 
-        tickQueenEggProduction(worldB, colonyB);
-        tickLifecycleTransitions(worldB, colonyB);
-        tickLarvaMaturation(worldB, colonyB);
+      tickQueenEggProduction(worldB, colonyB);
+      tickLifecycleTransitions(worldB, colonyB);
+      tickLarvaMaturation(worldB, colonyB);
 
-        if (reachTickA < 0 && colonyA.workerCount >= 10) reachTickA = t;
-        if (reachTickB < 0 && colonyB.workerCount >= 10) reachTickB = t;
+      if (reachTickA < 0 && colonyA.workerCount >= 10) reachTickA = t;
+      if (reachTickB < 0 && colonyB.workerCount >= 10) reachTickB = t;
 
-        if (reachTickA >= 0 && reachTickB >= 0) break;
-      }
+      if (reachTickA >= 0 && reachTickB >= 0) break;
+    }
 
-      expect(
-        reachTickB,
-        `Rich colony never reached workerCount=10 within ${MAX_TICKS} ticks`,
-      ).toBeGreaterThan(0);
+    expect(
+      reachTickB,
+      `Rich colony never reached workerCount=10 within ${MAX_TICKS} ticks`,
+    ).toBeGreaterThan(0);
 
-      const delta = reachTickA - reachTickB;
-      expect(
-        delta,
-        `Expected rich colony to reach 10 workers ≥${MIN_TICK_DELTA} ticks before lean ` +
+    const delta = reachTickA - reachTickB;
+    expect(
+      delta,
+      `Expected rich colony to reach 10 workers ≥${MIN_TICK_DELTA} ticks before lean ` +
         `(lean=${reachTickA}, rich=${reachTickB}, delta=${delta})`,
-      ).toBeGreaterThanOrEqual(MIN_TICK_DELTA);
-    },
-  );
+    ).toBeGreaterThanOrEqual(MIN_TICK_DELTA);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -474,7 +478,13 @@ describe('V22 difficulty brood modifier — AI egg interval', () => {
     const queenId = world.nextEntityId++;
     const posX = (QUEEN_TILE_X << FP_SHIFT) + (FP_ONE >> 1);
     const posY = (QUEEN_TILE_Y << FP_SHIFT) + (FP_ONE >> 1);
-    initAnt(world.ants, queenId, { colonyId: AI_COLONY_ID, posX, posY, task: AntTask.Idle, speed: 0 });
+    initAnt(world.ants, queenId, {
+      colonyId: AI_COLONY_ID,
+      posX,
+      posY,
+      task: AntTask.Idle,
+      speed: 0,
+    });
     world.ants.zone[queenId] = Zone.Underground;
 
     const colony = createColonyRecord(AI_COLONY_ID as ColonyId, queenId);
@@ -486,14 +496,17 @@ describe('V22 difficulty brood modifier — AI egg interval', () => {
       foodStored: 0,
       posX: QUEEN_TILE_X << FP_SHIFT,
       posY: QUEEN_TILE_Y << FP_SHIFT,
-      width: 2, height: 2,
+      width: 2,
+      height: 2,
     });
     colony.chambers.push({
       chamberId: 201,
       chamberType: ChamberType.Nursery,
       foodStored: 0,
-      posX: 0, posY: 0,
-      width: 4, height: 3,
+      posX: 0,
+      posY: 0,
+      width: 4,
+      height: 3,
     });
     const grid = createUndergroundGrid(20, 20);
     ugSet(grid, QUEEN_TILE_X, QUEEN_TILE_Y, UndergroundTileState.Open);
@@ -557,7 +570,9 @@ describe('V22 difficulty brood modifier — AI egg interval', () => {
 
   it('Hard modifier (numerator=3) keeps interval above MIN_EGG_INTERVAL_TICKS (100)', () => {
     // floor interval=150, Hard: 150*3>>2=112 > 100 — clamp does not fire in standard play.
-    expect((QUEEN_EGG_INTERVAL_FLOOR_TICKS * 3) >> 2).toBeGreaterThanOrEqual(MIN_EGG_INTERVAL_TICKS);
+    expect((QUEEN_EGG_INTERVAL_FLOOR_TICKS * 3) >> 2).toBeGreaterThanOrEqual(
+      MIN_EGG_INTERVAL_TICKS,
+    );
     expect(MIN_EGG_INTERVAL_TICKS).toBe(100);
   });
 });

--- a/src/sim/combat-alloc.test.ts
+++ b/src/sim/combat-alloc.test.ts
@@ -30,7 +30,15 @@ import type { ColonyId } from './colony/colony-store.js';
 function makeWorldWith2Colonies(seed = 42): { world: WorldState; cid1: ColonyId; cid2: ColonyId } {
   const world = createWorldState(seed);
   const queen1 = allocateEntityId(world);
-  initAnt(world.ants, queen1, { colonyId: 1, posX: 0 << FP_SHIFT, posY: 0 << FP_SHIFT, task: AntTask.Idle, subTask: 0, speed: 0, lifespan: WORKER_LIFESPAN_TICKS });
+  initAnt(world.ants, queen1, {
+    colonyId: 1,
+    posX: 0 << FP_SHIFT,
+    posY: 0 << FP_SHIFT,
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
+    lifespan: WORKER_LIFESPAN_TICKS,
+  });
   const colony1 = createColonyRecord(1 as ColonyId, queen1);
   colony1.entrances = [];
   colony1.rallyPoint = null;
@@ -38,7 +46,15 @@ function makeWorldWith2Colonies(seed = 42): { world: WorldState; cid1: ColonyId;
   world.colonies[1] = colony1;
 
   const queen2 = allocateEntityId(world);
-  initAnt(world.ants, queen2, { colonyId: 2, posX: 1 << FP_SHIFT, posY: 0 << FP_SHIFT, task: AntTask.Idle, subTask: 0, speed: 0, lifespan: WORKER_LIFESPAN_TICKS });
+  initAnt(world.ants, queen2, {
+    colonyId: 2,
+    posX: 1 << FP_SHIFT,
+    posY: 0 << FP_SHIFT,
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
+    lifespan: WORKER_LIFESPAN_TICKS,
+  });
   const colony2 = createColonyRecord(2 as ColonyId, queen2);
   colony2.entrances = [];
   colony2.rallyPoint = null;
@@ -48,11 +64,22 @@ function makeWorldWith2Colonies(seed = 42): { world: WorldState; cid1: ColonyId;
   return { world, cid1: 1 as ColonyId, cid2: 2 as ColonyId };
 }
 
-function spawnAnt(world: WorldState, colonyId: ColonyId, tileX: number, tileY: number, zone: Zone): number {
+function spawnAnt(
+  world: WorldState,
+  colonyId: ColonyId,
+  tileX: number,
+  tileY: number,
+  zone: Zone,
+): number {
   const id = allocateEntityId(world);
   initAnt(world.ants, id, {
-    colonyId, posX: (tileX << FP_SHIFT) + (FP_ONE >> 1), posY: (tileY << FP_SHIFT) + (FP_ONE >> 1),
-    task: AntTask.Idle, subTask: 0, speed: WORKER_BASE_SPEED, zone,
+    colonyId,
+    posX: (tileX << FP_SHIFT) + (FP_ONE >> 1),
+    posY: (tileY << FP_SHIFT) + (FP_ONE >> 1),
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: WORKER_BASE_SPEED,
+    zone,
   });
   world.colonies[colonyId]!.workers.push(id);
   world.colonies[colonyId]!.workerCount += 1;

--- a/src/sim/combat-cross-grid.test.ts
+++ b/src/sim/combat-cross-grid.test.ts
@@ -37,7 +37,12 @@ import { initAnt } from './ant/ant-store.js';
 import { AntTask, FightingSubState } from './enums.js';
 import { Zone } from './terrain.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
-import { WORKER_BASE_SPEED, WORKER_LIFESPAN_TICKS, PLAYER_COLONY_ID, ENEMY_COLONY_ID } from './constants.js';
+import {
+  WORKER_BASE_SPEED,
+  WORKER_LIFESPAN_TICKS,
+  PLAYER_COLONY_ID,
+  ENEMY_COLONY_ID,
+} from './constants.js';
 import type { WorldState } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 
@@ -46,9 +51,9 @@ import type { ColonyId } from './colony/colony-store.js';
 // ---------------------------------------------------------------------------
 
 interface CrossGridWorld {
-  world:          WorldState;
-  playerAntId:    number;
-  enemyQueenId:   number;
+  world: WorldState;
+  playerAntId: number;
+  enemyQueenId: number;
 }
 
 /**
@@ -78,13 +83,13 @@ function buildCrossGridWorld(seed = 1, queenTileX = 5, queenTileY = 5): CrossGri
   const playerQueen = allocateEntityId(world);
   initAnt(world.ants, playerQueen, {
     colonyId: PLAYER_COLONY_ID,
-    posX:     0 << FP_SHIFT,
-    posY:     0 << FP_SHIFT,
-    task:     AntTask.Idle,
-    subTask:  0,
-    speed:    0,
+    posX: 0 << FP_SHIFT,
+    posY: 0 << FP_SHIFT,
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
     lifespan: WORKER_LIFESPAN_TICKS,
-    zone:     Zone.Surface,
+    zone: Zone.Surface,
   });
   const playerColony = createColonyRecord(PLAYER_COLONY_ID as ColonyId, playerQueen);
   playerColony.entrances = [];
@@ -96,13 +101,13 @@ function buildCrossGridWorld(seed = 1, queenTileX = 5, queenTileY = 5): CrossGri
   const enemyQueenId = allocateEntityId(world);
   initAnt(world.ants, enemyQueenId, {
     colonyId: ENEMY_COLONY_ID,
-    posX:     (queenTileX << FP_SHIFT) + (FP_ONE >> 1),
-    posY:     (queenTileY << FP_SHIFT) + (FP_ONE >> 1),
-    task:     AntTask.Idle,
-    subTask:  0,
-    speed:    0,
+    posX: (queenTileX << FP_SHIFT) + (FP_ONE >> 1),
+    posY: (queenTileY << FP_SHIFT) + (FP_ONE >> 1),
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
     lifespan: WORKER_LIFESPAN_TICKS,
-    zone:     Zone.Underground,
+    zone: Zone.Underground,
   });
   // Same colony, same grid — default from initAnt already sets
   // currentGridColonyId = colonyId = ENEMY, but we re-assign for clarity.
@@ -120,13 +125,13 @@ function buildCrossGridWorld(seed = 1, queenTileX = 5, queenTileY = 5): CrossGri
   const playerAntId = allocateEntityId(world);
   initAnt(world.ants, playerAntId, {
     colonyId: PLAYER_COLONY_ID,
-    posX:     (queenTileX << FP_SHIFT) + (FP_ONE >> 1),
-    posY:     (queenTileY << FP_SHIFT) + (FP_ONE >> 1),
-    task:     AntTask.Fighting,
-    subTask:  FightingSubState.Engaging,
-    speed:    WORKER_BASE_SPEED,
+    posX: (queenTileX << FP_SHIFT) + (FP_ONE >> 1),
+    posY: (queenTileY << FP_SHIFT) + (FP_ONE >> 1),
+    task: AntTask.Fighting,
+    subTask: FightingSubState.Engaging,
+    speed: WORKER_BASE_SPEED,
     lifespan: WORKER_LIFESPAN_TICKS,
-    zone:     Zone.Underground,
+    zone: Zone.Underground,
   });
   world.ants.currentGridColonyId[playerAntId] = ENEMY_COLONY_ID;
   world.colonies[PLAYER_COLONY_ID]!.workers.push(playerAntId);
@@ -192,44 +197,48 @@ describe('combat cross-grid — tile-key gridColonyId extension (REQ-C4)', () =>
     const playerQueen = allocateEntityId(world);
     initAnt(world.ants, playerQueen, {
       colonyId: PLAYER_COLONY_ID,
-      posX:     (0 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (0 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Idle,
-      subTask:  0,
-      speed:    0,
+      posX: (0 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (0 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
       lifespan: WORKER_LIFESPAN_TICKS,
-      zone:     Zone.Surface,
+      zone: Zone.Surface,
     });
     const pc = createColonyRecord(PLAYER_COLONY_ID as ColonyId, playerQueen);
-    pc.entrances = []; pc.rallyPoint = null; pc.digFlowFieldDirty = false;
+    pc.entrances = [];
+    pc.rallyPoint = null;
+    pc.digFlowFieldDirty = false;
     world.colonies[PLAYER_COLONY_ID] = pc;
 
     const enemyQueen = allocateEntityId(world);
     initAnt(world.ants, enemyQueen, {
       colonyId: ENEMY_COLONY_ID,
-      posX:     (1 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (0 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Idle,
-      subTask:  0,
-      speed:    0,
+      posX: (1 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (0 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
       lifespan: WORKER_LIFESPAN_TICKS,
-      zone:     Zone.Surface,
+      zone: Zone.Surface,
     });
     const ec = createColonyRecord(ENEMY_COLONY_ID as ColonyId, enemyQueen);
-    ec.entrances = []; ec.rallyPoint = null; ec.digFlowFieldDirty = false;
+    ec.entrances = [];
+    ec.rallyPoint = null;
+    ec.digFlowFieldDirty = false;
     world.colonies[ENEMY_COLONY_ID] = ec;
 
     // Ant A: player-colony ant in the PLAYER grid at (7,7) Underground.
     const antA = allocateEntityId(world);
     initAnt(world.ants, antA, {
       colonyId: PLAYER_COLONY_ID,
-      posX:     (7 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (7 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Idle,
-      subTask:  0,
-      speed:    WORKER_BASE_SPEED,
+      posX: (7 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (7 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: WORKER_BASE_SPEED,
       lifespan: WORKER_LIFESPAN_TICKS,
-      zone:     Zone.Underground,
+      zone: Zone.Underground,
     });
     world.ants.currentGridColonyId[antA] = PLAYER_COLONY_ID;
     world.colonies[PLAYER_COLONY_ID]!.workers.push(antA);
@@ -239,13 +248,13 @@ describe('combat cross-grid — tile-key gridColonyId extension (REQ-C4)', () =>
     const antB = allocateEntityId(world);
     initAnt(world.ants, antB, {
       colonyId: ENEMY_COLONY_ID,
-      posX:     (7 << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (7 << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Idle,
-      subTask:  0,
-      speed:    WORKER_BASE_SPEED,
+      posX: (7 << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (7 << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: WORKER_BASE_SPEED,
       lifespan: WORKER_LIFESPAN_TICKS,
-      zone:     Zone.Underground,
+      zone: Zone.Underground,
     });
     world.ants.currentGridColonyId[antB] = ENEMY_COLONY_ID;
     world.colonies[ENEMY_COLONY_ID]!.workers.push(antB);

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -27,7 +27,15 @@ function makeWorldWith2Colonies(seed = 42): { world: WorldState; cid1: ColonyId;
   // Place queens at distinct tiles far from worker spawn points (tile 5,7 is the combat tile in tests).
   // Queens at tile (0,0) and (1,0) so they never collide with each other or the test workers.
   const queen1 = allocateEntityId(world);
-  initAnt(world.ants, queen1, { colonyId: 1, posX: 0 << FP_SHIFT, posY: 0 << FP_SHIFT, task: AntTask.Idle, subTask: 0, speed: 0, lifespan: WORKER_LIFESPAN_TICKS });
+  initAnt(world.ants, queen1, {
+    colonyId: 1,
+    posX: 0 << FP_SHIFT,
+    posY: 0 << FP_SHIFT,
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
+    lifespan: WORKER_LIFESPAN_TICKS,
+  });
   const colony1 = createColonyRecord(1 as ColonyId, queen1);
   colony1.entrances = [];
   colony1.rallyPoint = null;
@@ -35,7 +43,15 @@ function makeWorldWith2Colonies(seed = 42): { world: WorldState; cid1: ColonyId;
   world.colonies[1] = colony1;
 
   const queen2 = allocateEntityId(world);
-  initAnt(world.ants, queen2, { colonyId: 2, posX: 1 << FP_SHIFT, posY: 0 << FP_SHIFT, task: AntTask.Idle, subTask: 0, speed: 0, lifespan: WORKER_LIFESPAN_TICKS });
+  initAnt(world.ants, queen2, {
+    colonyId: 2,
+    posX: 1 << FP_SHIFT,
+    posY: 0 << FP_SHIFT,
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
+    lifespan: WORKER_LIFESPAN_TICKS,
+  });
   const colony2 = createColonyRecord(2 as ColonyId, queen2);
   colony2.entrances = [];
   colony2.rallyPoint = null;
@@ -46,11 +62,22 @@ function makeWorldWith2Colonies(seed = 42): { world: WorldState; cid1: ColonyId;
 }
 
 // Helper: spawn a worker ant of colonyId at (tileX, tileY, zone). Returns slot index.
-function spawnAnt(world: WorldState, colonyId: ColonyId, tileX: number, tileY: number, zone: Zone): number {
+function spawnAnt(
+  world: WorldState,
+  colonyId: ColonyId,
+  tileX: number,
+  tileY: number,
+  zone: Zone,
+): number {
   const id = allocateEntityId(world);
   initAnt(world.ants, id, {
-    colonyId, posX: (tileX << FP_SHIFT) + (FP_ONE >> 1), posY: (tileY << FP_SHIFT) + (FP_ONE >> 1),
-    task: AntTask.Idle, subTask: 0, speed: WORKER_BASE_SPEED, zone,
+    colonyId,
+    posX: (tileX << FP_SHIFT) + (FP_ONE >> 1),
+    posY: (tileY << FP_SHIFT) + (FP_ONE >> 1),
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: WORKER_BASE_SPEED,
+    zone,
   });
   world.colonies[colonyId]!.workers.push(id);
   world.colonies[colonyId]!.workerCount += 1;
@@ -58,14 +85,25 @@ function spawnAnt(world: WorldState, colonyId: ColonyId, tileX: number, tileY: n
 }
 
 // Helper: spawn a fighting ant (AntTask.Fighting) for V16 combat tests.
-function spawnFighter(world: WorldState, colonyId: ColonyId, tileX: number, tileY: number, zone: Zone): number {
+function spawnFighter(
+  world: WorldState,
+  colonyId: ColonyId,
+  tileX: number,
+  tileY: number,
+  zone: Zone,
+): number {
   const id = spawnAnt(world, colonyId, tileX, tileY, zone);
   world.ants.task[id] = AntTask.Fighting;
   return id;
 }
 
 // Helper: place a spider on tile (tileX, tileY) in the given behavior state.
-function placeSpider(world: WorldState, tileX: number, tileY: number, state: SpiderBehaviorState): SpiderState {
+function placeSpider(
+  world: WorldState,
+  tileX: number,
+  tileY: number,
+  state: SpiderBehaviorState,
+): SpiderState {
   const spider: SpiderState = {
     state,
     posX: tileX << FP_SHIFT,
@@ -122,7 +160,6 @@ describe('detectAndResolveCombat (V15 coin-flip path)', () => {
     expect(world.ants.alive[b]).toBe(1);
   });
 
-
   it('surface (5,7) and underground (5,7) do NOT fight (zone separation)', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
     const a = spawnAnt(world, cid1, 5, 7, Zone.Surface);
@@ -150,7 +187,6 @@ describe('detectAndResolveCombat (V15 coin-flip path)', () => {
     expect(run1.world.ants.alive[run1.b]).toBe(run2.world.ants.alive[run2.b]);
   });
 });
-
 
 describe('killAnt', () => {
   it('zeroes alive flag on victim', () => {
@@ -191,7 +227,7 @@ describe('killAnt', () => {
   // ---------------------------------------------------------------------
   // Issue #107 — V13+ atomically clears bidirectional carry pointers.
   // ---------------------------------------------------------------------
-  it('#107 (V13+) clears carryingBroodId and the brood\'s carriedBy when a carrier is killed', () => {
+  it("#107 (V13+) clears carryingBroodId and the brood's carriedBy when a carrier is killed", () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
     world.simVersion = 13;
     const carrier = spawnAnt(world, cid1, 5, 7, Zone.Underground);
@@ -204,7 +240,7 @@ describe('killAnt', () => {
     expect(world.ants.carriedBy[brood]).toBe(-1);
   });
 
-  it('#107 (V13+) symmetric — when the carried entity is killed, carrier\'s carryingBroodId clears', () => {
+  it("#107 (V13+) symmetric — when the carried entity is killed, carrier's carryingBroodId clears", () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
     world.simVersion = 13;
     const carrier = spawnAnt(world, cid1, 5, 7, Zone.Underground);
@@ -216,7 +252,6 @@ describe('killAnt', () => {
     expect(world.ants.carryingBroodId[carrier]).toBe(-1);
     expect(world.ants.carriedBy[brood]).toBe(-1);
   });
-
 
   it('#107 (V13+) is a no-op for ants without active carry slots (regression guard)', () => {
     const { world, cid1, cid2 } = makeWorldWith2Colonies();
@@ -230,12 +265,18 @@ describe('killAnt', () => {
   });
 });
 
-
 // =============================================================================
 // S1 — V16 HP/damage/cooldown combat tests
 // =============================================================================
 
-import { COMBAT_HP_BASE, COMBAT_COOLDOWN_TICKS, COMBAT_DAMAGE_BASE, COMBAT_DAMAGE_WORKER, COMBAT_DAMAGE_QUEEN, COMBAT_HP_QUEEN } from './constants.js';
+import {
+  COMBAT_HP_BASE,
+  COMBAT_COOLDOWN_TICKS,
+  COMBAT_DAMAGE_BASE,
+  COMBAT_DAMAGE_WORKER,
+  COMBAT_DAMAGE_QUEEN,
+  COMBAT_HP_QUEEN,
+} from './constants.js';
 
 function makeV16World(seed = 42): { world: WorldState; cid1: ColonyId; cid2: ColonyId } {
   const r = makeWorldWith2Colonies(seed);
@@ -305,10 +346,14 @@ describe('V16 combat resolver', () => {
     const { world, cid1, cid2 } = makeV16World();
     // Defender (cid1) on their own grid (currentGridColonyId=cid1, zone=Underground)
     const defender = spawnFighter(world, cid1, 5, 7, Zone.Underground);
-    world.ants.currentGridColonyId[defender] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
+    world.ants.currentGridColonyId[defender] = Number(
+      cid1,
+    ) as unknown as (typeof world.ants.currentGridColonyId)[0];
     // Attacker (cid2) on cid1's grid (invasion)
     const attacker = spawnFighter(world, cid2, 5, 7, Zone.Underground);
-    world.ants.currentGridColonyId[attacker] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
+    world.ants.currentGridColonyId[attacker] = Number(
+      cid1,
+    ) as unknown as (typeof world.ants.currentGridColonyId)[0];
 
     // Run exactly COMBAT_COOLDOWN_TICKS+1 = 6 ticks per round, 4 rounds = 24 ticks total
     // But windup is on tick 1, first strike at tick 1+5=6. So T=6, T=12, T=18, T=24?
@@ -347,7 +392,7 @@ describe('V16 combat resolver', () => {
     const { world, cid1, cid2 } = makeV16World();
     const a1 = spawnFighter(world, cid1, 5, 7, Zone.Surface);
     const a2 = spawnFighter(world, cid1, 5, 7, Zone.Surface); // backup
-    const b  = spawnFighter(world, cid2, 5, 7, Zone.Surface);
+    const b = spawnFighter(world, cid2, 5, 7, Zone.Surface);
     // After windup, a1 and b are in combat; a2 should NOT have cooldown set
     runCombatTicks(world, 1);
     expect(world.ants.attackCooldown[a1]).toBe(COMBAT_COOLDOWN_TICKS); // active
@@ -360,7 +405,7 @@ describe('V16 combat resolver', () => {
     const { world, cid1, cid2 } = makeV16World();
     const a1 = spawnFighter(world, cid1, 5, 7, Zone.Surface);
     const a2 = spawnFighter(world, cid1, 5, 7, Zone.Surface); // backup (higher slot)
-    const b  = spawnFighter(world, cid2, 5, 7, Zone.Surface);
+    const b = spawnFighter(world, cid2, 5, 7, Zone.Surface);
     // Force a1 to die quickly: set hp=4 so one strike kills.
     runCombatTicks(world, 1); // windup tick (a1 vs b paired, a2 unpaired)
     world.ants.hp[a1] = 4;
@@ -378,14 +423,18 @@ describe('V16 combat resolver', () => {
   it('home-ground bonus HP depletes first before base HP', () => {
     const { world, cid1, cid2 } = makeV16World();
     const defender = spawnFighter(world, cid1, 5, 7, Zone.Underground);
-    world.ants.currentGridColonyId[defender] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
+    world.ants.currentGridColonyId[defender] = Number(
+      cid1,
+    ) as unknown as (typeof world.ants.currentGridColonyId)[0];
     const attacker = spawnFighter(world, cid2, 5, 7, Zone.Underground);
-    world.ants.currentGridColonyId[attacker] = Number(cid1) as unknown as typeof world.ants.currentGridColonyId[0];
+    world.ants.currentGridColonyId[attacker] = Number(
+      cid1,
+    ) as unknown as (typeof world.ants.currentGridColonyId)[0];
     // Fighters skip windup: first strike fires on tick 1.
     // Attacker deals COMBAT_DAMAGE_BASE=4; defender bonus=4 absorbs all → bonus=0, base HP intact.
     runCombatTicks(world, 1); // first strike T=1 (no windup for fighters)
-    expect(world.ants.homeGroundBonusHp[defender]).toBe(0);   // bonus fully depleted by first strike
-    expect(world.ants.hp[defender]).toBe(COMBAT_HP_BASE);     // base HP untouched
+    expect(world.ants.homeGroundBonusHp[defender]).toBe(0); // bonus fully depleted by first strike
+    expect(world.ants.hp[defender]).toBe(COMBAT_HP_BASE); // base HP untouched
     // Second strike fires after COMBAT_COOLDOWN_TICKS=5 more ticks. Bonus=0 → base HP takes damage.
     runCombatTicks(world, COMBAT_COOLDOWN_TICKS);
     expect(world.ants.homeGroundBonusHp[defender]).toBe(0);
@@ -436,7 +485,6 @@ describe('V16 2v2 two-tile chamber frontage', () => {
   });
 });
 
-
 // =============================================================================
 // Non-fighter and queen combat stats (S1 follow-up)
 // =============================================================================
@@ -445,15 +493,15 @@ describe('non-fighter and queen combat stats (V17)', () => {
   it('fighter strikes on tick 1 against non-fighter; non-fighter winds up 5 ticks', () => {
     const { world, cid1, cid2 } = makeV17World();
     const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
-    const worker  = spawnAnt(world, cid2, 5, 7, Zone.Surface);   // AntTask.Idle = non-fighter
+    const worker = spawnAnt(world, cid2, 5, 7, Zone.Surface); // AntTask.Idle = non-fighter
     // Tick 1: fighter strikes immediately (no windup); worker starts winding up.
     runCombatTicks(world, 1);
     expect(world.ants.hp[worker]).toBe(COMBAT_HP_BASE - COMBAT_DAMAGE_BASE); // fighter dealt 4
-    expect(world.ants.hp[fighter]).toBe(COMBAT_HP_BASE);                      // worker hasn't struck yet
+    expect(world.ants.hp[fighter]).toBe(COMBAT_HP_BASE); // worker hasn't struck yet
     expect(world.ants.attackCooldown[worker]).toBe(COMBAT_COOLDOWN_TICKS); // 6→5
     // Worker strikes at tick 1 + COMBAT_COOLDOWN_TICKS = 6.
     runCombatTicks(world, COMBAT_COOLDOWN_TICKS - 1); // ticks 2-5: worker cooldown → 1
-    runCombatTicks(world, 1);                          // tick 6: worker cooldown → 0, strikes
+    runCombatTicks(world, 1); // tick 6: worker cooldown → 0, strikes
     expect(world.ants.hp[fighter]).toBe(COMBAT_HP_BASE - COMBAT_DAMAGE_WORKER);
   });
 
@@ -497,8 +545,11 @@ describe('non-fighter and queen combat stats (V17)', () => {
     const { world, cid1 } = makeV16World();
     const queenSlot = allocateEntityId(world);
     initAnt(world.ants, queenSlot, {
-      colonyId: Number(cid1), posX: 10 << 8, posY: 10 << 8,
-      task: AntTask.Idle, hp: COMBAT_HP_QUEEN,
+      colonyId: Number(cid1),
+      posX: 10 << 8,
+      posY: 10 << 8,
+      task: AntTask.Idle,
+      hp: COMBAT_HP_QUEEN,
     });
     expect(world.ants.hp[queenSlot]).toBe(COMBAT_HP_QUEEN);
   });
@@ -515,7 +566,7 @@ describe('spider combat gate (V23 #146/#147)', () => {
   // Pair a fighter with the spider and arm it to strike on the next resolve tick.
   function armFighterAgainstSpider(world: WorldState, fighterId: number): void {
     world.ants.combatOpponentId[fighterId] = -2; // already paired (skip windup)
-    world.ants.attackCooldown[fighterId] = 1;     // decrements to 0 → strikes this tick
+    world.ants.attackCooldown[fighterId] = 1; // decrements to 0 → strikes this tick
   }
 
   it('Patrolling spider takes fighter damage under V23', () => {

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -110,7 +110,10 @@ export function detectAndResolveCombat(world: WorldState, _rng: Rng): void {
     const firstCid = ants.colonyId[liveIdx[runStart]!]!;
     let multiColony = false;
     for (let q = runStart + 1; q < p; q++) {
-      if (ants.colonyId[liveIdx[q]!]! !== firstCid) { multiColony = true; break; }
+      if (ants.colonyId[liveIdx[q]!]! !== firstCid) {
+        multiColony = true;
+        break;
+      }
     }
     if (multiColony) {
       for (let q = runStart; q < p; q++) COMBAT_CONTESTED[liveIdx[q]!] = 1;
@@ -137,8 +140,8 @@ export function detectAndResolveCombat(world: WorldState, _rng: Rng): void {
       if (v23Spider) {
         const onSpiderTile =
           ants.zone[i] === 0 &&
-          (ants.posX[i]! >> FP_SHIFT) === spiderTileX &&
-          (ants.posY[i]! >> FP_SHIFT) === spiderTileY;
+          ants.posX[i]! >> FP_SHIFT === spiderTileX &&
+          ants.posY[i]! >> FP_SHIFT === spiderTileY;
         if (!onSpiderTile) ants.combatOpponentId[i] = -1;
       }
       continue;
@@ -168,9 +171,9 @@ export function detectAndResolveCombat(world: WorldState, _rng: Rng): void {
   if (world.spider !== null) {
     const ss = world.spider.state;
     const spiderCombatActive =
-      ss === 'Striking' || ss === 'Rampaging' ||
-      (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO &&
-        ss !== 'Feeding' && ss !== 'Retreating');
+      ss === 'Striking' ||
+      ss === 'Rampaging' ||
+      (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO && ss !== 'Feeding' && ss !== 'Retreating');
     if (spiderCombatActive) {
       resolveSpiderCombatOnTile(world);
     }
@@ -203,7 +206,7 @@ function applyDamage(world: WorldState, antIdx: number, damage: number): boolean
     damage -= bonus;
     ants.homeGroundBonusHp[antIdx] = 0;
   }
-  ants.hp[antIdx] = (ants.hp[antIdx]! - damage);
+  ants.hp[antIdx] = ants.hp[antIdx]! - damage;
   return ants.hp[antIdx]! <= 0;
 }
 
@@ -216,7 +219,7 @@ function strikeDamage(world: WorldState, antId: number, strikes: boolean): numbe
   if (!strikes) return 0;
   const { ants } = world;
   if (ants.task[antId] === AntTask.Fighting) {
-    return (ants.zone[antId] === 1 && ants.currentGridColonyId[antId] === ants.colonyId[antId]!)
+    return ants.zone[antId] === 1 && ants.currentGridColonyId[antId] === ants.colonyId[antId]!
       ? COMBAT_DAMAGE_HOMEGROUND
       : COMBAT_DAMAGE_BASE;
   }
@@ -250,17 +253,23 @@ function resolveCombatOnTile_v16(
   // its lowest-slot ant. Because participants ascend by slot, the first ant seen
   // for a colony is that colony's lowest slot. Colonies above the two lowest are
   // ignored — only the active pair matters this tick.
-  let cidA = -1, antA = -1, cidB = -1, antB = -1;
+  let cidA = -1,
+    antA = -1,
+    cidB = -1,
+    antB = -1;
   for (let p = lo; p < hi; p++) {
     const idx = liveIdx[p]!;
     if (ants.alive[idx] !== 1) continue;
     const cid = ants.colonyId[idx]!;
     if (cid === cidA || cid === cidB) continue; // lowest slot already captured
     if (cidA === -1 || cid < cidA) {
-      cidB = cidA; antB = antA; // demote current minimum
-      cidA = cid; antA = idx;
+      cidB = cidA;
+      antB = antA; // demote current minimum
+      cidA = cid;
+      antA = idx;
     } else if (cidB === -1 || cid < cidB) {
-      cidB = cid; antB = idx;
+      cidB = cid;
+      antB = idx;
     }
     // else: cid is larger than both tracked colonies — not part of the active pair.
   }
@@ -287,8 +296,10 @@ function resolveCombatOnTile_v16(
     // bonus if still on home ground; it's zeroed if they've moved off home ground.
     // This prevents unintended healing (bonus restored on replacement) while
     // also clearing stale bonus after a position change.
-    const aOnHome = ants.zone[antA] === 1 && ants.currentGridColonyId[antA] === ants.colonyId[antA]!;
-    const bOnHome = ants.zone[antB] === 1 && ants.currentGridColonyId[antB] === ants.colonyId[antB]!;
+    const aOnHome =
+      ants.zone[antA] === 1 && ants.currentGridColonyId[antA] === ants.colonyId[antA]!;
+    const bOnHome =
+      ants.zone[antB] === 1 && ants.currentGridColonyId[antB] === ants.colonyId[antB]!;
     if (aFresh) {
       ants.homeGroundBonusHp[antA] = aOnHome ? COMBAT_HP_HOMEGROUND_BONUS : 0;
     } else if (!aOnHome) {
@@ -308,8 +319,14 @@ function resolveCombatOnTile_v16(
     // Only reset the newly-paired side — veterans keep accumulated progress.
     // Non-fighters start at COMBAT_COOLDOWN_TICKS+1 when fighterStrikesNow so the
     // immediate decrement below leaves them at exactly COMBAT_COOLDOWN_TICKS.
-    if (aNew) ants.attackCooldown[antA] = aIsFighter ? 1 : COMBAT_COOLDOWN_TICKS + (fighterStrikesNow ? 1 : 0);
-    if (bNew) ants.attackCooldown[antB] = bIsFighter ? 1 : COMBAT_COOLDOWN_TICKS + (fighterStrikesNow ? 1 : 0);
+    if (aNew)
+      ants.attackCooldown[antA] = aIsFighter
+        ? 1
+        : COMBAT_COOLDOWN_TICKS + (fighterStrikesNow ? 1 : 0);
+    if (bNew)
+      ants.attackCooldown[antB] = bIsFighter
+        ? 1
+        : COMBAT_COOLDOWN_TICKS + (fighterStrikesNow ? 1 : 0);
     // Return early unless a newly-paired fighter is about to strike (cooldown=1).
     if (!fighterStrikesNow) return;
   }
@@ -444,16 +461,20 @@ export function killAnt(
     const aiColId = enemyAI.colonyId;
     const victimColId = ants.colonyId[antIndex]! as ColonyId;
     // operationAttackerDeaths: victim is a committed-cohort AI fighter.
-    if (victimColId === aiColId
-        && isInCohort(antIndex, enemyAI.operationFighterIds, enemyAI.operationFighterCount)) {
+    if (
+      victimColId === aiColId &&
+      isInCohort(antIndex, enemyAI.operationFighterIds, enemyAI.operationFighterCount)
+    ) {
       enemyAI.operationAttackerDeaths += 1;
     }
     // operationDefenderDeaths: victim is a non-AI ant (defender) killed by a committed-cohort AI fighter.
-    if (victimColId !== aiColId
-        && killerKind === 'Ant'
-        && killerColonyId === aiColId
-        && killerId !== null
-        && isInCohort(killerId, enemyAI.operationFighterIds, enemyAI.operationFighterCount)) {
+    if (
+      victimColId !== aiColId &&
+      killerKind === 'Ant' &&
+      killerColonyId === aiColId &&
+      killerId !== null &&
+      isInCohort(killerId, enemyAI.operationFighterIds, enemyAI.operationFighterCount)
+    ) {
       enemyAI.operationDefenderDeaths += 1;
     }
   }

--- a/src/sim/commands.test.ts
+++ b/src/sim/commands.test.ts
@@ -237,23 +237,86 @@ describe('SimCommand', () => {
       }
 
       expect(handleCommand({ type: 'NoOp', issuedAtTick: 0 })).toBe('noop@0');
-      expect(handleCommand({ type: 'SetBehaviorRatio', colonyId: 1, ratio: { forage: 5, fight: 2 }, issuedAtTick: 1 })).toBe('ratio:1');
-      expect(handleCommand({ type: 'MarkDigTile', colonyId: 1, tileX: 4, tileY: 8, issuedAtTick: 2 })).toBe('dig:4,8');
-      expect(handleCommand({ type: 'MarkFoodPile', colonyId: 1, tileX: 12, tileY: 16, issuedAtTick: 3 })).toBe('food:12,16');
-      expect(handleCommand({ type: 'CancelDigMark', colonyId: 1, tileX: 5, tileY: 9, issuedAtTick: 4 })).toBe('cancel:5,9');
-      expect(handleCommand({ type: 'PlaceChamber', colonyId: 1, chamberType: ChamberType.Queen, anchorTileX: 3, anchorTileY: 7, issuedAtTick: 5 })).toBe('chamber:3,7:type0');
-      expect(handleCommand({ type: 'DesignateEntrance', colonyId: 1, surfaceTileX: 20, surfaceTileY: 64, issuedAtTick: 6 })).toBe('entrance:20,64');
-      expect(handleCommand({ type: 'SetRallyPoint', colonyId: 1, tileX: 10, tileY: 20, issuedAtTick: 7 })).toBe('rally:1:10,20');
-      expect(handleCommand({ type: 'ClearRallyPoint', colonyId: 1, issuedAtTick: 8 })).toBe('clearrally:1');
-      expect(handleCommand({
-        type: 'SyncAIState', colonyId: 2, issuedAtTick: 9, state: 'WarFooting',
-        enteredTick: 2400, probeCount: 0, lastProbeEndTick: 0, invasionStartTick: 0,
-        invasionRallyTileX: -1, invasionRallyTileY: -1, recoveryEndTick: 0,
-        operationKind: 'None', operationStartTick: 0, operationTargetTileX: -1,
-        operationTargetTileY: -1, operationFighterIds: [], operationFighterCount: 0,
-        operationStartFighterCount: 0, operationAttackerDeaths: 0, operationDefenderDeaths: 0,
-      })).toBe('syncai:2:WarFooting');
-      expect(handleCommand({ type: 'MarkSpiderPriority', colonyId: 1, isPriority: true, issuedAtTick: 10 })).toBe('spiderpriority:1:true');
+      expect(
+        handleCommand({
+          type: 'SetBehaviorRatio',
+          colonyId: 1,
+          ratio: { forage: 5, fight: 2 },
+          issuedAtTick: 1,
+        }),
+      ).toBe('ratio:1');
+      expect(
+        handleCommand({ type: 'MarkDigTile', colonyId: 1, tileX: 4, tileY: 8, issuedAtTick: 2 }),
+      ).toBe('dig:4,8');
+      expect(
+        handleCommand({ type: 'MarkFoodPile', colonyId: 1, tileX: 12, tileY: 16, issuedAtTick: 3 }),
+      ).toBe('food:12,16');
+      expect(
+        handleCommand({ type: 'CancelDigMark', colonyId: 1, tileX: 5, tileY: 9, issuedAtTick: 4 }),
+      ).toBe('cancel:5,9');
+      expect(
+        handleCommand({
+          type: 'PlaceChamber',
+          colonyId: 1,
+          chamberType: ChamberType.Queen,
+          anchorTileX: 3,
+          anchorTileY: 7,
+          issuedAtTick: 5,
+        }),
+      ).toBe('chamber:3,7:type0');
+      expect(
+        handleCommand({
+          type: 'DesignateEntrance',
+          colonyId: 1,
+          surfaceTileX: 20,
+          surfaceTileY: 64,
+          issuedAtTick: 6,
+        }),
+      ).toBe('entrance:20,64');
+      expect(
+        handleCommand({
+          type: 'SetRallyPoint',
+          colonyId: 1,
+          tileX: 10,
+          tileY: 20,
+          issuedAtTick: 7,
+        }),
+      ).toBe('rally:1:10,20');
+      expect(handleCommand({ type: 'ClearRallyPoint', colonyId: 1, issuedAtTick: 8 })).toBe(
+        'clearrally:1',
+      );
+      expect(
+        handleCommand({
+          type: 'SyncAIState',
+          colonyId: 2,
+          issuedAtTick: 9,
+          state: 'WarFooting',
+          enteredTick: 2400,
+          probeCount: 0,
+          lastProbeEndTick: 0,
+          invasionStartTick: 0,
+          invasionRallyTileX: -1,
+          invasionRallyTileY: -1,
+          recoveryEndTick: 0,
+          operationKind: 'None',
+          operationStartTick: 0,
+          operationTargetTileX: -1,
+          operationTargetTileY: -1,
+          operationFighterIds: [],
+          operationFighterCount: 0,
+          operationStartFighterCount: 0,
+          operationAttackerDeaths: 0,
+          operationDefenderDeaths: 0,
+        }),
+      ).toBe('syncai:2:WarFooting');
+      expect(
+        handleCommand({
+          type: 'MarkSpiderPriority',
+          colonyId: 1,
+          isPriority: true,
+          issuedAtTick: 10,
+        }),
+      ).toBe('spiderpriority:1:true');
     });
   });
 
@@ -285,7 +348,13 @@ describe('SimCommand', () => {
     });
 
     it('both are assignable to SimCommand union (9 variants)', () => {
-      const a: SimCommand = { type: 'SetRallyPoint', colonyId: 1, tileX: 3, tileY: 9, issuedAtTick: 0 };
+      const a: SimCommand = {
+        type: 'SetRallyPoint',
+        colonyId: 1,
+        tileX: 3,
+        tileY: 9,
+        issuedAtTick: 0,
+      };
       const b: SimCommand = { type: 'ClearRallyPoint', colonyId: 1, issuedAtTick: 0 };
       expect(a.type).toBe('SetRallyPoint');
       expect(b.type).toBe('ClearRallyPoint');

--- a/src/sim/commands.ts
+++ b/src/sim/commands.ts
@@ -51,8 +51,8 @@ export interface PlaceChamberCommand extends SimCommandBase {
   readonly type: 'PlaceChamber';
   readonly colonyId: ColonyId;
   readonly chamberType: ChamberType;
-  readonly anchorTileX: number;  // top-left tile X (accepted Phase 3 PRD command shape)
-  readonly anchorTileY: number;  // top-left tile Y
+  readonly anchorTileX: number; // top-left tile X (accepted Phase 3 PRD command shape)
+  readonly anchorTileY: number; // top-left tile Y
 }
 
 /** PRD §3g — player designates a new nest entrance from the surface. */

--- a/src/sim/constants.test.ts
+++ b/src/sim/constants.test.ts
@@ -49,7 +49,7 @@ describe('PRD §9c lifecycle tick constants', () => {
   });
 
   it('WORKER_LIFESPAN_TICKS === 0x7FFFFFFF (INT32_MAX)', () => {
-    expect(WORKER_LIFESPAN_TICKS).toBe(0x7FFFFFFF);
+    expect(WORKER_LIFESPAN_TICKS).toBe(0x7fffffff);
   });
 
   it('QUEEN_EGG_INTERVAL_TICKS === 300', () => {
@@ -161,7 +161,7 @@ describe('PRD §9c grid dimension constants', () => {
   });
 });
 
-describe('PRD §7 §2 + Phase 10 amendment (CTRL-01\') DEFAULT_BEHAVIOR_RATIO', () => {
+describe("PRD §7 §2 + Phase 10 amendment (CTRL-01') DEFAULT_BEHAVIOR_RATIO", () => {
   it('forage === 10', () => {
     expect(DEFAULT_BEHAVIOR_RATIO.forage).toBe(10);
   });

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -18,7 +18,7 @@ export const EGG_HATCH_TICKS = 1200;
 export const LARVA_MATURE_TICKS = 1500;
 
 /** PRD §9c — Worker lifespan: effectively immortal (INT32_MAX ticks). */
-export const WORKER_LIFESPAN_TICKS = 0x7FFFFFFF;
+export const WORKER_LIFESPAN_TICKS = 0x7fffffff;
 
 /** PRD §9c — Ticks between queen egg-laying events (pre-V21 static value). */
 export const QUEEN_EGG_INTERVAL_TICKS = 300;
@@ -306,7 +306,7 @@ export const SEARCH_PAUSE_JITTER_TICKS = 5 as const;
  */
 export const DEFAULT_BEHAVIOR_RATIO = {
   forage: 10,
-  fight:  0,
+  fight: 0,
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -594,7 +594,6 @@ export const EXCURSION_WOBBLE_PERCENT = 20;
  */
 export const ENTRANCE_DEPOSIT_SUPPRESS_RADIUS = 3;
 
-
 // ---------------------------------------------------------------------------
 // S1 — Combat math (HP / damage / cooldown)
 // ---------------------------------------------------------------------------
@@ -734,7 +733,6 @@ export const AI_MAX_OPERATION_FIGHTERS = 32 as const;
  */
 export const AI_PROBE_FALLBACK_RADIUS_TILES = 40 as const;
 
-
 // ---------------------------------------------------------------------------
 // S3 — Neutral entity sentinel
 // ---------------------------------------------------------------------------
@@ -785,7 +783,6 @@ export const SPIDER_SWARM_FIGHTER_THRESHOLD = 6 as const;
 /** S3 — Manhattan tile radius within which spider hunts for worker density. */
 export const SPIDER_HUNT_SEARCH_RADIUS_TILES = 12 as const;
 
-
 /** S3 — Minimum workers on a tile to qualify as a hunt target. */
 export const SPIDER_HUNT_MIN_TARGET_WORKERS = 2 as const;
 
@@ -811,7 +808,7 @@ export const SPIDER_TERRITORY_RADIUS_TILES = 24 as const;
 
 /** S3 — Brood kills in a single rampage before spider exits to Feeding. */
 export const SPIDER_RAMPAGE_KILL_QUOTA = 2 as const;
-export const SPIDER_RAMPAGE_MAX_TICKS = 1200 as const;  // timeout if no kills after ~20s
+export const SPIDER_RAMPAGE_MAX_TICKS = 1200 as const; // timeout if no kills after ~20s
 
 /** S3 — HP threshold below which spider retreats. */
 export const SPIDER_RAMPAGE_RETREAT_HP = 20 as const;
@@ -886,4 +883,3 @@ export const SPIDER_FEED_HEAL_INTERVAL_TICKS = 10 as const;
  * it is surrounded. The spider moves at 2× ant speed, so a Chase reliably closes.
  */
 export const SPIDER_DEFENSE_TRIGGER_RADIUS = 6 as const;
-

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -8,7 +8,13 @@
 
 import { describe, it, expect } from 'vitest';
 import { tick } from './tick.js';
-import { createWorldState, allocateEntityId, SIM_VERSION_V13_INVARIANT_FIXES, SIM_VERSION_V20_SPIDER, SIM_VERSION_V23_SPIDER_AGGRO } from './types.js';
+import {
+  createWorldState,
+  allocateEntityId,
+  SIM_VERSION_V13_INVARIANT_FIXES,
+  SIM_VERSION_V20_SPIDER,
+  SIM_VERSION_V23_SPIDER_AGGRO,
+} from './types.js';
 import { initAnt } from './ant/ant-store.js';
 import { createColonyRecord } from './colony/colony-store.js';
 import { createPheromoneGrid, phGet, pheromoneGridKey } from './pheromone/pheromone-store.js';
@@ -43,102 +49,122 @@ function serializeWorldState(w: WorldState): string {
     rngState: w.rngState,
     nextEntityId: w.nextEntityId,
     simVersion: w.simVersion,
-    commandQueue: w.commandQueue.map(c => ({ ...c })),
+    commandQueue: w.commandQueue.map((c) => ({ ...c })),
     ants: {
-      posX:            Array.from(w.ants.posX),
-      posY:            Array.from(w.ants.posY),
-      alive:           Array.from(w.ants.alive),
-      age:             Array.from(w.ants.age),
-      task:            Array.from(w.ants.task),
-      subTask:         Array.from(w.ants.subTask),
-      speed:           Array.from(w.ants.speed),
-      lifespan:        Array.from(w.ants.lifespan),
-      colonyId:        Array.from(w.ants.colonyId),
-      foodCarrying:    Array.from(w.ants.foodCarrying),
+      posX: Array.from(w.ants.posX),
+      posY: Array.from(w.ants.posY),
+      alive: Array.from(w.ants.alive),
+      age: Array.from(w.ants.age),
+      task: Array.from(w.ants.task),
+      subTask: Array.from(w.ants.subTask),
+      speed: Array.from(w.ants.speed),
+      lifespan: Array.from(w.ants.lifespan),
+      colonyId: Array.from(w.ants.colonyId),
+      foodCarrying: Array.from(w.ants.foodCarrying),
       starvationTimer: Array.from(w.ants.starvationTimer),
       // Phase 7 ant fields:
-      zone:               Array.from(w.ants.zone),
-      digTileX:           Array.from(w.ants.digTileX),
-      digTileY:           Array.from(w.ants.digTileY),
-      digTicksRemaining:  Array.from(w.ants.digTicksRemaining),
-      targetPosX:         Array.from(w.ants.targetPosX),
-      targetPosY:         Array.from(w.ants.targetPosY),
+      zone: Array.from(w.ants.zone),
+      digTileX: Array.from(w.ants.digTileX),
+      digTileY: Array.from(w.ants.digTileY),
+      digTicksRemaining: Array.from(w.ants.digTicksRemaining),
+      targetPosX: Array.from(w.ants.targetPosX),
+      targetPosY: Array.from(w.ants.targetPosY),
       // Phase 09.1 Chunk 0 — grid-of-occupancy byte (new SoA field).
       currentGridColonyId: Array.from(w.ants.currentGridColonyId),
       // Phase 9 — 6 previously-omitted SoA fields (pre-existing serializer
       // gap closed here per 09.1-00-PLAN). If closure surfaces a latent
       // non-deterministic divergence in one of these fields, revert ONLY the
       // 6 search* lines and document in 09.1-MEMO.md §5 Deviations Log.
-      searchWave:         Array.from(w.ants.searchWave),
-      searchHeadingX:     Array.from(w.ants.searchHeadingX),
-      searchHeadingY:     Array.from(w.ants.searchHeadingY),
+      searchWave: Array.from(w.ants.searchWave),
+      searchHeadingX: Array.from(w.ants.searchHeadingX),
+      searchHeadingY: Array.from(w.ants.searchHeadingY),
       searchHeadingTicks: Array.from(w.ants.searchHeadingTicks),
-      searchPrevTileX:    Array.from(w.ants.searchPrevTileX),
-      searchPrevTileY:    Array.from(w.ants.searchPrevTileY),
+      searchPrevTileX: Array.from(w.ants.searchPrevTileX),
+      searchPrevTileY: Array.from(w.ants.searchPrevTileY),
       // Issue #27 — carrier wait flag (new SoA field). Must round-trip in
       // determinism asserts so a divergence in wait-state would break the
       // byte-identical compare.
-      waitingDeposit:     Array.from(w.ants.waitingDeposit),
+      waitingDeposit: Array.from(w.ants.waitingDeposit),
       // Issue #34 / #35 — Bresenham accumulator + pause counter. Same
       // round-trip rationale: divergence in either field changes future
       // tick output, so determinism compare must include them.
-      pathErr:            Array.from(w.ants.pathErr),
-      searchPauseTicks:   Array.from(w.ants.searchPauseTicks),
+      pathErr: Array.from(w.ants.pathErr),
+      searchPauseTicks: Array.from(w.ants.searchPauseTicks),
       // Phase 9 / S3 combat fields — spider writes these every tick; omitting
       // them would silently pass even if resolveSpiderCombatOnTile diverges.
-      hp:                 Array.from(w.ants.hp),
-      homeGroundBonusHp:  Array.from(w.ants.homeGroundBonusHp),
-      attackCooldown:     Array.from(w.ants.attackCooldown),
-      combatOpponentId:   Array.from(w.ants.combatOpponentId),
-      carryingBroodId:    Array.from(w.ants.carryingBroodId),
-      carriedBy:          Array.from(w.ants.carriedBy),
-      recentTilesX:       Array.from(w.ants.recentTilesX),
-      recentTilesY:       Array.from(w.ants.recentTilesY),
-      recentTilesHead:    Array.from(w.ants.recentTilesHead),
+      hp: Array.from(w.ants.hp),
+      homeGroundBonusHp: Array.from(w.ants.homeGroundBonusHp),
+      attackCooldown: Array.from(w.ants.attackCooldown),
+      combatOpponentId: Array.from(w.ants.combatOpponentId),
+      carryingBroodId: Array.from(w.ants.carryingBroodId),
+      carriedBy: Array.from(w.ants.carriedBy),
+      recentTilesX: Array.from(w.ants.recentTilesX),
+      recentTilesY: Array.from(w.ants.recentTilesY),
+      recentTilesHead: Array.from(w.ants.recentTilesHead),
     },
-    colonies: Object.keys(w.colonies).sort().reduce((acc, k) => {
-      const c = w.colonies[Number(k) as ColonyId]!;
-      acc[k] = {
-        colonyId:             c.colonyId,
-        queenEntityId:        c.queenEntityId,
-        queenStarvationTimer: c.queenStarvationTimer,
-        foodStored:           c.foodStored,
-        workerCount:          c.workerCount,
-        eggCount:             c.eggCount,
-        larvaeCount:          c.larvaeCount,
-        nurseCount:           c.nurseCount,
-        defeated:             c.defeated,
-        reconcileCountdown:   c.reconcileCountdown,
-        killCount:            c.killCount,
-        digFlowFieldDirty:    c.digFlowFieldDirty,
-        eggs:                 [...c.eggs],
-        larvae:               [...c.larvae],
-        workers:              [...c.workers],
-        chambers:             c.chambers.map(ch => ({ ...ch })),
-        entrances:            c.entrances.map(e => ({ ...e })),
-        targetRatio:          { ...c.targetRatio },
-        computedAllocation:   { ...c.computedAllocation },
-        taskCensus:           { ...c.taskCensus },
-      };
-      return acc;
-    }, {} as Record<string, unknown>),
-    pheromoneGrids: Object.keys(w.pheromoneGrids).sort().reduce((acc, k) => {
-      const g = w.pheromoneGrids[k]!;
-      acc[k] = { width: g.width, height: g.height, data: Array.from(g.data) };
-      return acc;
-    }, {} as Record<string, unknown>),
+    colonies: Object.keys(w.colonies)
+      .sort()
+      .reduce(
+        (acc, k) => {
+          const c = w.colonies[Number(k) as ColonyId]!;
+          acc[k] = {
+            colonyId: c.colonyId,
+            queenEntityId: c.queenEntityId,
+            queenStarvationTimer: c.queenStarvationTimer,
+            foodStored: c.foodStored,
+            workerCount: c.workerCount,
+            eggCount: c.eggCount,
+            larvaeCount: c.larvaeCount,
+            nurseCount: c.nurseCount,
+            defeated: c.defeated,
+            reconcileCountdown: c.reconcileCountdown,
+            killCount: c.killCount,
+            digFlowFieldDirty: c.digFlowFieldDirty,
+            eggs: [...c.eggs],
+            larvae: [...c.larvae],
+            workers: [...c.workers],
+            chambers: c.chambers.map((ch) => ({ ...ch })),
+            entrances: c.entrances.map((e) => ({ ...e })),
+            targetRatio: { ...c.targetRatio },
+            computedAllocation: { ...c.computedAllocation },
+            taskCensus: { ...c.taskCensus },
+          };
+          return acc;
+        },
+        {} as Record<string, unknown>,
+      ),
+    pheromoneGrids: Object.keys(w.pheromoneGrids)
+      .sort()
+      .reduce(
+        (acc, k) => {
+          const g = w.pheromoneGrids[k]!;
+          acc[k] = { width: g.width, height: g.height, data: Array.from(g.data) };
+          return acc;
+        },
+        {} as Record<string, unknown>,
+      ),
     // Phase 7: underground grids
-    undergroundGrids: Object.keys(w.undergroundGrids).sort().reduce((acc, k) => {
-      const g = w.undergroundGrids[Number(k) as ColonyId]!;
-      acc[k] = { width: g.width, height: g.height, data: Array.from(g.data) };
-      return acc;
-    }, {} as Record<string, unknown>),
+    undergroundGrids: Object.keys(w.undergroundGrids)
+      .sort()
+      .reduce(
+        (acc, k) => {
+          const g = w.undergroundGrids[Number(k) as ColonyId]!;
+          acc[k] = { width: g.width, height: g.height, data: Array.from(g.data) };
+          return acc;
+        },
+        {} as Record<string, unknown>,
+      ),
     // Phase 7: food piles and pending chambers
-    foodPiles: w.foodPiles.map(p => ({ ...p })),
-    pendingChambers: Object.keys(w.pendingChambers).sort().reduce((acc, k) => {
-      acc[k] = { ...w.pendingChambers[k]! };
-      return acc;
-    }, {} as Record<string, unknown>),
+    foodPiles: w.foodPiles.map((p) => ({ ...p })),
+    pendingChambers: Object.keys(w.pendingChambers)
+      .sort()
+      .reduce(
+        (acc, k) => {
+          acc[k] = { ...w.pendingChambers[k]! };
+          return acc;
+        },
+        {} as Record<string, unknown>,
+      ),
     // S3 V20 — spider entity and priority/scatter shadow fields
     spider: w.spider === null ? null : { ...w.spider },
     spiderPriorityColonyId: w.spiderPriorityColonyId,
@@ -154,13 +180,13 @@ function buildWorld(seed: number): { world: WorldState; queenId: number; colonyI
   const world = createWorldState(seed);
   const queenId = allocateEntityId(world);
   initAnt(world.ants, queenId, {
-    colonyId:  1,
-    posX:      32 << FP_SHIFT,
-    posY:      32 << FP_SHIFT,
-    task:      AntTask.Idle,
-    subTask:   0,
-    speed:     0,
-    lifespan:  WORKER_LIFESPAN_TICKS,
+    colonyId: 1,
+    posX: 32 << FP_SHIFT,
+    posY: 32 << FP_SHIFT,
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
+    lifespan: WORKER_LIFESPAN_TICKS,
   });
   world.colonies[1] = createColonyRecord(1, queenId);
   // Issue #15: chamber.foodStored is now per-chamber authoritative. The
@@ -172,13 +198,13 @@ function buildWorld(seed: number): { world: WorldState; queenId: number; colonyI
   world.colonies[1]!.foodStored = 0;
   for (let i = 0; i < 20; i++) {
     world.colonies[1]!.chambers.push({
-      chamberId:   1000 + i,
+      chamberId: 1000 + i,
       chamberType: ChamberType.FoodStorage,
-      foodStored:  5000,
-      posX:        0,
-      posY:        0,
-      width:       3,
-      height:      3,
+      foodStored: 5000,
+      posX: 0,
+      posY: 0,
+      width: 3,
+      height: 3,
     });
   }
   // 09 reproduction-gate memo: queen egg production requires a completed
@@ -192,22 +218,28 @@ function buildWorld(seed: number): { world: WorldState; queenId: number; colonyI
   // to simulate relocation via entrances (Test 6 has no entrances or
   // underground grid — it's a behavior-free lifecycle harness).
   world.colonies[1]!.chambers.push({
-    chamberId:   1100,
+    chamberId: 1100,
     chamberType: ChamberType.Queen,
-    foodStored:  0,
-    posX:        32 << FP_SHIFT, posY: 32 << FP_SHIFT, width: 2, height: 2,
+    foodStored: 0,
+    posX: 32 << FP_SHIFT,
+    posY: 32 << FP_SHIFT,
+    width: 2,
+    height: 2,
   });
   world.colonies[1]!.chambers.push({
-    chamberId:   1101,
+    chamberId: 1101,
     chamberType: ChamberType.Nursery,
-    foodStored:  0,
-    posX:        0, posY: 0, width: 2, height: 2,
+    foodStored: 0,
+    posX: 0,
+    posY: 0,
+    width: 2,
+    height: 2,
   });
   world.ants.zone[queenId] = 1; // Zone.Underground — Gate 6 precondition
   // Phase 3 PRD §2a caller-side extension fields (factory does not set these):
-  world.colonies[1]!.entrances          = [];
-  world.colonies[1]!.rallyPoint         = null;
-  world.colonies[1]!.digFlowFieldDirty  = false;
+  world.colonies[1]!.entrances = [];
+  world.colonies[1]!.rallyPoint = null;
+  world.colonies[1]!.digFlowFieldDirty = false;
   world.colonies[1]!.foodFlowFieldDirty = false;
   world.pheromoneGrids[pheromoneGridKey(1, PheromoneType.FoodTrail, 'surface')] =
     createPheromoneGrid(64, 64);
@@ -291,12 +323,26 @@ describe('SCEN-06: Determinism proof', () => {
   // Test 5: Same seed, different commands, different state
   it('Test 5: same seed + different commands at tick 50 produce different state', () => {
     const cmdsA: SimCommand[][] = [];
-    cmdsA[50] = [{ type: 'SetBehaviorRatio', colonyId: 1 as ColonyId, ratio: { forage: 10, fight: 0 }, issuedAtTick: 50 }];
+    cmdsA[50] = [
+      {
+        type: 'SetBehaviorRatio',
+        colonyId: 1 as ColonyId,
+        ratio: { forage: 10, fight: 0 },
+        issuedAtTick: 50,
+      },
+    ];
 
     const cmdsB: SimCommand[][] = [];
     // Phase 10 (CTRL-01'): pivot is forage↔fight, not forage↔dig (dig is auto-assigned per CTRL-06).
     // Both runs still produce non-equal serialized state since the ratio drives a different forage/fight split.
-    cmdsB[50] = [{ type: 'SetBehaviorRatio', colonyId: 1 as ColonyId, ratio: { forage: 0, fight: 10 }, issuedAtTick: 50 }];
+    cmdsB[50] = [
+      {
+        type: 'SetBehaviorRatio',
+        colonyId: 1 as ColonyId,
+        ratio: { forage: 0, fight: 10 },
+        issuedAtTick: 50,
+      },
+    ];
 
     const r1 = runSimulation(42, 100, cmdsA);
     const r2 = runSimulation(42, 100, cmdsB);
@@ -367,12 +413,22 @@ describe('issue #27: simVersion plumbing', () => {
       c.foodFlowFieldDirty = false;
       c.foodStored = 0;
       c.chambers.push({
-        chamberId: 1, chamberType: ChamberType.FoodStorage, foodStored: 100,
-        posX: 0, posY: 0, width: 1, height: 1,
+        chamberId: 1,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 100,
+        posX: 0,
+        posY: 0,
+        width: 1,
+        height: 1,
       });
       c.chambers.push({
-        chamberId: 2, chamberType: ChamberType.FoodStorage, foodStored: 200,
-        posX: 0, posY: 0, width: 1, height: 1,
+        chamberId: 2,
+        chamberType: ChamberType.FoodStorage,
+        foodStored: 200,
+        posX: 0,
+        posY: 0,
+        width: 1,
+        height: 1,
       });
       return c;
     }
@@ -417,16 +473,16 @@ describe('Phase 6 SC 2: starvation cascade', () => {
     const world = createWorldState(42);
     const queenId = allocateEntityId(world);
     initAnt(world.ants, queenId, {
-      colonyId:  1,
-      posX:      1024,
-      posY:      1024,
-      task:      AntTask.Idle,
-      subTask:   0,
-      speed:     0,
-      lifespan:  WORKER_LIFESPAN_TICKS,
+      colonyId: 1,
+      posX: 1024,
+      posY: 1024,
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
+      lifespan: WORKER_LIFESPAN_TICKS,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
-    world.colonies[1]!.foodStored = 0;                            // no food — queen cannot eat
+    world.colonies[1]!.foodStored = 0; // no food — queen cannot eat
     world.colonies[1]!.queenStarvationTimer = STARVATION_GRACE_TICKS; // timer at full grace
 
     // Run STARVATION_GRACE_TICKS + 1 ticks — timer decrements by 1 each tick until <= 0 → death
@@ -449,26 +505,26 @@ describe('Phase 6 SC 3: pheromone deposit on traversed cells', () => {
     const world = createWorldState(42);
     const queenId = allocateEntityId(world);
     initAnt(world.ants, queenId, {
-      colonyId:  1,
-      posX:      1024,
-      posY:      1024,
-      task:      AntTask.Idle,
-      subTask:   0,
-      speed:     0,
-      lifespan:  WORKER_LIFESPAN_TICKS,
+      colonyId: 1,
+      posX: 1024,
+      posY: 1024,
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
+      lifespan: WORKER_LIFESPAN_TICKS,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
     world.colonies[1]!.foodStored = 100000;
 
     const workerId = allocateEntityId(world);
     initAnt(world.ants, workerId, {
-      colonyId:  1,
-      posX:      10 << FP_SHIFT,
-      posY:      10 << FP_SHIFT,
-      task:      AntTask.Foraging,
-      subTask:   ForagingSubState.CarryingFood,
-      speed:     WORKER_BASE_SPEED,
-      lifespan:  WORKER_LIFESPAN_TICKS,
+      colonyId: 1,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.CarryingFood,
+      speed: WORKER_BASE_SPEED,
+      lifespan: WORKER_LIFESPAN_TICKS,
     });
     world.ants.foodCarrying[workerId] = 512; // carrying food — deposit rule activates
     world.colonies[1]!.workers.push(workerId);
@@ -495,13 +551,13 @@ describe('Phase 6 SC 4: CTRL-04 one-tick immediate allocation', () => {
     const world = createWorldState(42);
     const queenId = allocateEntityId(world);
     initAnt(world.ants, queenId, {
-      colonyId:  1,
-      posX:      1024,
-      posY:      1024,
-      task:      AntTask.Idle,
-      subTask:   0,
-      speed:     0,
-      lifespan:  WORKER_LIFESPAN_TICKS,
+      colonyId: 1,
+      posX: 1024,
+      posY: 1024,
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
+      lifespan: WORKER_LIFESPAN_TICKS,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
     world.colonies[1]!.foodStored = 100000;
@@ -510,11 +566,11 @@ describe('Phase 6 SC 4: CTRL-04 one-tick immediate allocation', () => {
     for (let i = 0; i < 10; i++) {
       const wid = allocateEntityId(world);
       initAnt(world.ants, wid, {
-        colonyId:  1,
-        posX:      1024,
-        posY:      1024,
-        task:      AntTask.Idle,
-        subTask:   0,
+        colonyId: 1,
+        posX: 1024,
+        posY: 1024,
+        task: AntTask.Idle,
+        subTask: 0,
       });
       world.colonies[1]!.workers.push(wid);
       world.colonies[1]!.workerCount += 1;
@@ -522,7 +578,7 @@ describe('Phase 6 SC 4: CTRL-04 one-tick immediate allocation', () => {
 
     // Set initial targetRatio → forage:10 (all 10 workers allocated to forage)
     world.colonies[1]!.targetRatio.forage = 10;
-    world.colonies[1]!.targetRatio.fight  = 0;
+    world.colonies[1]!.targetRatio.fight = 0;
 
     // Tick 0 (no commands): allocation reflects forage:10 ratio
     tick(world, []);
@@ -561,16 +617,19 @@ describe('Phase 7: createScenario determinism with MarkDigTile commands', () => 
 
     // Build a fixed command schedule: mark several tiles at specific ticks
     const cmds: SimCommand[][] = [];
-    cmds[0]  = [{ type: 'MarkDigTile', colonyId, tileX: 10, tileY: 5, issuedAtTick: 0 }];
+    cmds[0] = [{ type: 'MarkDigTile', colonyId, tileX: 10, tileY: 5, issuedAtTick: 0 }];
     cmds[10] = [{ type: 'MarkDigTile', colonyId, tileX: 15, tileY: 8, issuedAtTick: 10 }];
     cmds[20] = [{ type: 'MarkDigTile', colonyId, tileX: 20, tileY: 10, issuedAtTick: 20 }];
     cmds[30] = [{ type: 'CancelDigMark', colonyId, tileX: 10, tileY: 5, issuedAtTick: 30 }];
-    cmds[50] = [{
-      type: 'SetBehaviorRatio', colonyId,
-      // Phase 10 (CTRL-01'): pivot forage↔fight (dig is auto-assigned per CTRL-06).
-      ratio: { forage: 0, fight: 10 },
-      issuedAtTick: 50,
-    }];
+    cmds[50] = [
+      {
+        type: 'SetBehaviorRatio',
+        colonyId,
+        // Phase 10 (CTRL-01'): pivot forage↔fight (dig is auto-assigned per CTRL-06).
+        ratio: { forage: 0, fight: 10 },
+        issuedAtTick: 50,
+      },
+    ];
 
     function runScenario(): string {
       const world = createScenario(42);
@@ -592,13 +651,13 @@ describe('No-allocation invariant: object identity in steady state', () => {
     const world = createWorldState(42);
     const queenId = allocateEntityId(world);
     initAnt(world.ants, queenId, {
-      colonyId:  1,
-      posX:      32 << FP_SHIFT,
-      posY:      32 << FP_SHIFT,
-      task:      AntTask.Idle,
-      subTask:   0,
-      speed:     0,
-      lifespan:  WORKER_LIFESPAN_TICKS,
+      colonyId: 1,
+      posX: 32 << FP_SHIFT,
+      posY: 32 << FP_SHIFT,
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
+      lifespan: WORKER_LIFESPAN_TICKS,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
     world.colonies[1]!.foodStored = 100000;
@@ -608,9 +667,9 @@ describe('No-allocation invariant: object identity in steady state', () => {
 
     // Capture object references after warmup
     const colony = world.colonies[1]!;
-    const targetRatioRef        = colony.targetRatio;
+    const targetRatioRef = colony.targetRatio;
     const computedAllocationRef = colony.computedAllocation;
-    const taskCensusRef         = colony.taskCensus;
+    const taskCensusRef = colony.taskCensus;
 
     // Run 100 more ticks
     for (let i = 0; i < 100; i++) tick(world, []);
@@ -725,13 +784,13 @@ function buildCrossGridCombatWorld(seed: number): WorldState {
   const playerAntId = allocateEntityId(world);
   initAnt(world.ants, playerAntId, {
     colonyId: PLAYER_COLONY_ID,
-    posX:     (ENEMY_START_X << FP_SHIFT) + (FP_ONE >> 1),
-    posY:     (ENEMY_START_Y << FP_SHIFT) + (FP_ONE >> 1),
-    task:     AntTask.Fighting,
-    subTask:  0,
-    speed:    WORKER_BASE_SPEED,
+    posX: (ENEMY_START_X << FP_SHIFT) + (FP_ONE >> 1),
+    posY: (ENEMY_START_Y << FP_SHIFT) + (FP_ONE >> 1),
+    task: AntTask.Fighting,
+    subTask: 0,
+    speed: WORKER_BASE_SPEED,
     lifespan: WORKER_LIFESPAN_TICKS,
-    zone:     Zone.Surface,
+    zone: Zone.Surface,
   });
   world.colonies[PLAYER_COLONY_ID]!.workers.push(playerAntId);
   world.colonies[PLAYER_COLONY_ID]!.workerCount += 1;
@@ -746,13 +805,13 @@ function buildCrossGridCombatWorld(seed: number): WorldState {
   const hostileId = allocateEntityId(world);
   initAnt(world.ants, hostileId, {
     colonyId: ENEMY_COLONY_ID,
-    posX:     (hostileTileX << FP_SHIFT) + (FP_ONE >> 1),
-    posY:     (hostileTileY << FP_SHIFT) + (FP_ONE >> 1),
-    task:     AntTask.Idle,
-    subTask:  0,
-    speed:    0, // pinned — keeps the test scenario stable and combat-reachable
+    posX: (hostileTileX << FP_SHIFT) + (FP_ONE >> 1),
+    posY: (hostileTileY << FP_SHIFT) + (FP_ONE >> 1),
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0, // pinned — keeps the test scenario stable and combat-reachable
     lifespan: WORKER_LIFESPAN_TICKS,
-    zone:     Zone.Underground,
+    zone: Zone.Underground,
   });
   world.ants.currentGridColonyId[hostileId] = ENEMY_COLONY_ID;
   world.colonies[ENEMY_COLONY_ID]!.workers.push(hostileId);
@@ -811,7 +870,7 @@ describe('Phase 09.1 Chunk 4 — cross-grid combat parity (REQ-C4c)', () => {
       if (worldA.ants.alive[id] !== 1) continue;
       if (worldA.ants.zone[id] !== Zone.Underground) continue;
       const owner = worldA.ants.colonyId[id];
-      const grid  = worldA.ants.currentGridColonyId[id];
+      const grid = worldA.ants.currentGridColonyId[id];
       if (owner !== grid) {
         anyDiverged = true;
         if (owner === PLAYER_COLONY_ID && grid === ENEMY_COLONY_ID) {
@@ -880,7 +939,7 @@ describe('S3 V20: spider replay determinism (Hunting → Striking → Rampaging)
 
     function buildSpiderWorld(): WorldState {
       const world = createScenario(SEED);
-      // Fast-fail: world must be V20 so world.spider is non-null. 
+      // Fast-fail: world must be V20 so world.spider is non-null.
       // regresses to a sub-V20 LATEST, this assert fires before the spider!-dereference
       // below would throw a TypeError — clearer than an opaque null-deref.
       expect(world.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V20_SPIDER);
@@ -1103,4 +1162,3 @@ describe('S3 V23 redesign: meander + feed-after-kill replay determinism', () => 
     expect({ ...after, killedThisTick: before.killedThisTick }).toEqual(before);
   });
 });
-

--- a/src/sim/dig-system.test.ts
+++ b/src/sim/dig-system.test.ts
@@ -4,25 +4,17 @@
 // Pre-allocate out and queue as new Int32Array(width * height).
 
 import { describe, it, expect } from 'vitest';
-import {
-  createDigFlowFields,
-  ensureDigFlowField,
-  computeDigFlowField,
-} from './dig-system.js';
-import {
-  createUndergroundGrid,
-  ugSet,
-  UndergroundTileState,
-} from './terrain.js';
+import { createDigFlowFields, ensureDigFlowField, computeDigFlowField } from './dig-system.js';
+import { createUndergroundGrid, ugSet, UndergroundTileState } from './terrain.js';
 
 // ---------------------------------------------------------------------------
 // Direction constants (match dig-system.ts internal encoding)
 // 0=North, 1=East, 2=South, 3=West, -1=source, -2=unreachable
 // ---------------------------------------------------------------------------
 const NORTH = 0;
-const EAST  = 1;
+const EAST = 1;
 const SOUTH = 2;
-const WEST  = 3;
+const WEST = 3;
 const SOURCE = -1;
 const UNREACHABLE = -2;
 
@@ -32,7 +24,7 @@ const UNREACHABLE = -2;
 function makeBuffers(width: number, height: number) {
   const size = width * height;
   return {
-    out:   new Int32Array(size),
+    out: new Int32Array(size),
     queue: new Int32Array(size),
   };
 }
@@ -41,9 +33,9 @@ function makeBuffers(width: number, height: number) {
 // Test 1: Empty grid (all Solid) — no Marked tiles → all unreachable
 // ---------------------------------------------------------------------------
 describe('computeDigFlowField', () => {
-
   it('empty grid (all Solid) produces all -2 (unreachable)', () => {
-    const width = 4, height = 4;
+    const width = 4,
+      height = 4;
     const grid = createUndergroundGrid(width, height);
     const { out, queue } = makeBuffers(width, height);
 
@@ -59,7 +51,8 @@ describe('computeDigFlowField', () => {
   // ---------------------------------------------------------------------------
   it('single Marked tile with adjacent Open tiles — neighbors point toward source', () => {
     // 8×4 grid; Marked at (3,2); Open neighbors at (2,2),(4,2),(3,1),(3,3)
-    const width = 8, height = 4;
+    const width = 8,
+      height = 4;
     const grid = createUndergroundGrid(width, height);
 
     ugSet(grid, 3, 2, UndergroundTileState.Marked);
@@ -72,19 +65,19 @@ describe('computeDigFlowField', () => {
     computeDigFlowField(grid, out, queue);
 
     // The source tile itself
-    expect(out[2 * width + 3]).toBe(SOURCE);  // (3,2)
+    expect(out[2 * width + 3]).toBe(SOURCE); // (3,2)
 
     // West of source → East points back to (3,2)
-    expect(out[2 * width + 2]).toBe(EAST);    // (2,2): go East to reach (3,2)
+    expect(out[2 * width + 2]).toBe(EAST); // (2,2): go East to reach (3,2)
 
     // East of source → West points back to (3,2)
-    expect(out[2 * width + 4]).toBe(WEST);    // (4,2): go West to reach (3,2)
+    expect(out[2 * width + 4]).toBe(WEST); // (4,2): go West to reach (3,2)
 
     // North of source (row 1) → South points back to (3,2)
-    expect(out[1 * width + 3]).toBe(SOUTH);   // (3,1): go South to reach (3,2)
+    expect(out[1 * width + 3]).toBe(SOUTH); // (3,1): go South to reach (3,2)
 
     // South of source (row 3) → North points back to (3,2)
-    expect(out[3 * width + 3]).toBe(NORTH);   // (3,3): go North to reach (3,2)
+    expect(out[3 * width + 3]).toBe(NORTH); // (3,3): go North to reach (3,2)
 
     // All Solid tiles (rest of the grid) remain -2
     const markedIdx = 2 * width + 3;
@@ -104,7 +97,8 @@ describe('computeDigFlowField', () => {
     // Tiles 1–4 should point West (toward col 0); tiles 5–8 should point East (toward col 9).
     // Tile 4 and 5 are equidistant — BFS is deterministic so the tiebreak goes to whichever
     // was enqueued first (source at col 0 is seeded first in the linear scan).
-    const width = 10, height = 1;
+    const width = 10,
+      height = 1;
     const grid = createUndergroundGrid(width, height);
 
     ugSet(grid, 0, 0, UndergroundTileState.Marked);
@@ -116,8 +110,8 @@ describe('computeDigFlowField', () => {
     const { out, queue } = makeBuffers(width, height);
     computeDigFlowField(grid, out, queue);
 
-    expect(out[0]).toBe(SOURCE);  // (0,0) Marked
-    expect(out[9]).toBe(SOURCE);  // (9,0) Marked
+    expect(out[0]).toBe(SOURCE); // (0,0) Marked
+    expect(out[9]).toBe(SOURCE); // (9,0) Marked
 
     // Tiles near left source should point West (toward col 0)
     // The BFS from source 0 expands East first; source 9 expands West.
@@ -145,7 +139,8 @@ describe('computeDigFlowField', () => {
   it('Solid wall blocks BFS — tiles on far side are unreachable', () => {
     // 6×1 grid: Marked at (0,0), Open at (1,0),(2,0), Solid at (3,0), Open at (4,0),(5,0)
     // Tiles (4,0) and (5,0) should be unreachable (-2) because (3,0) is Solid.
-    const width = 6, height = 1;
+    const width = 6,
+      height = 1;
     const grid = createUndergroundGrid(width, height);
 
     ugSet(grid, 0, 0, UndergroundTileState.Marked);
@@ -158,12 +153,12 @@ describe('computeDigFlowField', () => {
     const { out, queue } = makeBuffers(width, height);
     computeDigFlowField(grid, out, queue);
 
-    expect(out[0]).toBe(SOURCE);        // (0,0) Marked
-    expect(out[1]).toBe(WEST);          // (1,0) points West toward (0,0)
-    expect(out[2]).toBe(WEST);          // (2,0) points West
-    expect(out[3]).toBe(UNREACHABLE);   // (3,0) Solid — unreachable
-    expect(out[4]).toBe(UNREACHABLE);   // (4,0) cut off by wall
-    expect(out[5]).toBe(UNREACHABLE);   // (5,0) cut off by wall
+    expect(out[0]).toBe(SOURCE); // (0,0) Marked
+    expect(out[1]).toBe(WEST); // (1,0) points West toward (0,0)
+    expect(out[2]).toBe(WEST); // (2,0) points West
+    expect(out[3]).toBe(UNREACHABLE); // (3,0) Solid — unreachable
+    expect(out[4]).toBe(UNREACHABLE); // (4,0) cut off by wall
+    expect(out[5]).toBe(UNREACHABLE); // (5,0) cut off by wall
   });
 
   // ---------------------------------------------------------------------------
@@ -172,7 +167,8 @@ describe('computeDigFlowField', () => {
   it('BeingDug tiles are passable — flow-field routes through them', () => {
     // 3×1 grid: Marked at (0,0), BeingDug at (1,0), Open at (2,0)
     // (2,0) should get a direction toward (0,0) via (1,0).
-    const width = 3, height = 1;
+    const width = 3,
+      height = 1;
     const grid = createUndergroundGrid(width, height);
 
     ugSet(grid, 0, 0, UndergroundTileState.Marked);
@@ -182,16 +178,17 @@ describe('computeDigFlowField', () => {
     const { out, queue } = makeBuffers(width, height);
     computeDigFlowField(grid, out, queue);
 
-    expect(out[0]).toBe(SOURCE);  // (0,0) Marked
-    expect(out[1]).toBe(WEST);    // (1,0) BeingDug: points West toward (0,0)
-    expect(out[2]).toBe(WEST);    // (2,0) Open: points West through BeingDug
+    expect(out[0]).toBe(SOURCE); // (0,0) Marked
+    expect(out[1]).toBe(WEST); // (1,0) BeingDug: points West toward (0,0)
+    expect(out[2]).toBe(WEST); // (2,0) Open: points West through BeingDug
   });
 
   // ---------------------------------------------------------------------------
   // Test 6: Pre-allocated queue reuse — second call on same buffers works correctly
   // ---------------------------------------------------------------------------
   it('second call with same buffers produces correct results (queue reuse)', () => {
-    const width = 4, height = 1;
+    const width = 4,
+      height = 1;
     const grid1 = createUndergroundGrid(width, height);
     const grid2 = createUndergroundGrid(width, height);
 
@@ -221,7 +218,6 @@ describe('computeDigFlowField', () => {
     expect(out[1]).toBe(EAST);
     expect(out[0]).toBe(EAST);
   });
-
 });
 
 // ---------------------------------------------------------------------------

--- a/src/sim/dig-system.ts
+++ b/src/sim/dig-system.ts
@@ -12,9 +12,7 @@
 // DO NOT use Math.random(), Date, performance.now(), or floating-point arithmetic.
 
 import type { ColonyId } from './colony/colony-store.js';
-import {
-  UndergroundTileState,
-} from './terrain.js';
+import { UndergroundTileState } from './terrain.js';
 import type { UndergroundGrid } from './terrain.js';
 // Issue #87 — shared BFS expansion. Direction encoding:
 //   0=N (row decreases), 1=E, 2=S, 3=W; -1=source, -2=unreachable.

--- a/src/sim/entrance-flow.ts
+++ b/src/sim/entrance-flow.ts
@@ -147,7 +147,7 @@ export function computeEntranceFlowField(
     const state = data[idx]!;
     if (state !== UndergroundTileState.Open && state !== UndergroundTileState.BeingDug) continue;
     if (out[idx] !== -2) continue; // dedupe: multiple entrances at same column
-    out[idx] = -1;                 // source tile
+    out[idx] = -1; // source tile
     queue[tail++] = idx;
   }
 
@@ -233,8 +233,8 @@ export function computeSurfaceEntranceFlowField(
   // ESLint-clean, single-instruction. If SURFACE_GRID_WIDTH ever leaves
   // power-of-2 territory, this needs a strategy change (and the
   // SHIFT/MASK constants below need to update accordingly).
-  const SURFACE_WIDTH_SHIFT = 7;       // log2(128)
-  const SURFACE_WIDTH_MASK  = width - 1; // 127
+  const SURFACE_WIDTH_SHIFT = 7; // log2(128)
+  const SURFACE_WIDTH_MASK = width - 1; // 127
   const REVERSE = [2, 3, 0, 1] as const;
   const NEIGHBOR_DR = [-1, 0, 1, 0] as const;
   const NEIGHBOR_DC = [0, 1, 0, -1] as const;

--- a/src/sim/enums.test.ts
+++ b/src/sim/enums.test.ts
@@ -179,11 +179,16 @@ describe('AntTask exhaustive switch (type narrowing)', () => {
   // the type alias narrows correctly so the `default` arm is unreachable.
   function describeTask(task: AntTask): string {
     switch (task) {
-      case AntTask.Idle:     return 'idle';
-      case AntTask.Foraging: return 'foraging';
-      case AntTask.Digging:  return 'digging';
-      case AntTask.Fighting: return 'fighting';
-      case AntTask.Nursing:  return 'nursing';
+      case AntTask.Idle:
+        return 'idle';
+      case AntTask.Foraging:
+        return 'foraging';
+      case AntTask.Digging:
+        return 'digging';
+      case AntTask.Fighting:
+        return 'fighting';
+      case AntTask.Nursing:
+        return 'nursing';
       default: {
         const _exhaustive: never = task as unknown as never;
         return _exhaustive;
@@ -222,16 +227,21 @@ describe('headless survival (Node --experimental-strip-types)', () => {
     // to a singleton — we want to prove the switch works over the full union at runtime.
     function dispatchTask(task: AntTask): string {
       switch (task) {
-        case AntTask.Foraging: return 'foraging';
-        default:               return 'other';
+        case AntTask.Foraging:
+          return 'foraging';
+        default:
+          return 'other';
       }
     }
 
     function dispatchSubState(sub: ForagingSubState): string {
       switch (sub) {
-        case ForagingSubState.SearchingFood:   return 'searching';
-        case ForagingSubState.CarryingFood:    return 'carrying';
-        case ForagingSubState.ReturningToNest: return 'returning';
+        case ForagingSubState.SearchingFood:
+          return 'searching';
+        case ForagingSubState.CarryingFood:
+          return 'carrying';
+        case ForagingSubState.ReturningToNest:
+          return 'returning';
         default: {
           const _exhaustive: never = sub as unknown as never;
           return _exhaustive;

--- a/src/sim/enums.ts
+++ b/src/sim/enums.ts
@@ -15,13 +15,13 @@
 // ---------------------------------------------------------------------------
 
 export const AntTask = {
-  Idle:     0,
+  Idle: 0,
   Foraging: 1,
-  Digging:  2,
+  Digging: 2,
   Fighting: 3,
-  Nursing:  4,
+  Nursing: 4,
 } as const;
-export type AntTask = typeof AntTask[keyof typeof AntTask];
+export type AntTask = (typeof AntTask)[keyof typeof AntTask];
 
 // ---------------------------------------------------------------------------
 // ForagingSubState — sub-state for ants with AntTask.Foraging (PRD §1 lines 62-66)
@@ -29,11 +29,11 @@ export type AntTask = typeof AntTask[keyof typeof AntTask];
 // ---------------------------------------------------------------------------
 
 export const ForagingSubState = {
-  SearchingFood:   0,
-  CarryingFood:    1,
+  SearchingFood: 0,
+  CarryingFood: 1,
   ReturningToNest: 2, // PRD §1 line 66 — required; downstream plans reference this member
 } as const;
-export type ForagingSubState = typeof ForagingSubState[keyof typeof ForagingSubState];
+export type ForagingSubState = (typeof ForagingSubState)[keyof typeof ForagingSubState];
 
 // ---------------------------------------------------------------------------
 // DiggingSubState — sub-state for ants with AntTask.Digging (PRD §1 lines 72-74)
@@ -41,9 +41,9 @@ export type ForagingSubState = typeof ForagingSubState[keyof typeof ForagingSubS
 
 export const DiggingSubState = {
   MovingToTile: 0,
-  Excavating:   1,
+  Excavating: 1,
 } as const;
-export type DiggingSubState = typeof DiggingSubState[keyof typeof DiggingSubState];
+export type DiggingSubState = (typeof DiggingSubState)[keyof typeof DiggingSubState];
 
 // ---------------------------------------------------------------------------
 // NursingSubState — sub-state for ants with AntTask.Nursing (PRD §1 lines 82-84)
@@ -52,10 +52,10 @@ export type DiggingSubState = typeof DiggingSubState[keyof typeof DiggingSubStat
 
 export const NursingSubState = {
   MovingToBrood: 0,
-  Feeding:       1, // PRD §1 line 84 — member is `Feeding`, NOT `FeedingBrood`
-  Attending:     2, // S4 V21+ — nurse dwells at Nursery after deposit; accelerates adjacent larvae
+  Feeding: 1, // PRD §1 line 84 — member is `Feeding`, NOT `FeedingBrood`
+  Attending: 2, // S4 V21+ — nurse dwells at Nursery after deposit; accelerates adjacent larvae
 } as const;
-export type NursingSubState = typeof NursingSubState[keyof typeof NursingSubState];
+export type NursingSubState = (typeof NursingSubState)[keyof typeof NursingSubState];
 
 // ---------------------------------------------------------------------------
 // FightingSubState — sub-state for ants with AntTask.Fighting (PRD §1 lines 91-93)
@@ -64,27 +64,27 @@ export type NursingSubState = typeof NursingSubState[keyof typeof NursingSubStat
 
 export const FightingSubState = {
   MovingToRally: 0, // PRD §1 line 92
-  Engaging:      1, // PRD §1 line 93 — both members canonical at Phase 2 scope
+  Engaging: 1, // PRD §1 line 93 — both members canonical at Phase 2 scope
 } as const;
-export type FightingSubState = typeof FightingSubState[keyof typeof FightingSubState];
+export type FightingSubState = (typeof FightingSubState)[keyof typeof FightingSubState];
 
 // ---------------------------------------------------------------------------
 // ChamberType — underground chamber classification (PRD §2)
 // ---------------------------------------------------------------------------
 
 export const ChamberType = {
-  Queen:       0,
-  Nursery:     1,
+  Queen: 0,
+  Nursery: 1,
   FoodStorage: 2,
 } as const;
-export type ChamberType = typeof ChamberType[keyof typeof ChamberType];
+export type ChamberType = (typeof ChamberType)[keyof typeof ChamberType];
 
 // ---------------------------------------------------------------------------
 // PheromoneType — pheromone trail classification (PRD §5a)
 // ---------------------------------------------------------------------------
 
 export const PheromoneType = {
-  FoodTrail:   0,
+  FoodTrail: 0,
   DangerTrail: 1,
 } as const;
-export type PheromoneType = typeof PheromoneType[keyof typeof PheromoneType];
+export type PheromoneType = (typeof PheromoneType)[keyof typeof PheromoneType];

--- a/src/sim/fighter-rally-hold.test.ts
+++ b/src/sim/fighter-rally-hold.test.ts
@@ -50,10 +50,10 @@ import type { ColonyId } from './colony/colony-store.js';
 const COLONY_ID = 1 as ColonyId;
 
 interface RallyWorld {
-  world:       WorldState;
-  fighterIds:  number[];
-  rallyTileX:  number;
-  rallyTileY:  number;
+  world: WorldState;
+  fighterIds: number[];
+  rallyTileX: number;
+  rallyTileY: number;
 }
 
 /**
@@ -75,20 +75,20 @@ function buildRallyWorld(
   const queenId = allocateEntityId(world);
   initAnt(world.ants, queenId, {
     colonyId: COLONY_ID,
-    posX:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-    posY:     (5 << FP_SHIFT) + (FP_ONE >> 1),
-    task:     AntTask.Idle,
-    subTask:  0,
-    speed:    0,
+    posX: (5 << FP_SHIFT) + (FP_ONE >> 1),
+    posY: (5 << FP_SHIFT) + (FP_ONE >> 1),
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
     lifespan: WORKER_LIFESPAN_TICKS,
-    zone:     Zone.Surface,
+    zone: Zone.Surface,
   });
 
   const colony = createColonyRecord(COLONY_ID, queenId);
-  colony.entrances         = [];
-  colony.rallyPoint        = { tileX: rallyTileX, tileY: rallyTileY };
+  colony.entrances = [];
+  colony.rallyPoint = { tileX: rallyTileX, tileY: rallyTileY };
   colony.digFlowFieldDirty = false;
-  colony.foodStored        = 100000; // ample — no starvation during the run
+  colony.foodStored = 100000; // ample — no starvation during the run
   world.colonies[COLONY_ID] = colony;
 
   const fighterIds: number[] = [];
@@ -96,13 +96,13 @@ function buildRallyWorld(
     const id = allocateEntityId(world);
     initAnt(world.ants, id, {
       colonyId: COLONY_ID,
-      posX:     (tx << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (ty << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Fighting,
-      subTask:  FightingSubState.MovingToRally,
-      speed:    WORKER_BASE_SPEED,
+      posX: (tx << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (ty << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Fighting,
+      subTask: FightingSubState.MovingToRally,
+      speed: WORKER_BASE_SPEED,
       lifespan: WORKER_LIFESPAN_TICKS,
-      zone:     Zone.Surface,
+      zone: Zone.Surface,
     });
     colony.workers.push(id);
     colony.workerCount += 1;
@@ -150,12 +150,12 @@ describe('fighter rally hold — anti-oscillation (snapshot-reproduction bug)', 
     // (dx=dy=0). Without the fix each fighter re-targets the rally center
     // every tick, walks toward it, collides, gets bumped — visible ABAB.
     const startTiles: Array<readonly [number, number]> = [
-      [RALLY_X,     RALLY_Y    ], // center
-      [RALLY_X,     RALLY_Y - 1], // N
-      [RALLY_X + 1, RALLY_Y    ], // E
-      [RALLY_X,     RALLY_Y + 1], // S
-      [RALLY_X - 1, RALLY_Y    ], // W
-      [RALLY_X,     RALLY_Y - 2], // N2 (radius 2)
+      [RALLY_X, RALLY_Y], // center
+      [RALLY_X, RALLY_Y - 1], // N
+      [RALLY_X + 1, RALLY_Y], // E
+      [RALLY_X, RALLY_Y + 1], // S
+      [RALLY_X - 1, RALLY_Y], // W
+      [RALLY_X, RALLY_Y - 2], // N2 (radius 2)
     ];
     const { world, fighterIds } = buildRallyWorld(RALLY_X, RALLY_Y, startTiles);
 
@@ -186,7 +186,12 @@ describe('fighter rally hold — anti-oscillation (snapshot-reproduction bug)', 
     // up visually as jitter even when tile coords look stable across
     // end-of-tick snapshots.
     const TICKS = 30;
-    interface Snap { tileX: number; tileY: number; posX: number; posY: number }
+    interface Snap {
+      tileX: number;
+      tileY: number;
+      posX: number;
+      posY: number;
+    }
     const trace: Snap[][] = [];
     for (let t = 0; t < TICKS; t++) {
       const cmds = world.commandQueue.splice(0);
@@ -196,8 +201,8 @@ describe('fighter rally hold — anti-oscillation (snapshot-reproduction bug)', 
         snap.push({
           tileX: tileXOf(world, id),
           tileY: tileYOf(world, id),
-          posX:  world.ants.posX[id]!,
-          posY:  world.ants.posY[id]!,
+          posX: world.ants.posX[id]!,
+          posY: world.ants.posY[id]!,
         });
       }
       trace.push(snap);
@@ -342,10 +347,10 @@ describe('fighter rally hold — anti-oscillation (snapshot-reproduction bug)', 
  * the rally tile coords — that's the whole point of the test).
  */
 interface InvasionRallyWorld {
-  world:        WorldState;
-  fighterIds:   number[];
-  rallyTileX:   number;
-  rallyTileY:   number;
+  world: WorldState;
+  fighterIds: number[];
+  rallyTileX: number;
+  rallyTileY: number;
 }
 
 function buildInvasionRallyWorld(
@@ -380,8 +385,10 @@ function buildInvasionRallyWorld(
   if (!enemyEntrances[0]!.isOpen) {
     throw new Error('expected enemy entrance to be open');
   }
-  if (enemyEntrances[0]!.surfaceTileX !== rallyTileX
-      || enemyEntrances[0]!.surfaceTileY !== rallyTileY) {
+  if (
+    enemyEntrances[0]!.surfaceTileX !== rallyTileX ||
+    enemyEntrances[0]!.surfaceTileY !== rallyTileY
+  ) {
     throw new Error('expected enemy entrance to be at (ENEMY_START_X, ENEMY_START_Y)');
   }
 
@@ -391,13 +398,13 @@ function buildInvasionRallyWorld(
     const id = allocateEntityId(world);
     initAnt(world.ants, id, {
       colonyId: PLAYER_COLONY_ID,
-      posX:     (tx << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (ty << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Fighting,
-      subTask:  FightingSubState.MovingToRally,
-      speed:    WORKER_BASE_SPEED,
+      posX: (tx << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (ty << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Fighting,
+      subTask: FightingSubState.MovingToRally,
+      speed: WORKER_BASE_SPEED,
       lifespan: WORKER_LIFESPAN_TICKS,
-      zone:     Zone.Surface,
+      zone: Zone.Surface,
     });
     world.colonies[PLAYER_COLONY_ID]!.workers.push(id);
     world.colonies[PLAYER_COLONY_ID]!.workerCount += 1;
@@ -432,7 +439,8 @@ describe('fighter rally hold — carve out rally-on-entrance (invasion regressio
     expect(world.ants.colonyId[id]).toBe(PLAYER_COLONY_ID);
     expect(world.ants.currentGridColonyId[id]).toBe(PLAYER_COLONY_ID);
     expect(world.colonies[PLAYER_COLONY_ID]!.rallyPoint).toEqual({
-      tileX: rallyTileX, tileY: rallyTileY,
+      tileX: rallyTileX,
+      tileY: rallyTileY,
     });
 
     // Act — tick until the fighter descends, or bail after MAX ticks.
@@ -473,8 +481,7 @@ describe('fighter rally hold — carve out rally-on-entrance (invasion regressio
     // (Manhattan≤1), then descends the next tick.
     expect(tileBeforeDescend).not.toBeNull();
     const manhattanBeforeDescend =
-      Math.abs(tileBeforeDescend![0] - rallyTileX) +
-      Math.abs(tileBeforeDescend![1] - rallyTileY);
+      Math.abs(tileBeforeDescend![0] - rallyTileX) + Math.abs(tileBeforeDescend![1] - rallyTileY);
     expect(manhattanBeforeDescend).toBeLessThanOrEqual(1);
     // Descent flipped the grid-of-occupancy to the enemy colony.
     expect(world.ants.zone[id]).toBe(Zone.Underground);
@@ -491,9 +498,9 @@ describe('fighter rally hold — carve out rally-on-entrance (invasion regressio
     // at a time (occupancy resolver enforces same-colony tile uniqueness
     // on the surface). Generous 300-tick budget covers all four.
     const startTiles: Array<readonly [number, number]> = [
-      [ENEMY_START_X - 5, ENEMY_START_Y    ],
+      [ENEMY_START_X - 5, ENEMY_START_Y],
       [ENEMY_START_X - 5, ENEMY_START_Y + 1],
-      [ENEMY_START_X - 4, ENEMY_START_Y    ],
+      [ENEMY_START_X - 4, ENEMY_START_Y],
       [ENEMY_START_X - 4, ENEMY_START_Y + 1],
     ];
     const { world, fighterIds } = buildInvasionRallyWorld(startTiles);

--- a/src/sim/food-system.test.ts
+++ b/src/sim/food-system.test.ts
@@ -179,7 +179,8 @@ describe('tickFoodPileSpawn — placement constraints', () => {
     if (world.foodPiles.length === before.length + 1) {
       const placed = world.foodPiles[world.foodPiles.length - 1]!;
       for (const existing of before) {
-        const dist = Math.abs(placed.tileX - existing.tileX) + Math.abs(placed.tileY - existing.tileY);
+        const dist =
+          Math.abs(placed.tileX - existing.tileX) + Math.abs(placed.tileY - existing.tileY);
         expect(dist).toBeGreaterThanOrEqual(FOOD_PILE_MIN_SEPARATION);
       }
     }
@@ -200,12 +201,14 @@ describe('tickFoodPileSpawn — placement constraints', () => {
       // Check distance to all entrances + rally points across all colonies.
       for (const colony of Object.values(world.colonies)) {
         for (const e of colony.entrances ?? []) {
-          const dist = Math.abs(placed.tileX - e.surfaceTileX) + Math.abs(placed.tileY - e.surfaceTileY);
+          const dist =
+            Math.abs(placed.tileX - e.surfaceTileX) + Math.abs(placed.tileY - e.surfaceTileY);
           expect(dist).toBeGreaterThanOrEqual(FOOD_PILE_MIN_COLONY_DISTANCE);
         }
         if (colony.rallyPoint) {
-          const dist = Math.abs(placed.tileX - colony.rallyPoint.tileX)
-                     + Math.abs(placed.tileY - colony.rallyPoint.tileY);
+          const dist =
+            Math.abs(placed.tileX - colony.rallyPoint.tileX) +
+            Math.abs(placed.tileY - colony.rallyPoint.tileY);
           expect(dist).toBeGreaterThanOrEqual(FOOD_PILE_MIN_COLONY_DISTANCE);
         }
       }
@@ -330,7 +333,15 @@ describe('tickFoodPileSpawn — integration via tick()', () => {
     // regression that mis-implements the modulo gate.
     const world = createScenario(42);
     world.foodPiles = []; // start empty so any spawn would be a +1 we'd see
-    for (const t of [1, 100, 500, 999, 1234, FOOD_PILE_SPAWN_INTERVAL_TICKS - 1, FOOD_PILE_SPAWN_INTERVAL_TICKS + 1]) {
+    for (const t of [
+      1,
+      100,
+      500,
+      999,
+      1234,
+      FOOD_PILE_SPAWN_INTERVAL_TICKS - 1,
+      FOOD_PILE_SPAWN_INTERVAL_TICKS + 1,
+    ]) {
       world.tick = t;
       tickFoodPileSpawn(world, new Rng(world.rngState));
       expect(world.foodPiles.length).toBe(0); // strict: no growth

--- a/src/sim/food-system.ts
+++ b/src/sim/food-system.ts
@@ -190,7 +190,10 @@ export function tickFoodPileSpawn(world: WorldState, rng: Rng): void {
     for (const colony of colonies) {
       if (colony.entrances) {
         for (const e of colony.entrances) {
-          if (Math.abs(tileX - e.surfaceTileX) + Math.abs(tileY - e.surfaceTileY) < FOOD_PILE_MIN_COLONY_DISTANCE) {
+          if (
+            Math.abs(tileX - e.surfaceTileX) + Math.abs(tileY - e.surfaceTileY) <
+            FOOD_PILE_MIN_COLONY_DISTANCE
+          ) {
             tooCloseToColony = true;
             break;
           }
@@ -198,7 +201,10 @@ export function tickFoodPileSpawn(world: WorldState, rng: Rng): void {
       }
       if (tooCloseToColony) break;
       if (colony.rallyPoint) {
-        if (Math.abs(tileX - colony.rallyPoint.tileX) + Math.abs(tileY - colony.rallyPoint.tileY) < FOOD_PILE_MIN_COLONY_DISTANCE) {
+        if (
+          Math.abs(tileX - colony.rallyPoint.tileX) + Math.abs(tileY - colony.rallyPoint.tileY) <
+          FOOD_PILE_MIN_COLONY_DISTANCE
+        ) {
           tooCloseToColony = true;
           break;
         }

--- a/src/sim/food.test.ts
+++ b/src/sim/food.test.ts
@@ -28,12 +28,18 @@ describe('FoodPile interface', () => {
 
   it('two FoodPile objects are independent', () => {
     const pile1: FoodPile = {
-      foodPileId: 1, tileX: 10, tileY: 20,
-      pickupsRemaining: 30, pickupsInitial: 30,
+      foodPileId: 1,
+      tileX: 10,
+      tileY: 20,
+      pickupsRemaining: 30,
+      pickupsInitial: 30,
     };
     const pile2: FoodPile = {
-      foodPileId: 2, tileX: 30, tileY: 40,
-      pickupsRemaining: 100, pickupsInitial: 100,
+      foodPileId: 2,
+      tileX: 30,
+      tileY: 40,
+      pickupsRemaining: 100,
+      pickupsInitial: 100,
     };
     expect(pile1.foodPileId).toBe(1);
     expect(pile2.foodPileId).toBe(2);
@@ -46,8 +52,11 @@ describe('FoodPile interface', () => {
 
   it('pile objects do not carry a priority flag (priority lives on ColonyRecord per Phase 9)', () => {
     const pile: FoodPile = {
-      foodPileId: 5, tileX: 0, tileY: 0,
-      pickupsRemaining: 20, pickupsInitial: 20,
+      foodPileId: 5,
+      tileX: 0,
+      tileY: 0,
+      pickupsRemaining: 20,
+      pickupsInitial: 20,
     };
     expect(Object.prototype.hasOwnProperty.call(pile, 'isMarkedPriority')).toBe(false);
   });

--- a/src/sim/foraging-excursion.test.ts
+++ b/src/sim/foraging-excursion.test.ts
@@ -44,14 +44,14 @@ function runSeed(seed: number, maxTicks: number): SeedStats {
   // grow the pool, so a pool-only detector goes silent the moment the
   // first ant reaches a chamber.
   let prevPlayerFood = colonyFoodTotal(world.colonies[PLAYER_COLONY_ID]!);
-  let prevEnemyFood  = colonyFoodTotal(world.colonies[ENEMY_COLONY_ID]!);
+  let prevEnemyFood = colonyFoodTotal(world.colonies[ENEMY_COLONY_ID]!);
 
   for (let t = 0; t < maxTicks; t++) {
     const cmds = world.commandQueue.splice(0);
     tick(world, cmds);
 
     const playerFood = colonyFoodTotal(world.colonies[PLAYER_COLONY_ID]!);
-    const enemyFood  = colonyFoodTotal(world.colonies[ENEMY_COLONY_ID]!);
+    const enemyFood = colonyFoodTotal(world.colonies[ENEMY_COLONY_ID]!);
 
     if (playerFirstDepositTick === null && playerFood > prevPlayerFood) {
       playerFirstDepositTick = t;
@@ -60,17 +60,17 @@ function runSeed(seed: number, maxTicks: number): SeedStats {
       enemyFirstDepositTick = t;
     }
     prevPlayerFood = playerFood;
-    prevEnemyFood  = enemyFood;
+    prevEnemyFood = enemyFood;
   }
 
   const playerColony = world.colonies[PLAYER_COLONY_ID]!;
-  const enemyColony  = world.colonies[ENEMY_COLONY_ID]!;
+  const enemyColony = world.colonies[ENEMY_COLONY_ID]!;
 
   return {
     playerQueenAlive: isAlive(world.ants, playerColony.queenEntityId),
-    enemyQueenAlive:  isAlive(world.ants, enemyColony.queenEntityId),
+    enemyQueenAlive: isAlive(world.ants, enemyColony.queenEntityId),
     playerFoodStored: colonyFoodTotal(playerColony),
-    enemyFoodStored:  colonyFoodTotal(enemyColony),
+    enemyFoodStored: colonyFoodTotal(enemyColony),
     playerFirstDepositTick,
     enemyFirstDepositTick,
   };
@@ -86,35 +86,39 @@ describe('foraging excursion survival harness (09 memo)', () => {
   const TICKS = 1000;
   const TEST_TIMEOUT_MS = 30000;
 
-  it('queens survive across the seed sample (no-command autonomous foraging)', () => {
-    let playerAlive = 0;
-    let enemyAlive  = 0;
-    let playerDeposits = 0;
-    let enemyDeposits  = 0;
+  it(
+    'queens survive across the seed sample (no-command autonomous foraging)',
+    () => {
+      let playerAlive = 0;
+      let enemyAlive = 0;
+      let playerDeposits = 0;
+      let enemyDeposits = 0;
 
-    for (let seed = 0; seed < SEEDS; seed++) {
-      const s = runSeed(seed, TICKS);
-      if (s.playerQueenAlive) playerAlive += 1;
-      if (s.enemyQueenAlive)  enemyAlive  += 1;
-      if (s.playerFirstDepositTick !== null) playerDeposits += 1;
-      if (s.enemyFirstDepositTick  !== null) enemyDeposits  += 1;
-    }
+      for (let seed = 0; seed < SEEDS; seed++) {
+        const s = runSeed(seed, TICKS);
+        if (s.playerQueenAlive) playerAlive += 1;
+        if (s.enemyQueenAlive) enemyAlive += 1;
+        if (s.playerFirstDepositTick !== null) playerDeposits += 1;
+        if (s.enemyFirstDepositTick !== null) enemyDeposits += 1;
+      }
 
-    // Acceptance target from the memo is ≥95% at 200 seeds × 2000 ticks.
-    // At SEEDS=24 × TICKS=1200 the bar is set conservatively (≥3/4) so a
-    // single seed unlucky at this shorter horizon doesn't false-alarm CI.
-    // The local 200-seed run (scripts/check-foraging-survival.ts) is the
-    // authoritative acceptance gate.
-    // Integer threshold arithmetic — no float literals in src/sim/.
-    const threshold = (SEEDS * 3) >> 2;
-    expect(playerAlive).toBeGreaterThanOrEqual(threshold);
-    expect(enemyAlive ).toBeGreaterThanOrEqual(threshold);
+      // Acceptance target from the memo is ≥95% at 200 seeds × 2000 ticks.
+      // At SEEDS=24 × TICKS=1200 the bar is set conservatively (≥3/4) so a
+      // single seed unlucky at this shorter horizon doesn't false-alarm CI.
+      // The local 200-seed run (scripts/check-foraging-survival.ts) is the
+      // authoritative acceptance gate.
+      // Integer threshold arithmetic — no float literals in src/sim/.
+      const threshold = (SEEDS * 3) >> 2;
+      expect(playerAlive).toBeGreaterThanOrEqual(threshold);
+      expect(enemyAlive).toBeGreaterThanOrEqual(threshold);
 
-    // Autonomous foraging must actually deliver food — if deposits are zero
-    // across the sample the autonomy claim is dead on arrival.
-    expect(playerDeposits).toBeGreaterThanOrEqual(threshold);
-    expect(enemyDeposits ).toBeGreaterThanOrEqual(threshold);
-  }, TEST_TIMEOUT_MS);
+      // Autonomous foraging must actually deliver food — if deposits are zero
+      // across the sample the autonomy claim is dead on arrival.
+      expect(playerDeposits).toBeGreaterThanOrEqual(threshold);
+      expect(enemyDeposits).toBeGreaterThanOrEqual(threshold);
+    },
+    TEST_TIMEOUT_MS,
+  );
 
   it('harness is deterministic — same seed → same stats across runs', () => {
     // Replay regression guard: two runs with the same seed must produce

--- a/src/sim/game-over.test.ts
+++ b/src/sim/game-over.test.ts
@@ -11,15 +11,33 @@ import { MATCH_TIMEOUT_TICKS, STALEMATE_FOOD_THRESHOLD_FP } from './constants.js
 function makeWorldWith2Colonies(): { world: WorldState; queen1: number; queen2: number } {
   const world = createWorldState(42);
   const queen1 = allocateEntityId(world);
-  initAnt(world.ants, queen1, { colonyId: 1, posX: 0, posY: 0, task: AntTask.Idle, subTask: 0, speed: 0 });
+  initAnt(world.ants, queen1, {
+    colonyId: 1,
+    posX: 0,
+    posY: 0,
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
+  });
   const c1 = createColonyRecord(1 as ColonyId, queen1);
-  c1.entrances = []; c1.rallyPoint = null; c1.digFlowFieldDirty = false;
+  c1.entrances = [];
+  c1.rallyPoint = null;
+  c1.digFlowFieldDirty = false;
   world.colonies[1] = c1;
 
   const queen2 = allocateEntityId(world);
-  initAnt(world.ants, queen2, { colonyId: 2, posX: 0, posY: 0, task: AntTask.Idle, subTask: 0, speed: 0 });
+  initAnt(world.ants, queen2, {
+    colonyId: 2,
+    posX: 0,
+    posY: 0,
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
+  });
   const c2 = createColonyRecord(2 as ColonyId, queen2);
-  c2.entrances = []; c2.rallyPoint = null; c2.digFlowFieldDirty = false;
+  c2.entrances = [];
+  c2.rallyPoint = null;
+  c2.digFlowFieldDirty = false;
   world.colonies[2] = c2;
 
   return { world, queen1, queen2 };
@@ -109,7 +127,10 @@ describe('game-over detection', () => {
 // S5 (V22) — checkTiebreaks
 // ---------------------------------------------------------------------------
 
-function makeV22WorldWith2Colonies(playerColonyId = 1, aiColonyId = 2): {
+function makeV22WorldWith2Colonies(
+  playerColonyId = 1,
+  aiColonyId = 2,
+): {
   world: WorldState;
   queen1: number;
   queen2: number;
@@ -120,23 +141,50 @@ function makeV22WorldWith2Colonies(playerColonyId = 1, aiColonyId = 2): {
   world.difficulty = 'Normal';
   // Default food pile prevents spurious stalemate in tests that only check other conditions.
   // Stalemate tests explicitly set world.foodPiles = [] to override this.
-  world.foodPiles = [{ foodPileId: 1, tileX: 10, tileY: 10, pickupsRemaining: 1, pickupsInitial: 1 }];
+  world.foodPiles = [
+    { foodPileId: 1, tileX: 10, tileY: 10, pickupsRemaining: 1, pickupsInitial: 1 },
+  ];
 
   const queen1 = allocateEntityId(world);
-  initAnt(world.ants, queen1, { colonyId: playerColonyId, posX: 0, posY: 0, task: AntTask.Idle, subTask: 0, speed: 0 });
+  initAnt(world.ants, queen1, {
+    colonyId: playerColonyId,
+    posX: 0,
+    posY: 0,
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
+  });
   const c1 = createColonyRecord(playerColonyId as ColonyId, queen1);
-  c1.entrances = []; c1.rallyPoint = null; c1.digFlowFieldDirty = false;
+  c1.entrances = [];
+  c1.rallyPoint = null;
+  c1.digFlowFieldDirty = false;
   world.colonies[playerColonyId] = c1;
 
   const queen2 = allocateEntityId(world);
-  initAnt(world.ants, queen2, { colonyId: aiColonyId, posX: 0, posY: 0, task: AntTask.Idle, subTask: 0, speed: 0 });
+  initAnt(world.ants, queen2, {
+    colonyId: aiColonyId,
+    posX: 0,
+    posY: 0,
+    task: AntTask.Idle,
+    subTask: 0,
+    speed: 0,
+  });
   const c2 = createColonyRecord(aiColonyId as ColonyId, queen2);
-  c2.entrances = []; c2.rallyPoint = null; c2.digFlowFieldDirty = false;
+  c2.entrances = [];
+  c2.rallyPoint = null;
+  c2.digFlowFieldDirty = false;
   world.colonies[aiColonyId] = c2;
 
   const addWorker = (colonyId: number): number => {
     const id = allocateEntityId(world);
-    initAnt(world.ants, id, { colonyId: colonyId as ColonyId, posX: 1, posY: 1, task: AntTask.Idle, subTask: 0, speed: 0 });
+    initAnt(world.ants, id, {
+      colonyId: colonyId as ColonyId,
+      posX: 1,
+      posY: 1,
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
+    });
     // Must push into colony.workers so livingWorkerCount (which iterates colony.workers) sees this ant.
     world.colonies[colonyId]!.workers.push(id);
     world.colonies[colonyId]!.workerCount += 1;
@@ -157,21 +205,26 @@ describe('checkTiebreaks (S5 V22)', () => {
     it('returns MutualDestruction when worker counts are equal', () => {
       const { world, addWorker } = makeV22WorldWith2Colonies();
       world.tick = MATCH_TIMEOUT_TICKS;
-      addWorker(1); addWorker(2); // one worker each
+      addWorker(1);
+      addWorker(2); // one worker each
       expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.MutualDestruction);
     });
 
     it('returns Victory when player has more workers', () => {
       const { world, addWorker } = makeV22WorldWith2Colonies();
       world.tick = MATCH_TIMEOUT_TICKS;
-      addWorker(1); addWorker(1); addWorker(2); // 2 player vs 1 AI
+      addWorker(1);
+      addWorker(1);
+      addWorker(2); // 2 player vs 1 AI
       expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.Victory);
     });
 
     it('returns Defeat when AI has more workers', () => {
       const { world, addWorker } = makeV22WorldWith2Colonies();
       world.tick = MATCH_TIMEOUT_TICKS;
-      addWorker(1); addWorker(2); addWorker(2); // 1 player vs 2 AI
+      addWorker(1);
+      addWorker(2);
+      addWorker(2); // 1 player vs 2 AI
       expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.Defeat);
     });
 
@@ -190,7 +243,9 @@ describe('checkTiebreaks (S5 V22)', () => {
   describe('Stalemate tiebreak', () => {
     it('returns None when food piles remain on the map', () => {
       const { world } = makeV22WorldWith2Colonies();
-      world.foodPiles = [{ foodPileId: 99, tileX: 5, tileY: 5, pickupsRemaining: 1, pickupsInitial: 1 }];
+      world.foodPiles = [
+        { foodPileId: 99, tileX: 5, tileY: 5, pickupsRemaining: 1, pickupsInitial: 1 },
+      ];
       // both colonies below threshold
       expect(checkTiebreaks(world, 1 as ColonyId)).toBe(GameOutcome.None);
     });

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -11,17 +11,14 @@ export const GameOutcome = {
   Defeat: 2,
   MutualDestruction: 3,
 } as const;
-export type GameOutcome = typeof GameOutcome[keyof typeof GameOutcome];
+export type GameOutcome = (typeof GameOutcome)[keyof typeof GameOutcome];
 
 import type { WorldState, AIState } from './types.js';
 import type { ColonyId, ColonyRecord } from './colony/colony-store.js';
 import { emitEvent } from './telemetry.js';
 import { FP_SHIFT } from './fixed.js';
 import { colonyFoodTotal } from './colony/colony-system.js';
-import {
-  MATCH_TIMEOUT_TICKS,
-  STALEMATE_FOOD_THRESHOLD_FP,
-} from './constants.js';
+import { MATCH_TIMEOUT_TICKS, STALEMATE_FOOD_THRESHOLD_FP } from './constants.js';
 
 /**
  * S2 — infer queen_death cause from the kill context and game outcome.
@@ -159,7 +156,8 @@ export function checkQueenDeath(world: WorldState, playerColonyId?: ColonyId): G
     const qid = colony.queenEntityId;
     const locX = ctx ? ctx.tile.x : (world.ants.posX[qid] ?? 0) >> FP_SHIFT;
     const locY = ctx ? ctx.tile.y : (world.ants.posY[qid] ?? 0) >> FP_SHIFT;
-    const grid: 'surface' | 'underground' = (world.ants.zone[qid] ?? 1) === 0 ? 'surface' : 'underground';
+    const grid: 'surface' | 'underground' =
+      (world.ants.zone[qid] ?? 1) === 0 ? 'surface' : 'underground';
 
     emitEvent(world, {
       tick: world.tick,
@@ -261,7 +259,11 @@ export function checkTiebreaks(world: WorldState, playerColonyId: ColonyId): Gam
     emitEvent(world, {
       tick: world.tick,
       type: 'round_end',
-      payload: { reason: 'TimeoutTiebreak', playerWorkerCount: playerWorkers, aiWorkerCount: aiWorkers },
+      payload: {
+        reason: 'TimeoutTiebreak',
+        playerWorkerCount: playerWorkers,
+        aiWorkerCount: aiWorkers,
+      },
     });
     if (playerWorkers > aiWorkers) return GameOutcome.Victory;
     if (aiWorkers > playerWorkers) return GameOutcome.Defeat;
@@ -279,7 +281,11 @@ export function checkTiebreaks(world: WorldState, playerColonyId: ColonyId): Gam
     emitEvent(world, {
       tick: world.tick,
       type: 'round_end',
-      payload: { reason: 'StalemateTiebreak', playerWorkerCount: playerWorkers, aiWorkerCount: aiWorkers },
+      payload: {
+        reason: 'StalemateTiebreak',
+        playerWorkerCount: playerWorkers,
+        aiWorkerCount: aiWorkers,
+      },
     });
     return GameOutcome.MutualDestruction;
   }

--- a/src/sim/invasion-routing.test.ts
+++ b/src/sim/invasion-routing.test.ts
@@ -53,10 +53,10 @@ import type { WorldState } from './types.js';
 // ---------------------------------------------------------------------------
 
 interface InvasionWorld {
-  world:           WorldState;
-  playerAntId:     number;
-  enemyEntTileX:   number;
-  enemyEntTileY:   number;
+  world: WorldState;
+  playerAntId: number;
+  enemyEntTileX: number;
+  enemyEntTileY: number;
 }
 
 /**
@@ -89,12 +89,12 @@ function buildInvasionWorld(seed = 42): InvasionWorld {
   const playerAntId = allocateEntityId(world);
   initAnt(world.ants, playerAntId, {
     colonyId: PLAYER_COLONY_ID,
-    posX:     (enemyEntTileX << FP_SHIFT) + (FP_ONE >> 1),
-    posY:     (enemyEntTileY << FP_SHIFT) + (FP_ONE >> 1),
-    task:     AntTask.Idle,  // caller overrides to Fighting / Foraging per test
-    subTask:  0,
-    speed:    WORKER_BASE_SPEED,
-    zone:     Zone.Surface,
+    posX: (enemyEntTileX << FP_SHIFT) + (FP_ONE >> 1),
+    posY: (enemyEntTileY << FP_SHIFT) + (FP_ONE >> 1),
+    task: AntTask.Idle, // caller overrides to Fighting / Foraging per test
+    subTask: 0,
+    speed: WORKER_BASE_SPEED,
+    zone: Zone.Surface,
   });
   world.colonies[PLAYER_COLONY_ID]!.workers.push(playerAntId);
   world.colonies[PLAYER_COLONY_ID]!.workerCount += 1;
@@ -191,12 +191,12 @@ describe('invasion-routing — Fighting ant descent-intent gate (REQ-C3)', () =>
     const hostileId = allocateEntityId(world);
     initAnt(world.ants, hostileId, {
       colonyId: ENEMY_COLONY_ID,
-      posX:     (hostileTileX << FP_SHIFT) + (FP_ONE >> 1),
-      posY:     (hostileTileY << FP_SHIFT) + (FP_ONE >> 1),
-      task:     AntTask.Idle,
-      subTask:  0,
-      speed:    0, // pin hostile in place so distance-decrease is unambiguous
-      zone:     Zone.Underground,
+      posX: (hostileTileX << FP_SHIFT) + (FP_ONE >> 1),
+      posY: (hostileTileY << FP_SHIFT) + (FP_ONE >> 1),
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0, // pin hostile in place so distance-decrease is unambiguous
+      zone: Zone.Underground,
     });
     world.ants.currentGridColonyId[hostileId] = ENEMY_COLONY_ID;
     world.colonies[ENEMY_COLONY_ID]!.workers.push(hostileId);
@@ -227,8 +227,9 @@ describe('invasion-routing — Fighting ant descent-intent gate (REQ-C3)', () =>
     expect(world.ants.zone[hostileId]).toBe(Zone.Underground);
 
     // Distance at the start of the targeting phase.
-    const d0 = Math.abs(tileXOf(world, playerAntId) - hostileTileX)
-             + Math.abs(tileYOf(world, playerAntId) - hostileTileY);
+    const d0 =
+      Math.abs(tileXOf(world, playerAntId) - hostileTileX) +
+      Math.abs(tileYOf(world, playerAntId) - hostileTileY);
 
     // Tick forward enough for a visible approach. At WORKER_BASE_SPEED the
     // invader moves ~0.5 tiles/tick along the chosen axis, so 10 ticks
@@ -236,8 +237,9 @@ describe('invasion-routing — Fighting ant descent-intent gate (REQ-C3)', () =>
     // Manhattan gap which is at most ~10 tiles (shaft→hostile).
     tickN(world, 10);
 
-    const dN = Math.abs(tileXOf(world, playerAntId) - hostileTileX)
-             + Math.abs(tileYOf(world, playerAntId) - hostileTileY);
+    const dN =
+      Math.abs(tileXOf(world, playerAntId) - hostileTileX) +
+      Math.abs(tileYOf(world, playerAntId) - hostileTileY);
 
     // MANDATORY outcome assertions — invader moved toward the hostile.
     expect(world.ants.zone[playerAntId]).toBe(Zone.Underground);

--- a/src/sim/pheromone/food-trail-decays-after-depletion.test.ts
+++ b/src/sim/pheromone/food-trail-decays-after-depletion.test.ts
@@ -24,10 +24,7 @@ import { createScenario } from '../scenario.js';
 import { tick } from '../tick.js';
 import { PheromoneType } from '../enums.js';
 import { pheromoneGridKey, phGet, phSet } from './pheromone-store.js';
-import {
-  PLAYER_COLONY_ID,
-  PHEROMONE_CAP,
-} from '../constants.js';
+import { PLAYER_COLONY_ID, PHEROMONE_CAP } from '../constants.js';
 import { recordFoodPileDepletion } from '../food-system.js';
 
 describe('issue #112 — food-trail decays naturally after pile depletion', () => {
@@ -79,62 +76,66 @@ describe('issue #112 — food-trail decays naturally after pile depletion', () =
     expect(lastValue).toBe(0);
   });
 
-  it('integration: forced fast depletion → trail at vanished tile decays naturally without re-saturation', { timeout: 60000 }, () => {
-    // Steady-state version of the above: drive a real scenario, force one
-    // pile to deplete quickly (lower its charge count), then verify the trail
-    // at that tile converges to 0 over time without any code path
-    // re-saturating it. No manual ant-suppression — we let in-flight carriers
-    // complete their return cycle naturally.
-    const world = createScenario(42);
-    const trailKey = pheromoneGridKey(PLAYER_COLONY_ID, PheromoneType.FoodTrail, 'surface');
+  it(
+    'integration: forced fast depletion → trail at vanished tile decays naturally without re-saturation',
+    { timeout: 60000 },
+    () => {
+      // Steady-state version of the above: drive a real scenario, force one
+      // pile to deplete quickly (lower its charge count), then verify the trail
+      // at that tile converges to 0 over time without any code path
+      // re-saturating it. No manual ant-suppression — we let in-flight carriers
+      // complete their return cycle naturally.
+      const world = createScenario(42);
+      const trailKey = pheromoneGridKey(PLAYER_COLONY_ID, PheromoneType.FoodTrail, 'surface');
 
-    // Lower every pile's charge count to 2 so depletion happens within the
-    // first round of foraging trips rather than after thousands of ticks.
-    for (const p of world.foodPiles) {
-      p.pickupsRemaining = 2;
-      p.pickupsInitial = 2;
-    }
-
-    const DEPLETION_BUDGET_TICKS = 5000;
-    let depletionTick = -1;
-    for (let t = 0; t < DEPLETION_BUDGET_TICKS && depletionTick === -1; t++) {
-      tick(world, []);
-      if (world.recentlyDepletedFood.length > 0) {
-        depletionTick = world.tick;
+      // Lower every pile's charge count to 2 so depletion happens within the
+      // first round of foraging trips rather than after thousands of ticks.
+      for (const p of world.foodPiles) {
+        p.pickupsRemaining = 2;
+        p.pickupsInitial = 2;
       }
-    }
-    // Fail loud if depletion didn't happen — that's a regression in the
-    // depletion mechanic itself, not "ambient flakiness." Lowering each pile
-    // to 2 charges above gives us several orders of magnitude of slack;
-    // 5000 ticks is well beyond what 3 starting workers need to drain a
-    // 2-charge pile. If this fires, investigate the foraging path before
-    // bumping the budget.
-    expect(depletionTick).toBeGreaterThanOrEqual(0);
 
-    const depletedTile = world.recentlyDepletedFood[0]!;
-    const grid = world.pheromoneGrids[trailKey]!;
-    const startValue = phGet(grid, depletedTile.tileX, depletedTile.tileY);
+      const DEPLETION_BUDGET_TICKS = 5000;
+      let depletionTick = -1;
+      for (let t = 0; t < DEPLETION_BUDGET_TICKS && depletionTick === -1; t++) {
+        tick(world, []);
+        if (world.recentlyDepletedFood.length > 0) {
+          depletionTick = world.tick;
+        }
+      }
+      // Fail loud if depletion didn't happen — that's a regression in the
+      // depletion mechanic itself, not "ambient flakiness." Lowering each pile
+      // to 2 charges above gives us several orders of magnitude of slack;
+      // 5000 ticks is well beyond what 3 starting workers need to drain a
+      // 2-charge pile. If this fires, investigate the foraging path before
+      // bumping the budget.
+      expect(depletionTick).toBeGreaterThanOrEqual(0);
 
-    // Decay window — generous enough for in-flight carriers to clear plus
-    // pheromone decay to drain. 1000 ticks at 20Hz = 50 sim seconds.
-    const DECAY_WINDOW = 1000;
-    let maxValueDuringWindow = startValue;
-    for (let t = 0; t < DECAY_WINDOW; t++) {
-      tick(world, []);
-      const v = phGet(grid, depletedTile.tileX, depletedTile.tileY);
-      if (v > maxValueDuringWindow) maxValueDuringWindow = v;
-    }
+      const depletedTile = world.recentlyDepletedFood[0]!;
+      const grid = world.pheromoneGrids[trailKey]!;
+      const startValue = phGet(grid, depletedTile.tileX, depletedTile.tileY);
 
-    const finalValue = phGet(grid, depletedTile.tileX, depletedTile.tileY);
+      // Decay window — generous enough for in-flight carriers to clear plus
+      // pheromone decay to drain. 1000 ticks at 20Hz = 50 sim seconds.
+      const DECAY_WINDOW = 1000;
+      let maxValueDuringWindow = startValue;
+      for (let t = 0; t < DECAY_WINDOW; t++) {
+        tick(world, []);
+        const v = phGet(grid, depletedTile.tileX, depletedTile.tileY);
+        if (v > maxValueDuringWindow) maxValueDuringWindow = v;
+      }
 
-    // The trail at a depleted tile should not refresh to a strong value
-    // post-depletion. Allow ambient pheromone bleed from cross-pile carrier
-    // traffic; the hard invariant is no permanent re-saturation.
-    expect(finalValue).toBeLessThan(PHEROMONE_CAP);
-    // Peak value during the window should not exceed the starting value by
-    // more than a "single carrier walking through" bump. Use bit-shift
-    // (PHEROMONE_CAP >> 2 = quarter cap) to satisfy the sim/ no-float-divide
-    // ESLint rule even though this is a test file.
-    expect(maxValueDuringWindow - startValue).toBeLessThanOrEqual(PHEROMONE_CAP >> 2);
-  });
+      const finalValue = phGet(grid, depletedTile.tileX, depletedTile.tileY);
+
+      // The trail at a depleted tile should not refresh to a strong value
+      // post-depletion. Allow ambient pheromone bleed from cross-pile carrier
+      // traffic; the hard invariant is no permanent re-saturation.
+      expect(finalValue).toBeLessThan(PHEROMONE_CAP);
+      // Peak value during the window should not exceed the starting value by
+      // more than a "single carrier walking through" bump. Use bit-shift
+      // (PHEROMONE_CAP >> 2 = quarter cap) to satisfy the sim/ no-float-divide
+      // ESLint rule even though this is a test file.
+      expect(maxValueDuringWindow - startValue).toBeLessThanOrEqual(PHEROMONE_CAP >> 2);
+    },
+  );
 });

--- a/src/sim/pheromone/pheromone-store.test.ts
+++ b/src/sim/pheromone/pheromone-store.test.ts
@@ -13,16 +13,10 @@
 //   10. Independence across separate createPheromoneGrid() allocations
 
 import { describe, it, expect } from 'vitest';
-import {
-  createPheromoneGrid,
-  phGet,
-  phSet,
-  pheromoneGridKey,
-} from './pheromone-store.js';
+import { createPheromoneGrid, phGet, phSet, pheromoneGridKey } from './pheromone-store.js';
 import { PheromoneType } from '../enums.js';
 
 describe('pheromone-store', () => {
-
   // -------------------------------------------------------------------------
   // Test 1 — Grid allocation: correct shape and zero-initialisation
   // -------------------------------------------------------------------------
@@ -71,8 +65,8 @@ describe('pheromone-store', () => {
   it('phGet returns 0 for negative x and y coordinates', () => {
     const g = createPheromoneGrid(10, 10);
     phSet(g, 0, 0, 7);
-    expect(phGet(g, -1,  0)).toBe(0);
-    expect(phGet(g,  0, -1)).toBe(0);
+    expect(phGet(g, -1, 0)).toBe(0);
+    expect(phGet(g, 0, -1)).toBe(0);
     expect(phGet(g, -5, -5)).toBe(0);
   });
 
@@ -83,8 +77,8 @@ describe('pheromone-store', () => {
   it('phGet returns 0 for x >= width or y >= height', () => {
     const g = createPheromoneGrid(10, 10);
     phSet(g, 9, 9, 7);
-    expect(phGet(g, 10,  0)).toBe(0);
-    expect(phGet(g,  0, 10)).toBe(0);
+    expect(phGet(g, 10, 0)).toBe(0);
+    expect(phGet(g, 0, 10)).toBe(0);
     expect(phGet(g, 10, 10)).toBe(0);
     expect(phGet(g, 99, 99)).toBe(0);
   });
@@ -101,11 +95,11 @@ describe('pheromone-store', () => {
     }
     const snapshot = Int32Array.from(g.data);
 
-    phSet(g, -1,  0,  999); // negative x
-    phSet(g,  0, -1,  999); // negative y
-    phSet(g,  4,  0,  999); // x >= width
-    phSet(g,  0,  4,  999); // y >= height
-    phSet(g, 10, 10,  999); // both out
+    phSet(g, -1, 0, 999); // negative x
+    phSet(g, 0, -1, 999); // negative y
+    phSet(g, 4, 0, 999); // x >= width
+    phSet(g, 0, 4, 999); // y >= height
+    phSet(g, 10, 10, 999); // both out
 
     // data must be bit-for-bit identical to the snapshot
     expect(g.data).toEqual(snapshot);
@@ -132,10 +126,10 @@ describe('pheromone-store', () => {
   // -------------------------------------------------------------------------
 
   it('PHER-02: FoodTrail and DangerTrail grids are independent per colony', () => {
-    const foodGrid   = createPheromoneGrid(16, 16);
+    const foodGrid = createPheromoneGrid(16, 16);
     const dangerGrid = createPheromoneGrid(16, 16);
 
-    const foodKey   = pheromoneGridKey(1, PheromoneType.FoodTrail,   'surface');
+    const foodKey = pheromoneGridKey(1, PheromoneType.FoodTrail, 'surface');
     const dangerKey = pheromoneGridKey(1, PheromoneType.DangerTrail, 'surface');
 
     // Keys must be distinct
@@ -145,7 +139,7 @@ describe('pheromone-store', () => {
 
     // Store in a plain map (simulating WorldState.pheromoneGrids)
     const grids: Record<string, ReturnType<typeof createPheromoneGrid>> = {
-      [foodKey]:   foodGrid,
+      [foodKey]: foodGrid,
       [dangerKey]: dangerGrid,
     };
 
@@ -174,5 +168,4 @@ describe('pheromone-store', () => {
     phSet(a, 2, 2, 55);
     expect(phGet(b, 2, 2)).toBe(0);
   });
-
 });

--- a/src/sim/pheromone/pheromone-store.ts
+++ b/src/sim/pheromone/pheromone-store.ts
@@ -25,8 +25,8 @@ export type Zone = 'surface' | 'underground';
  * All fields are readonly — mutate only via phSet().
  */
 export interface PheromoneGrid {
-  readonly data:   Int32Array;
-  readonly width:  number;
+  readonly data: Int32Array;
+  readonly width: number;
   readonly height: number;
 }
 
@@ -40,7 +40,7 @@ export interface PheromoneGrid {
  */
 export function createPheromoneGrid(width: number, height: number): PheromoneGrid {
   return {
-    data:   new Int32Array(width * height),
+    data: new Int32Array(width * height),
     width,
     height,
   };

--- a/src/sim/pheromone/pheromone-system.test.ts
+++ b/src/sim/pheromone/pheromone-system.test.ts
@@ -10,7 +10,12 @@
 // bans those globals in src/sim/. Wall-clock assertions live in bench/.
 
 import { describe, it, expect } from 'vitest';
-import { depositFoodTrail, tickPheromoneDecay, sampleGradient, sampleForagingDirection } from './pheromone-system.js';
+import {
+  depositFoodTrail,
+  tickPheromoneDecay,
+  sampleGradient,
+  sampleForagingDirection,
+} from './pheromone-system.js';
 import { createPheromoneGrid, phGet, phSet } from './pheromone-store.js';
 import { Rng } from '../rng.js';
 import {
@@ -131,7 +136,7 @@ describe('tickPheromoneDecay (PHER-04)', () => {
 
     for (let i = 0; i < K; i++) {
       tickPheromoneDecay(foodGrid, PHEROMONE_DECAY_FP); // 5
-      tickPheromoneDecay(dangerGrid, DANGER_DECAY_FP);  // 10
+      tickPheromoneDecay(dangerGrid, DANGER_DECAY_FP); // 10
     }
 
     // After 10 ticks with higher decay rate, danger should have lower strength.
@@ -268,14 +273,14 @@ describe('sampleGradient (PHER-05)', () => {
     const replayRng = new Rng(exploreSeed);
     const replayRoll = replayRng.nextInt(100);
     expect(replayRoll).toBe(exploreRoll); // Sanity: same seed same roll
-    expect(replayRoll).toBeLessThan(10);  // Must be explore
+    expect(replayRoll).toBeLessThan(10); // Must be explore
 
     const expectedIdx = replayRng.nextInt(4);
     const DIRS = [
-      { dx: 0,  dy: -1 }, // up
-      { dx: 0,  dy:  1 }, // down
-      { dx: -1, dy:  0 }, // left
-      { dx:  1, dy:  0 }, // right
+      { dx: 0, dy: -1 }, // up
+      { dx: 0, dy: 1 }, // down
+      { dx: -1, dy: 0 }, // left
+      { dx: 1, dy: 0 }, // right
     ];
     const expected = DIRS[expectedIdx]!;
 
@@ -341,7 +346,7 @@ describe('sampleForagingDirection (09 pheromone-reacquisition memo)', () => {
     // share is 10% * 75% = 7.5%. 4σ of ~7.5% over 2000 = ~40.
     const nonRight = exploreCount;
     expect(nonRight).toBeGreaterThan(100); // must see some exploration
-    expect(nonRight).toBeLessThan(250);    // not dominated by it
+    expect(nonRight).toBeLessThan(250); // not dominated by it
   });
 
   it('no immediate trail, trail at Manhattan distance 2 → steps toward it', () => {
@@ -418,8 +423,9 @@ describe('sampleForagingDirection (09 pheromone-reacquisition memo)', () => {
     for (let seed = 0; seed < 50; seed++) {
       const r1 = new Rng(seed);
       const r2 = new Rng(seed);
-      expect(sampleForagingDirection(grid, 5, 5, r1))
-        .toEqual(sampleForagingDirection(grid, 5, 5, r2));
+      expect(sampleForagingDirection(grid, 5, 5, r1)).toEqual(
+        sampleForagingDirection(grid, 5, 5, r2),
+      );
     }
   });
 

--- a/src/sim/pheromone/pheromone-system.ts
+++ b/src/sim/pheromone/pheromone-system.ts
@@ -28,10 +28,10 @@ import {
 // ---------------------------------------------------------------------------
 
 const DIRS = [
-  { dx: 0,  dy: -1 }, // up
-  { dx: 0,  dy:  1 }, // down
-  { dx: -1, dy:  0 }, // left
-  { dx:  1, dy:  0 }, // right
+  { dx: 0, dy: -1 }, // up
+  { dx: 0, dy: 1 }, // down
+  { dx: -1, dy: 0 }, // left
+  { dx: 1, dy: 0 }, // right
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -352,7 +352,7 @@ export function sampleForagingDirection(
       // non-prev cell (or a lateral cell) win the tie-break.
       if (hasPrev) {
         const stepX = absX >= absY ? (dx > 0 ? 1 : dx < 0 ? -1 : 0) : 0;
-        const stepY = absX >= absY ? 0 : (dy > 0 ? 1 : dy < 0 ? -1 : 0);
+        const stepY = absX >= absY ? 0 : dy > 0 ? 1 : dy < 0 ? -1 : 0;
         if (tileX + stepX === prevTileX && tileY + stepY === prevTileY) continue;
       }
       const s = phGet(grid, sx, sy);

--- a/src/sim/predescent-gate.test.ts
+++ b/src/sim/predescent-gate.test.ts
@@ -83,13 +83,13 @@ function spawnInvaderOnEnemyEntrance(world: WorldState): number {
   const id = allocateEntityId(world);
   initAnt(world.ants, id, {
     colonyId: PLAYER_COLONY_ID,
-    posX:     center(ENEMY_START_X),
-    posY:     center(ENEMY_START_Y),
-    task:     AntTask.Fighting,
-    subTask:  0,
-    speed:    WORKER_BASE_SPEED,
+    posX: center(ENEMY_START_X),
+    posY: center(ENEMY_START_Y),
+    task: AntTask.Fighting,
+    subTask: 0,
+    speed: WORKER_BASE_SPEED,
     lifespan: WORKER_LIFESPAN_TICKS,
-    zone:     Zone.Surface,
+    zone: Zone.Surface,
   });
   world.colonies[PLAYER_COLONY_ID]!.workers.push(id);
   world.colonies[PLAYER_COLONY_ID]!.workerCount += 1;
@@ -105,14 +105,14 @@ function spawnCarrierOnPlayerEntrance(world: WorldState): number {
   const id = allocateEntityId(world);
   initAnt(world.ants, id, {
     colonyId: PLAYER_COLONY_ID,
-    posX:     center(PLAYER_START_X),
-    posY:     center(PLAYER_START_Y),
-    task:     AntTask.Foraging,
-    subTask:  ForagingSubState.CarryingFood,
-    speed:    WORKER_BASE_SPEED,
+    posX: center(PLAYER_START_X),
+    posY: center(PLAYER_START_Y),
+    task: AntTask.Foraging,
+    subTask: ForagingSubState.CarryingFood,
+    speed: WORKER_BASE_SPEED,
     lifespan: WORKER_LIFESPAN_TICKS,
-    hp:       COMBAT_HP_BASE,
-    zone:     Zone.Surface,
+    hp: COMBAT_HP_BASE,
+    zone: Zone.Surface,
   });
   world.ants.foodCarrying[id] = FP_ONE; // carrying food → has descent intent
   world.colonies[PLAYER_COLONY_ID]!.workers.push(id);
@@ -170,7 +170,10 @@ describe('pre-descent gate — #164 foreign Fighter vs. a surface queen on an en
     let descended = false;
     for (let i = 0; i < 5; i++) {
       tick(world, []);
-      if (world.ants.zone[invaderId] === Zone.Underground) { descended = true; break; }
+      if (world.ants.zone[invaderId] === Zone.Underground) {
+        descended = true;
+        break;
+      }
     }
 
     expect(descended).toBe(true);
@@ -223,7 +226,10 @@ describe('pre-descent gate — #165 rampaging spider blockade at an entrance', (
     let descended = false;
     for (let i = 0; i < 5; i++) {
       tick(world, []);
-      if (world.ants.zone[carrierId] === Zone.Underground) { descended = true; break; }
+      if (world.ants.zone[carrierId] === Zone.Underground) {
+        descended = true;
+        break;
+      }
     }
 
     expect(descended).toBe(true);

--- a/src/sim/scenario.test.ts
+++ b/src/sim/scenario.test.ts
@@ -36,7 +36,6 @@ import {
 } from './constants.js';
 
 describe('createScenario', () => {
-
   // -------------------------------------------------------------------------
   // SCEN-02 — Symmetric colony placement
   // -------------------------------------------------------------------------
@@ -105,7 +104,7 @@ describe('createScenario', () => {
     it('each colony queen is alive', () => {
       const world = createScenario(42);
       const playerQueenId = world.colonies[PLAYER_COLONY_ID]!.queenEntityId;
-      const enemyQueenId  = world.colonies[ENEMY_COLONY_ID]!.queenEntityId;
+      const enemyQueenId = world.colonies[ENEMY_COLONY_ID]!.queenEntityId;
       expect(isAlive(world.ants, playerQueenId)).toBe(true);
       expect(isAlive(world.ants, enemyQueenId)).toBe(true);
     });
@@ -150,9 +149,7 @@ describe('createScenario', () => {
     it('no food pile is within FOOD_PILE_MIN_COLONY_DISTANCE of player start', () => {
       const world = createScenario(42);
       for (const pile of world.foodPiles) {
-        const dist =
-          Math.abs(pile.tileX - PLAYER_START_X) +
-          Math.abs(pile.tileY - PLAYER_START_Y);
+        const dist = Math.abs(pile.tileX - PLAYER_START_X) + Math.abs(pile.tileY - PLAYER_START_Y);
         expect(dist).toBeGreaterThanOrEqual(FOOD_PILE_MIN_COLONY_DISTANCE);
       }
     });
@@ -160,9 +157,7 @@ describe('createScenario', () => {
     it('no food pile is within FOOD_PILE_MIN_COLONY_DISTANCE of enemy start', () => {
       const world = createScenario(42);
       for (const pile of world.foodPiles) {
-        const dist =
-          Math.abs(pile.tileX - ENEMY_START_X) +
-          Math.abs(pile.tileY - ENEMY_START_Y);
+        const dist = Math.abs(pile.tileX - ENEMY_START_X) + Math.abs(pile.tileY - ENEMY_START_Y);
         expect(dist).toBeGreaterThanOrEqual(FOOD_PILE_MIN_COLONY_DISTANCE);
       }
     });
@@ -345,7 +340,7 @@ describe('createScenario', () => {
     it('entrances arrays of both colonies are independent references', () => {
       const world = createScenario(42);
       const player = world.colonies[PLAYER_COLONY_ID]!;
-      const enemy  = world.colonies[ENEMY_COLONY_ID]!;
+      const enemy = world.colonies[ENEMY_COLONY_ID]!;
       const enemyStart = enemy.entrances.length;
       // Push into player entrances; enemy's array length must not change.
       player.entrances.push({ entranceId: 99, surfaceTileX: 0, surfaceTileY: 0, isOpen: false });
@@ -386,7 +381,7 @@ describe('createScenario', () => {
       const world = createScenario(42);
       for (const cid of [PLAYER_COLONY_ID, ENEMY_COLONY_ID]) {
         for (const pType of [PheromoneType.FoodTrail, PheromoneType.DangerTrail]) {
-          const surfaceKey     = pheromoneGridKey(cid, pType, 'surface');
+          const surfaceKey = pheromoneGridKey(cid, pType, 'surface');
           const undergroundKey = pheromoneGridKey(cid, pType, 'underground');
           expect(world.pheromoneGrids[surfaceKey]).toBeDefined();
           expect(world.pheromoneGrids[undergroundKey]).toBeDefined();
@@ -436,7 +431,7 @@ describe('createScenario', () => {
         tick(world, []);
       }
       const player = world.colonies[PLAYER_COLONY_ID]!;
-      const enemy  = world.colonies[ENEMY_COLONY_ID]!;
+      const enemy = world.colonies[ENEMY_COLONY_ID]!;
       expect(world.ants.alive[player.queenEntityId]).toBe(1);
       expect(world.ants.alive[enemy.queenEntityId]).toBe(1);
       expect(player.defeated).toBe(false);
@@ -458,7 +453,8 @@ describe('createScenario', () => {
       for (let t = 0; t < 1500; t++) {
         tick(world, []);
         for (const cid of [PLAYER_COLONY_ID, ENEMY_COLONY_ID]) {
-          const grid = world.pheromoneGrids[pheromoneGridKey(cid, PheromoneType.FoodTrail, 'surface')]!;
+          const grid =
+            world.pheromoneGrids[pheromoneGridKey(cid, PheromoneType.FoodTrail, 'surface')]!;
           let totalStrength = 0;
           for (let i = 0; i < grid.data.length; i++) totalStrength += grid.data[i]!;
           if (totalStrength > peak[cid]!) peak[cid] = totalStrength;
@@ -482,9 +478,7 @@ describe('createScenario', () => {
       // baseline.
       const world = createScenario(42);
       const REACQUIRE_RADIUS = 3;
-      const trailKey = pheromoneGridKey(
-        PLAYER_COLONY_ID, PheromoneType.FoodTrail, 'surface',
-      );
+      const trailKey = pheromoneGridKey(PLAYER_COLONY_ID, PheromoneType.FoodTrail, 'surface');
 
       // Phase A — tick forward until pheromone exists and stays alive for 10
       // consecutive ticks (confirms the forage loop is actively maintained,
@@ -577,5 +571,4 @@ describe('createScenario', () => {
       }
     });
   });
-
 });

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -12,7 +12,13 @@
 import type { WorldState, SpiderState } from './types.js';
 import { createWorldState, allocateEntityId } from './types.js';
 import { createDefaultAIStateRecord, tierIndex } from './ai-state.js';
-import { createSurfaceGrid, createUndergroundGrid, SurfaceTileState, UndergroundTileState, ugSet } from './terrain.js';
+import {
+  createSurfaceGrid,
+  createUndergroundGrid,
+  SurfaceTileState,
+  UndergroundTileState,
+  ugSet,
+} from './terrain.js';
 import { initAnt } from './ant/ant-store.js';
 import { createColonyRecord } from './colony/colony-store.js';
 import { createPheromoneGrid, pheromoneGridKey } from './pheromone/pheromone-store.js';
@@ -76,7 +82,7 @@ import {
 function generateFoodPiles(world: WorldState, rng: Rng): void {
   const colonies = [
     { x: PLAYER_START_X, y: PLAYER_START_Y },
-    { x: ENEMY_START_X,  y: ENEMY_START_Y  },
+    { x: ENEMY_START_X, y: ENEMY_START_Y },
   ];
 
   for (
@@ -177,22 +183,22 @@ function initColony(
   const queenId = allocateEntityId(world);
   initAnt(world.ants, queenId, {
     colonyId,
-    posX:     startX << FP_SHIFT,
-    posY:     startY << FP_SHIFT,
-    task:     AntTask.Idle,
+    posX: startX << FP_SHIFT,
+    posY: startY << FP_SHIFT,
+    task: AntTask.Idle,
     lifespan: WORKER_LIFESPAN_TICKS,
-    hp:       COMBAT_HP_QUEEN,
+    hp: COMBAT_HP_QUEEN,
   });
 
   const colony = createColonyRecord(colonyId, queenId);
 
   // Phase 3 PRD §2a caller-side extension contract —
   // factory intentionally does not set these three fields:
-  colony.entrances         = [];
-  colony.rallyPoint        = null;
+  colony.entrances = [];
+  colony.rallyPoint = null;
   colony.digFlowFieldDirty = false;
   colony.foodFlowFieldDirty = false;
-  colony.foodStored        = STARTING_FOOD;
+  colony.foodStored = STARTING_FOOD;
 
   // Phase 9 playability: seed each colony with one pre-excavated open entrance
   // at the colony's start column so the forage loop closes on tick 0.
@@ -210,10 +216,10 @@ function initColony(
   const underground = world.undergroundGrids[colonyId];
   if (underground) {
     colony.entrances.push({
-      entranceId:   allocateEntityId(world),
+      entranceId: allocateEntityId(world),
       surfaceTileX: startX,
       surfaceTileY: startY,
-      isOpen:       true,
+      isOpen: true,
     });
     // Pre-excavate the shaft (underground tiles at the entrance column).
     for (let sy = 0; sy < ENTRANCE_SHAFT_DEPTH; sy++) {
@@ -264,10 +270,12 @@ function _placeSpider(world: WorldState): SpiderState {
     const ty = (h2 >>> 0) % SURFACE_GRID_HEIGHT;
 
     // Check Manhattan distance from both colony starts
-    const d1 = (tx > PLAYER_START_X ? tx - PLAYER_START_X : PLAYER_START_X - tx) +
-               (ty > PLAYER_START_Y ? ty - PLAYER_START_Y : PLAYER_START_Y - ty);
-    const d2 = (tx > ENEMY_START_X  ? tx - ENEMY_START_X  : ENEMY_START_X  - tx) +
-               (ty > ENEMY_START_Y  ? ty - ENEMY_START_Y  : ENEMY_START_Y  - ty);
+    const d1 =
+      (tx > PLAYER_START_X ? tx - PLAYER_START_X : PLAYER_START_X - tx) +
+      (ty > PLAYER_START_Y ? ty - PLAYER_START_Y : PLAYER_START_Y - ty);
+    const d2 =
+      (tx > ENEMY_START_X ? tx - ENEMY_START_X : ENEMY_START_X - tx) +
+      (ty > ENEMY_START_Y ? ty - ENEMY_START_Y : ENEMY_START_Y - ty);
     if (d1 >= minDist && d2 >= minDist && Math.abs(d1 - d2) <= 20) {
       lairTileX = tx;
       lairTileY = ty;
@@ -329,7 +337,10 @@ function _placeSpider(world: WorldState): SpiderState {
  * @param difficulty - S5 player-selected difficulty tier. Stored on world.difficulty.
  *                     Defaults to 'Normal' for backward-compatible call sites.
  */
-export function createScenario(seed: number, difficulty: 'Easy' | 'Normal' | 'Hard' = 'Normal'): WorldState {
+export function createScenario(
+  seed: number,
+  difficulty: 'Easy' | 'Normal' | 'Hard' = 'Normal',
+): WorldState {
   // --- Step 1: Create base WorldState ---
   const world = createWorldState(seed);
   world.difficulty = difficulty;
@@ -360,7 +371,7 @@ export function createScenario(seed: number, difficulty: 'Easy' | 'Normal' | 'Ha
 
   // --- Steps 5-6: Colony initialization (player + enemy) ---
   initColony(world, PLAYER_COLONY_ID, PLAYER_START_X, PLAYER_START_Y, rng);
-  initColony(world, ENEMY_COLONY_ID,  ENEMY_START_X,  ENEMY_START_Y,  rng);
+  initColony(world, ENEMY_COLONY_ID, ENEMY_START_X, ENEMY_START_Y, rng);
   // S5 (V22): encode difficulty scaling into the AI colony record so lifecycle-system
   // can apply the numerator without branching on PLAYER_COLONY_ID at runtime.
   world.colonies[ENEMY_COLONY_ID]!.eggIntervalNumerator =
@@ -371,10 +382,16 @@ export function createScenario(seed: number, difficulty: 'Easy' | 'Normal' | 'Ha
   // All 8 must exist so tick-step lookups never hit a missing key.
   for (const cid of [PLAYER_COLONY_ID, ENEMY_COLONY_ID]) {
     for (const pType of [PheromoneType.FoodTrail, PheromoneType.DangerTrail]) {
-      const surfaceKey     = pheromoneGridKey(cid, pType, 'surface');
+      const surfaceKey = pheromoneGridKey(cid, pType, 'surface');
       const undergroundKey = pheromoneGridKey(cid, pType, 'underground');
-      world.pheromoneGrids[surfaceKey]     = createPheromoneGrid(SURFACE_GRID_WIDTH,     SURFACE_GRID_HEIGHT);
-      world.pheromoneGrids[undergroundKey] = createPheromoneGrid(UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
+      world.pheromoneGrids[surfaceKey] = createPheromoneGrid(
+        SURFACE_GRID_WIDTH,
+        SURFACE_GRID_HEIGHT,
+      );
+      world.pheromoneGrids[undergroundKey] = createPheromoneGrid(
+        UNDERGROUND_GRID_WIDTH,
+        UNDERGROUND_GRID_HEIGHT,
+      );
     }
   }
 

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -93,7 +93,12 @@ function makeWorld(seed = 0): WorldState {
 }
 
 /** Place a surface worker at tile (tx, ty) in the world. Returns ant index. */
-function placeWorker(world: WorldState, tx: number, ty: number, colonyId = PLAYER_COLONY_ID): number {
+function placeWorker(
+  world: WorldState,
+  tx: number,
+  ty: number,
+  colonyId = PLAYER_COLONY_ID,
+): number {
   const id = world.nextEntityId++;
   initAnt(world.ants, id, {
     colonyId,
@@ -104,7 +109,12 @@ function placeWorker(world: WorldState, tx: number, ty: number, colonyId = PLAYE
   return id;
 }
 
-function placeFighter(world: WorldState, tx: number, ty: number, colonyId = PLAYER_COLONY_ID): number {
+function placeFighter(
+  world: WorldState,
+  tx: number,
+  ty: number,
+  colonyId = PLAYER_COLONY_ID,
+): number {
   const id = world.nextEntityId++;
   initAnt(world.ants, id, {
     colonyId,
@@ -346,13 +356,18 @@ describe('tickSpider', () => {
     });
   });
 
-
   describe('rampageTargetColonyId — weighted colony selection', () => {
     it('sets rampageTargetColonyId on Rampaging entry and clears it on exit', () => {
       const world = makeWorld();
-      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = createColonyRecord(PLAYER_COLONY_ID, 0);
+      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = createColonyRecord(
+        PLAYER_COLONY_ID,
+        0,
+      );
       world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!.entrances = [];
-      world.colonies[ENEMY_COLONY_ID as unknown as ColonyId] = createColonyRecord(ENEMY_COLONY_ID, 1);
+      world.colonies[ENEMY_COLONY_ID as unknown as ColonyId] = createColonyRecord(
+        ENEMY_COLONY_ID,
+        1,
+      );
       world.colonies[ENEMY_COLONY_ID as unknown as ColonyId]!.entrances = [];
       world.spider = makeSpider({
         state: 'Patrolling',
@@ -362,8 +377,10 @@ describe('tickSpider', () => {
 
       tickSpider(world);
       expect(world.spider!.state).toBe('Rampaging');
-      expect(world.spider!.rampageTargetColonyId === PLAYER_COLONY_ID ||
-             world.spider!.rampageTargetColonyId === ENEMY_COLONY_ID).toBe(true);
+      expect(
+        world.spider!.rampageTargetColonyId === PLAYER_COLONY_ID ||
+          world.spider!.rampageTargetColonyId === ENEMY_COLONY_ID,
+      ).toBe(true);
 
       // Transition to Feeding via kill quota — target should be cleared.
       world.spider!.rampageKillsThisRampage = SPIDER_RAMPAGE_KILL_QUOTA;
@@ -376,10 +393,16 @@ describe('tickSpider', () => {
       // Run 20 rampages across varying seeds and ticks; none should produce -1.
       for (let seed = 1; seed <= 20; seed++) {
         const world = makeWorld(seed * 1000);
-        world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = createColonyRecord(PLAYER_COLONY_ID, 0);
-      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!.entrances = [];
-        world.colonies[ENEMY_COLONY_ID as unknown as ColonyId] = createColonyRecord(ENEMY_COLONY_ID, 1);
-      world.colonies[ENEMY_COLONY_ID as unknown as ColonyId]!.entrances = [];
+        world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = createColonyRecord(
+          PLAYER_COLONY_ID,
+          0,
+        );
+        world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!.entrances = [];
+        world.colonies[ENEMY_COLONY_ID as unknown as ColonyId] = createColonyRecord(
+          ENEMY_COLONY_ID,
+          1,
+        );
+        world.colonies[ENEMY_COLONY_ID as unknown as ColonyId]!.entrances = [];
         world.spider = makeSpider({
           state: 'Patrolling',
           hungerTicks: SPIDER_HUNGER_MAX_TICKS[1] - 1,
@@ -394,9 +417,15 @@ describe('tickSpider', () => {
       // Over 50 rampages with varying ticks, both colonies should be chosen at least once.
       const chosen = new Set<number>();
       const world = makeWorld(42);
-      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = createColonyRecord(PLAYER_COLONY_ID, 0);
+      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = createColonyRecord(
+        PLAYER_COLONY_ID,
+        0,
+      );
       world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!.entrances = [];
-      world.colonies[ENEMY_COLONY_ID as unknown as ColonyId] = createColonyRecord(ENEMY_COLONY_ID, 1);
+      world.colonies[ENEMY_COLONY_ID as unknown as ColonyId] = createColonyRecord(
+        ENEMY_COLONY_ID,
+        1,
+      );
       world.colonies[ENEMY_COLONY_ID as unknown as ColonyId]!.entrances = [];
       for (let tick = 0; tick < 50; tick++) {
         world.spider = makeSpider({
@@ -541,7 +570,11 @@ describe('tickSpider', () => {
 
     it('does not exceed SPIDER_HP_FULL', () => {
       const world = makeWorld();
-      world.spider = makeSpider({ state: 'Retreating', hp: SPIDER_HP_FULL - 1, retreatStartTick: 0 });
+      world.spider = makeSpider({
+        state: 'Retreating',
+        hp: SPIDER_HP_FULL - 1,
+        retreatStartTick: 0,
+      });
       world.tick = 20;
 
       tickSpider(world);
@@ -593,7 +626,11 @@ describe('tickSpider', () => {
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       const sx = 64;
       const sy = 32;
-      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: HUNGRY_TICKS });
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS,
+      });
       world.spider.nextHuntTick = 9999;
       world.tick = SPIDER_GRACE_TICKS; // past grace so the spider is active and hungry
       const antId = placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS, sy);
@@ -612,11 +649,15 @@ describe('tickSpider', () => {
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       const sx = 64;
       const sy = 32;
-      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: HUNGRY_TICKS });
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS,
+      });
       world.spider.nextHuntTick = 9999;
       world.tick = SPIDER_GRACE_TICKS; // past grace so the spider is active and hungry
       const near = placeWorker(world, sx + 1, sy); // dist 1
-      placeWorker(world, sx + 3, sy);              // dist 3 (farther)
+      placeWorker(world, sx + 3, sy); // dist 3 (farther)
 
       tickSpider(world);
 
@@ -629,7 +670,11 @@ describe('tickSpider', () => {
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       const sx = 64;
       const sy = 32;
-      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: HUNGRY_TICKS });
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS,
+      });
       world.spider.nextHuntTick = 9999;
       placeWorker(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy); // out of range
 
@@ -677,7 +722,11 @@ describe('tickSpider', () => {
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       const sx = 64;
       const sy = 32;
-      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: HUNGRY_TICKS });
+      world.spider = makeSpider({
+        posX: sx << FP_SHIFT,
+        posY: sy << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS,
+      });
       world.spider.nextHuntTick = 9999;
       world.tick = SPIDER_GRACE_TICKS; // past grace so the no-chase is queen-exclusion, not dormancy
       const queenId = placeWorker(world, sx + 1, sy);
@@ -807,7 +856,7 @@ describe('tickSpider', () => {
       const sy = 32;
       world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: 0 });
       world.spider.nextHuntTick = 9999;
-      placeFighter(world, sx + 6, sy);            // dist 6 (farther)
+      placeFighter(world, sx + 6, sy); // dist 6 (farther)
       const near = placeFighter(world, sx, sy + 5); // dist 5 (nearer)
 
       tickSpider(world);
@@ -906,7 +955,7 @@ describe('tickSpider', () => {
       const col = createColonyRecord(PLAYER_COLONY_ID, -1);
       col.entrances = [{ entranceId: 1, surfaceTileX: sx, surfaceTileY: sy, isOpen: true }];
       world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = col;
-      placeWorker(world, sx, sy);                              // descender pinned on the entrance
+      placeWorker(world, sx, sy); // descender pinned on the entrance
       placeFighter(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy); // attacker within defense radius
 
       tickSpider(world);
@@ -1006,7 +1055,7 @@ describe('tickSpider', () => {
       const sx = 64;
       const sy = 32;
       campingSpider(world, sx, sy); // entrance at (sx, sy)
-      placeWorker(world, sx, sy);   // descender sitting ON the entrance → must be held, not chased
+      placeWorker(world, sx, sy); // descender sitting ON the entrance → must be held, not chased
 
       tickSpider(world);
 

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -64,7 +64,11 @@ const HUNT_DIRTY: number[] = [];
 const SURFACE_DANGER_SUFFIX = `:${PheromoneType.DangerTrail}:surface`;
 
 // Module-level scratch for findNearestEntrance return value — avoids per-Rampaging-tick allocation.
-const NEAREST_ENTRANCE_SCRATCH: { x: number; y: number; colonyId: number } = { x: -1, y: -1, colonyId: -1 };
+const NEAREST_ENTRANCE_SCRATCH: { x: number; y: number; colonyId: number } = {
+  x: -1,
+  y: -1,
+  colonyId: -1,
+};
 
 // ---------------------------------------------------------------------------
 // Hunt target selection — deterministic (no rng draws)
@@ -110,8 +114,9 @@ function findHuntTarget(
     if (i === huntQueenId0 || i === huntQueenId1) continue; // queens are not prey
     const ax = ants.posX[i]! >> FP_SHIFT;
     const ay = ants.posY[i]! >> FP_SHIFT;
-    const dist = (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +
-                 (ay > spiderTileY ? ay - spiderTileY : spiderTileY - ay);
+    const dist =
+      (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +
+      (ay > spiderTileY ? ay - spiderTileY : spiderTileY - ay);
     if (dist > r) continue;
     const key = (ay << HUNT_KEY_SHIFT) + ax;
     if (HUNT_TILE_COUNTS[key] === 0) HUNT_DIRTY.push(key);
@@ -172,10 +177,14 @@ function findChaseTarget(world: WorldState, spider: SpiderState): number {
     if (i === chaseQueenId0 || i === chaseQueenId1) continue; // queens are not prey
     const ax = ants.posX[i]! >> FP_SHIFT;
     const ay = ants.posY[i]! >> FP_SHIFT;
-    const dist = (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +
-                 (ay > spiderTileY ? ay - spiderTileY : spiderTileY - ay);
+    const dist =
+      (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +
+      (ay > spiderTileY ? ay - spiderTileY : spiderTileY - ay);
     if (dist > r) continue;
-    if (dist < bestDist) { bestDist = dist; bestId = i; } // strict < ⇒ lower id wins on tie
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestId = i;
+    } // strict < ⇒ lower id wins on tie
   }
   return bestId;
 }
@@ -211,7 +220,7 @@ function isSurfaceAntOnTile(world: WorldState, tileX: number, tileY: number): bo
     if (ants.alive[i] !== 1) continue;
     if (ants.zone[i] !== 0) continue; // surface only
     if (i === queenId0 || i === queenId1) continue; // queens are not bite-able
-    if ((ants.posX[i]! >> FP_SHIFT) === tileX && (ants.posY[i]! >> FP_SHIFT) === tileY) return true;
+    if (ants.posX[i]! >> FP_SHIFT === tileX && ants.posY[i]! >> FP_SHIFT === tileY) return true;
   }
   return false;
 }
@@ -239,10 +248,14 @@ function findNearestAttackingFighter(world: WorldState, spider: SpiderState): nu
     if (ants.task[i] !== AntTask.Fighting) continue;
     const ax = ants.posX[i]! >> FP_SHIFT;
     const ay = ants.posY[i]! >> FP_SHIFT;
-    const dist = (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +
-                 (ay > spiderTileY ? ay - spiderTileY : spiderTileY - ay);
+    const dist =
+      (ax > spiderTileX ? ax - spiderTileX : spiderTileX - ax) +
+      (ay > spiderTileY ? ay - spiderTileY : spiderTileY - ay);
     if (dist > r) continue;
-    if (dist < bestDist) { bestDist = dist; bestId = i; } // strict < ⇒ lower id wins on tie
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestId = i;
+    } // strict < ⇒ lower id wins on tie
   }
   return bestId;
 }
@@ -299,7 +312,6 @@ function findNearestEntrance(
   return NEAREST_ENTRANCE_SCRATCH;
 }
 
-
 // ---------------------------------------------------------------------------
 // Rampage target colony selection — 60/40 weighted toward richer colony
 // ---------------------------------------------------------------------------
@@ -340,7 +352,7 @@ function pickRampageTarget(world: WorldState, spider: SpiderState): number {
   // deterministic, no rngState draw.
   const h = hash32(world.terrainSeed ^ spider.rampageStartTick);
   // 60% → richer colony (index 0), 40% → poorer (index 1).
-  return (h % 100) < 60 ? candidates[0]!.colonyId : candidates[1]!.colonyId;
+  return h % 100 < 60 ? candidates[0]!.colonyId : candidates[1]!.colonyId;
 }
 
 // ---------------------------------------------------------------------------
@@ -385,10 +397,22 @@ function tickPatrolMovement(world: WorldState, spider: SpiderState): void {
   let tx: number;
   let ty: number;
   switch (phase) {
-    case 0: tx = lx + r; ty = ly - r; break;
-    case 1: tx = lx + r; ty = ly + r; break;
-    case 2: tx = lx - r; ty = ly + r; break;
-    default: tx = lx - r; ty = ly - r; break;
+    case 0:
+      tx = lx + r;
+      ty = ly - r;
+      break;
+    case 1:
+      tx = lx + r;
+      ty = ly + r;
+      break;
+    case 2:
+      tx = lx - r;
+      ty = ly + r;
+      break;
+    default:
+      tx = lx - r;
+      ty = ly - r;
+      break;
   }
   // Clamp target within grid
   if (tx < 0) tx = 0;
@@ -422,15 +446,30 @@ function seedDangerPheromone(world: WorldState, spider: SpiderState): void {
     if (!colonyKey.endsWith(SURFACE_DANGER_SUFFIX)) continue;
     const grid = world.pheromoneGrids[colonyKey]!;
     // center (spider is always within surface bounds)
-    { const v = phGet(grid, tileX, tileY) + center; phSet(grid, tileX, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+    {
+      const v = phGet(grid, tileX, tileY) + center;
+      phSet(grid, tileX, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v);
+    }
     // north
-    if (tileY > 0) { const v = phGet(grid, tileX, tileY - 1) + nb; phSet(grid, tileX, tileY - 1, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+    if (tileY > 0) {
+      const v = phGet(grid, tileX, tileY - 1) + nb;
+      phSet(grid, tileX, tileY - 1, v > PHEROMONE_CAP ? PHEROMONE_CAP : v);
+    }
     // south
-    if (tileY < h - 1) { const v = phGet(grid, tileX, tileY + 1) + nb; phSet(grid, tileX, tileY + 1, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+    if (tileY < h - 1) {
+      const v = phGet(grid, tileX, tileY + 1) + nb;
+      phSet(grid, tileX, tileY + 1, v > PHEROMONE_CAP ? PHEROMONE_CAP : v);
+    }
     // west
-    if (tileX > 0) { const v = phGet(grid, tileX - 1, tileY) + nb; phSet(grid, tileX - 1, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+    if (tileX > 0) {
+      const v = phGet(grid, tileX - 1, tileY) + nb;
+      phSet(grid, tileX - 1, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v);
+    }
     // east
-    if (tileX < w - 1) { const v = phGet(grid, tileX + 1, tileY) + nb; phSet(grid, tileX + 1, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v); }
+    if (tileX < w - 1) {
+      const v = phGet(grid, tileX + 1, tileY) + nb;
+      phSet(grid, tileX + 1, tileY, v > PHEROMONE_CAP ? PHEROMONE_CAP : v);
+    }
   }
 }
 
@@ -563,9 +602,11 @@ export function tickSpider(world: WorldState): void {
 // ---------------------------------------------------------------------------
 function tickSpiderV22(world: WorldState, spider: SpiderState): void {
   // HP regeneration: 1 HP per 20 ticks while Retreating or Feeding.
-  if ((spider.state === 'Retreating' || spider.state === 'Feeding') &&
-      (world.tick % 20 === 0) &&
-      spider.hp < SPIDER_HP_FULL) {
+  if (
+    (spider.state === 'Retreating' || spider.state === 'Feeding') &&
+    world.tick % 20 === 0 &&
+    spider.hp < SPIDER_HP_FULL
+  ) {
     spider.hp += SPIDER_HP_REGEN_PER_20_TICKS;
     if (spider.hp > SPIDER_HP_FULL) spider.hp = SPIDER_HP_FULL;
   }
@@ -578,8 +619,10 @@ function tickSpiderV22(world: WorldState, spider: SpiderState): void {
   // --- Priority retreating-threshold check (applies to Striking, Chasing, Rampaging) ---
   // This runs before state-specific logic so a combat-damaged spider retreats
   // immediately, even on the same tick its duration would have expired.
-  if ((spider.state === 'Striking' || spider.state === 'Chasing' || spider.state === 'Rampaging') &&
-      spider.hp < SPIDER_RAMPAGE_RETREAT_HP) {
+  if (
+    (spider.state === 'Striking' || spider.state === 'Chasing' || spider.state === 'Rampaging') &&
+    spider.hp < SPIDER_RAMPAGE_RETREAT_HP
+  ) {
     if (spider.state === 'Striking') {
       emitSpiderHuntEnd(world, 'swarm_retreat', spider.killsThisStrike);
     } else if (spider.state === 'Chasing') {
@@ -619,9 +662,8 @@ function tickSpiderV22(world: WorldState, spider: SpiderState): void {
       } else {
         // V23 (#146): opportunistic chase — a lone ant within trigger radius takes
         // precedence over the scheduled tile-density hunt (but not over rampaging).
-        const chaseId = world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO
-          ? findChaseTarget(world, spider)
-          : -1;
+        const chaseId =
+          world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO ? findChaseTarget(world, spider) : -1;
         if (chaseId >= 0) {
           spider.state = 'Chasing';
           spider.chaseTargetAntId = chaseId;
@@ -764,8 +806,10 @@ function tickSpiderV22(world: WorldState, spider: SpiderState): void {
     }
 
     case 'Retreating': {
-      if (spider.hp >= SPIDER_HP_FULL &&
-          world.tick >= spider.retreatStartTick + SPIDER_RETREAT_MIN_TICKS) {
+      if (
+        spider.hp >= SPIDER_HP_FULL &&
+        world.tick >= spider.retreatStartTick + SPIDER_RETREAT_MIN_TICKS
+      ) {
         spider.state = 'Patrolling';
         spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
       }
@@ -780,7 +824,10 @@ function tickSpiderV22(world: WorldState, spider: SpiderState): void {
   if (spider.state === 'Rampaging' && spider.rampageTargetColonyId < 0) {
     spider.rampageTargetColonyId = pickRampageTarget(world, spider);
   }
-  const rampageNearest = spider.state === 'Rampaging' ? findNearestEntrance(world, spider, spider.rampageTargetColonyId) : null;
+  const rampageNearest =
+    spider.state === 'Rampaging'
+      ? findNearestEntrance(world, spider, spider.rampageTargetColonyId)
+      : null;
   switch (spider.state) {
     case 'Patrolling': {
       tickPatrolMovement(world, spider);
@@ -800,7 +847,11 @@ function tickSpiderV22(world: WorldState, spider: SpiderState): void {
       // handled dead/underground/leash-expired targets, so the id is live here).
       const tid = spider.chaseTargetAntId;
       if (tid >= 0 && world.ants.alive[tid] === 1) {
-        moveTowardTile(spider, world.ants.posX[tid]! >> FP_SHIFT, world.ants.posY[tid]! >> FP_SHIFT);
+        moveTowardTile(
+          spider,
+          world.ants.posX[tid]! >> FP_SHIFT,
+          world.ants.posY[tid]! >> FP_SHIFT,
+        );
       }
       break;
     }
@@ -829,7 +880,6 @@ function tickSpiderV22(world: WorldState, spider: SpiderState): void {
   if (isOnSurface) {
     seedDangerPheromone(world, spider);
   }
-
 
   // --- scatterReticleTile shadow field: written at end for next tick's step 13e ---
   // Hunting/Striking scatter around the hunt target tile; Chasing (V23) scatters around
@@ -1010,11 +1060,7 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
   //     would let the pinned ant slip underground next tick (movement reads the
   //     spider's state before the spider ticks). Holding is not passive: the spider
   //     still bites back any ant that steps onto its tile via tile-coincident combat.
-  if (
-    spider.state === 'Patrolling' ||
-    spider.state === 'Hunting' ||
-    spider.state === 'Rampaging'
-  ) {
+  if (spider.state === 'Patrolling' || spider.state === 'Hunting' || spider.state === 'Rampaging') {
     let holdGate = false;
     if (spider.state === 'Rampaging' && spider.rampageTargetColonyId >= 0) {
       const camped = findNearestEntrance(world, spider, spider.rampageTargetColonyId);
@@ -1105,7 +1151,11 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
       if (world.tick - spider.strikeStartTick >= SPIDER_STRIKE_TICKS) {
         // Kills route through step 3 (killedThisTick → Feeding). Reaching here
         // means no feed this strike (no kill, or a fighter-adjacent kill); scatter.
-        emitSpiderHuntEnd(world, spider.killsThisStrike > 0 ? 'kill' : 'scatter', spider.killsThisStrike);
+        emitSpiderHuntEnd(
+          world,
+          spider.killsThisStrike > 0 ? 'kill' : 'scatter',
+          spider.killsThisStrike,
+        );
         clearSpiderPairingSentinels(world);
         spider.state = 'Patrolling';
         spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
@@ -1161,11 +1211,14 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
         spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
         spider.rampageTargetColonyId = -1;
         world.spiderPriorityColonyId = null;
-      } else if (spider.rampageTargetColonyId < 0 ||
-                 findNearestEntrance(world, spider, spider.rampageTargetColonyId) === null) {
+      } else if (
+        spider.rampageTargetColonyId < 0 ||
+        findNearestEntrance(world, spider, spider.rampageTargetColonyId) === null
+      ) {
         // No target yet, or the camped colony sealed its only open entrance.
         // (Re-pick first; if still no open entrance, resume patrolling.)
-        if (spider.rampageTargetColonyId < 0) spider.rampageTargetColonyId = pickRampageTarget(world, spider);
+        if (spider.rampageTargetColonyId < 0)
+          spider.rampageTargetColonyId = pickRampageTarget(world, spider);
         if (findNearestEntrance(world, spider, spider.rampageTargetColonyId) === null) {
           emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
           clearSpiderPairingSentinels(world);
@@ -1214,12 +1267,18 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
       } else {
         const sx = spider.posX >> FP_SHIFT;
         const sy = spider.posY >> FP_SHIFT;
-        if (spider.feedArrivedTick < 0 && sx === spider.feedAwayTileX && sy === spider.feedAwayTileY) {
+        if (
+          spider.feedArrivedTick < 0 &&
+          sx === spider.feedAwayTileX &&
+          sy === spider.feedAwayTileY
+        ) {
           spider.feedArrivedTick = world.tick;
         }
         if (spider.feedArrivedTick >= 0) {
-          if ((world.tick - spider.feedArrivedTick) % SPIDER_FEED_HEAL_INTERVAL_TICKS === 0 &&
-              spider.hp < SPIDER_HP_FULL) {
+          if (
+            (world.tick - spider.feedArrivedTick) % SPIDER_FEED_HEAL_INTERVAL_TICKS === 0 &&
+            spider.hp < SPIDER_HP_FULL
+          ) {
             spider.hp += 1;
             if (spider.hp > SPIDER_HP_FULL) spider.hp = SPIDER_HP_FULL;
           }
@@ -1240,9 +1299,10 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
   }
 
   // 6. Movement.
-  const rampageNearest = spider.state === 'Rampaging'
-    ? findNearestEntrance(world, spider, spider.rampageTargetColonyId)
-    : null;
+  const rampageNearest =
+    spider.state === 'Rampaging'
+      ? findNearestEntrance(world, spider, spider.rampageTargetColonyId)
+      : null;
   switch (spider.state) {
     case 'Patrolling': {
       // Slow meander across the whole map: step only every Nth tick toward a
@@ -1269,7 +1329,11 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
     case 'Chasing': {
       const tid = spider.chaseTargetAntId;
       if (tid >= 0 && world.ants.alive[tid] === 1) {
-        moveTowardTile(spider, world.ants.posX[tid]! >> FP_SHIFT, world.ants.posY[tid]! >> FP_SHIFT);
+        moveTowardTile(
+          spider,
+          world.ants.posX[tid]! >> FP_SHIFT,
+          world.ants.posY[tid]! >> FP_SHIFT,
+        );
       }
       break;
     }

--- a/src/sim/surface-features.test.ts
+++ b/src/sim/surface-features.test.ts
@@ -8,10 +8,7 @@
 //   - surfaceMovementAt convenience helper
 
 import { describe, it, expect } from 'vitest';
-import {
-  createWorldState,
-  type WorldState,
-} from './types.js';
+import { createWorldState, type WorldState } from './types.js';
 import { createColonyRecord } from './colony/colony-store.js';
 import {
   surfaceFeatureAt,
@@ -34,12 +31,14 @@ function installColonyWithEntrance(
   surfaceTileY: number,
 ): void {
   const colony = createColonyRecord(colonyId, /* queenEntityId */ 0);
-  colony.entrances = [{
-    entranceId: 0,
-    surfaceTileX,
-    surfaceTileY,
-    isOpen: true,
-  }];
+  colony.entrances = [
+    {
+      entranceId: 0,
+      surfaceTileX,
+      surfaceTileY,
+      isOpen: true,
+    },
+  ];
   colony.rallyPoint = null;
   colony.digFlowFieldDirty = false;
   world.colonies[colonyId] = colony;
@@ -215,8 +214,10 @@ describe('surfaceFeatureAt — gameplay suppression', () => {
     // the centre return null OR a slice anchored OUTSIDE the rectangle.
     const tiles: Array<[number, number]> = [
       [50, 50],
-      [50 - r, 50 - r], [50 + r, 50 - r],
-      [50 - r, 50 + r], [50 + r, 50 + r],
+      [50 - r, 50 - r],
+      [50 + r, 50 - r],
+      [50 - r, 50 + r],
+      [50 + r, 50 + r],
     ];
     for (const [tx, ty] of tiles) {
       const slice = surfaceFeatureAt(world, tx, ty);
@@ -259,7 +260,10 @@ describe('surfaceFeatureAt — gameplay suppression', () => {
     for (let y = 60; y < 90 && second === null; y++) {
       for (let x = 60; x < 90; x++) {
         const slice = surfaceFeatureAt(baseline, x, y);
-        if (slice !== null) { second = { x, y, slice }; break; }
+        if (slice !== null) {
+          second = { x, y, slice };
+          break;
+        }
       }
     }
     expect(second).not.toBeNull();
@@ -298,11 +302,11 @@ describe('surfaceFeatureAt — gameplay suppression', () => {
     // theory.
     const r = SURFACE_FEATURE_ENTRANCE_RADIUS;
     let demonstrationCount = 0;
-    seedLoop:
-    for (let seed = 1; seed < 80; seed++) {
+    seedLoop: for (let seed = 1; seed < 80; seed++) {
       const baseline = createWorldState(seed);
       // Place an entrance at a known location with room around it.
-      const ex = 30, ey = 30;
+      const ex = 30,
+        ey = 30;
       // Examine tiles just OUTSIDE the entrance suppression rectangle
       // — on the perimeter where the shadow bug would manifest.
       for (let dy = -r - 6; dy <= r + 6; dy++) {
@@ -319,8 +323,7 @@ describe('surfaceFeatureAt — gameplay suppression', () => {
           // the shadow bug.
           const ax = baselineSlice.anchorX;
           const ay = baselineSlice.anchorY;
-          const anchorInsideZone =
-            ax >= ex - r && ax <= ex + r && ay >= ey - r && ay <= ey + r;
+          const anchorInsideZone = ax >= ex - r && ax <= ex + r && ay >= ey - r && ay <= ey + r;
           if (!anchorInsideZone) continue;
           // Setup: install the entrance, re-query.
           const withEntrance = createWorldState(seed);
@@ -341,8 +344,10 @@ describe('surfaceFeatureAt — gameplay suppression', () => {
           // baseline (proves a different anchor took over).
           if (v8Slice === null) continue;
           const v8AnchorOutsideZone =
-            v8Slice.anchorX < ex - r || v8Slice.anchorX > ex + r ||
-            v8Slice.anchorY < ey - r || v8Slice.anchorY > ey + r;
+            v8Slice.anchorX < ex - r ||
+            v8Slice.anchorX > ex + r ||
+            v8Slice.anchorY < ey - r ||
+            v8Slice.anchorY > ey + r;
           // baselineSlice anchor is INSIDE the zone (anchorInsideZone
           // gate above); requiring v8 anchor to be OUTSIDE the zone
           // is sufficient to prove a different anchor surfaced — they
@@ -360,7 +365,6 @@ describe('surfaceFeatureAt — gameplay suppression', () => {
     // contrived setup.
     expect(demonstrationCount).toBeGreaterThanOrEqual(1);
   });
-
 });
 
 describe('surfaceMovementAt', () => {
@@ -430,9 +434,12 @@ describe('overlap-suppression invariant — UAT "two overlapping rocks" guard', 
               // fine — we only count the direct "anchor-covers-tile"
               // relationship.
               if (
-                candSlice.anchorX === ax && candSlice.anchorY === ay &&
-                x >= ax && x < ax + candSlice.footprintTilesWide &&
-                y >= ay && y < ay + candSlice.footprintTilesTall
+                candSlice.anchorX === ax &&
+                candSlice.anchorY === ay &&
+                x >= ax &&
+                x < ax + candSlice.footprintTilesWide &&
+                y >= ay &&
+                y < ay + candSlice.footprintTilesTall
               ) {
                 candidatesActive++;
               }

--- a/src/sim/surface-features.ts
+++ b/src/sim/surface-features.ts
@@ -38,14 +38,14 @@ import type { WorldState } from './types.js';
  * selector output. Don't reorder.
  */
 export const SurfaceFeatureKind = {
-  Boulder:    0,
-  Bush:       1,
+  Boulder: 0,
+  Bush: 1,
   GrassClump: 2,
-  Twig:       3,  // 4×2 fallen-twig log — HardBlock
-  Leaf:       4,  // 3×3 dead leaf — HardBlock
-  BigLeaf:    5,  // 3×4 large dead leaf "ship" — HardBlock
+  Twig: 3, // 4×2 fallen-twig log — HardBlock
+  Leaf: 4, // 3×3 dead leaf — HardBlock
+  BigLeaf: 5, // 3×4 large dead leaf "ship" — HardBlock
 } as const;
-export type SurfaceFeatureKind = typeof SurfaceFeatureKind[keyof typeof SurfaceFeatureKind];
+export type SurfaceFeatureKind = (typeof SurfaceFeatureKind)[keyof typeof SurfaceFeatureKind];
 
 /**
  * How a feature affects ant movement on the tiles it covers.
@@ -60,11 +60,12 @@ export type SurfaceFeatureKind = typeof SurfaceFeatureKind[keyof typeof SurfaceF
  *     ship in step 3). Step 4 of issue #44 wires the passability guard.
  */
 export const SurfaceMovementEffect = {
-  Cosmetic:  0,
-  SoftCost:  1,
+  Cosmetic: 0,
+  SoftCost: 1,
   HardBlock: 2,
 } as const;
-export type SurfaceMovementEffect = typeof SurfaceMovementEffect[keyof typeof SurfaceMovementEffect];
+export type SurfaceMovementEffect =
+  (typeof SurfaceMovementEffect)[keyof typeof SurfaceMovementEffect];
 
 /**
  * What `surfaceFeatureAt` returns for a covered tile. Identifies which
@@ -72,13 +73,13 @@ export type SurfaceMovementEffect = typeof SurfaceMovementEffect[keyof typeof Su
  * and movement to act without recomputing.
  */
 export interface SurfaceFeatureSlice {
-  kind:               SurfaceFeatureKind;
-  variantIndex:       number;  // 0..(registry entry's variantCount - 1)
-  anchorX:            number;  // upper-left tile of the feature's footprint
-  anchorY:            number;
-  footprintTilesWide: number;  // copy of the registry value for caller convenience
+  kind: SurfaceFeatureKind;
+  variantIndex: number; // 0..(registry entry's variantCount - 1)
+  anchorX: number; // upper-left tile of the feature's footprint
+  anchorY: number;
+  footprintTilesWide: number; // copy of the registry value for caller convenience
   footprintTilesTall: number;
-  movement:           SurfaceMovementEffect;
+  movement: SurfaceMovementEffect;
 }
 
 // ---------------------------------------------------------------------------
@@ -130,46 +131,46 @@ const SURFACE_FEATURES: ReadonlyArray<SurfaceFeatureRegistryEntry> = [
   {
     kind: SurfaceFeatureKind.Boulder,
     salt: 151,
-    probability: 1,                     // ~0.4% per tile (~16 anchors / 1000 tiles × 16-tile fp ≈ 6% pre-supp)
+    probability: 1, // ~0.4% per tile (~16 anchors / 1000 tiles × 16-tile fp ≈ 6% pre-supp)
     footprintTilesWide: 4,
-    footprintTilesTall: 4,              // 64×64 px — substantial ant-scale boulder
-    variantCount: 3,                    // round / flat / lichen
+    footprintTilesTall: 4, // 64×64 px — substantial ant-scale boulder
+    variantCount: 3, // round / flat / lichen
     movement: SurfaceMovementEffect.HardBlock,
   },
   {
     kind: SurfaceFeatureKind.Twig,
     salt: 154,
-    probability: 1,                     // ~0.4% — fallen twig (6×3 = 18 tiles)
+    probability: 1, // ~0.4% — fallen twig (6×3 = 18 tiles)
     footprintTilesWide: 6,
-    footprintTilesTall: 3,              // 96×48 px — long horizontal log
-    variantCount: 2,                    // smooth / bark
+    footprintTilesTall: 3, // 96×48 px — long horizontal log
+    variantCount: 2, // smooth / bark
     movement: SurfaceMovementEffect.HardBlock,
   },
   {
     kind: SurfaceFeatureKind.Leaf,
     salt: 155,
-    probability: 1,                     // ~0.4%
+    probability: 1, // ~0.4%
     footprintTilesWide: 4,
-    footprintTilesTall: 4,              // 64×64 px
-    variantCount: 3,                    // broad / curled / torn
+    footprintTilesTall: 4, // 64×64 px
+    variantCount: 3, // broad / curled / torn
     movement: SurfaceMovementEffect.HardBlock,
   },
   {
     kind: SurfaceFeatureKind.BigLeaf,
     salt: 156,
-    probability: 1,                     // ~0.4% — the rare ship-canopy anchor
+    probability: 1, // ~0.4% — the rare ship-canopy anchor
     footprintTilesWide: 5,
-    footprintTilesTall: 6,              // 80×96 px — ant-scale "ship"
-    variantCount: 2,                    // broad / torn
+    footprintTilesTall: 6, // 80×96 px — ant-scale "ship"
+    variantCount: 2, // broad / torn
     movement: SurfaceMovementEffect.HardBlock,
   },
   {
     kind: SurfaceFeatureKind.Bush,
     salt: 152,
-    probability: 3,                     // ~1.2% — wildflower/clover clump
+    probability: 3, // ~1.2% — wildflower/clover clump
     footprintTilesWide: 4,
-    footprintTilesTall: 4,              // 64×64 px
-    variantCount: 3,                    // clover / flower / dense
+    footprintTilesTall: 4, // 64×64 px
+    variantCount: 3, // clover / flower / dense
     // A bush at ant scale reads as dense vegetation an ant pushes through,
     // not a solid wall. SoftCost; step 5 wires the actual cost.
     movement: SurfaceMovementEffect.SoftCost,
@@ -177,10 +178,10 @@ const SURFACE_FEATURES: ReadonlyArray<SurfaceFeatureRegistryEntry> = [
   {
     kind: SurfaceFeatureKind.GrassClump,
     salt: 153,
-    probability: 5,                     // ~2.0% — most common, vertical-bias spikes
+    probability: 5, // ~2.0% — most common, vertical-bias spikes
     footprintTilesWide: 4,
-    footprintTilesTall: 4,              // 64×64 px
-    variantCount: 3,                    // dense / sparse / tilted
+    footprintTilesTall: 4, // 64×64 px
+    variantCount: 3, // dense / sparse / tilted
     movement: SurfaceMovementEffect.SoftCost,
   },
 ];
@@ -330,11 +331,7 @@ function isAnchorGameplaySuppressed(
  * anchor positions.
  */
 function tileHash(tileX: number, tileY: number, salt: number, terrainSeed: number): number {
-  let h = (
-    tileX * 374761393 +
-    tileY * 668265263 +
-    (salt ^ terrainSeed) * 2246822519
-  ) | 0;
+  let h = (tileX * 374761393 + tileY * 668265263 + (salt ^ terrainSeed) * 2246822519) | 0;
   h = (h ^ (h >>> 13)) | 0;
   h = Math.imul(h, 1274126177);
   return (h ^ (h >>> 16)) >>> 0;
@@ -480,14 +477,18 @@ export function surfaceFeatureAt(
         if (isAnchorSuppressedByOverlap(world, ax, ay, ei, terrainSeed)) {
           break;
         }
-        if (isAnchorGameplaySuppressed(world, ax, ay, entry.footprintTilesWide, entry.footprintTilesTall)) {
+        if (
+          isAnchorGameplaySuppressed(
+            world,
+            ax,
+            ay,
+            entry.footprintTilesWide,
+            entry.footprintTilesTall,
+          )
+        ) {
           break;
         }
-        if (
-          bestEntryIndex < 0 ||
-          ay < bestAy ||
-          (ay === bestAy && ax < bestAx)
-        ) {
+        if (bestEntryIndex < 0 || ay < bestAy || (ay === bestAy && ax < bestAx)) {
           bestAx = ax;
           bestAy = ay;
           bestEntryIndex = ei;

--- a/src/sim/telemetry.test.ts
+++ b/src/sim/telemetry.test.ts
@@ -73,7 +73,9 @@ describe('emitEvent — combat_kill eviction at cap', () => {
     // The evicted event was tick=0; tick=1 is now the oldest
     expect(world.events[0]!.tick).toBe(1);
     // The new event is last
-    expect(world.events[PLAYTRACE_EVENT_CAP_PER_ROUND - 1]!.tick).toBe(PLAYTRACE_EVENT_CAP_PER_ROUND);
+    expect(world.events[PLAYTRACE_EVENT_CAP_PER_ROUND - 1]!.tick).toBe(
+      PLAYTRACE_EVENT_CAP_PER_ROUND,
+    );
   });
 
   it('evicts oldest combat_kill when a structural event pushes over cap', () => {
@@ -109,7 +111,9 @@ describe('emitEvent — structural drop when no combat_kill available', () => {
     expect(world.droppedStructuralCount).toBe(1);
     expect(world.droppedCombatKillCount).toBe(0);
     // Last event should NOT be tick=9999 (was dropped)
-    expect(world.events[PLAYTRACE_EVENT_CAP_PER_ROUND - 1]!.tick).toBe(PLAYTRACE_EVENT_CAP_PER_ROUND - 1);
+    expect(world.events[PLAYTRACE_EVENT_CAP_PER_ROUND - 1]!.tick).toBe(
+      PLAYTRACE_EVENT_CAP_PER_ROUND - 1,
+    );
   });
 
   it('evicts combat_kills before falling back to structural drop', () => {
@@ -151,7 +155,9 @@ describe('V15 migration — deserializeWorldState', () => {
     delete raw['droppedCombatKillCount'];
     delete raw['droppedStructuralCount'];
 
-    const restored = deserializeWorldState(raw as unknown as Parameters<typeof deserializeWorldState>[0]);
+    const restored = deserializeWorldState(
+      raw as unknown as Parameters<typeof deserializeWorldState>[0],
+    );
     expect(restored.events).toEqual([]);
     expect(restored.droppedCombatKillCount).toBe(0);
     expect(restored.droppedStructuralCount).toBe(0);

--- a/src/sim/telemetry.ts
+++ b/src/sim/telemetry.ts
@@ -22,12 +22,7 @@ export const PLAYTRACE_EVENT_CAP_PER_ROUND = 2000;
 // AIState alias — real union defined in S2; string covers all legal values
 // until then. The names are the canonical PascalCase strings that appear in
 // the wire envelope.
-export type AIState =
-  | 'Peacetime'
-  | 'WarFooting'
-  | 'Probing'
-  | 'Invading'
-  | 'Recovery';
+export type AIState = 'Peacetime' | 'WarFooting' | 'Probing' | 'Invading' | 'Recovery';
 
 // ---------------------------------------------------------------------------
 // SimEvent discriminated union (9 types — CF-P1-005)
@@ -101,12 +96,7 @@ export type SimEvent =
       tick: number;
       type: 'spider_rampage_end';
       payload: {
-        outcome:
-          | 'killed_in_nest'
-          | 'killed_by_player'
-          | 'killed_by_ai'
-          | 'quota_met'
-          | 'retreated';
+        outcome: 'killed_in_nest' | 'killed_by_player' | 'killed_by_ai' | 'quota_met' | 'retreated';
         broodKilled: number;
         queenKilled: boolean;
       };
@@ -127,12 +117,7 @@ export type SimEvent =
       payload: {
         // cause is null in V15 traces (S0b proof-of-concept). S1/S2 will fill
         // this in from the kill-site context when those stages land (RC-P1-003).
-        cause:
-          | 'InvasionKill'
-          | 'SpiderRampage'
-          | 'Starvation'
-          | 'MutualDestruction'
-          | null;
+        cause: 'InvasionKill' | 'SpiderRampage' | 'Starvation' | 'MutualDestruction' | null;
         location: { x: number; y: number; grid: 'surface' | 'underground' };
         aiStateAtTime: AIState | null;
       };

--- a/src/sim/terrain.test.ts
+++ b/src/sim/terrain.test.ts
@@ -71,7 +71,10 @@ describe('createSurfaceGrid', () => {
     const g = createSurfaceGrid(128, 128);
     let allZero = true;
     for (let i = 0; i < g.data.length; i++) {
-      if (g.data[i] !== 0) { allZero = false; break; }
+      if (g.data[i] !== 0) {
+        allZero = false;
+        break;
+      }
     }
     expect(allZero).toBe(true);
   });
@@ -97,7 +100,10 @@ describe('createUndergroundGrid', () => {
     const g = createUndergroundGrid(128, 64);
     let allZero = true;
     for (let i = 0; i < g.data.length; i++) {
-      if (g.data[i] !== 0) { allZero = false; break; }
+      if (g.data[i] !== 0) {
+        allZero = false;
+        break;
+      }
     }
     expect(allZero).toBe(true);
   });

--- a/src/sim/terrain.ts
+++ b/src/sim/terrain.ts
@@ -14,10 +14,10 @@
 // ---------------------------------------------------------------------------
 
 export const Zone = {
-  Surface:     0,
+  Surface: 0,
   Underground: 1,
 } as const;
-export type Zone = typeof Zone[keyof typeof Zone];
+export type Zone = (typeof Zone)[keyof typeof Zone];
 
 // ---------------------------------------------------------------------------
 // SurfaceTileState — tile content on the surface grid (PRD §1)
@@ -25,21 +25,21 @@ export type Zone = typeof Zone[keyof typeof Zone];
 
 export const SurfaceTileState = {
   Grass: 0,
-  Dirt:  1,
+  Dirt: 1,
 } as const;
-export type SurfaceTileState = typeof SurfaceTileState[keyof typeof SurfaceTileState];
+export type SurfaceTileState = (typeof SurfaceTileState)[keyof typeof SurfaceTileState];
 
 // ---------------------------------------------------------------------------
 // UndergroundTileState — tile content in the underground grid (PRD §1)
 // ---------------------------------------------------------------------------
 
 export const UndergroundTileState = {
-  Solid:    0,
-  Marked:   1,
+  Solid: 0,
+  Marked: 1,
   BeingDug: 2,
-  Open:     3,
+  Open: 3,
 } as const;
-export type UndergroundTileState = typeof UndergroundTileState[keyof typeof UndergroundTileState];
+export type UndergroundTileState = (typeof UndergroundTileState)[keyof typeof UndergroundTileState];
 
 // ---------------------------------------------------------------------------
 // SurfaceGrid — 2D row-major Uint8Array grid for surface tiles (PRD §1)
@@ -49,8 +49,8 @@ export type UndergroundTileState = typeof UndergroundTileState[keyof typeof Unde
 // ---------------------------------------------------------------------------
 
 export interface SurfaceGrid {
-  readonly data:   Uint8Array;
-  readonly width:  number;
+  readonly data: Uint8Array;
+  readonly width: number;
   readonly height: number;
 }
 
@@ -62,8 +62,8 @@ export interface SurfaceGrid {
 // ---------------------------------------------------------------------------
 
 export interface UndergroundGrid {
-  readonly data:   Uint8Array;
-  readonly width:  number;
+  readonly data: Uint8Array;
+  readonly width: number;
   readonly height: number;
 }
 
@@ -80,7 +80,7 @@ export interface UndergroundGrid {
  */
 export function createSurfaceGrid(width: number, height: number): SurfaceGrid {
   return {
-    data:   new Uint8Array(width * height),
+    data: new Uint8Array(width * height),
     width,
     height,
   };
@@ -95,7 +95,7 @@ export function createSurfaceGrid(width: number, height: number): SurfaceGrid {
  */
 export function createUndergroundGrid(width: number, height: number): UndergroundGrid {
   return {
-    data:   new Uint8Array(width * height),
+    data: new Uint8Array(width * height),
     width,
     height,
   };
@@ -117,7 +117,12 @@ export function sgGet(grid: SurfaceGrid, tileX: number, tileY: number): SurfaceT
  * Note: `readonly data` prevents reassignment of the array reference,
  * but Uint8Array element writes are allowed.
  */
-export function sgSet(grid: SurfaceGrid, tileX: number, tileY: number, state: SurfaceTileState): void {
+export function sgSet(
+  grid: SurfaceGrid,
+  tileX: number,
+  tileY: number,
+  state: SurfaceTileState,
+): void {
   grid.data[tileY * grid.width + tileX] = state;
 }
 
@@ -131,6 +136,11 @@ export function ugGet(grid: UndergroundGrid, tileX: number, tileY: number): Unde
 /**
  * Writes a tile state to an UndergroundGrid.
  */
-export function ugSet(grid: UndergroundGrid, tileX: number, tileY: number, state: UndergroundTileState): void {
+export function ugSet(
+  grid: UndergroundGrid,
+  tileX: number,
+  tileY: number,
+  state: UndergroundTileState,
+): void {
   grid.data[tileY * grid.width + tileX] = state;
 }

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -21,8 +21,20 @@ import { GameOutcome } from './game-over.js';
 import type { SimCommand } from './commands.js';
 import { initAnt } from './ant/ant-store.js';
 import { createColonyRecord } from './colony/colony-store.js';
-import { createPheromoneGrid, phGet, phSet, pheromoneGridKey } from './pheromone/pheromone-store.js';
-import { AntTask, ForagingSubState, PheromoneType, FightingSubState, ChamberType, NursingSubState } from './enums.js';
+import {
+  createPheromoneGrid,
+  phGet,
+  phSet,
+  pheromoneGridKey,
+} from './pheromone/pheromone-store.js';
+import {
+  AntTask,
+  ForagingSubState,
+  PheromoneType,
+  FightingSubState,
+  ChamberType,
+  NursingSubState,
+} from './enums.js';
 import type { WorldState } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 import {
@@ -38,7 +50,11 @@ import { FP_SHIFT } from './fixed.js';
 // Test harness helpers
 // ---------------------------------------------------------------------------
 
-function makeWorldWithColony(seed: number = 42): { world: WorldState; colonyId: ColonyId; queenId: number } {
+function makeWorldWithColony(seed: number = 42): {
+  world: WorldState;
+  colonyId: ColonyId;
+  queenId: number;
+} {
   const world = createWorldState(seed);
   const queenId = allocateEntityId(world);
   initAnt(world.ants, queenId, {
@@ -81,17 +97,22 @@ describe('tick() basic (Phase 5 preserved)', () => {
 
   it('does not allocate via .slice() or the array iterator — PRD line 708 "No allocation" contract', () => {
     const world = createWorldState(42);
-    const cmds: SimCommand[] = Array.from({ length: 100 }, (_, i): SimCommand => ({
-      type: 'NoOp',
-      issuedAtTick: i,
-    }));
+    const cmds: SimCommand[] = Array.from(
+      { length: 100 },
+      (_, i): SimCommand => ({
+        type: 'NoOp',
+        issuedAtTick: i,
+      }),
+    );
     const guarded = new Proxy(cmds, {
       get(target, prop, receiver) {
         if (prop === 'slice') {
           throw new Error('PRD-708 violation: tick() must not call .slice()');
         }
         if (prop === Symbol.iterator) {
-          throw new Error('PRD-708 violation: tick() must not use for...of on commands (allocates iterator object)');
+          throw new Error(
+            'PRD-708 violation: tick() must not use for...of on commands (allocates iterator object)',
+          );
         }
         return Reflect.get(target, prop, receiver);
       },
@@ -259,7 +280,12 @@ describe('Step 1: command processing', () => {
     const forageBefore = colony.targetRatio.forage;
     const cmds: SimCommand[] = [
       { type: 'SetBehaviorRatio', colonyId, ratio: 5, issuedAtTick: 0 } as unknown as SimCommand,
-      { type: 'SetBehaviorRatio', colonyId, ratio: 'bogus', issuedAtTick: 0 } as unknown as SimCommand,
+      {
+        type: 'SetBehaviorRatio',
+        colonyId,
+        ratio: 'bogus',
+        issuedAtTick: 0,
+      } as unknown as SimCommand,
     ];
     expect(() => tick(world, cmds)).not.toThrow();
     expect(world.colonies[colonyId]!.targetRatio.forage).toBe(forageBefore);
@@ -451,10 +477,10 @@ describe('Step ordering observable proofs', () => {
     }
 
     // Set allocation: want 5 foragers; need = 5 - 3 = 2 (the 2 idle ants)
-    colony.computedAllocation.nurse  = 0;
+    colony.computedAllocation.nurse = 0;
     colony.computedAllocation.forage = 5;
-    colony.computedAllocation.dig    = 0;
-    colony.computedAllocation.fight  = 0;
+    colony.computedAllocation.dig = 0;
+    colony.computedAllocation.fight = 0;
 
     tick(world, []);
 
@@ -489,11 +515,11 @@ describe('Step ordering observable proofs', () => {
 
     // Player has shifted the behavior triangle strongly toward forage.
     colony.computedAllocation.forage = 1;
-    colony.computedAllocation.dig    = 0;
-    colony.computedAllocation.fight  = 0;
-    colony.computedAllocation.nurse  = 0;
+    colony.computedAllocation.dig = 0;
+    colony.computedAllocation.fight = 0;
+    colony.computedAllocation.nurse = 0;
     colony.targetRatio.forage = 10;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
 
     // Tick 1: step 10a sees Digging (not Idle) → skipped. Step 10b tickDigExecution
     // runs and releases the sticky digger to AntTask.Idle.
@@ -519,12 +545,14 @@ describe('Step ordering observable proofs', () => {
     colony.workerCount = 1;
     colony.eggCount = 0;
     colony.larvaeCount = 0;
-    colony.entrances = [{
-      entranceId:   allocateEntityId(world),
-      surfaceTileX: 0,
-      surfaceTileY: 0,
-      isOpen:       true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: allocateEntityId(world),
+        surfaceTileX: 0,
+        surfaceTileY: 0,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
 
@@ -543,13 +571,13 @@ describe('Step ordering observable proofs', () => {
     // to the over-foraged state so step 9b fires on tick 1 (normally
     // taskCensus is written by the prior tick's step 10a — we skip that
     // ramp-up to keep the test focused on the leash gate).
-    colony.computedAllocation.nurse  = 0;
+    colony.computedAllocation.nurse = 0;
     colony.computedAllocation.forage = 0;
-    colony.computedAllocation.dig    = 0;
-    colony.computedAllocation.fight  = 1;
+    colony.computedAllocation.dig = 0;
+    colony.computedAllocation.fight = 1;
     colony.taskCensus.forage = 1;
     colony.targetRatio.forage = 0;
-    colony.targetRatio.fight  = 10;
+    colony.targetRatio.fight = 10;
 
     tick(world, []);
 
@@ -568,12 +596,14 @@ describe('Step ordering observable proofs', () => {
     colony.workerCount = 1;
     colony.eggCount = 0;
     colony.larvaeCount = 0;
-    colony.entrances = [{
-      entranceId:   allocateEntityId(world),
-      surfaceTileX: 0,
-      surfaceTileY: 0,
-      isOpen:       true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: allocateEntityId(world),
+        surfaceTileX: 0,
+        surfaceTileY: 0,
+        isOpen: true,
+      },
+    ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
 
@@ -588,10 +618,10 @@ describe('Step ordering observable proofs', () => {
     world.ants.foodCarrying[wid] = 256;
     colony.workers.push(wid);
 
-    colony.computedAllocation.nurse  = 0;
+    colony.computedAllocation.nurse = 0;
     colony.computedAllocation.forage = 0;
-    colony.computedAllocation.dig    = 0;
-    colony.computedAllocation.fight  = 1;
+    colony.computedAllocation.dig = 0;
+    colony.computedAllocation.fight = 1;
 
     tick(world, []);
 
@@ -619,12 +649,12 @@ describe('Step ordering observable proofs', () => {
     colony.workers.push(wid);
 
     // Set allocation: want 1 digger, 0 foragers (over-allocated forager)
-    colony.computedAllocation.nurse  = 0;
+    colony.computedAllocation.nurse = 0;
     colony.computedAllocation.forage = 0;
-    colony.computedAllocation.dig    = 1;
-    colony.computedAllocation.fight  = 0;
+    colony.computedAllocation.dig = 1;
+    colony.computedAllocation.fight = 0;
     colony.targetRatio.forage = 0;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
     // Phase 10 (CTRL-06): dig is auto-assigned via need.dig from Marked tiles, not
     // via targetRatio. Step 10a's auto-dig override will set computedAllocation.dig=0
     // here (no Marked tiles, no active digger). The pre-set dig=1 above is noise but
@@ -661,7 +691,14 @@ describe('Step ordering observable proofs', () => {
       // a ratio that doesn't depend on dig-work the test never set up.
       for (let e = 0; e < 9; e++) {
         const eid = allocateEntityId(w);
-        initAnt(w.ants, eid, { colonyId: 1, posX: 100, posY: 100, task: AntTask.Idle, subTask: 0, speed: 0 });
+        initAnt(w.ants, eid, {
+          colonyId: 1,
+          posX: 100,
+          posY: 100,
+          task: AntTask.Idle,
+          subTask: 0,
+          speed: 0,
+        });
         w.ants.age[eid] = 0; // age 0 — will not hatch in 1 tick
         colony.eggs.push(eid);
         colony.eggCount += 1;
@@ -672,11 +709,13 @@ describe('Step ordering observable proofs', () => {
       // Without this chamber, allocateWorkers returns nurse=0 and the
       // {3,4,0,3} expectation below would collapse to {0,6,0,4}.
       colony.chambers.push({
-        chamberId:   9001,
+        chamberId: 9001,
         chamberType: ChamberType.Nursery,
-        foodStored:  0,
-        posX:        0, posY: 0,
-        width:       2, height: 2,
+        foodStored: 0,
+        posX: 0,
+        posY: 0,
+        width: 2,
+        height: 2,
       });
 
       for (let i = 0; i < 10; i++) {
@@ -687,7 +726,7 @@ describe('Step ordering observable proofs', () => {
 
       // targetRatio that produces {nurse:3, forage:4, dig:0, fight:3} via allocateWorkers(10, 9, ratio).
       colony.targetRatio.forage = 4;
-      colony.targetRatio.fight  = 3;
+      colony.targetRatio.fight = 3;
 
       tick(w, []);
 
@@ -742,7 +781,7 @@ describe('Step ordering observable proofs', () => {
       // of which hold for any valid allocation that step 10a produces.
       colony.computedAllocation = { nurse: 1, forage: 2, dig: 2, fight: 1 };
       colony.targetRatio.forage = 10;
-      colony.targetRatio.fight  = 3;
+      colony.targetRatio.fight = 3;
 
       tick(w, []);
 
@@ -780,7 +819,14 @@ describe('09 reproduction-gate memo — starvation-shape regression', () => {
     // 30 larvae (already-hatched brood).
     for (let e = 0; e < 30; e++) {
       const lid = allocateEntityId(w);
-      initAnt(w.ants, lid, { colonyId: 1, posX: 100, posY: 100, task: AntTask.Idle, subTask: 0, speed: 0 });
+      initAnt(w.ants, lid, {
+        colonyId: 1,
+        posX: 100,
+        posY: 100,
+        task: AntTask.Idle,
+        subTask: 0,
+        speed: 0,
+      });
       colony.larvae.push(lid);
       colony.larvaeCount += 1;
     }
@@ -794,12 +840,12 @@ describe('09 reproduction-gate memo — starvation-shape regression', () => {
     // Forage-favored triangle; no chambers at all (intentional — this is the
     // pre-excavation colony state from the memo).
     colony.targetRatio.forage = 10;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
 
     tick(w, []);
 
     const alloc = colony.computedAllocation;
-    const tc    = colony.taskCensus;
+    const tc = colony.taskCensus;
 
     // Memo gate: no Nursery → nurse=0 even with 30 brood.
     expect(alloc.nurse).toBe(0);
@@ -819,7 +865,14 @@ describe('09 reproduction-gate memo — starvation-shape regression', () => {
 
     for (let e = 0; e < 30; e++) {
       const lid = allocateEntityId(w);
-      initAnt(w.ants, lid, { colonyId: 1, posX: 100, posY: 100, task: AntTask.Idle, subTask: 0, speed: 0 });
+      initAnt(w.ants, lid, {
+        colonyId: 1,
+        posX: 100,
+        posY: 100,
+        task: AntTask.Idle,
+        subTask: 0,
+        speed: 0,
+      });
       colony.larvae.push(lid);
       colony.larvaeCount += 1;
     }
@@ -831,7 +884,7 @@ describe('09 reproduction-gate memo — starvation-shape regression', () => {
     }
 
     colony.targetRatio.forage = 3;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
     // Phase 10 (CTRL-06): dig is auto-assigned via Marked-tile presence; this fixture
     // has no Marked tiles so computedAllocation.dig stays 0 and the assertions below
     // (nurse=0 under no-Nursery memo gate; brood inert; sum=workerCount) hold.
@@ -858,7 +911,14 @@ describe('09 reproduction-gate memo — starvation-shape regression', () => {
 
     for (let e = 0; e < 30; e++) {
       const lid = allocateEntityId(w);
-      initAnt(w.ants, lid, { colonyId: 1, posX: 100, posY: 100, task: AntTask.Idle, subTask: 0, speed: 0 });
+      initAnt(w.ants, lid, {
+        colonyId: 1,
+        posX: 100,
+        posY: 100,
+        task: AntTask.Idle,
+        subTask: 0,
+        speed: 0,
+      });
       colony.larvae.push(lid);
       colony.larvaeCount += 1;
     }
@@ -870,14 +930,17 @@ describe('09 reproduction-gate memo — starvation-shape regression', () => {
     }
 
     colony.chambers.push({
-      chamberId:   9000,
+      chamberId: 9000,
       chamberType: ChamberType.Nursery,
-      foodStored:  0,
-      posX: 0, posY: 0, width: 2, height: 2,
+      foodStored: 0,
+      posX: 0,
+      posY: 0,
+      width: 2,
+      height: 2,
     });
 
     colony.targetRatio.forage = 10;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
 
     tick(w, []);
 
@@ -971,14 +1034,27 @@ describe('Tick writeback and return', () => {
   it('Test 17: rngState advances after tick with movement-consuming forager', () => {
     const world = createWorldState(42);
     const queenId = allocateEntityId(world);
-    initAnt(world.ants, queenId, { colonyId: 1, posX: 1024, posY: 1024, task: AntTask.Idle, subTask: 0, speed: 0 });
+    initAnt(world.ants, queenId, {
+      colonyId: 1,
+      posX: 1024,
+      posY: 1024,
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
+    });
     world.colonies[1] = createColonyRecord(1, queenId);
     world.colonies[1]!.foodStored = 10000;
 
     // Add a forager so movement uses rng
     for (let i = 0; i < 3; i++) {
       const wid = allocateEntityId(world);
-      initAnt(world.ants, wid, { colonyId: 1, posX: 1024, posY: 1024, task: AntTask.Foraging, subTask: ForagingSubState.SearchingFood });
+      initAnt(world.ants, wid, {
+        colonyId: 1,
+        posX: 1024,
+        posY: 1024,
+        task: AntTask.Foraging,
+        subTask: ForagingSubState.SearchingFood,
+      });
       world.colonies[1]!.workers.push(wid);
       world.colonies[1]!.workerCount += 1;
     }
@@ -1023,25 +1099,51 @@ describe('Multi-colony iteration', () => {
 
     // Colony 1
     const q1 = allocateEntityId(world);
-    initAnt(world.ants, q1, { colonyId: 1, posX: 100, posY: 100, task: AntTask.Idle, subTask: 0, speed: 0 });
+    initAnt(world.ants, q1, {
+      colonyId: 1,
+      posX: 100,
+      posY: 100,
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
+    });
     world.colonies[1] = createColonyRecord(1, q1);
     world.colonies[1]!.foodStored = 5000;
 
     // Colony 2
     const q2 = allocateEntityId(world);
-    initAnt(world.ants, q2, { colonyId: 2, posX: 200, posY: 200, task: AntTask.Idle, subTask: 0, speed: 0 });
+    initAnt(world.ants, q2, {
+      colonyId: 2,
+      posX: 200,
+      posY: 200,
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
+    });
     world.colonies[2] = createColonyRecord(2, q2);
     world.colonies[2]!.foodStored = 5000;
 
     // Add 2 workers to each colony
     for (let i = 0; i < 2; i++) {
       const w1 = allocateEntityId(world);
-      initAnt(world.ants, w1, { colonyId: 1, posX: 100, posY: 100, task: AntTask.Foraging, subTask: ForagingSubState.SearchingFood });
+      initAnt(world.ants, w1, {
+        colonyId: 1,
+        posX: 100,
+        posY: 100,
+        task: AntTask.Foraging,
+        subTask: ForagingSubState.SearchingFood,
+      });
       world.colonies[1]!.workers.push(w1);
       world.colonies[1]!.workerCount += 1;
 
       const w2 = allocateEntityId(world);
-      initAnt(world.ants, w2, { colonyId: 2, posX: 200, posY: 200, task: AntTask.Foraging, subTask: ForagingSubState.SearchingFood });
+      initAnt(world.ants, w2, {
+        colonyId: 2,
+        posX: 200,
+        posY: 200,
+        task: AntTask.Foraging,
+        subTask: ForagingSubState.SearchingFood,
+      });
       world.colonies[2]!.workers.push(w2);
       world.colonies[2]!.workerCount += 1;
     }
@@ -1146,21 +1248,36 @@ describe('Phase 7: MarkDigTile command processing', () => {
   function makeWorldWithUnderground(seed = 42) {
     const world = createWorldState(seed);
     const queenId = allocateEntityId(world);
-    initAnt(world.ants, queenId, { colonyId: 1, posX: 1024, posY: 1024, task: AntTask.Idle, subTask: 0 });
+    initAnt(world.ants, queenId, {
+      colonyId: 1,
+      posX: 1024,
+      posY: 1024,
+      task: AntTask.Idle,
+      subTask: 0,
+    });
     world.colonies[1] = createColonyRecord(1, queenId);
     world.colonies[1]!.foodStored = 10000;
     // Phase 3 extension fields required by tick.ts
     world.colonies[1]!.entrances = [];
     world.colonies[1]!.rallyPoint = null;
     world.colonies[1]!.digFlowFieldDirty = false;
-    world.undergroundGrids[1] = createUndergroundGrid(UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
+    world.undergroundGrids[1] = createUndergroundGrid(
+      UNDERGROUND_GRID_WIDTH,
+      UNDERGROUND_GRID_HEIGHT,
+    );
     return { world, colonyId: 1 as ColonyId };
   }
 
   // Test P7-1: MarkDigTile on Solid tile → becomes Marked, digFlowFieldDirty set true
   it('Test P7-1: MarkDigTile on Solid tile → Marked + digFlowFieldDirty=true', () => {
     const { world, colonyId } = makeWorldWithUnderground();
-    const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 10, tileY: 10, issuedAtTick: 0 };
+    const cmd: SimCommand = {
+      type: 'MarkDigTile',
+      colonyId,
+      tileX: 10,
+      tileY: 10,
+      issuedAtTick: 0,
+    };
     tick(world, [cmd]);
     const underground = world.undergroundGrids[colonyId]!;
     expect(ugGet(underground, 10, 10)).toBe(UndergroundTileState.Marked);
@@ -1173,7 +1290,13 @@ describe('Phase 7: MarkDigTile command processing', () => {
     const underground = world.undergroundGrids[colonyId]!;
     // Pre-set tile to Open
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
-    const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 10, tileY: 10, issuedAtTick: 0 };
+    const cmd: SimCommand = {
+      type: 'MarkDigTile',
+      colonyId,
+      tileX: 10,
+      tileY: 10,
+      issuedAtTick: 0,
+    };
     tick(world, [cmd]);
     // Should remain Open (not changed to Marked)
     expect(ugGet(underground, 10, 10)).toBe(UndergroundTileState.Open);
@@ -1199,8 +1322,11 @@ describe('Phase 7: MarkDigTile command processing', () => {
   it('Issue #30: DesignateEntrance still marks the row-0 shaft tile at the entrance column', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     const cmd: SimCommand = {
-      type: 'DesignateEntrance', colonyId,
-      surfaceTileX: 40, surfaceTileY: 64, issuedAtTick: 0,
+      type: 'DesignateEntrance',
+      colonyId,
+      surfaceTileX: 40,
+      surfaceTileY: 64,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     const underground = world.undergroundGrids[colonyId]!;
@@ -1212,7 +1338,13 @@ describe('Phase 7: MarkDigTile command processing', () => {
   // Test P7-3: MarkDigTile out of bounds → silent drop
   it('Test P7-3: MarkDigTile out of bounds → silent drop, no throw', () => {
     const { world, colonyId } = makeWorldWithUnderground();
-    const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: -1, tileY: 10, issuedAtTick: 0 };
+    const cmd: SimCommand = {
+      type: 'MarkDigTile',
+      colonyId,
+      tileX: -1,
+      tileY: 10,
+      issuedAtTick: 0,
+    };
     expect(() => tick(world, [cmd])).not.toThrow();
     expect(world.tick).toBe(1);
   });
@@ -1223,7 +1355,13 @@ describe('Phase 7: MarkDigTile command processing', () => {
     const underground = world.undergroundGrids[colonyId]!;
     // Pre-mark the tile
     underground.data[5 * UNDERGROUND_GRID_WIDTH + 5] = UndergroundTileState.Marked;
-    const cmd: SimCommand = { type: 'CancelDigMark', colonyId, tileX: 5, tileY: 5, issuedAtTick: 0 };
+    const cmd: SimCommand = {
+      type: 'CancelDigMark',
+      colonyId,
+      tileX: 5,
+      tileY: 5,
+      issuedAtTick: 0,
+    };
     tick(world, [cmd]);
     expect(ugGet(underground, 5, 5)).toBe(UndergroundTileState.Solid);
   });
@@ -1233,7 +1371,13 @@ describe('Phase 7: MarkDigTile command processing', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     const underground = world.undergroundGrids[colonyId]!;
     underground.data[7 * UNDERGROUND_GRID_WIDTH + 7] = UndergroundTileState.BeingDug;
-    const cmd: SimCommand = { type: 'CancelDigMark', colonyId, tileX: 7, tileY: 7, issuedAtTick: 0 };
+    const cmd: SimCommand = {
+      type: 'CancelDigMark',
+      colonyId,
+      tileX: 7,
+      tileY: 7,
+      issuedAtTick: 0,
+    };
     tick(world, [cmd]);
     // Should remain BeingDug
     expect(ugGet(underground, 7, 7)).toBe(UndergroundTileState.BeingDug);
@@ -1242,11 +1386,23 @@ describe('Phase 7: MarkDigTile command processing', () => {
   // Test P7-6: MarkFoodPile sets colony.priorityFoodPileId and re-clicking the same pile clears it
   it('Test P7-6: MarkFoodPile sets colony priority on first click, clears on second (toggle off)', () => {
     const { world, colonyId } = makeWorldWithUnderground();
-    const pile: FoodPile = { foodPileId: 0, tileX: 20, tileY: 30 , pickupsRemaining: 50, pickupsInitial: 50};
+    const pile: FoodPile = {
+      foodPileId: 0,
+      tileX: 20,
+      tileY: 30,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    };
     world.foodPiles.push(pile);
     const colony = world.colonies[colonyId]!;
     expect(colony.priorityFoodPileId).toBeNull();
-    const cmd: SimCommand = { type: 'MarkFoodPile', colonyId, tileX: 20, tileY: 30, issuedAtTick: 0 };
+    const cmd: SimCommand = {
+      type: 'MarkFoodPile',
+      colonyId,
+      tileX: 20,
+      tileY: 30,
+      issuedAtTick: 0,
+    };
     tick(world, [cmd]);
     expect(colony.priorityFoodPileId).toBe(0);
     // Toggle-off on re-click of the same pile.
@@ -1257,8 +1413,20 @@ describe('Phase 7: MarkDigTile command processing', () => {
   // Phase 9: selecting a different pile is an EXCLUSIVE redirect, not an additive mark.
   it('MarkFoodPile redirect: clicking a second pile replaces the first (exclusive per colony)', () => {
     const { world, colonyId } = makeWorldWithUnderground();
-    world.foodPiles.push({ foodPileId: 0, tileX: 20, tileY: 30 , pickupsRemaining: 50, pickupsInitial: 50});
-    world.foodPiles.push({ foodPileId: 1, tileX: 40, tileY: 50 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 0,
+      tileX: 20,
+      tileY: 30,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
+    world.foodPiles.push({
+      foodPileId: 1,
+      tileX: 40,
+      tileY: 50,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     const colony = world.colonies[colonyId]!;
     tick(world, [{ type: 'MarkFoodPile', colonyId, tileX: 20, tileY: 30, issuedAtTick: 0 }]);
     expect(colony.priorityFoodPileId).toBe(0);
@@ -1276,8 +1444,16 @@ describe('Phase 7: MarkDigTile command processing', () => {
       colonyId: colonyB,
       priorityFoodPileId: null,
     };
-    world.foodPiles.push({ foodPileId: 7, tileX: 10, tileY: 10 , pickupsRemaining: 50, pickupsInitial: 50});
-    tick(world, [{ type: 'MarkFoodPile', colonyId: colonyA, tileX: 10, tileY: 10, issuedAtTick: 0 }]);
+    world.foodPiles.push({
+      foodPileId: 7,
+      tileX: 10,
+      tileY: 10,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
+    tick(world, [
+      { type: 'MarkFoodPile', colonyId: colonyA, tileX: 10, tileY: 10, issuedAtTick: 0 },
+    ]);
     expect(world.colonies[colonyA]!.priorityFoodPileId).toBe(7);
     expect(world.colonies[colonyB]!.priorityFoodPileId).toBeNull();
   });
@@ -1313,9 +1489,8 @@ describe('Phase 7: MarkDigTile command processing', () => {
     // Footprint tiles (were Solid before) are now Marked. Anchor tile was Open → stays Open.
     for (let dy = 0; dy < dims.height; dy++) {
       for (let dx = 0; dx < dims.width; dx++) {
-        const expected = (dx === 0 && dy === 0)
-          ? UndergroundTileState.Open
-          : UndergroundTileState.Marked;
+        const expected =
+          dx === 0 && dy === 0 ? UndergroundTileState.Open : UndergroundTileState.Marked;
         expect(ugGet(underground, 10 + dx, 10 + dy)).toBe(expected);
       }
     }
@@ -1335,8 +1510,12 @@ describe('Phase 7: MarkDigTile command processing', () => {
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
     // Place first chamber
     const cmd1: SimCommand = {
-      type: 'PlaceChamber', colonyId,
-      chamberType: ChamberType.Nursery, anchorTileX: 10, anchorTileY: 10, issuedAtTick: 0,
+      type: 'PlaceChamber',
+      colonyId,
+      chamberType: ChamberType.Nursery,
+      anchorTileX: 10,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     tick(world, [cmd1]);
     expect(world.pendingChambers[`${colonyId}:10:10`]).toBeDefined();
@@ -1344,8 +1523,12 @@ describe('Phase 7: MarkDigTile command processing', () => {
     // Open anchor (12,10) too so only the overlap rule (not the tunnel-end rule) rejects cmd2.
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 12] = UndergroundTileState.Open;
     const cmd2: SimCommand = {
-      type: 'PlaceChamber', colonyId,
-      chamberType: ChamberType.FoodStorage, anchorTileX: 12, anchorTileY: 10, issuedAtTick: 1,
+      type: 'PlaceChamber',
+      colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: 12,
+      anchorTileY: 10,
+      issuedAtTick: 1,
     };
     tick(world, [cmd2]);
     // Overlapping chamber should NOT have been created
@@ -1359,9 +1542,12 @@ describe('Phase 7: MarkDigTile command processing', () => {
     const underground = world.undergroundGrids[colonyId]!;
     underground.data[0 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
+      type: 'PlaceChamber',
+      colonyId,
       chamberType: ChamberType.Queen,
-      anchorTileX: 10, anchorTileY: 0, issuedAtTick: 0,
+      anchorTileX: 10,
+      anchorTileY: 0,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.pendingChambers[`${colonyId}:10:0`]).toBeUndefined();
@@ -1372,7 +1558,8 @@ describe('Phase 7: MarkDigTile command processing', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     const dims = CHAMBER_DIMENSIONS[ChamberType.Queen]!;
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
+      type: 'PlaceChamber',
+      colonyId,
       chamberType: ChamberType.Queen,
       // anchorTileX so that anchor + width > UNDERGROUND_GRID_WIDTH
       anchorTileX: UNDERGROUND_GRID_WIDTH - dims.width + 1,
@@ -1388,8 +1575,11 @@ describe('Phase 7: MarkDigTile command processing', () => {
   it('Test P7-10: DesignateEntrance creates NestEntrance; shaft tiles marked', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     const cmd: SimCommand = {
-      type: 'DesignateEntrance', colonyId,
-      surfaceTileX: 50, surfaceTileY: 0, issuedAtTick: 0,
+      type: 'DesignateEntrance',
+      colonyId,
+      surfaceTileX: 50,
+      surfaceTileY: 0,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     const colony = world.colonies[colonyId]!;
@@ -1416,8 +1606,11 @@ describe('Phase 7: MarkDigTile command processing', () => {
       });
     }
     const cmd: SimCommand = {
-      type: 'DesignateEntrance', colonyId,
-      surfaceTileX: 99, surfaceTileY: 0, issuedAtTick: 0,
+      type: 'DesignateEntrance',
+      colonyId,
+      surfaceTileX: 99,
+      surfaceTileY: 0,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     // Should remain at MAX_ENTRANCES_PER_COLONY
@@ -1428,8 +1621,11 @@ describe('Phase 7: MarkDigTile command processing', () => {
   it('Test P7-12: DesignateEntrance rejected if duplicate surfaceTileX/Y', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     const cmd: SimCommand = {
-      type: 'DesignateEntrance', colonyId,
-      surfaceTileX: 50, surfaceTileY: 0, issuedAtTick: 0,
+      type: 'DesignateEntrance',
+      colonyId,
+      surfaceTileX: 50,
+      surfaceTileY: 0,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     const colony = world.colonies[colonyId]!;
@@ -1447,18 +1643,14 @@ describe('Phase 7: MarkDigTile command processing', () => {
   // the build UI.
   // ---------------------------------------------------------------------------
 
-  function setupPendingQueenAt(
-    world: WorldState,
-    colonyId: ColonyId,
-    ax: number,
-    ay: number,
-  ) {
+  function setupPendingQueenAt(world: WorldState, colonyId: ColonyId, ax: number, ay: number) {
     const dims = CHAMBER_DIMENSIONS[ChamberType.Queen]!;
     const underground = world.undergroundGrids[colonyId]!;
     // Mark the entire footprint, mirroring what PlaceChamber does.
     for (let dy = 0; dy < dims.height; dy++) {
       for (let dx = 0; dx < dims.width; dx++) {
-        underground.data[(ay + dy) * UNDERGROUND_GRID_WIDTH + (ax + dx)] = UndergroundTileState.Marked;
+        underground.data[(ay + dy) * UNDERGROUND_GRID_WIDTH + (ax + dx)] =
+          UndergroundTileState.Marked;
       }
     }
     const pcKey = `${colonyId}:${ax}:${ay}`;
@@ -1479,7 +1671,11 @@ describe('Phase 7: MarkDigTile command processing', () => {
     const { pcKey } = setupPendingQueenAt(world, colonyId, 20, 5);
     // Cancel a footprint tile (not the anchor, to avoid coincidental key matches).
     const cmd: SimCommand = {
-      type: 'CancelDigMark', colonyId, tileX: 21, tileY: 5, issuedAtTick: 0,
+      type: 'CancelDigMark',
+      colonyId,
+      tileX: 21,
+      tileY: 5,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.pendingChambers[pcKey]).toBeUndefined();
@@ -1507,7 +1703,9 @@ describe('Phase 7: MarkDigTile command processing', () => {
     // An Open tile (e.g. anchor that was tunnel-end) must stay Open.
     underground.data[8 * UNDERGROUND_GRID_WIDTH + 30] = UndergroundTileState.Open;
     // Cancel a Marked footprint tile that is NOT the BeingDug or Open one.
-    tick(world, [{ type: 'CancelDigMark', colonyId, tileX: 30 + (dims.width - 1), tileY: 8, issuedAtTick: 0 }]);
+    tick(world, [
+      { type: 'CancelDigMark', colonyId, tileX: 30 + (dims.width - 1), tileY: 8, issuedAtTick: 0 },
+    ]);
     expect(world.pendingChambers[pcKey]).toBeUndefined();
     // BeingDug and Open survive.
     expect(ugGet(underground, 31, 8)).toBe(UndergroundTileState.BeingDug);
@@ -1532,17 +1730,23 @@ describe('Phase 7: MarkDigTile command processing', () => {
     const { pcKey: keyA } = setupPendingQueenAt(world, colonyId, 20, 5);
     // Place a second pending chamber far from A.
     const dims = CHAMBER_DIMENSIONS[ChamberType.Nursery]!;
-    const bx = 60, by = 20;
+    const bx = 60,
+      by = 20;
     const underground = world.undergroundGrids[colonyId]!;
     for (let dy = 0; dy < dims.height; dy++) {
       for (let dx = 0; dx < dims.width; dx++) {
-        underground.data[(by + dy) * UNDERGROUND_GRID_WIDTH + (bx + dx)] = UndergroundTileState.Marked;
+        underground.data[(by + dy) * UNDERGROUND_GRID_WIDTH + (bx + dx)] =
+          UndergroundTileState.Marked;
       }
     }
     const keyB = `${colonyId}:${bx}:${by}`;
     world.pendingChambers[keyB] = {
-      colonyId, chamberType: ChamberType.Nursery,
-      anchorTileX: bx, anchorTileY: by, width: dims.width, height: dims.height,
+      colonyId,
+      chamberType: ChamberType.Nursery,
+      anchorTileX: bx,
+      anchorTileY: by,
+      width: dims.width,
+      height: dims.height,
     };
     // Cancel inside A's footprint.
     tick(world, [{ type: 'CancelDigMark', colonyId, tileX: 21, tileY: 5, issuedAtTick: 0 }]);
@@ -1561,19 +1765,30 @@ describe('Phase 7: MarkDigTile command processing', () => {
     // Set up a sibling colony B with its own underground grid.
     const colonyB = (colonyA + 1) as ColonyId;
     const queenB = allocateEntityId(world);
-    initAnt(world.ants, queenB, { colonyId: colonyB, posX: 4096, posY: 4096, task: AntTask.Idle, subTask: 0 });
+    initAnt(world.ants, queenB, {
+      colonyId: colonyB,
+      posX: 4096,
+      posY: 4096,
+      task: AntTask.Idle,
+      subTask: 0,
+    });
     world.colonies[colonyB] = createColonyRecord(colonyB, queenB);
     world.colonies[colonyB]!.entrances = [];
     world.colonies[colonyB]!.rallyPoint = null;
     world.colonies[colonyB]!.digFlowFieldDirty = false;
-    world.undergroundGrids[colonyB] = createUndergroundGrid(UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
+    world.undergroundGrids[colonyB] = createUndergroundGrid(
+      UNDERGROUND_GRID_WIDTH,
+      UNDERGROUND_GRID_HEIGHT,
+    );
     // Same anchor coords, but different colonies — the v9 loop must not
     // collapse them into one match.
     const { pcKey: keyA } = setupPendingQueenAt(world, colonyA, 20, 5);
     const { pcKey: keyB } = setupPendingQueenAt(world, colonyB, 20, 5);
     expect(keyA).not.toBe(keyB);
     // Cancel in colony A only.
-    tick(world, [{ type: 'CancelDigMark', colonyId: colonyA, tileX: 20, tileY: 5, issuedAtTick: 0 }]);
+    tick(world, [
+      { type: 'CancelDigMark', colonyId: colonyA, tileX: 20, tileY: 5, issuedAtTick: 0 },
+    ]);
     expect(world.pendingChambers[keyA]).toBeUndefined();
     expect(world.pendingChambers[keyB]).toBeDefined();
   });
@@ -1617,17 +1832,23 @@ describe('Phase 7: MarkDigTile command processing', () => {
     // shared mechanism that orphans the entry.
     const { world, colonyId } = makeWorldWithUnderground();
     const dims = CHAMBER_DIMENSIONS[ChamberType.Nursery]!;
-    const ax = 30, ay = 8;
+    const ax = 30,
+      ay = 8;
     const underground = world.undergroundGrids[colonyId]!;
     for (let dy = 0; dy < dims.height; dy++) {
       for (let dx = 0; dx < dims.width; dx++) {
-        underground.data[(ay + dy) * UNDERGROUND_GRID_WIDTH + (ax + dx)] = UndergroundTileState.Marked;
+        underground.data[(ay + dy) * UNDERGROUND_GRID_WIDTH + (ax + dx)] =
+          UndergroundTileState.Marked;
       }
     }
     const pcKey = `${colonyId}:${ax}:${ay}`;
     world.pendingChambers[pcKey] = {
-      colonyId, chamberType: ChamberType.Nursery,
-      anchorTileX: ax, anchorTileY: ay, width: dims.width, height: dims.height,
+      colonyId,
+      chamberType: ChamberType.Nursery,
+      anchorTileX: ax,
+      anchorTileY: ay,
+      width: dims.width,
+      height: dims.height,
     };
     tick(world, [{ type: 'CancelDigMark', colonyId, tileX: ax + 1, tileY: ay, issuedAtTick: 0 }]);
     expect(world.pendingChambers[pcKey]).toBeUndefined();
@@ -1642,13 +1863,22 @@ describe('Phase 7: Step ordering tests', () => {
   function makeWorldWithUnderground(seed = 42) {
     const world = createWorldState(seed);
     const queenId = allocateEntityId(world);
-    initAnt(world.ants, queenId, { colonyId: 1, posX: 1024, posY: 1024, task: AntTask.Idle, subTask: 0 });
+    initAnt(world.ants, queenId, {
+      colonyId: 1,
+      posX: 1024,
+      posY: 1024,
+      task: AntTask.Idle,
+      subTask: 0,
+    });
     world.colonies[1] = createColonyRecord(1, queenId);
     world.colonies[1]!.foodStored = 10000;
     world.colonies[1]!.entrances = [];
     world.colonies[1]!.rallyPoint = null;
     world.colonies[1]!.digFlowFieldDirty = false;
-    world.undergroundGrids[1] = createUndergroundGrid(UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
+    world.undergroundGrids[1] = createUndergroundGrid(
+      UNDERGROUND_GRID_WIDTH,
+      UNDERGROUND_GRID_HEIGHT,
+    );
     return { world, colonyId: 1 as ColonyId };
   }
 
@@ -1656,7 +1886,13 @@ describe('Phase 7: Step ordering tests', () => {
   it('Test P7-13: flow-field recomputed in step 9 before step 10 tick dig execution', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     // Mark a tile in step 1 of next tick — dirty flag will be set; step 9 recomputes
-    const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 10, tileY: 10, issuedAtTick: 0 };
+    const cmd: SimCommand = {
+      type: 'MarkDigTile',
+      colonyId,
+      tileX: 10,
+      tileY: 10,
+      issuedAtTick: 0,
+    };
     tick(world, [cmd]);
     // After tick: digFlowFieldDirty was reset by step 9 recompute
     expect(world.colonies[colonyId]!.digFlowFieldDirty).toBe(false);
@@ -1667,11 +1903,13 @@ describe('Phase 7: Step ordering tests', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     const underground = world.undergroundGrids[colonyId]!;
     const dims = CHAMBER_DIMENSIONS[ChamberType.Nursery]!;
-    const ax = 20, ay = 5;
+    const ax = 20,
+      ay = 5;
     // Pre-open all footprint tiles
     for (let dy = 0; dy < dims.height; dy++) {
       for (let dx = 0; dx < dims.width; dx++) {
-        underground.data[(ay + dy) * UNDERGROUND_GRID_WIDTH + (ax + dx)] = UndergroundTileState.Open;
+        underground.data[(ay + dy) * UNDERGROUND_GRID_WIDTH + (ax + dx)] =
+          UndergroundTileState.Open;
       }
     }
     // Create PendingChamber directly (bypassing PlaceChamber command)
@@ -1699,7 +1937,8 @@ describe('Phase 7: Step ordering tests', () => {
 
     // 1×1 chamber so only one tile needs to be Open
     const dims = { width: 1, height: 1 };
-    const ax = 15, ay = 3;
+    const ax = 15,
+      ay = 3;
 
     // Set the single footprint tile to BeingDug
     underground.data[ay * UNDERGROUND_GRID_WIDTH + ax] = UndergroundTileState.BeingDug;
@@ -1861,7 +2100,7 @@ describe('Phase 7: Integration tests', () => {
     // ticks see `computeDigDemand` return 0 because an ant is already
     // Digging, so the strict 1-cap holds across the 10-tick window.
     colony.targetRatio.forage = 10;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
 
     // Mark a tile adjacent to the pre-excavated player shaft (entrance column=24,
     // shaft Open at underground rows 0..ENTRANCE_SHAFT_DEPTH-1). Picking a
@@ -1887,7 +2126,9 @@ describe('Phase 7: Integration tests', () => {
     // Workers should have been reassigned to Digging via step 10a
     expect(world.tick).toBe(10);
     // At least some workers are Digging (after allocation kicked in)
-    const diggingCount = colony.workers.filter(wid => world.ants.task[wid] === AntTask.Digging).length;
+    const diggingCount = colony.workers.filter(
+      (wid) => world.ants.task[wid] === AntTask.Digging,
+    ).length;
     expect(diggingCount).toBeGreaterThan(0);
   });
 
@@ -1915,7 +2156,7 @@ describe('Phase 7: Integration tests', () => {
     tick(world, []);
 
     // checkEntranceCompletion (step 12) should have set isOpen=true
-    const entrance = colony.entrances.find(e => e.surfaceTileX === 50);
+    const entrance = colony.entrances.find((e) => e.surfaceTileX === 50);
     expect(entrance).toBeDefined();
     expect(entrance!.isOpen).toBe(true);
   });
@@ -1928,7 +2169,8 @@ describe('Phase 7: Integration tests', () => {
 
     const chamberType = ChamberType.FoodStorage;
     const dims = CHAMBER_DIMENSIONS[chamberType]!;
-    const ax = 30, ay = 10;
+    const ax = 30,
+      ay = 10;
 
     // PRD §3c tunnel-end: open anchors for both placements; surrounding Solid gives adjacency.
     // Add entrance + open shaft at ax so the v5 reachability BFS can reach the anchor.
@@ -1954,13 +2196,16 @@ describe('Phase 7: Integration tests', () => {
     const underground = world.undergroundGrids[colonyId]!;
     for (let dy = 0; dy < dims.height; dy++) {
       for (let dx = 0; dx < dims.width; dx++) {
-        underground.data[(ay + dy) * UNDERGROUND_GRID_WIDTH + (ax + dx)] = UndergroundTileState.Open;
+        underground.data[(ay + dy) * UNDERGROUND_GRID_WIDTH + (ax + dx)] =
+          UndergroundTileState.Open;
       }
     }
     tick(world, []);
 
     // ChamberRecord should exist with correct dimensions
-    const chamber = colony.chambers.find(ch => (ch.posX >> FP_SHIFT) === ax && (ch.posY >> FP_SHIFT) === ay);
+    const chamber = colony.chambers.find(
+      (ch) => ch.posX >> FP_SHIFT === ax && ch.posY >> FP_SHIFT === ay,
+    );
     expect(chamber).toBeDefined();
     expect(chamber!.width).toBe(dims.width);
     expect(chamber!.height).toBe(dims.height);
@@ -2009,13 +2254,22 @@ describe('Regression: reviewer P1 fixes', () => {
   function makeWorldWithUnderground(seed = 42) {
     const world = createWorldState(seed);
     const queenId = allocateEntityId(world);
-    initAnt(world.ants, queenId, { colonyId: 1, posX: 1024, posY: 1024, task: AntTask.Idle, subTask: 0 });
+    initAnt(world.ants, queenId, {
+      colonyId: 1,
+      posX: 1024,
+      posY: 1024,
+      task: AntTask.Idle,
+      subTask: 0,
+    });
     world.colonies[1] = createColonyRecord(1, queenId);
     world.colonies[1]!.foodStored = 10000;
     world.colonies[1]!.entrances = [];
     world.colonies[1]!.rallyPoint = null;
     world.colonies[1]!.digFlowFieldDirty = false;
-    world.undergroundGrids[1] = createUndergroundGrid(UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
+    world.undergroundGrids[1] = createUndergroundGrid(
+      UNDERGROUND_GRID_WIDTH,
+      UNDERGROUND_GRID_HEIGHT,
+    );
     return { world, colonyId: 1 as ColonyId };
   }
 
@@ -2026,8 +2280,12 @@ describe('Regression: reviewer P1 fixes', () => {
     colony.entrances.push({ entranceId: 99, surfaceTileX: 50, surfaceTileY: 10, isOpen: true });
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
-      colonyId, posX: 20 << FP_SHIFT, posY: 10 << FP_SHIFT,
-      task: AntTask.Foraging, subTask: ForagingSubState.CarryingFood, speed: 1,
+      colonyId,
+      posX: 20 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.CarryingFood,
+      speed: 1,
     });
     world.ants.foodCarrying[antId] = 5;
     const x0 = world.ants.posX[antId]!;
@@ -2041,8 +2299,12 @@ describe('Regression: reviewer P1 fixes', () => {
     colony.entrances.push({ entranceId: 7, surfaceTileX: 40, surfaceTileY: 10, isOpen: true });
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
-      colonyId, posX: 10 << FP_SHIFT, posY: 5 << FP_SHIFT,
-      task: AntTask.Foraging, subTask: ForagingSubState.SearchingFood, speed: 1,
+      colonyId,
+      posX: 10 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.SearchingFood,
+      speed: 1,
     });
     world.ants.zone[antId] = 1; // Underground
     const x0 = world.ants.posX[antId]!;
@@ -2058,8 +2320,12 @@ describe('Regression: reviewer P1 fixes', () => {
     // No entrances at all
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
-      colonyId, posX: 20 << FP_SHIFT, posY: 10 << FP_SHIFT,
-      task: AntTask.Nursing, subTask: 0, speed: 1,
+      colonyId,
+      posX: 20 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Nursing,
+      subTask: 0,
+      speed: 1,
     });
     const x0 = world.ants.posX[antId]!;
     const y0 = world.ants.posY[antId]!;
@@ -2080,8 +2346,12 @@ describe('Regression: reviewer P1 fixes', () => {
     world.simVersion = LEGACY_SIM_VERSION;
     // Everything is Solid by default — anchor (10,10) is Solid
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
-      chamberType: ChamberType.Queen, anchorTileX: 10, anchorTileY: 10, issuedAtTick: 0,
+      type: 'PlaceChamber',
+      colonyId,
+      chamberType: ChamberType.Queen,
+      anchorTileX: 10,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.pendingChambers[`${colonyId}:10:10`]).toBeUndefined();
@@ -2096,12 +2366,17 @@ describe('Regression: reviewer P1 fixes', () => {
     // Open a 3×3 region around (10,10) — no adjacent Solid
     for (let dy = -1; dy <= 1; dy++) {
       for (let dx = -1; dx <= 1; dx++) {
-        underground.data[(10 + dy) * UNDERGROUND_GRID_WIDTH + (10 + dx)] = UndergroundTileState.Open;
+        underground.data[(10 + dy) * UNDERGROUND_GRID_WIDTH + (10 + dx)] =
+          UndergroundTileState.Open;
       }
     }
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
-      chamberType: ChamberType.Queen, anchorTileX: 10, anchorTileY: 10, issuedAtTick: 0,
+      type: 'PlaceChamber',
+      colonyId,
+      chamberType: ChamberType.Queen,
+      anchorTileX: 10,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.pendingChambers[`${colonyId}:10:10`]).toBeUndefined();
@@ -2113,8 +2388,12 @@ describe('Regression: reviewer P1 fixes', () => {
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open; // anchor
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 11] = UndergroundTileState.BeingDug; // footprint conflict
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
-      chamberType: ChamberType.Queen, anchorTileX: 10, anchorTileY: 10, issuedAtTick: 0,
+      type: 'PlaceChamber',
+      colonyId,
+      chamberType: ChamberType.Queen,
+      anchorTileX: 10,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.pendingChambers[`${colonyId}:10:10`]).toBeUndefined();
@@ -2123,15 +2402,21 @@ describe('Regression: reviewer P1 fixes', () => {
   it('PlaceChamber rejected: pendingChambers key already exists at anchor', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     // Add entrance + open shaft so the v5 reachability BFS can reach the anchor at (10,10).
-    world.colonies[colonyId]!.entrances = [{ entranceId: 1, surfaceTileX: 10, surfaceTileY: 0, isOpen: true }];
+    world.colonies[colonyId]!.entrances = [
+      { entranceId: 1, surfaceTileX: 10, surfaceTileY: 0, isOpen: true },
+    ];
     const underground = world.undergroundGrids[colonyId]!;
     for (let y = 0; y < 10; y++) {
       underground.data[y * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
     }
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
-      chamberType: ChamberType.Queen, anchorTileX: 10, anchorTileY: 10, issuedAtTick: 0,
+      type: 'PlaceChamber',
+      colonyId,
+      chamberType: ChamberType.Queen,
+      anchorTileX: 10,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.pendingChambers[`${colonyId}:10:10`]).toBeDefined();
@@ -2150,20 +2435,30 @@ describe('Regression: reviewer P1 fixes', () => {
       { entranceId: 1, surfaceTileX: 10, surfaceTileY: 0, isOpen: true },
       { entranceId: 2, surfaceTileX: 30, surfaceTileY: 0, isOpen: true },
     ];
-    for (let y = 0; y < 10; y++) underground.data[y * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
-    for (let y = 0; y < 20; y++) underground.data[y * UNDERGROUND_GRID_WIDTH + 30] = UndergroundTileState.Open;
+    for (let y = 0; y < 10; y++)
+      underground.data[y * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
+    for (let y = 0; y < 20; y++)
+      underground.data[y * UNDERGROUND_GRID_WIDTH + 30] = UndergroundTileState.Open;
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
     underground.data[20 * UNDERGROUND_GRID_WIDTH + 30] = UndergroundTileState.Open;
     const c1: SimCommand = {
-      type: 'PlaceChamber', colonyId,
-      chamberType: ChamberType.Queen, anchorTileX: 10, anchorTileY: 10, issuedAtTick: 0,
+      type: 'PlaceChamber',
+      colonyId,
+      chamberType: ChamberType.Queen,
+      anchorTileX: 10,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     tick(world, [c1]);
     const pendingBefore = Object.keys(world.pendingChambers).length;
     expect(pendingBefore).toBe(1);
     const c2: SimCommand = {
-      type: 'PlaceChamber', colonyId,
-      chamberType: ChamberType.Queen, anchorTileX: 30, anchorTileY: 20, issuedAtTick: 1,
+      type: 'PlaceChamber',
+      colonyId,
+      chamberType: ChamberType.Queen,
+      anchorTileX: 30,
+      anchorTileY: 20,
+      issuedAtTick: 1,
     };
     tick(world, [c2]);
     expect(Object.keys(world.pendingChambers).length).toBe(pendingBefore);
@@ -2175,13 +2470,22 @@ describe('Regression: reviewer P1 fixes', () => {
     // Seed an existing Queen chamber directly in colony.chambers.
     const colony = world.colonies[colonyId]!;
     colony.chambers.push({
-      chamberId: 999, chamberType: ChamberType.Queen, foodStored: 0,
-      posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, width: 5, height: 3,
+      chamberId: 999,
+      chamberType: ChamberType.Queen,
+      foodStored: 0,
+      posX: 5 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      width: 5,
+      height: 3,
     });
     underground.data[20 * UNDERGROUND_GRID_WIDTH + 30] = UndergroundTileState.Open;
     const c: SimCommand = {
-      type: 'PlaceChamber', colonyId,
-      chamberType: ChamberType.Queen, anchorTileX: 30, anchorTileY: 20, issuedAtTick: 0,
+      type: 'PlaceChamber',
+      colonyId,
+      chamberType: ChamberType.Queen,
+      anchorTileX: 30,
+      anchorTileY: 20,
+      issuedAtTick: 0,
     };
     tick(world, [c]);
     expect(world.pendingChambers[`${colonyId}:30:20`]).toBeUndefined();
@@ -2195,17 +2499,27 @@ describe('Regression: reviewer P1 fixes', () => {
       { entranceId: 1, surfaceTileX: 10, surfaceTileY: 0, isOpen: true },
       { entranceId: 2, surfaceTileX: 30, surfaceTileY: 0, isOpen: true },
     ];
-    for (let y = 0; y < 10; y++) underground.data[y * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
-    for (let y = 0; y < 20; y++) underground.data[y * UNDERGROUND_GRID_WIDTH + 30] = UndergroundTileState.Open;
+    for (let y = 0; y < 10; y++)
+      underground.data[y * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
+    for (let y = 0; y < 20; y++)
+      underground.data[y * UNDERGROUND_GRID_WIDTH + 30] = UndergroundTileState.Open;
     underground.data[10 * UNDERGROUND_GRID_WIDTH + 10] = UndergroundTileState.Open;
     underground.data[20 * UNDERGROUND_GRID_WIDTH + 30] = UndergroundTileState.Open;
     const c1: SimCommand = {
-      type: 'PlaceChamber', colonyId,
-      chamberType: ChamberType.FoodStorage, anchorTileX: 10, anchorTileY: 10, issuedAtTick: 0,
+      type: 'PlaceChamber',
+      colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: 10,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     const c2: SimCommand = {
-      type: 'PlaceChamber', colonyId,
-      chamberType: ChamberType.FoodStorage, anchorTileX: 30, anchorTileY: 20, issuedAtTick: 1,
+      type: 'PlaceChamber',
+      colonyId,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: 30,
+      anchorTileY: 20,
+      issuedAtTick: 1,
     };
     tick(world, [c1]);
     tick(world, [c2]);
@@ -2217,8 +2531,11 @@ describe('Regression: reviewer P1 fixes', () => {
   it('DesignateEntrance rejected: surfaceTileX out of bounds', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     const cmd: SimCommand = {
-      type: 'DesignateEntrance', colonyId,
-      surfaceTileX: -1, surfaceTileY: 0, issuedAtTick: 0,
+      type: 'DesignateEntrance',
+      colonyId,
+      surfaceTileX: -1,
+      surfaceTileY: 0,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.colonies[colonyId]!.entrances.length).toBe(0);
@@ -2227,15 +2544,21 @@ describe('Regression: reviewer P1 fixes', () => {
   it('DesignateEntrance rejected: same-column duplicate (different surfaceTileY)', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     const cmd1: SimCommand = {
-      type: 'DesignateEntrance', colonyId,
-      surfaceTileX: 50, surfaceTileY: 0, issuedAtTick: 0,
+      type: 'DesignateEntrance',
+      colonyId,
+      surfaceTileX: 50,
+      surfaceTileY: 0,
+      issuedAtTick: 0,
     };
     tick(world, [cmd1]);
     expect(world.colonies[colonyId]!.entrances.length).toBe(1);
     // Same column, different surfaceTileY — PRD §3g column uniqueness rejects this
     const cmd2: SimCommand = {
-      type: 'DesignateEntrance', colonyId,
-      surfaceTileX: 50, surfaceTileY: 5, issuedAtTick: 1,
+      type: 'DesignateEntrance',
+      colonyId,
+      surfaceTileX: 50,
+      surfaceTileY: 5,
+      issuedAtTick: 1,
     };
     tick(world, [cmd2]);
     expect(world.colonies[colonyId]!.entrances.length).toBe(1);
@@ -2243,10 +2566,19 @@ describe('Regression: reviewer P1 fixes', () => {
 
   it('DesignateEntrance rejected: food pile at surface tile', () => {
     const { world, colonyId } = makeWorldWithUnderground();
-    world.foodPiles.push({ foodPileId: 0, tileX: 50, tileY: 0 , pickupsRemaining: 50, pickupsInitial: 50});
+    world.foodPiles.push({
+      foodPileId: 0,
+      tileX: 50,
+      tileY: 0,
+      pickupsRemaining: 50,
+      pickupsInitial: 50,
+    });
     const cmd: SimCommand = {
-      type: 'DesignateEntrance', colonyId,
-      surfaceTileX: 50, surfaceTileY: 0, issuedAtTick: 0,
+      type: 'DesignateEntrance',
+      colonyId,
+      surfaceTileX: 50,
+      surfaceTileY: 0,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.colonies[colonyId]!.entrances.length).toBe(0);
@@ -2256,8 +2588,11 @@ describe('Regression: reviewer P1 fixes', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     world.colonies[colonyId]!.rallyPoint = { tileX: 50, tileY: 0 };
     const cmd: SimCommand = {
-      type: 'DesignateEntrance', colonyId,
-      surfaceTileX: 50, surfaceTileY: 0, issuedAtTick: 0,
+      type: 'DesignateEntrance',
+      colonyId,
+      surfaceTileX: 50,
+      surfaceTileY: 0,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.colonies[colonyId]!.entrances.length).toBe(0);
@@ -2278,14 +2613,20 @@ describe('Regression: reviewer P1 fixes', () => {
       chamberId: 7,
       chamberType: ChamberType.FoodStorage,
       foodStored: 0,
-      posX: 20 << FP_SHIFT, posY: 10 << FP_SHIFT,
-      width: 4, height: 3,
+      posX: 20 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      width: 4,
+      height: 3,
     });
     // Also open a path from ant position to chamber so nothing else interferes
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
-      colonyId, posX: 10 << FP_SHIFT, posY: 10 << FP_SHIFT,
-      task: AntTask.Foraging, subTask: ForagingSubState.CarryingFood, speed: 1,
+      colonyId,
+      posX: 10 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.CarryingFood,
+      speed: 1,
     });
     world.ants.zone[antId] = 1; // Underground
     world.ants.foodCarrying[antId] = 5;
@@ -2302,8 +2643,12 @@ describe('Regression: reviewer P1 fixes', () => {
     colony.entrances.push({ entranceId: 1, surfaceTileX: 40, surfaceTileY: 10, isOpen: true });
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
-      colonyId, posX: 10 << FP_SHIFT, posY: 5 << FP_SHIFT,
-      task: AntTask.Foraging, subTask: ForagingSubState.CarryingFood, speed: 1,
+      colonyId,
+      posX: 10 << FP_SHIFT,
+      posY: 5 << FP_SHIFT,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.CarryingFood,
+      speed: 1,
     });
     world.ants.zone[antId] = 1; // Underground
     world.ants.foodCarrying[antId] = 5;
@@ -2327,17 +2672,27 @@ describe('Regression: reviewer P1 fixes', () => {
       }
     }
     colony.chambers.push({
-      chamberId: 9, chamberType: ChamberType.FoodStorage, foodStored: 0,
-      posX: 30 << FP_SHIFT, posY: 10 << FP_SHIFT, width: 4, height: 3,
+      chamberId: 9,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 0,
+      posX: 30 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      width: 4,
+      height: 3,
     });
     // Plant a strong surface food-trail gradient to the WEST to prove it's ignored.
     const surfaceGrid = createPheromoneGrid(SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT);
     phSet(surfaceGrid, 5, 10, 9999);
-    world.pheromoneGrids[pheromoneGridKey(colonyId, PheromoneType.FoodTrail, 'surface')] = surfaceGrid;
+    world.pheromoneGrids[pheromoneGridKey(colonyId, PheromoneType.FoodTrail, 'surface')] =
+      surfaceGrid;
     const antId = allocateEntityId(world);
     initAnt(world.ants, antId, {
-      colonyId, posX: 20 << FP_SHIFT, posY: 10 << FP_SHIFT,
-      task: AntTask.Foraging, subTask: ForagingSubState.CarryingFood, speed: 1,
+      colonyId,
+      posX: 20 << FP_SHIFT,
+      posY: 10 << FP_SHIFT,
+      task: AntTask.Foraging,
+      subTask: ForagingSubState.CarryingFood,
+      speed: 1,
     });
     world.ants.zone[antId] = 1; // Underground
     world.ants.foodCarrying[antId] = 5;
@@ -2353,14 +2708,22 @@ describe('Regression: reviewer P1 fixes', () => {
     const queen2 = allocateEntityId(world);
     initAnt(world.ants, queen2, { colonyId: 2, posX: 0, posY: 0, task: AntTask.Idle, subTask: 0 });
     world.colonies[2] = createColonyRecord(2, queen2);
-    world.colonies[2]!.entrances = [{ entranceId: 999, surfaceTileX: 50, surfaceTileY: 0, isOpen: true }];
+    world.colonies[2]!.entrances = [
+      { entranceId: 999, surfaceTileX: 50, surfaceTileY: 0, isOpen: true },
+    ];
     world.colonies[2]!.rallyPoint = null;
     world.colonies[2]!.digFlowFieldDirty = false;
-    world.undergroundGrids[2] = createUndergroundGrid(UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
+    world.undergroundGrids[2] = createUndergroundGrid(
+      UNDERGROUND_GRID_WIDTH,
+      UNDERGROUND_GRID_HEIGHT,
+    );
 
     const cmd: SimCommand = {
-      type: 'DesignateEntrance', colonyId,
-      surfaceTileX: 50, surfaceTileY: 0, issuedAtTick: 0,
+      type: 'DesignateEntrance',
+      colonyId,
+      surfaceTileX: 50,
+      surfaceTileY: 0,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.colonies[colonyId]!.entrances.length).toBe(0);
@@ -2380,12 +2743,23 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
   function makeWorldWithEntrance(seed = 42, entranceX = 10) {
     const world = createWorldState(seed);
     const queenId = allocateEntityId(world);
-    initAnt(world.ants, queenId, { colonyId: 1, posX: 1024, posY: 1024, task: AntTask.Idle, subTask: 0 });
+    initAnt(world.ants, queenId, {
+      colonyId: 1,
+      posX: 1024,
+      posY: 1024,
+      task: AntTask.Idle,
+      subTask: 0,
+    });
     world.colonies[1] = createColonyRecord(1, queenId);
     world.colonies[1]!.foodStored = 10000;
-    world.colonies[1]!.entrances = [{
-      entranceId: 999, surfaceTileX: entranceX, surfaceTileY: 0, isOpen: true,
-    }];
+    world.colonies[1]!.entrances = [
+      {
+        entranceId: 999,
+        surfaceTileX: entranceX,
+        surfaceTileY: 0,
+        isOpen: true,
+      },
+    ];
     world.colonies[1]!.rallyPoint = null;
     world.colonies[1]!.digFlowFieldDirty = false;
     const ug = createUndergroundGrid(UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
@@ -2404,9 +2778,12 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     // adjacent to the marked column. Reachable via the marked column +
     // own footprint expansion.
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
+      type: 'PlaceChamber',
+      colonyId,
       chamberType: ChamberType.FoodStorage,
-      anchorTileX: entranceX, anchorTileY: 10, issuedAtTick: 0,
+      anchorTileX: entranceX,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     const pcKey = `${colonyId}:${entranceX}:10`;
@@ -2425,9 +2802,12 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     void ug;
     void entranceX;
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
+      type: 'PlaceChamber',
+      colonyId,
       chamberType: ChamberType.FoodStorage,
-      anchorTileX: 50, anchorTileY: 30, issuedAtTick: 0,
+      anchorTileX: 50,
+      anchorTileY: 30,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.pendingChambers[`${colonyId}:50:30`]).toBeUndefined();
@@ -2438,9 +2818,12 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     // Drop the entrance.
     world.colonies[colonyId]!.entrances = [];
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
+      type: 'PlaceChamber',
+      colonyId,
       chamberType: ChamberType.FoodStorage,
-      anchorTileX: 5, anchorTileY: 5, issuedAtTick: 0,
+      anchorTileX: 5,
+      anchorTileY: 5,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.pendingChambers[`${colonyId}:5:5`]).toBeUndefined();
@@ -2453,9 +2836,12 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     }
     // Place 4×3 FoodStorage at (entranceX, 10). All footprint tiles start Solid.
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
+      type: 'PlaceChamber',
+      colonyId,
       chamberType: ChamberType.FoodStorage,
-      anchorTileX: entranceX, anchorTileY: 10, issuedAtTick: 0,
+      anchorTileX: entranceX,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     // Every Solid footprint tile should be Marked now.
@@ -2476,9 +2862,12 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     }
     // Anchor on a Marked tile at row 10 (mid-tunnel).
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
+      type: 'PlaceChamber',
+      colonyId,
       chamberType: ChamberType.FoodStorage,
-      anchorTileX: entranceX, anchorTileY: 10, issuedAtTick: 0,
+      anchorTileX: entranceX,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeDefined();
@@ -2492,9 +2881,12 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     // Set the proposed anchor tile to BeingDug.
     ug.data[10 * UNDERGROUND_GRID_WIDTH + entranceX] = UndergroundTileState.BeingDug;
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
+      type: 'PlaceChamber',
+      colonyId,
       chamberType: ChamberType.FoodStorage,
-      anchorTileX: entranceX, anchorTileY: 10, issuedAtTick: 0,
+      anchorTileX: entranceX,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeUndefined();
@@ -2507,9 +2899,12 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     }
     // Place chamber on Solid; should enter PendingChamber state.
     const cmd: SimCommand = {
-      type: 'PlaceChamber', colonyId,
+      type: 'PlaceChamber',
+      colonyId,
       chamberType: ChamberType.FoodStorage,
-      anchorTileX: entranceX, anchorTileY: 10, issuedAtTick: 0,
+      anchorTileX: entranceX,
+      anchorTileY: 10,
+      issuedAtTick: 0,
     };
     tick(world, [cmd]);
     expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeDefined();
@@ -2524,7 +2919,7 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     // ChamberRecord should exist; PendingChamber is gone.
     const colony = world.colonies[colonyId]!;
     const chamber = colony.chambers.find(
-      (ch) => (ch.posX >> FP_SHIFT) === entranceX && (ch.posY >> FP_SHIFT) === 10,
+      (ch) => ch.posX >> FP_SHIFT === entranceX && ch.posY >> FP_SHIFT === 10,
     );
     expect(chamber).toBeDefined();
     expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeUndefined();
@@ -2741,7 +3136,7 @@ describe('Phase 9 tick integration', () => {
       lifespan: WORKER_LIFESPAN_TICKS,
     });
     world.ants.zone[enemyFighterId] = 0; // Surface
-    world.ants.zone[playerQueenId] = 0;  // Surface
+    world.ants.zone[playerQueenId] = 0; // Surface
 
     // Register fighter in enemy colony workers
     world.colonies[enemyColonyId]!.workers.push(enemyFighterId);
@@ -2753,7 +3148,12 @@ describe('Phase 9 tick integration', () => {
     // In either case, the result is consistent with the post-combat state.
     // With seed 42, the PRNG determines the winner — we just verify no throw
     // and that result is a valid GameOutcome.
-    const validOutcomes = [GameOutcome.None, GameOutcome.Defeat, GameOutcome.Victory, GameOutcome.MutualDestruction];
+    const validOutcomes = [
+      GameOutcome.None,
+      GameOutcome.Defeat,
+      GameOutcome.Victory,
+      GameOutcome.MutualDestruction,
+    ];
     expect(validOutcomes).toContain(result);
     // Combat ran: either the enemy fighter or the player queen is dead (or both still alive if no valid combat)
     // At minimum world.tick advanced — confirms tick ran to completion
@@ -2778,7 +3178,8 @@ describe('cross-world flow-field cache isolation', () => {
     entranceCol: number,
     rallyTileX: number,
   ): Promise<{ world: WorldState; antId: number; colonyId: ColonyId }> {
-    const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } = await import('./terrain.js');
+    const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } =
+      await import('./terrain.js');
     const { FP_ONE } = await import('./fixed.js');
     const { initAnt: _initAnt } = await import('./ant/ant-store.js');
     const world = createWorldState(42);
@@ -2800,12 +3201,14 @@ describe('cross-world flow-field cache isolation', () => {
     // Rally at (rallyTileX, 0) — only used to give updateFightAntTargets a
     // target; the fighter is underground so it routes to the entrance first.
     colony.rallyPoint = { tileX: rallyTileX, tileY: 0 };
-    colony.entrances = [{
-      entranceId: 10,
-      surfaceTileX: entranceCol,
-      surfaceTileY: 5,
-      isOpen: true,
-    }];
+    colony.entrances = [
+      {
+        entranceId: 10,
+        surfaceTileX: entranceCol,
+        surfaceTileY: 5,
+        isOpen: true,
+      },
+    ];
     world.colonies[colonyId] = colony;
 
     // 16x16 underground grid. Fully open in row 0 so the ant can sidestep
@@ -2851,7 +3254,7 @@ describe('cross-world flow-field cache isolation', () => {
     const beforeA = worldA.ants.posX[antA]! >> FP_SHIFT;
     tick(worldA, []);
     const afterA = worldA.ants.posX[antA]! >> FP_SHIFT;
-    expect(afterA).toBeLessThan(beforeA);  // stepped west toward col 2
+    expect(afterA).toBeLessThan(beforeA); // stepped west toward col 2
 
     // Clear the module-level caches between worlds (simulates bootFresh /
     // bootFromSave flow: new world, same colony id).
@@ -2864,7 +3267,7 @@ describe('cross-world flow-field cache isolation', () => {
     const beforeB = worldB.ants.posX[antB]! >> FP_SHIFT;
     tick(worldB, []);
     const afterB = worldB.ants.posX[antB]! >> FP_SHIFT;
-    expect(afterB).toBeGreaterThan(beforeB);  // stepped east toward col 14 in world B
+    expect(afterB).toBeGreaterThan(beforeB); // stepped east toward col 14 in world B
   });
 
   it('#160 — world B routes per its own topology WITHOUT an explicit reset (per-world caches)', async () => {
@@ -2894,7 +3297,8 @@ describe('cross-world flow-field cache isolation', () => {
   });
 
   it('food chamber routing honors world-B topology after reset', async () => {
-    const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } = await import('./terrain.js');
+    const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } =
+      await import('./terrain.js');
     const { FP_ONE } = await import('./fixed.js');
     const { initAnt: _initAnt } = await import('./ant/ant-store.js');
 
@@ -2904,9 +3308,12 @@ describe('cross-world flow-field cache isolation', () => {
       const queenId = allocateEntityId(world);
       _initAnt(world.ants, queenId, {
         colonyId,
-        posX: 1024, posY: 1024,
-        task: AntTask.Idle, subTask: 0,
-        speed: 0, lifespan: WORKER_LIFESPAN_TICKS,
+        posX: 1024,
+        posY: 1024,
+        task: AntTask.Idle,
+        subTask: 0,
+        speed: 0,
+        lifespan: WORKER_LIFESPAN_TICKS,
       });
       const colony = createColonyRecord(colonyId, queenId);
       colony.foodStored = 10000;
@@ -2919,7 +3326,8 @@ describe('cross-world flow-field cache isolation', () => {
         foodStored: 0,
         posX: chamberTileX << FP_SHIFT,
         posY: 3 << FP_SHIFT,
-        width: 1, height: 1,
+        width: 1,
+        height: 1,
       });
       world.colonies[colonyId] = colony;
 
@@ -2979,7 +3387,8 @@ describe('cross-world flow-field cache isolation', () => {
   // the nearer chamber fills, instead of letting carriers stall at the cap.
   // -------------------------------------------------------------------------
   it('issue #15 — full FoodStorage chamber stops seeding the food flow-field; carriers redirect to non-full chamber', async () => {
-    const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } = await import('./terrain.js');
+    const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } =
+      await import('./terrain.js');
     const { FP_ONE } = await import('./fixed.js');
     const { initAnt: _initAnt } = await import('./ant/ant-store.js');
     const { FOOD_CHAMBER_CAPACITY: CAP } = await import('./constants.js');
@@ -2991,9 +3400,12 @@ describe('cross-world flow-field cache isolation', () => {
     const queenId = allocateEntityId(world);
     _initAnt(world.ants, queenId, {
       colonyId,
-      posX: 1024, posY: 1024,
-      task: AntTask.Idle, subTask: 0,
-      speed: 0, lifespan: WORKER_LIFESPAN_TICKS,
+      posX: 1024,
+      posY: 1024,
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
+      lifespan: WORKER_LIFESPAN_TICKS,
     });
     const colony = createColonyRecord(colonyId, queenId);
     colony.foodStored = 0;
@@ -3011,12 +3423,22 @@ describe('cross-world flow-field cache isolation', () => {
     // this ordering, withdrawFood would dip chamber A below the cap and the
     // BFS would re-seed from the now-not-full chamber, defeating the test.
     colony.chambers.push({
-      chamberId: 101, chamberType: ChamberType.FoodStorage, foodStored: 100,
-      posX: 14 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 1, height: 1,
+      chamberId: 101,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 100,
+      posX: 14 << FP_SHIFT,
+      posY: 3 << FP_SHIFT,
+      width: 1,
+      height: 1,
     });
     colony.chambers.push({
-      chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: CAP,
-      posX: 2 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 1, height: 1,
+      chamberId: 100,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: CAP,
+      posX: 2 << FP_SHIFT,
+      posY: 3 << FP_SHIFT,
+      width: 1,
+      height: 1,
     });
     world.colonies[colonyId] = colony;
 
@@ -3081,7 +3503,8 @@ describe('cross-world flow-field cache isolation', () => {
   // the carrier's load arrives at B, not A.
   // -------------------------------------------------------------------------
   it('issue #15 follow-up — queen-drain oscillation does NOT pin a carrier on a near-full chamber', async () => {
-    const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } = await import('./terrain.js');
+    const { createUndergroundGrid, UndergroundTileState, ugSet, Zone } =
+      await import('./terrain.js');
     const { FP_ONE } = await import('./fixed.js');
     const { initAnt: _initAnt } = await import('./ant/ant-store.js');
     const { FOOD_CHAMBER_CAPACITY: CAP } = await import('./constants.js');
@@ -3097,9 +3520,12 @@ describe('cross-world flow-field cache isolation', () => {
     // purely to keep the test's mental model close to the dump scenario.
     _initAnt(world.ants, queenId, {
       colonyId,
-      posX: 5 << FP_SHIFT, posY: 3 << FP_SHIFT,
-      task: AntTask.Idle, subTask: 0,
-      speed: 0, lifespan: WORKER_LIFESPAN_TICKS,
+      posX: 5 << FP_SHIFT,
+      posY: 3 << FP_SHIFT,
+      task: AntTask.Idle,
+      subTask: 0,
+      speed: 0,
+      lifespan: WORKER_LIFESPAN_TICKS,
     });
     const colony = createColonyRecord(colonyId, queenId);
     colony.foodStored = 0;
@@ -3110,12 +3536,22 @@ describe('cross-world flow-field cache isolation', () => {
 
     // Chamber A near (col 5) full. Chamber B far (col 14) empty/depositable.
     colony.chambers.push({
-      chamberId: 100, chamberType: ChamberType.FoodStorage, foodStored: CAP,
-      posX: 5 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 1, height: 1,
+      chamberId: 100,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: CAP,
+      posX: 5 << FP_SHIFT,
+      posY: 3 << FP_SHIFT,
+      width: 1,
+      height: 1,
     });
     colony.chambers.push({
-      chamberId: 101, chamberType: ChamberType.FoodStorage, foodStored: 0,
-      posX: 14 << FP_SHIFT, posY: 3 << FP_SHIFT, width: 1, height: 1,
+      chamberId: 101,
+      chamberType: ChamberType.FoodStorage,
+      foodStored: 0,
+      posX: 14 << FP_SHIFT,
+      posY: 3 << FP_SHIFT,
+      width: 1,
+      height: 1,
     });
     world.colonies[colonyId] = colony;
 
@@ -3156,7 +3592,10 @@ describe('cross-world flow-field cache isolation', () => {
     let landedInB = false;
     for (let t = 0; t < 60; t++) {
       tick(world, []);
-      if (chamberB.foodStored > 0) { landedInB = true; break; }
+      if (chamberB.foodStored > 0) {
+        landedInB = true;
+        break;
+      }
     }
 
     expect(landedInB).toBe(true);
@@ -3245,14 +3684,20 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     colony.workerCount = 3;
     for (let i = 0; i < 3; i++) {
       const wid = allocateEntityId(world);
-      initAnt(world.ants, wid, { colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT, task: AntTask.Idle, subTask: 0 });
+      initAnt(world.ants, wid, {
+        colonyId,
+        posX: 24 << FP_SHIFT,
+        posY: 1 << FP_SHIFT,
+        task: AntTask.Idle,
+        subTask: 0,
+      });
       world.ants.zone[wid] = 1; // Underground; matches the Open shaft cell
       colony.workers.push(wid);
     }
 
     // Forage-only ratio so non-dig demand is 0; auto-dig is the only signal.
     colony.targetRatio.forage = 10;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
 
     // t=0 preconditions
     expect(colony.workers.length).toBe(3);
@@ -3261,7 +3706,8 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     expect(initialIdle).toBe(3);
     expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Solid);
     let initialDigging = 0;
-    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) initialDigging += 1;
+    for (const wid of colony.workers)
+      if (world.ants.task[wid] === AntTask.Digging) initialDigging += 1;
     expect(initialDigging).toBe(0);
     expect(colony.computedAllocation.dig).toBe(0);
 
@@ -3273,7 +3719,8 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Marked);
     expect(colony.computedAllocation.dig).toBe(1);
     let diggingCount = 0;
-    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) diggingCount += 1;
+    for (const wid of colony.workers)
+      if (world.ants.task[wid] === AntTask.Digging) diggingCount += 1;
     expect(diggingCount).toBeGreaterThanOrEqual(1);
     // Strict cap holds even on the activation tick.
     expect(diggingCount).toBe(1);
@@ -3287,12 +3734,18 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     colony.workerCount = 5;
     for (let i = 0; i < 5; i++) {
       const wid = allocateEntityId(world);
-      initAnt(world.ants, wid, { colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT, task: AntTask.Idle, subTask: 0 });
+      initAnt(world.ants, wid, {
+        colonyId,
+        posX: 24 << FP_SHIFT,
+        posY: 1 << FP_SHIFT,
+        task: AntTask.Idle,
+        subTask: 0,
+      });
       world.ants.zone[wid] = 1;
       colony.workers.push(wid);
     }
     colony.targetRatio.forage = 10;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
 
     // Mark 5 tiles in a column adjacent to the Open shaft.
     const markCmds: SimCommand[] = [];
@@ -3306,7 +3759,8 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
       expect(ugGet(underground, 25, dy)).toBe(UndergroundTileState.Solid);
     }
     let initialDigging = 0;
-    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) initialDigging += 1;
+    for (const wid of colony.workers)
+      if (world.ants.task[wid] === AntTask.Digging) initialDigging += 1;
     expect(initialDigging).toBe(0);
 
     tick(world, markCmds);
@@ -3358,7 +3812,7 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
       foragerIds.push(wid);
     }
     colony.targetRatio.forage = 10;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
     // Pre-populate computedAllocation so step 10a doesn't try to reassign these.
     colony.computedAllocation = { nurse: 0, forage: 3, dig: 0, fight: 0 };
 
@@ -3367,7 +3821,8 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Idle) initialIdle += 1;
     expect(initialIdle).toBe(0);
     let initialDigging = 0;
-    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) initialDigging += 1;
+    for (const wid of colony.workers)
+      if (world.ants.task[wid] === AntTask.Digging) initialDigging += 1;
     expect(initialDigging).toBe(0);
     // Snapshot foragers' tasks at t=0 — they must NOT be preempted at t=N.
     const t0Tasks: Record<number, number> = {};
@@ -3382,7 +3837,8 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     // t=N=5 outcomes
     expect(ugGet(underground, 25, 1)).toBe(UndergroundTileState.Marked); // tile still Marked (nobody reached it)
     let diggingCount = 0;
-    for (const wid of colony.workers) if (world.ants.task[wid] === AntTask.Digging) diggingCount += 1;
+    for (const wid of colony.workers)
+      if (world.ants.task[wid] === AntTask.Digging) diggingCount += 1;
     expect(diggingCount).toBe(0);
     // No forager was preempted to dig.
     for (const wid of foragerIds) {
@@ -3419,7 +3875,7 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     colony.digFlowFieldDirty = true;
 
     colony.targetRatio.forage = 10;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
 
     // t=0 preconditions
     expect(world.ants.task[wid]).toBe(AntTask.Digging);
@@ -3485,25 +3941,34 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
 
     // t=0 preconditions
     let aiDiggingT0 = 0;
-    for (const wid of aiColony.workers) if (world.ants.task[wid] === AntTask.Digging) aiDiggingT0 += 1;
+    for (const wid of aiColony.workers)
+      if (world.ants.task[wid] === AntTask.Digging) aiDiggingT0 += 1;
     expect(aiDiggingT0).toBe(0);
     expect(world.ants.task[aiWorkerId]).toBe(AntTask.Idle);
 
     // Issue MarkDigTile on the AI colony — same command surface as the player.
-    const cmd: SimCommand = { type: 'MarkDigTile', colonyId: aiColonyId, tileX: markX, tileY: markY, issuedAtTick: 0 };
+    const cmd: SimCommand = {
+      type: 'MarkDigTile',
+      colonyId: aiColonyId,
+      tileX: markX,
+      tileY: markY,
+      issuedAtTick: 0,
+    };
     tick(world, [cmd]);
 
     // t=N outcomes — AI colony has exactly 1 Digging ant via the auto-dig path.
     expect(ugGet(aiUg, markX, markY)).toBe(UndergroundTileState.Marked);
     expect(aiColony.computedAllocation.dig).toBe(1);
     let aiDiggingT1 = 0;
-    for (const wid of aiColony.workers) if (world.ants.task[wid] === AntTask.Digging) aiDiggingT1 += 1;
+    for (const wid of aiColony.workers)
+      if (world.ants.task[wid] === AntTask.Digging) aiDiggingT1 += 1;
     expect(aiDiggingT1).toBe(1);
 
     // Player colony got NO Digging ants (no Mark in player colony) — proves the path is colony-scoped.
     const playerColony = world.colonies[playerColonyId]!;
     let playerDiggingT1 = 0;
-    for (const wid of playerColony.workers) if (world.ants.task[wid] === AntTask.Digging) playerDiggingT1 += 1;
+    for (const wid of playerColony.workers)
+      if (world.ants.task[wid] === AntTask.Digging) playerDiggingT1 += 1;
     expect(playerDiggingT1).toBe(0);
   });
 
@@ -3528,21 +3993,36 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     colony.workerCount = 1;
     const wid = allocateEntityId(world);
     initAnt(world.ants, wid, {
-      colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
-      task: AntTask.Idle, subTask: 0,
+      colonyId,
+      posX: 24 << FP_SHIFT,
+      posY: 1 << FP_SHIFT,
+      task: AntTask.Idle,
+      subTask: 0,
     });
     world.ants.zone[wid] = 1;
     colony.workers.push(wid);
 
     for (let e = 0; e < 30; e++) {
       const lid = allocateEntityId(world);
-      initAnt(world.ants, lid, { colonyId, posX: 100, posY: 100, task: AntTask.Idle, subTask: 0, speed: 0 });
+      initAnt(world.ants, lid, {
+        colonyId,
+        posX: 100,
+        posY: 100,
+        task: AntTask.Idle,
+        subTask: 0,
+        speed: 0,
+      });
       colony.larvae.push(lid);
       colony.larvaeCount += 1;
     }
     colony.chambers.push({
-      chamberId: 9100, chamberType: ChamberType.Nursery,
-      foodStored: 0, posX: 0, posY: 0, width: 2, height: 2,
+      chamberId: 9100,
+      chamberType: ChamberType.Nursery,
+      foodStored: 0,
+      posX: 0,
+      posY: 0,
+      width: 2,
+      height: 2,
     });
 
     // t=0 preconditions
@@ -3579,8 +4059,11 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     for (let i = 0; i < 3; i++) {
       const wid = allocateEntityId(world);
       initAnt(world.ants, wid, {
-        colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
-        task: AntTask.Idle, subTask: 0,
+        colonyId,
+        posX: 24 << FP_SHIFT,
+        posY: 1 << FP_SHIFT,
+        task: AntTask.Idle,
+        subTask: 0,
       });
       world.ants.zone[wid] = 1;
       colony.workers.push(wid);
@@ -3588,7 +4071,7 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     }
 
     colony.targetRatio.forage = 0;
-    colony.targetRatio.fight  = 10;
+    colony.targetRatio.fight = 10;
 
     let initialIdle = 0;
     for (const id of widList) if (world.ants.task[id] === AntTask.Idle) initialIdle += 1;
@@ -3632,8 +4115,11 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     for (let i = 0; i < 3; i++) {
       const wid = allocateEntityId(world);
       initAnt(world.ants, wid, {
-        colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
-        task: AntTask.Idle, subTask: 0,
+        colonyId,
+        posX: 24 << FP_SHIFT,
+        posY: 1 << FP_SHIFT,
+        task: AntTask.Idle,
+        subTask: 0,
       });
       world.ants.zone[wid] = 1;
       colony.workers.push(wid);
@@ -3643,7 +4129,7 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     // Valid post-Phase-10 zero-ratio. WR-10 keeps this as-is (the snap only
     // catches legacy {forage:0, dig:N, fight:0} inputs).
     colony.targetRatio.forage = 0;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
 
     const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 25, tileY: 1, issuedAtTick: 0 };
     tick(world, [cmd]);
@@ -3655,10 +4141,10 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     expect(colony.computedAllocation.fight).toBe(0);
     expect(colony.computedAllocation.dig).toBe(1);
     let diggingCount = 0;
-    let idleCount    = 0;
+    let idleCount = 0;
     for (const id of widList) {
       if (world.ants.task[id] === AntTask.Digging) diggingCount += 1;
-      if (world.ants.task[id] === AntTask.Idle)    idleCount    += 1;
+      if (world.ants.task[id] === AntTask.Idle) idleCount += 1;
     }
     expect(diggingCount).toBe(1);
     expect(idleCount).toBe(2); // remaining Idle ants stay Idle (no other role demands)
@@ -3683,8 +4169,11 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     for (let i = 0; i < 2; i++) {
       const wid = allocateEntityId(world);
       initAnt(world.ants, wid, {
-        colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
-        task: AntTask.Idle, subTask: 0,
+        colonyId,
+        posX: 24 << FP_SHIFT,
+        posY: 1 << FP_SHIFT,
+        task: AntTask.Idle,
+        subTask: 0,
       });
       world.ants.zone[wid] = 1;
       colony.workers.push(wid);
@@ -3716,7 +4205,7 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     let diggingCount = 0;
     let foragingCount = 0;
     for (const id of widList) {
-      if (world.ants.task[id] === AntTask.Digging)  diggingCount  += 1;
+      if (world.ants.task[id] === AntTask.Digging) diggingCount += 1;
       if (world.ants.task[id] === AntTask.Foraging) foragingCount += 1;
     }
     expect(diggingCount).toBe(0);
@@ -3734,8 +4223,11 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     colony.workerCount = 1;
     const wid = allocateEntityId(world);
     initAnt(world.ants, wid, {
-      colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
-      task: AntTask.Idle, subTask: 0,
+      colonyId,
+      posX: 24 << FP_SHIFT,
+      posY: 1 << FP_SHIFT,
+      task: AntTask.Idle,
+      subTask: 0,
     });
     world.ants.zone[wid] = 1;
     colony.workers.push(wid);
@@ -3769,27 +4261,42 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     colony.workerCount = 1;
     const wid = allocateEntityId(world);
     initAnt(world.ants, wid, {
-      colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
-      task: AntTask.Idle, subTask: 0,
+      colonyId,
+      posX: 24 << FP_SHIFT,
+      posY: 1 << FP_SHIFT,
+      task: AntTask.Idle,
+      subTask: 0,
     });
     world.ants.zone[wid] = 1;
     colony.workers.push(wid);
 
     for (let e = 0; e < 30; e++) {
       const lid = allocateEntityId(world);
-      initAnt(world.ants, lid, { colonyId, posX: 100, posY: 100, task: AntTask.Idle, subTask: 0, speed: 0 });
+      initAnt(world.ants, lid, {
+        colonyId,
+        posX: 100,
+        posY: 100,
+        task: AntTask.Idle,
+        subTask: 0,
+        speed: 0,
+      });
       colony.larvae.push(lid);
       colony.larvaeCount += 1;
     }
     colony.chambers.push({
-      chamberId: 9300, chamberType: ChamberType.Nursery,
-      foodStored: 0, posX: 0, posY: 0, width: 2, height: 2,
+      chamberId: 9300,
+      chamberType: ChamberType.Nursery,
+      foodStored: 0,
+      posX: 0,
+      posY: 0,
+      width: 2,
+      height: 2,
     });
 
     // Slider-to-fight; combined with the nurse cap this leaves zero ratio
     // budget for any carve — the all-nurse case.
     colony.targetRatio.forage = 0;
-    colony.targetRatio.fight  = 10;
+    colony.targetRatio.fight = 10;
 
     const cmd: SimCommand = { type: 'MarkDigTile', colonyId, tileX: 25, tileY: 1, issuedAtTick: 0 };
     tick(world, [cmd]);
@@ -3801,7 +4308,6 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     expect(colony.computedAllocation.dig).toBe(0); // no ratio-driven slot to carve
     expect(world.ants.task[wid]).toBe(AntTask.Nursing);
   });
-
 
   it('Test 8 (WR-07): dig slot reserved while digger is active → nurse not preempted by forage', () => {
     // Regression for codex P1 v2: in a 2-worker / brood-heavy / forage-only
@@ -3823,8 +4329,11 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     colony.workerCount = 2;
     const widDigger = allocateEntityId(world);
     initAnt(world.ants, widDigger, {
-      colonyId, posX: 25 << FP_SHIFT, posY: 1 << FP_SHIFT,
-      task: AntTask.Digging, subTask: DiggingSubState.Excavating,
+      colonyId,
+      posX: 25 << FP_SHIFT,
+      posY: 1 << FP_SHIFT,
+      task: AntTask.Digging,
+      subTask: DiggingSubState.Excavating,
     });
     world.ants.zone[widDigger] = 1;
     world.ants.digTileX[widDigger] = 25;
@@ -3837,8 +4346,11 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     // Worker B: Idle, the candidate for nurse vs forage.
     const widIdle = allocateEntityId(world);
     initAnt(world.ants, widIdle, {
-      colonyId, posX: 24 << FP_SHIFT, posY: 1 << FP_SHIFT,
-      task: AntTask.Idle, subTask: 0,
+      colonyId,
+      posX: 24 << FP_SHIFT,
+      posY: 1 << FP_SHIFT,
+      task: AntTask.Idle,
+      subTask: 0,
     });
     world.ants.zone[widIdle] = 1;
     colony.workers.push(widIdle);
@@ -3846,17 +4358,29 @@ describe('Phase 10 / CTRL-06 auto-dig', () => {
     // Brood + Nursery so nurse=1, available=1, allocation={nurse:1, forage:1}.
     for (let e = 0; e < 30; e++) {
       const lid = allocateEntityId(world);
-      initAnt(world.ants, lid, { colonyId, posX: 100, posY: 100, task: AntTask.Idle, subTask: 0, speed: 0 });
+      initAnt(world.ants, lid, {
+        colonyId,
+        posX: 100,
+        posY: 100,
+        task: AntTask.Idle,
+        subTask: 0,
+        speed: 0,
+      });
       colony.larvae.push(lid);
       colony.larvaeCount += 1;
     }
     colony.chambers.push({
-      chamberId: 9200, chamberType: ChamberType.Nursery,
-      foodStored: 0, posX: 0, posY: 0, width: 2, height: 2,
+      chamberId: 9200,
+      chamberType: ChamberType.Nursery,
+      foodStored: 0,
+      posX: 0,
+      posY: 0,
+      width: 2,
+      height: 2,
     });
 
     colony.targetRatio.forage = 10;
-    colony.targetRatio.fight  = 0;
+    colony.targetRatio.fight = 0;
 
     // t=0 preconditions
     expect(world.ants.task[widDigger]).toBe(AntTask.Digging);
@@ -3898,63 +4422,121 @@ describe('Issue #60 — command coordinate validation', () => {
   });
 
   it('MarkDigTile with NaN coords is dropped (no underground state change)', () => {
-    const cmd = { type: 'MarkDigTile', colonyId: PLAYER, tileX: NaN, tileY: 5, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'MarkDigTile',
+      colonyId: PLAYER,
+      tileX: NaN,
+      tileY: 5,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     const before = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
     expect(() => tick(world, [cmd])).not.toThrow();
     const after = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
     expect(after).toBe(before);
   });
   it('CancelDigMark with NaN coords is dropped', () => {
-    const cmd = { type: 'CancelDigMark', colonyId: PLAYER, tileX: NaN, tileY: NaN, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'CancelDigMark',
+      colonyId: PLAYER,
+      tileX: NaN,
+      tileY: NaN,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     expect(() => tick(world, [cmd])).not.toThrow();
   });
   it('MarkDigTile with non-integer coords is dropped', () => {
-    // eslint-disable-next-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
-    const cmd = { type: 'MarkDigTile', colonyId: PLAYER, tileX: 1.5, tileY: 5, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'MarkDigTile',
+      colonyId: PLAYER,
+      tileX: 1.5, // eslint-disable-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
+      tileY: 5,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     const before = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
     tick(world, [cmd]);
     const after = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
     expect(after).toBe(before);
   });
   it('MarkDigTile with Infinity coords is dropped (no underground state change)', () => {
-    const cmd = { type: 'MarkDigTile', colonyId: PLAYER, tileX: Infinity, tileY: 5, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'MarkDigTile',
+      colonyId: PLAYER,
+      tileX: Infinity,
+      tileY: 5,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     const before = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
     expect(() => tick(world, [cmd])).not.toThrow();
     const after = JSON.stringify(Array.from(world.undergroundGrids[PLAYER]!.data));
     expect(after).toBe(before);
   });
   it('SetRallyPoint with NaN coords is dropped — rallyPoint stays null', () => {
-    const cmd = { type: 'SetRallyPoint', colonyId: PLAYER, tileX: NaN, tileY: NaN, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'SetRallyPoint',
+      colonyId: PLAYER,
+      tileX: NaN,
+      tileY: NaN,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     tick(world, [cmd]);
     expect(world.colonies[PLAYER]!.rallyPoint).toBeNull();
   });
   it('SetRallyPoint with non-integer coords is dropped', () => {
-    // eslint-disable-next-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
-    const cmd = { type: 'SetRallyPoint', colonyId: PLAYER, tileX: 5.5, tileY: 5, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'SetRallyPoint',
+      colonyId: PLAYER,
+      tileX: 5.5, // eslint-disable-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
+      tileY: 5,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     tick(world, [cmd]);
     expect(world.colonies[PLAYER]!.rallyPoint).toBeNull();
   });
   it('SetRallyPoint with valid integer coords sets rallyPoint normally', () => {
-    const cmd: SimCommand = { type: 'SetRallyPoint', colonyId: PLAYER, tileX: 7, tileY: 8, issuedAtTick: 0 };
+    const cmd: SimCommand = {
+      type: 'SetRallyPoint',
+      colonyId: PLAYER,
+      tileX: 7,
+      tileY: 8,
+      issuedAtTick: 0,
+    };
     tick(world, [cmd]);
     expect(world.colonies[PLAYER]!.rallyPoint).toEqual({ tileX: 7, tileY: 8 });
   });
   it('DesignateEntrance with NaN coords is dropped — no new entrance pushed', () => {
     const before = world.colonies[PLAYER]!.entrances.length;
-    const cmd = { type: 'DesignateEntrance', colonyId: PLAYER, surfaceTileX: NaN, surfaceTileY: 0, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'DesignateEntrance',
+      colonyId: PLAYER,
+      surfaceTileX: NaN,
+      surfaceTileY: 0,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     tick(world, [cmd]);
     expect(world.colonies[PLAYER]!.entrances.length).toBe(before);
   });
   it('DesignateEntrance with non-integer coords is dropped', () => {
     const before = world.colonies[PLAYER]!.entrances.length;
-    // eslint-disable-next-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
-    const cmd = { type: 'DesignateEntrance', colonyId: PLAYER, surfaceTileX: 7.5, surfaceTileY: 0, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'DesignateEntrance',
+      colonyId: PLAYER,
+      surfaceTileX: 7.5, // eslint-disable-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
+      surfaceTileY: 0,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     tick(world, [cmd]);
     expect(world.colonies[PLAYER]!.entrances.length).toBe(before);
   });
   it('PlaceChamber with NaN anchor is dropped — no PendingChamber created', () => {
     const before = Object.keys(world.pendingChambers).length;
-    const cmd = { type: 'PlaceChamber', colonyId: PLAYER, chamberType: ChamberType.FoodStorage, anchorTileX: NaN, anchorTileY: NaN, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'PlaceChamber',
+      colonyId: PLAYER,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: NaN,
+      anchorTileY: NaN,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     tick(world, [cmd]);
     expect(Object.keys(world.pendingChambers).length).toBe(before);
     // Critically: no malformed `${colonyId}:NaN:NaN` key should have been created.
@@ -3962,14 +4544,26 @@ describe('Issue #60 — command coordinate validation', () => {
   });
   it('PlaceChamber with non-integer anchor is dropped', () => {
     const before = Object.keys(world.pendingChambers).length;
-    // eslint-disable-next-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
-    const cmd = { type: 'PlaceChamber', colonyId: PLAYER, chamberType: ChamberType.FoodStorage, anchorTileX: 5.5, anchorTileY: 5, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'PlaceChamber',
+      colonyId: PLAYER,
+      chamberType: ChamberType.FoodStorage,
+      anchorTileX: 5.5, // eslint-disable-line no-restricted-syntax -- intentional non-integer probe to exercise the integer guard
+      anchorTileY: 5,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     tick(world, [cmd]);
     expect(Object.keys(world.pendingChambers).length).toBe(before);
   });
   it('MarkFoodPile with NaN coords is dropped — priorityFoodPileId unchanged', () => {
     const before = world.colonies[PLAYER]!.priorityFoodPileId;
-    const cmd = { type: 'MarkFoodPile', colonyId: PLAYER, tileX: NaN, tileY: NaN, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'MarkFoodPile',
+      colonyId: PLAYER,
+      tileX: NaN,
+      tileY: NaN,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     tick(world, [cmd]);
     expect(world.colonies[PLAYER]!.priorityFoodPileId).toBe(before);
   });
@@ -3978,7 +4572,13 @@ describe('Issue #60 — command coordinate validation', () => {
     // if a malformed command somehow reaches the queue (cast-defeated TS,
     // tampered inputLog), the colony state never absorbs the NaN.
     const { serializeWorldState } = await import('../platform/save.js');
-    const cmd = { type: 'SetRallyPoint', colonyId: PLAYER, tileX: NaN, tileY: NaN, issuedAtTick: 0 } as unknown as SimCommand;
+    const cmd = {
+      type: 'SetRallyPoint',
+      colonyId: PLAYER,
+      tileX: NaN,
+      tileY: NaN,
+      issuedAtTick: 0,
+    } as unknown as SimCommand;
     tick(world, [cmd]);
     const json = JSON.stringify(serializeWorldState(world));
     expect(json).not.toContain('NaN');

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -44,10 +44,7 @@ import {
   isFoodChamberDepositable,
   colonyFoodTotal,
 } from './colony/colony-system.js';
-import {
-  tickQueenEggProduction,
-  tickLifecycleTransitions,
-} from './colony/lifecycle-system.js';
+import { tickQueenEggProduction, tickLifecycleTransitions } from './colony/lifecycle-system.js';
 import { tickLarvaMaturation } from './colony/larva-maturation.js';
 import {
   tickPheromoneDeposit,
@@ -62,11 +59,7 @@ import {
 } from './ant/ant-system.js';
 import { tickPheromoneDecay } from './pheromone/pheromone-system.js';
 import { tickFoodPileSpawn } from './food-system.js';
-import {
-  computeDigFlowField,
-  ensureDigFlowField,
-  createDigFlowFields,
-} from './dig-system.js';
+import { computeDigFlowField, ensureDigFlowField, createDigFlowFields } from './dig-system.js';
 import type { DigFlowFields } from './dig-system.js';
 import {
   computeEntranceFlowField,
@@ -274,7 +267,10 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         srec.operationTargetTileY = sc.operationTargetTileY;
         srec.operationFighterIds.set(sc.operationFighterIds);
         srec.operationFighterIds.fill(-1, sc.operationFighterIds.length);
-        srec.operationFighterCount = Math.min(sc.operationFighterCount, sc.operationFighterIds.length);
+        srec.operationFighterCount = Math.min(
+          sc.operationFighterCount,
+          sc.operationFighterIds.length,
+        );
         srec.operationStartFighterCount = sc.operationStartFighterCount;
         srec.operationAttackerDeaths = sc.operationAttackerDeaths;
         srec.operationDefenderDeaths = sc.operationDefenderDeaths;
@@ -327,7 +323,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         // do the honest narrowing on each field.
         const ratioObj = ratioRaw as { forage?: unknown; fight?: unknown; dig?: unknown };
         let nextForage = ratioObj.forage as number;
-        let nextFight  = ratioObj.fight  as number;
+        let nextFight = ratioObj.fight as number;
         if ('dig' in ratioObj) {
           // Mirror migrateBehaviorRatio in platform/save.ts byte-for-byte:
           //   1. coerce missing/non-finite forage and fight to 0
@@ -338,10 +334,10 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
           // partial-field legacy shapes, breaking SCEN-06 replay determinism
           // for non-loadSave call paths (debug snapshot replay, ad-hoc tests).
           if (!Number.isFinite(nextForage)) nextForage = 0;
-          if (!Number.isFinite(nextFight))  nextFight  = 0;
+          if (!Number.isFinite(nextFight)) nextFight = 0;
           if (nextForage === 0 && nextFight === 0) {
             nextForage = 10;
-            nextFight  = 0;
+            nextFight = 0;
           }
         }
         // Validate ratio fields: reject NaN, +/-Infinity, and negatives.
@@ -352,17 +348,17 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         if (nextForage < 0 || nextFight < 0) break;
         // Field-by-field copy to preserve object identity for copyWorldState determinism.
         colony.targetRatio.forage = nextForage;
-        colony.targetRatio.fight  = nextFight;
+        colony.targetRatio.fight = nextFight;
         // CTRL-04: run allocateWorkers immediately in the same tick the command is issued.
         // alloc0.dig is 0 here under the two-role contract — auto-dig (Plan 02 step 10a)
         // overwrites colony.computedAllocation.dig later in this same tick when need.dig > 0.
         const brood0 = colony.eggCount + colony.larvaeCount;
         const hasNursery0 = hasCompletedChamber(colony, ChamberType.Nursery);
         const alloc0 = allocateWorkers(colony.workerCount, brood0, colony.targetRatio, hasNursery0);
-        colony.computedAllocation.nurse  = alloc0.nurse;
+        colony.computedAllocation.nurse = alloc0.nurse;
         colony.computedAllocation.forage = alloc0.forage;
-        colony.computedAllocation.dig    = alloc0.dig;
-        colony.computedAllocation.fight  = alloc0.fight;
+        colony.computedAllocation.dig = alloc0.dig;
+        colony.computedAllocation.fight = alloc0.fight;
         colony.nurseCount = alloc0.nurse;
         break;
       }
@@ -392,7 +388,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         if (ugGet(underground, cmd.tileX, cmd.tileY) !== UndergroundTileState.Solid) break;
         ugSet(underground, cmd.tileX, cmd.tileY, UndergroundTileState.Marked);
         const colony1 = world.colonies[cmd.colonyId];
-        if (colony1) colony1.digFlowFieldDirty = true;   // typed field (Plan 03 Task 1)
+        if (colony1) colony1.digFlowFieldDirty = true; // typed field (Plan 03 Task 1)
         break;
       }
       case 'MarkFoodPile': {
@@ -416,9 +412,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
           }
         }
         if (matched === null) break;
-        colony.priorityFoodPileId = (colony.priorityFoodPileId === matched)
-          ? null
-          : matched;
+        colony.priorityFoodPileId = colony.priorityFoodPileId === matched ? null : matched;
         break;
       }
       case 'CancelDigMark': {
@@ -431,7 +425,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         if (ugGet(underground, cmd.tileX, cmd.tileY) !== UndergroundTileState.Marked) break;
         ugSet(underground, cmd.tileX, cmd.tileY, UndergroundTileState.Solid);
         const colony2 = world.colonies[cmd.colonyId];
-        if (colony2) colony2.digFlowFieldDirty = true;   // typed field (Plan 03 Task 1)
+        if (colony2) colony2.digFlowFieldDirty = true; // typed field (Plan 03 Task 1)
         // Issue #54 (v9+) — if the cancelled tile is inside a pending chamber's
         // footprint, drop the pending chamber and revert any of its remaining
         // Marked tiles back to Solid. Pre-v9 the pending chamber stayed
@@ -494,7 +488,10 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         if (cmd.chamberType === ChamberType.Queen) {
           let hasQueen = false;
           for (let qi = 0; qi < colony3.chambers.length; qi++) {
-            if (colony3.chambers[qi]!.chamberType === ChamberType.Queen) { hasQueen = true; break; }
+            if (colony3.chambers[qi]!.chamberType === ChamberType.Queen) {
+              hasQueen = true;
+              break;
+            }
           }
           if (!hasQueen) {
             for (const pcKey in world.pendingChambers) {
@@ -525,7 +522,10 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
           let conflictsBeingDug = false;
           for (let dy = 0; dy < dims.height && !conflictsBeingDug; dy++) {
             for (let dx = 0; dx < dims.width; dx++) {
-              if (ugGet(underground, cmd.anchorTileX + dx, cmd.anchorTileY + dy) === UndergroundTileState.BeingDug) {
+              if (
+                ugGet(underground, cmd.anchorTileX + dx, cmd.anchorTileY + dy) ===
+                UndergroundTileState.BeingDug
+              ) {
                 conflictsBeingDug = true;
                 break;
               }
@@ -541,9 +541,14 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         for (const ch of colony3.chambers) {
           const chTileX = ch.posX >> FP_SHIFT;
           const chTileY = ch.posY >> FP_SHIFT;
-          if (cmd.anchorTileX < chTileX + ch.width && cmd.anchorTileX + dims.width > chTileX &&
-              cmd.anchorTileY < chTileY + ch.height && cmd.anchorTileY + dims.height > chTileY) {
-            overlaps = true; break;
+          if (
+            cmd.anchorTileX < chTileX + ch.width &&
+            cmd.anchorTileX + dims.width > chTileX &&
+            cmd.anchorTileY < chTileY + ch.height &&
+            cmd.anchorTileY + dims.height > chTileY
+          ) {
+            overlaps = true;
+            break;
           }
         }
         if (overlaps) break;
@@ -552,9 +557,14 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
           if (!Object.hasOwn(world.pendingChambers, pcKey)) continue;
           const pc = world.pendingChambers[pcKey]!;
           if (pc.colonyId !== cmd.colonyId) continue;
-          if (cmd.anchorTileX < pc.anchorTileX + pc.width && cmd.anchorTileX + dims.width > pc.anchorTileX &&
-              cmd.anchorTileY < pc.anchorTileY + pc.height && cmd.anchorTileY + dims.height > pc.anchorTileY) {
-            overlaps = true; break;
+          if (
+            cmd.anchorTileX < pc.anchorTileX + pc.width &&
+            cmd.anchorTileX + dims.width > pc.anchorTileX &&
+            cmd.anchorTileY < pc.anchorTileY + pc.height &&
+            cmd.anchorTileY + dims.height > pc.anchorTileY
+          ) {
+            overlaps = true;
+            break;
           }
         }
         if (overlaps) break;
@@ -573,10 +583,17 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         // disconnected pre-existing Open cavern could pass them — but
         // those edge cases are unchanged by this PR (pre-v5 replays use
         // the legacy gates verbatim).
-        if (!isFootprintReachableAfterDigs(
-              world, colony3, cmd.anchorTileX, cmd.anchorTileY,
-              dims.width, dims.height,
-            )) break;
+        if (
+          !isFootprintReachableAfterDigs(
+            world,
+            colony3,
+            cmd.anchorTileX,
+            cmd.anchorTileY,
+            dims.width,
+            dims.height,
+          )
+        )
+          break;
         // All checks passed — mark footprint Solid tiles and create PendingChamber
         for (let dy = 0; dy < dims.height; dy++) {
           for (let dx = 0; dx < dims.width; dx++) {
@@ -588,14 +605,14 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
           }
         }
         world.pendingChambers[newPcKey] = {
-          colonyId:    cmd.colonyId,
+          colonyId: cmd.colonyId,
           chamberType: cmd.chamberType,
           anchorTileX: cmd.anchorTileX,
           anchorTileY: cmd.anchorTileY,
-          width:       dims.width,
-          height:      dims.height,
+          width: dims.width,
+          height: dims.height,
         };
-        colony3.digFlowFieldDirty = true;   // typed field (Plan 03 Task 1)
+        colony3.digFlowFieldDirty = true; // typed field (Plan 03 Task 1)
         break;
       }
       case 'DesignateEntrance': {
@@ -636,9 +653,12 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
           if (onFoodPile) break;
         }
         // Colony rally-point collision
-        if (colony4.rallyPoint !== null &&
-            colony4.rallyPoint.tileX === cmd.surfaceTileX &&
-            colony4.rallyPoint.tileY === cmd.surfaceTileY) break;
+        if (
+          colony4.rallyPoint !== null &&
+          colony4.rallyPoint.tileX === cmd.surfaceTileX &&
+          colony4.rallyPoint.tileY === cmd.surfaceTileY
+        )
+          break;
         // Another colony's entrance already occupies this surface tile
         {
           let occupiedByOther = false;
@@ -670,7 +690,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
           entranceId,
           surfaceTileX: cmd.surfaceTileX,
           surfaceTileY: cmd.surfaceTileY,
-          isOpen:       false,
+          isOpen: false,
         });
         // Auto-mark shaft tiles (tileY=0 .. ENTRANCE_SHAFT_DEPTH-1 at surfaceTileX) for excavation
         for (let sy = 0; sy < ENTRANCE_SHAFT_DEPTH; sy++) {
@@ -678,7 +698,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
             ugSet(underground, cmd.surfaceTileX, sy, UndergroundTileState.Marked);
           }
         }
-        colony4.digFlowFieldDirty = true;   // typed field (Plan 03 Task 1)
+        colony4.digFlowFieldDirty = true; // typed field (Plan 03 Task 1)
         break;
       }
       case 'SetRallyPoint': {
@@ -708,7 +728,14 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         if (!Array.isArray(cmd.fighterIds) || cmd.fighterIds.length === 0) break;
         // Invasion cohorts < 3 fighters trigger immediate rout on first tick; reject them.
         if (cmd.kind === 'Invasion' && cmd.fighterIds.length < 3) break;
-        setAIRallyOperation(world, cmd.colonyId, cmd.rallyTileX, cmd.rallyTileY, cmd.fighterIds, cmd.kind);
+        setAIRallyOperation(
+          world,
+          cmd.colonyId,
+          cmd.rallyTileX,
+          cmd.rallyTileY,
+          cmd.fighterIds,
+          cmd.kind,
+        );
         break;
       }
       case 'MarkSpiderPriority': {
@@ -763,20 +790,19 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     const brood8 = colony.eggCount + colony.larvaeCount;
     const hasNursery8 = hasCompletedChamber(colony, ChamberType.Nursery);
     const alloc8 = allocateWorkers(colony.workerCount, brood8, colony.targetRatio, hasNursery8);
-    colony.computedAllocation.nurse  = alloc8.nurse;
+    colony.computedAllocation.nurse = alloc8.nurse;
     colony.computedAllocation.forage = alloc8.forage;
-    colony.computedAllocation.dig    = alloc8.dig;
-    colony.computedAllocation.fight  = alloc8.fight;
+    colony.computedAllocation.dig = alloc8.dig;
+    colony.computedAllocation.fight = alloc8.fight;
     colony.nurseCount = alloc8.nurse;
     // Starvation escape hatch: when the colony has no food AND every worker is
     // allocated as a nurse (forage===0), demote one nurse to forager so the
     // colony isn't starvation-locked. This covers the small-colony case where
     // computeNurseCount's ceil(workers/4) cap assigns the only worker as a
     // nurse, leaving zero foragers regardless of food level.
-    if (alloc8.forage === 0 && alloc8.nurse > 0 &&
-        colonyFoodTotal(colony) === 0) {
-      colony.computedAllocation.nurse  -= 1;
-      colony.computedAllocation.forage  = 1;
+    if (alloc8.forage === 0 && alloc8.nurse > 0 && colonyFoodTotal(colony) === 0) {
+      colony.computedAllocation.nurse -= 1;
+      colony.computedAllocation.forage = 1;
       colony.nurseCount -= 1;
     }
   }
@@ -814,7 +840,8 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       !colony.foodFlowFieldDirty &&
       !firstEntranceCompute &&
       !firstDigCompute
-    ) continue;
+    )
+      continue;
 
     if (colony.digFlowFieldDirty || firstDigCompute) {
       const out = ensureDigFlowField(digFlowFields, colony.colonyId, gridSize);
@@ -969,16 +996,20 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
 
     // (a) Count current per-task totals by iterating colony.workers (skip dead).
     //     Only the 4 target categories; idle is a transient eligibility state, not a census slot.
-    let actualForage = 0, actualDig = 0, actualFight = 0, actualNurse = 0, actualIdle = 0;
+    let actualForage = 0,
+      actualDig = 0,
+      actualFight = 0,
+      actualNurse = 0,
+      actualIdle = 0;
     for (let i = 0; i < colony.workers.length; i++) {
       const id = colony.workers[i]!;
       if (world.ants.alive[id] !== 1) continue;
       const t = world.ants.task[id]!;
-      if      (t === AntTask.Foraging) actualForage += 1;
-      else if (t === AntTask.Digging)  actualDig    += 1;
-      else if (t === AntTask.Fighting) actualFight  += 1;
-      else if (t === AntTask.Nursing)  actualNurse  += 1;
-      else                             actualIdle   += 1;
+      if (t === AntTask.Foraging) actualForage += 1;
+      else if (t === AntTask.Digging) actualDig += 1;
+      else if (t === AntTask.Fighting) actualFight += 1;
+      else if (t === AntTask.Nursing) actualNurse += 1;
+      else actualIdle += 1;
     }
 
     // Phase 10 / CTRL-06 (D-02 LOCKED) — auto-dig demand override.
@@ -1031,16 +1062,17 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // need to introspect Mark/BeingDug grid state, and the drift is one
     // tick / one slot per dig job.
     const undergroundGrid10a = world.undergroundGrids[colony.colonyId];
-    const rawDigDemand = undergroundGrid10a !== undefined
-      ? computeDigDemand(colony, undergroundGrid10a, world.ants)
-      : 0;
+    const rawDigDemand =
+      undergroundGrid10a !== undefined
+        ? computeDigDemand(colony, undergroundGrid10a, world.ants)
+        : 0;
     const wantDigSlot = rawDigDemand > 0 || actualDig > 0;
     // Try to carve from forage first (D-02 preference), then fight. nurse is
     // never carved (CLNY-09 invariant). digDemand is the canonical 0/1 flag
     // both for `colony.computedAllocation.dig` and `need.dig` below.
     let digDemand = 0;
     let carvedForage = colony.computedAllocation.forage;
-    let carvedFight  = colony.computedAllocation.fight;
+    let carvedFight = colony.computedAllocation.fight;
     if (wantDigSlot) {
       if (colony.computedAllocation.forage > 0) {
         digDemand = 1;
@@ -1107,46 +1139,58 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // (c) Walk the sorted eligibles and reassign into under-represented targets.
     //     Canonical target iteration order: forage → dig → fight → nurse (matches PRD §7a result shape).
     //     This deterministic if/else chain is the ONLY selection strategy.
-    let needForage = carvedForage                    - actualForage;
-    let needDig    = colony.computedAllocation.dig    - actualDig;
-    let needFight  = carvedFight                      - actualFight;
-    let needNurse  = colony.computedAllocation.nurse  - actualNurse;
+    let needForage = carvedForage - actualForage;
+    let needDig = colony.computedAllocation.dig - actualDig;
+    let needFight = carvedFight - actualFight;
+    let needNurse = colony.computedAllocation.nurse - actualNurse;
 
     for (let i = 0; i < eligible.length; i++) {
       const id = eligible[i]!;
       let newTask = -1;
       let newSubTask = 0;
 
-      if      (needForage > 0) { newTask = AntTask.Foraging; newSubTask = ForagingSubState.SearchingFood; needForage -= 1; }
-      else if (needDig    > 0) { newTask = AntTask.Digging;  newSubTask = DiggingSubState.MovingToTile;   needDig    -= 1; }
-      else if (needFight  > 0) { newTask = AntTask.Fighting; newSubTask = FightingSubState.MovingToRally; needFight  -= 1; }
-      else if (needNurse  > 0) { newTask = AntTask.Nursing;  newSubTask = NursingSubState.MovingToBrood;  needNurse  -= 1; }
-      else break; // no remaining under-represented targets; leave rest of eligibles in their current state
+      if (needForage > 0) {
+        newTask = AntTask.Foraging;
+        newSubTask = ForagingSubState.SearchingFood;
+        needForage -= 1;
+      } else if (needDig > 0) {
+        newTask = AntTask.Digging;
+        newSubTask = DiggingSubState.MovingToTile;
+        needDig -= 1;
+      } else if (needFight > 0) {
+        newTask = AntTask.Fighting;
+        newSubTask = FightingSubState.MovingToRally;
+        needFight -= 1;
+      } else if (needNurse > 0) {
+        newTask = AntTask.Nursing;
+        newSubTask = NursingSubState.MovingToBrood;
+        needNurse -= 1;
+      } else break; // no remaining under-represented targets; leave rest of eligibles in their current state
 
       // Decrement actual for the OLD task (so counts stay consistent), increment for new.
       const oldTask = world.ants.task[id]!;
-      if      (oldTask === AntTask.Foraging) actualForage -= 1;
-      else if (oldTask === AntTask.Digging)  actualDig    -= 1;
-      else if (oldTask === AntTask.Fighting) actualFight  -= 1;
-      else if (oldTask === AntTask.Nursing)  actualNurse  -= 1;
-      else                                   actualIdle   -= 1;
+      if (oldTask === AntTask.Foraging) actualForage -= 1;
+      else if (oldTask === AntTask.Digging) actualDig -= 1;
+      else if (oldTask === AntTask.Fighting) actualFight -= 1;
+      else if (oldTask === AntTask.Nursing) actualNurse -= 1;
+      else actualIdle -= 1;
 
-      world.ants.task[id]    = newTask;
+      world.ants.task[id] = newTask;
       world.ants.subTask[id] = newSubTask;
 
-      if      (newTask === AntTask.Foraging) actualForage += 1;
-      else if (newTask === AntTask.Digging)  actualDig    += 1;
-      else if (newTask === AntTask.Fighting) actualFight  += 1;
-      else if (newTask === AntTask.Nursing)  actualNurse  += 1;
+      if (newTask === AntTask.Foraging) actualForage += 1;
+      else if (newTask === AntTask.Digging) actualDig += 1;
+      else if (newTask === AntTask.Fighting) actualFight += 1;
+      else if (newTask === AntTask.Nursing) actualNurse += 1;
     }
 
     void actualIdle; // tracked for internal consistency; not exposed on ColonyRecord (Plan 03 removed idleCount)
 
     // (d) Final census write — true post-reassignment distribution (4 fields: PRD §2 WorkerAllocation).
     colony.taskCensus.forage = actualForage;
-    colony.taskCensus.dig    = actualDig;
-    colony.taskCensus.fight  = actualFight;
-    colony.taskCensus.nurse  = actualNurse;
+    colony.taskCensus.dig = actualDig;
+    colony.taskCensus.fight = actualFight;
+    colony.taskCensus.nurse = actualNurse;
   }
 
   // Step 10b: Phase 7 dig-worker state machine (Marked→BeingDug claim, BeingDug→Open countdown).
@@ -1166,8 +1210,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   // updateFightAntTargets so spider priority takes precedence over the rally point.
   // Colony identity is carried in world.spiderPriorityColonyId (not a
   // hard-coded player branch) — CLNY-08 compliant.
-  if (world.spiderPriorityColonyId !== null &&
-      world.spider !== null) {
+  if (world.spiderPriorityColonyId !== null && world.spider !== null) {
     const spiderPriorityCid = world.spiderPriorityColonyId;
     const spTileX = world.spider.posX >> FP_SHIFT;
     const spTileY = world.spider.posY >> FP_SHIFT;
@@ -1223,7 +1266,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       // Push ant away from reticle: target = ant_tile + (ant_tile - reticle_tile).
       let tx = ax + (ax - rx);
       // Exact on-reticle: push north if possible, south otherwise (edge guard).
-      let ty = (ay === ry && ax === rx) ? (ay > 0 ? ay - 1 : ay + 1) : ay + (ay - ry);
+      let ty = ay === ry && ax === rx ? (ay > 0 ? ay - 1 : ay + 1) : ay + (ay - ry);
       if (tx < 0) tx = 0;
       if (tx >= SURFACE_GRID_WIDTH) tx = SURFACE_GRID_WIDTH - 1;
       if (ty < 0) ty = 0;
@@ -1405,8 +1448,7 @@ function isFootprintReachableAfterDigs(
   const h = underground.height;
 
   const inFootprint = (x: number, y: number): boolean =>
-    x >= anchorTileX && x < anchorTileX + width &&
-    y >= anchorTileY && y < anchorTileY + height;
+    x >= anchorTileX && x < anchorTileX + width && y >= anchorTileY && y < anchorTileY + height;
 
   const isTraversable = (x: number, y: number): boolean => {
     if (x < 0 || y < 0 || x >= w || y >= h) return false;

--- a/src/sim/tile-key.ts
+++ b/src/sim/tile-key.ts
@@ -53,10 +53,8 @@ export function makeTileKey(
   tileY: number,
   gridColonyId: ColonyId = 0,
 ): number {
-  const gridByte = zone === Zone.Underground ? (gridColonyId & 0xff) : 0;
+  const gridByte = zone === Zone.Underground ? gridColonyId & 0xff : 0;
   return (
-    ((zone & 0xff) << 24) |
-    (gridByte << 16) |
-    ((tileY * TILE_KEY_STRIDE + tileX) & 0xffff)
-  ) | 0;
+    ((zone & 0xff) << 24) | (gridByte << 16) | ((tileY * TILE_KEY_STRIDE + tileX) & 0xffff) | 0
+  );
 }

--- a/src/sim/types.test.ts
+++ b/src/sim/types.test.ts
@@ -88,9 +88,23 @@ describe('WorldState', () => {
     it('Phase 6 init: ants has 17 Int32Arrays of length MAX_ENTITIES', () => {
       const world = createWorldState(42);
       const antFields = [
-        'posX', 'posY', 'colonyId', 'task', 'subTask',
-        'speed', 'foodCarrying', 'starvationTimer', 'age', 'alive', 'lifespan',
-        'zone', 'digTileX', 'digTileY', 'digTicksRemaining', 'targetPosX', 'targetPosY',
+        'posX',
+        'posY',
+        'colonyId',
+        'task',
+        'subTask',
+        'speed',
+        'foodCarrying',
+        'starvationTimer',
+        'age',
+        'alive',
+        'lifespan',
+        'zone',
+        'digTileX',
+        'digTileY',
+        'digTicksRemaining',
+        'targetPosX',
+        'targetPosY',
       ] as const;
       expect(antFields.length).toBe(17);
       for (const field of antFields) {
@@ -330,12 +344,12 @@ describe('WorldState', () => {
         // first capacity slots only) would drop history for ants past the
         // first slot. Write to two different ant slots at non-zero ring
         // indices to verify stride-correct copy.
-        const stride = RECENT_TILES_LEN;  // ant i's ring slots: [i*stride .. i*stride + stride - 1]
+        const stride = RECENT_TILES_LEN; // ant i's ring slots: [i*stride .. i*stride + stride - 1]
         // Sanity: confirm flat-array length matches capacity * stride.
         expect(src.ants.recentTilesX.length).toBe(src.ants.alive.length * stride);
-        src.ants.recentTilesX[0] = 7;             // ant 0, ring index 0
+        src.ants.recentTilesX[0] = 7; // ant 0, ring index 0
         src.ants.recentTilesY[0] = 8;
-        src.ants.recentTilesX[stride + 1] = 11;   // ant 1, ring index 1
+        src.ants.recentTilesX[stride + 1] = 11; // ant 1, ring index 1
         src.ants.recentTilesY[stride + 1] = 12;
         src.ants.recentTilesHead[0] = 1;
         src.ants.recentTilesHead[1] = 2;
@@ -385,7 +399,9 @@ describe('WorldState', () => {
       it('colony creation: dst gains colony with correct scalar fields after copy', () => {
         src.colonies[1] = createColonyRecord(1, 42);
         // Phase 3 PRD §2a caller-side init (required before copyWorldState reads these fields)
-        src.colonies[1]!.entrances = []; src.colonies[1]!.rallyPoint = null; src.colonies[1]!.digFlowFieldDirty = false;
+        src.colonies[1]!.entrances = [];
+        src.colonies[1]!.rallyPoint = null;
+        src.colonies[1]!.digFlowFieldDirty = false;
         src.colonies[1]!.foodStored = 500;
         copyWorldState(src, dst);
         expect(dst.colonies[1]).toBeDefined();
@@ -396,7 +412,9 @@ describe('WorldState', () => {
       it('colony deletion propagation: colony removed from src is removed from dst on next copy', () => {
         src.colonies[2] = createColonyRecord(2, 50);
         // Phase 3 PRD §2a caller-side init
-        src.colonies[2]!.entrances = []; src.colonies[2]!.rallyPoint = null; src.colonies[2]!.digFlowFieldDirty = false;
+        src.colonies[2]!.entrances = [];
+        src.colonies[2]!.rallyPoint = null;
+        src.colonies[2]!.digFlowFieldDirty = false;
         copyWorldState(src, dst);
         expect(dst.colonies[2]).toBeDefined();
         delete src.colonies[2];
@@ -407,7 +425,9 @@ describe('WorldState', () => {
       it('colony bucket arrays independence: workers array values copied but not same reference', () => {
         src.colonies[1] = createColonyRecord(1, 10);
         // Phase 3 PRD §2a caller-side init
-        src.colonies[1]!.entrances = []; src.colonies[1]!.rallyPoint = null; src.colonies[1]!.digFlowFieldDirty = false;
+        src.colonies[1]!.entrances = [];
+        src.colonies[1]!.rallyPoint = null;
+        src.colonies[1]!.digFlowFieldDirty = false;
         src.colonies[1]!.workers = [10, 20, 30];
         copyWorldState(src, dst);
         expect(dst.colonies[1]!.workers).toEqual([10, 20, 30]);
@@ -417,7 +437,9 @@ describe('WorldState', () => {
       it('nested plain-object reuse: targetRatio object identity preserved through copy (zero-alloc steady state)', () => {
         src.colonies[1] = createColonyRecord(1, 10);
         // Phase 3 PRD §2a caller-side init
-        src.colonies[1]!.entrances = []; src.colonies[1]!.rallyPoint = null; src.colonies[1]!.digFlowFieldDirty = false;
+        src.colonies[1]!.entrances = [];
+        src.colonies[1]!.rallyPoint = null;
+        src.colonies[1]!.digFlowFieldDirty = false;
         copyWorldState(src, dst);
         const beforeRatio = dst.colonies[1]!.targetRatio;
         // Mutate src ratio, then copy again
@@ -432,7 +454,9 @@ describe('WorldState', () => {
       it('taskCensus shape preserved through copy: 4 fields (nurse, forage, dig, fight) — no idle', () => {
         src.colonies[1] = createColonyRecord(1, 10);
         // Phase 3 PRD §2a caller-side init
-        src.colonies[1]!.entrances = []; src.colonies[1]!.rallyPoint = null; src.colonies[1]!.digFlowFieldDirty = false;
+        src.colonies[1]!.entrances = [];
+        src.colonies[1]!.rallyPoint = null;
+        src.colonies[1]!.digFlowFieldDirty = false;
         src.colonies[1]!.taskCensus = { nurse: 2, forage: 3, dig: 1, fight: 0 };
         copyWorldState(src, dst);
         const keys = Object.keys(dst.colonies[1]!.taskCensus).sort();
@@ -527,7 +551,13 @@ describe('WorldState', () => {
       });
 
       it('foodPiles: add pile to src, copy, verify dst has it', () => {
-        src.foodPiles.push({ foodPileId: 1, tileX: 10, tileY: 20 , pickupsRemaining: 50, pickupsInitial: 50});
+        src.foodPiles.push({
+          foodPileId: 1,
+          tileX: 10,
+          tileY: 20,
+          pickupsRemaining: 50,
+          pickupsInitial: 50,
+        });
         copyWorldState(src, dst);
         expect(dst.foodPiles.length).toBe(1);
         expect(dst.foodPiles[0]!.tileX).toBe(10);
@@ -535,8 +565,20 @@ describe('WorldState', () => {
       });
 
       it('foodPiles: shrink src array, copy, verify dst shrinks', () => {
-        src.foodPiles.push({ foodPileId: 1, tileX: 1, tileY: 1 , pickupsRemaining: 50, pickupsInitial: 50});
-        src.foodPiles.push({ foodPileId: 2, tileX: 2, tileY: 2 , pickupsRemaining: 50, pickupsInitial: 50});
+        src.foodPiles.push({
+          foodPileId: 1,
+          tileX: 1,
+          tileY: 1,
+          pickupsRemaining: 50,
+          pickupsInitial: 50,
+        });
+        src.foodPiles.push({
+          foodPileId: 2,
+          tileX: 2,
+          tileY: 2,
+          pickupsRemaining: 50,
+          pickupsInitial: 50,
+        });
         copyWorldState(src, dst);
         expect(dst.foodPiles.length).toBe(2);
         src.foodPiles.pop();
@@ -546,8 +588,11 @@ describe('WorldState', () => {
 
       it('issue #112: foodPile pickup-charge fields round-trip via copyWorldState', () => {
         src.foodPiles.push({
-          foodPileId: 1, tileX: 5, tileY: 5,
-          pickupsRemaining: 42, pickupsInitial: 99,
+          foodPileId: 1,
+          tileX: 5,
+          tileY: 5,
+          pickupsRemaining: 42,
+          pickupsInitial: 99,
         });
         copyWorldState(src, dst);
         expect(dst.foodPiles[0]!.pickupsRemaining).toBe(42);
@@ -586,14 +631,28 @@ describe('WorldState', () => {
       });
 
       it('pendingChambers: add entry by key, copy, verify dst has it', () => {
-        src.pendingChambers['1:5:10'] = { colonyId: 1, chamberType: 0, anchorTileX: 5, anchorTileY: 10, width: 5, height: 3 };
+        src.pendingChambers['1:5:10'] = {
+          colonyId: 1,
+          chamberType: 0,
+          anchorTileX: 5,
+          anchorTileY: 10,
+          width: 5,
+          height: 3,
+        };
         copyWorldState(src, dst);
         expect(dst.pendingChambers['1:5:10']).toBeDefined();
         expect(dst.pendingChambers['1:5:10']!.anchorTileX).toBe(5);
       });
 
       it('pendingChambers: remove entry from src, copy, verify dst entry removed', () => {
-        src.pendingChambers['1:5:10'] = { colonyId: 1, chamberType: 0, anchorTileX: 5, anchorTileY: 10, width: 5, height: 3 };
+        src.pendingChambers['1:5:10'] = {
+          colonyId: 1,
+          chamberType: 0,
+          anchorTileX: 5,
+          anchorTileY: 10,
+          width: 5,
+          height: 3,
+        };
         copyWorldState(src, dst);
         expect(dst.pendingChambers['1:5:10']).toBeDefined();
         delete src.pendingChambers['1:5:10'];
@@ -626,7 +685,9 @@ describe('WorldState', () => {
 
       it('copies colony.entrances: add entrance to src colony, copy, verify', () => {
         src.colonies[1] = createColonyRecord(1, 42);
-        src.colonies[1]!.entrances = [{ entranceId: 1, surfaceTileX: 10, surfaceTileY: 64, isOpen: true }];
+        src.colonies[1]!.entrances = [
+          { entranceId: 1, surfaceTileX: 10, surfaceTileY: 64, isOpen: true },
+        ];
         src.colonies[1]!.rallyPoint = null;
         src.colonies[1]!.digFlowFieldDirty = false;
         copyWorldState(src, dst);
@@ -697,7 +758,12 @@ describe('WorldState', () => {
         src.colonies[1]!.rallyPoint = null;
         src.colonies[1]!.digFlowFieldDirty = false;
         copyWorldState(src, dst);
-        dst.colonies[1]!.entrances.push({ entranceId: 99, surfaceTileX: 50, surfaceTileY: 64, isOpen: false });
+        dst.colonies[1]!.entrances.push({
+          entranceId: 99,
+          surfaceTileX: 50,
+          surfaceTileY: 64,
+          isOpen: false,
+        });
         expect(src.colonies[1]!.entrances.length).toBe(0);
       });
 
@@ -739,7 +805,6 @@ describe('WorldState', () => {
         expect(dst.colonies[1]!.priorityFoodPileId).toBeNull();
       });
     });
-
   }); // end describe('copyWorldState')
 
   describe('allocateEntityId', () => {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -308,16 +308,10 @@ export const SIM_VERSION_V23_SPIDER_AGGRO = 23 as const;
 export const SIM_VERSION_V24_NURSERY_CAPACITY = 24 as const;
 export const LATEST_SIM_VERSION = SIM_VERSION_V24_NURSERY_CAPACITY;
 
-
 /**
  * S2 — AI colony state machine states.
  */
-export type AIState =
-  | 'Peacetime'
-  | 'WarFooting'
-  | 'Probing'
-  | 'Invading'
-  | 'Recovery';
+export type AIState = 'Peacetime' | 'WarFooting' | 'Probing' | 'Invading' | 'Recovery';
 
 /**
  * S2 — Per-AI-colony state record. Lives in WorldState.aiState[].
@@ -336,45 +330,45 @@ export type SpiderBehaviorState =
 /** S3 — Single neutral spider entity. Lives in WorldState.spider (null if not in scenario). */
 export interface SpiderState {
   state: SpiderBehaviorState;
-  posX: number;                    // fixed-point (FP_SHIFT=8)
+  posX: number; // fixed-point (FP_SHIFT=8)
   posY: number;
-  lairTileX: number;               // integer tile coords
+  lairTileX: number; // integer tile coords
   lairTileY: number;
   territoryRadiusTiles: number;
   hp: number;
   attackCooldown: number;
-  hungerTicks: number;             // accrues only while state !== 'Feeding'
+  hungerTicks: number; // accrues only while state !== 'Feeding'
   nextHuntTick: number;
   huntStartTick: number;
   strikeStartTick: number;
   feedingStartTick: number;
   retreatStartTick: number;
-  rampageStartTick: number;          // tick at which current Rampaging episode began
+  rampageStartTick: number; // tick at which current Rampaging episode began
   huntTargetTileX: number;
   huntTargetTileY: number;
   killsThisStrike: number;
   rampageKillsThisRampage: number;
-  rampageTargetColonyId: number;  // colony targeted for current rampage; -1 when not rampaging
-  chaseTargetAntId: number;       // V23: ant id being chased; -1 when not Chasing
-  chaseStartTick: number;         // V23: tick the current chase began (leash-timeout reference)
-  killedThisTick: number;         // V23: 0/1 flag set by combat (step 17), consumed by tickSpider (17.5); never persists as 1
-  lastKillTileX: number;          // V23: tile of the most recent kill (= spider tile); -1 default
+  rampageTargetColonyId: number; // colony targeted for current rampage; -1 when not rampaging
+  chaseTargetAntId: number; // V23: ant id being chased; -1 when not Chasing
+  chaseStartTick: number; // V23: tick the current chase began (leash-timeout reference)
+  killedThisTick: number; // V23: 0/1 flag set by combat (step 17), consumed by tickSpider (17.5); never persists as 1
+  lastKillTileX: number; // V23: tile of the most recent kill (= spider tile); -1 default
   lastKillTileY: number;
-  feedAwayTileX: number;          // V23: ~10-tile feed destination after a kill; -1 default
+  feedAwayTileX: number; // V23: ~10-tile feed destination after a kill; -1 default
   feedAwayTileY: number;
-  feedArrivedTick: number;        // V23: tick the spider reached feedAwayTile (heal-window clock); -1 while traveling
+  feedArrivedTick: number; // V23: tick the spider reached feedAwayTile (heal-window clock); -1 while traveling
 }
 
 export interface AIStateRecord {
   colonyId: ColonyId;
   state: AIState;
-  enteredTick: number;             // tick at which the current state was entered
-  probeCount: number;              // probes fired since last Peacetime
-  lastProbeEndTick: number;        // for spacing between probes
-  invasionStartTick: number;       // 0 if not Invading
-  invasionRallyTileX: number;      // -1 if no active rally; integer tile coords
+  enteredTick: number; // tick at which the current state was entered
+  probeCount: number; // probes fired since last Peacetime
+  lastProbeEndTick: number; // for spacing between probes
+  invasionStartTick: number; // 0 if not Invading
+  invasionRallyTileX: number; // -1 if no active rally; integer tile coords
   invasionRallyTileY: number;
-  recoveryEndTick: number;         // 0 if not in Recovery
+  recoveryEndTick: number; // 0 if not in Recovery
 
   // Committed-force operation tracking (CF-P0-005)
   operationKind: 'None' | 'Probe' | 'Invasion';
@@ -382,16 +376,16 @@ export interface AIStateRecord {
   operationTargetTileX: number;
   operationTargetTileY: number;
   operationFighterIds: Int32Array; // committed cohort, fixed-length buffer (AI_MAX_OPERATION_FIGHTERS=32), padded with -1
-  operationFighterCount: number;   // active length of operationFighterIds
+  operationFighterCount: number; // active length of operationFighterIds
   operationStartFighterCount: number;
   operationAttackerDeaths: number;
   operationDefenderDeaths: number;
 }
 
 export interface WorldState {
-  tick: number;             // 0 at creation; incremented once per tick
-  rngState: number;         // Mulberry32 state (uint32); initialized from seed
-  nextEntityId: EntityId;   // starts at 0 (PRD §3); allocateEntityId returns current and post-increments
+  tick: number; // 0 at creation; incremented once per tick
+  rngState: number; // Mulberry32 state (uint32); initialized from seed
+  nextEntityId: EntityId; // starts at 0 (PRD §3); allocateEntityId returns current and post-increments
   commandQueue: SimCommand[]; // staging seam — drained by platform accumulator between ticks
 
   /**
@@ -495,14 +489,14 @@ export interface WorldState {
   terrainSeed: number;
 
   // Phase 6 additions (PRD §3):
-  ants: AntComponents;                          // SoA ant component storage — 17 parallel Int32Arrays
-  colonies: Record<ColonyId, ColonyRecord>;     // per-colony state keyed by integer ColonyId
+  ants: AntComponents; // SoA ant component storage — 17 parallel Int32Arrays
+  colonies: Record<ColonyId, ColonyRecord>; // per-colony state keyed by integer ColonyId
   pheromoneGrids: Record<string, PheromoneGrid>; // pheromone intensity grids keyed by pheromoneGridKey()
 
   // Phase 7 additions (PRD §2e):
-  surface: SurfaceGrid;                                    // shared surface terrain (SURF-01)
-  undergroundGrids: Record<ColonyId, UndergroundGrid>;     // per-colony underground (UNDR-08)
-  foodPiles: FoodPile[];                                   // surface food sources (SURF-02 + issue #112 depletion/respawn)
+  surface: SurfaceGrid; // shared surface terrain (SURF-01)
+  undergroundGrids: Record<ColonyId, UndergroundGrid>; // per-colony underground (UNDR-08)
+  foodPiles: FoodPile[]; // surface food sources (SURF-02 + issue #112 depletion/respawn)
 
   /**
    * Issue #112 — Bounded record of recently-depleted food-pile tiles, used by
@@ -513,7 +507,7 @@ export interface WorldState {
    */
   recentlyDepletedFood: DepletionRecord[];
 
-  pendingChambers: Record<string, PendingChamber>;         // keyed by `${colonyId}:${anchorTileX}:${anchorTileY}` (PRD §2d)
+  pendingChambers: Record<string, PendingChamber>; // keyed by `${colonyId}:${anchorTileX}:${anchorTileY}` (PRD §2d)
 
   // S0b — playtrace telemetry (ADR-0013 v2 / D-31 / D-34).
   // events: accumulated this session; NOT serialized to saves (transient —
@@ -570,7 +564,7 @@ export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIE
   return {
     tick: 0,
     rngState: seedU32,
-    nextEntityId: 0,      // PRD §3 line 130: starts at 0, no recycling
+    nextEntityId: 0, // PRD §3 line 130: starts at 0, no recycling
     commandQueue: [],
     simVersion: LATEST_SIM_VERSION,
     difficulty: 'Normal',
@@ -586,8 +580,8 @@ export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIE
     surface: createSurfaceGrid(SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT),
     undergroundGrids: {},
     foodPiles: [],
-    recentlyDepletedFood: [],   // issue #112 — empty until first depletion
-    pendingChambers: {},    // empty Record; PlaceChamberCommand creates entries
+    recentlyDepletedFood: [], // issue #112 — empty until first depletion
+    pendingChambers: {}, // empty Record; PlaceChamberCommand creates entries
     // S0b — telemetry fields.
     events: [],
     droppedCombatKillCount: 0,
@@ -816,29 +810,29 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
       dst.colonies[colonyId] = createColonyRecord(s.colonyId, s.queenEntityId);
       // Phase 3 PRD §2a caller-side extension defaults (factory does not set these):
       const fresh = dst.colonies[colonyId]!;
-      fresh.entrances         = [];
-      fresh.rallyPoint        = null;
+      fresh.entrances = [];
+      fresh.rallyPoint = null;
       fresh.digFlowFieldDirty = false;
       fresh.foodFlowFieldDirty = false;
-      fresh.killCount         = 0;
+      fresh.killCount = 0;
       fresh.priorityFoodPileId = null;
     }
     const d = dst.colonies[colonyId]!;
 
     // Scalar fields — direct assignment
-    d.colonyId             = s.colonyId;
-    d.queenEntityId        = s.queenEntityId;
+    d.colonyId = s.colonyId;
+    d.queenEntityId = s.queenEntityId;
     d.queenStarvationTimer = s.queenStarvationTimer;
-    d.foodStored           = s.foodStored;
-    d.workerCount          = s.workerCount;
-    d.eggCount             = s.eggCount;
-    d.larvaeCount          = s.larvaeCount;
-    d.nurseCount           = s.nurseCount;
-    d.defeated             = s.defeated;
-    d.reconcileCountdown   = s.reconcileCountdown;
-    d.killCount            = s.killCount;
-    d.priorityFoodPileId   = s.priorityFoodPileId;
-    d.queenLastEggTick     = s.queenLastEggTick;
+    d.foodStored = s.foodStored;
+    d.workerCount = s.workerCount;
+    d.eggCount = s.eggCount;
+    d.larvaeCount = s.larvaeCount;
+    d.nurseCount = s.nurseCount;
+    d.defeated = s.defeated;
+    d.reconcileCountdown = s.reconcileCountdown;
+    d.killCount = s.killCount;
+    d.priorityFoodPileId = s.priorityFoodPileId;
+    d.queenLastEggTick = s.queenLastEggTick;
     d.eggIntervalNumerator = s.eggIntervalNumerator;
 
     // Bucket arrays — reuse via length truncation + index copy (no new array)
@@ -874,18 +868,18 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
     // Nested plain-object fields — field-by-field copy (NOT spread — preserves object identity)
     // Phase 10 (CTRL-01'): targetRatio is two-field {forage, fight}. WorkerAllocation
     // (computedAllocation, taskCensus) keeps its `dig` slot per D-03 — auto-dig writes it.
-    d.targetRatio.forage           = s.targetRatio.forage;
-    d.targetRatio.fight            = s.targetRatio.fight;
+    d.targetRatio.forage = s.targetRatio.forage;
+    d.targetRatio.fight = s.targetRatio.fight;
 
-    d.computedAllocation.nurse     = s.computedAllocation.nurse;
-    d.computedAllocation.forage    = s.computedAllocation.forage;
-    d.computedAllocation.dig       = s.computedAllocation.dig;
-    d.computedAllocation.fight     = s.computedAllocation.fight;
+    d.computedAllocation.nurse = s.computedAllocation.nurse;
+    d.computedAllocation.forage = s.computedAllocation.forage;
+    d.computedAllocation.dig = s.computedAllocation.dig;
+    d.computedAllocation.fight = s.computedAllocation.fight;
 
-    d.taskCensus.nurse             = s.taskCensus.nurse;
-    d.taskCensus.forage            = s.taskCensus.forage;
-    d.taskCensus.dig               = s.taskCensus.dig;
-    d.taskCensus.fight             = s.taskCensus.fight;
+    d.taskCensus.nurse = s.taskCensus.nurse;
+    d.taskCensus.forage = s.taskCensus.forage;
+    d.taskCensus.dig = s.taskCensus.dig;
+    d.taskCensus.fight = s.taskCensus.fight;
 
     // Phase 3 extension fields — typed copies (no `as any` — fields are required on interface)
 
@@ -966,7 +960,8 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   }
 
   // --- Issue #112: recentlyDepletedFood — length-adjust + field-by-field copy ---
-  while (dst.recentlyDepletedFood.length > src.recentlyDepletedFood.length) dst.recentlyDepletedFood.pop();
+  while (dst.recentlyDepletedFood.length > src.recentlyDepletedFood.length)
+    dst.recentlyDepletedFood.pop();
   for (let i = 0; i < src.recentlyDepletedFood.length; i++) {
     if (i < dst.recentlyDepletedFood.length) {
       Object.assign(dst.recentlyDepletedFood[i]!, src.recentlyDepletedFood[i]!);

--- a/tests/menu-and-dialog.spec.ts
+++ b/tests/menu-and-dialog.spec.ts
@@ -15,7 +15,9 @@ async function bootGame(page: Page): Promise<void> {
   await page.locator('canvas').first().waitFor({ state: 'attached' });
   // Wait until the ready event has fired and the boot has dispatched —
   // SavePrompt or Playing. window.__phase9_ui is published by setActiveOverlay.
-  await page.waitForFunction(() => typeof (window as { __phase9_ui?: unknown }).__phase9_ui !== 'undefined');
+  await page.waitForFunction(
+    () => typeof (window as { __phase9_ui?: unknown }).__phase9_ui !== 'undefined',
+  );
   // Clear any prior save so we always boot into Playing (no SavePrompt).
   await page.evaluate(() => localStorage.removeItem('subterrans:save:v3'));
   await page.reload();
@@ -34,7 +36,9 @@ async function activeOverlay(page: Page): Promise<string> {
 }
 
 test.describe('Issue #116 — Esc opens / closes pause menu', () => {
-  test('Esc on a clean canvas opens the pause menu (single press, not racing closed)', async ({ page }) => {
+  test('Esc on a clean canvas opens the pause menu (single press, not racing closed)', async ({
+    page,
+  }) => {
     await bootGame(page);
     expect(await activeOverlay(page)).toBe('none');
 
@@ -58,7 +62,9 @@ test.describe('Issue #116 — Esc opens / closes pause menu', () => {
     expect(await activeOverlay(page)).toBe('none');
   });
 
-  test('opening the menu pauses the game loop (no tick advances while menu is up)', async ({ page }) => {
+  test('opening the menu pauses the game loop (no tick advances while menu is up)', async ({
+    page,
+  }) => {
     await bootGame(page);
     // Take two tick samples ~200ms apart with the menu OPEN; they should match.
     await page.keyboard.press('Escape');
@@ -84,14 +90,18 @@ test.describe('Issue #116 — Esc opens / closes pause menu', () => {
 });
 
 test.describe('Issue #115/#116 — single click triggers single dispatch', () => {
-  test('clicking the pheromone toggle once flips the persisted setting once (not twice → no-op)', async ({ page }) => {
+  test('clicking the pheromone toggle once flips the persisted setting once (not twice → no-op)', async ({
+    page,
+  }) => {
     await bootGame(page);
     // Default pheromoneOverlay is true.
     const before = await page.evaluate(() => {
       try {
         const raw = localStorage.getItem('subterrans:settings:v1');
         return raw === null ? true : (JSON.parse(raw).settings?.pheromoneOverlay ?? true);
-      } catch { return true; }
+      } catch {
+        return true;
+      }
     });
     expect(before).toBe(true);
 
@@ -104,8 +114,12 @@ test.describe('Issue #115/#116 — single click triggers single dispatch', () =>
     // is 320×40 with 10px gap, stacked centered. We compute the rect to click.
     const settingsRect = await page.evaluate(() => {
       // Mirror pauseMenuItems('main', ...) layout for index=2 (Settings).
-      const CANVAS_W = 800, CANVAS_H = 592;
-      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const CANVAS_W = 800,
+        CANVAS_H = 592;
+      const BTN_W = 320,
+        BTN_H = 40,
+        GAP = 10,
+        TITLE_H = 56;
       const n = 4; // resume, save-load, settings, debug-snapshot
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
@@ -118,8 +132,12 @@ test.describe('Issue #115/#116 — single click triggers single dispatch', () =>
 
     // Settings sub-screen has 3 items: pheromone-toggle, speed-cycle, back.
     const toggleRect = await page.evaluate(() => {
-      const CANVAS_W = 800, CANVAS_H = 592;
-      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const CANVAS_W = 800,
+        CANVAS_H = 592;
+      const BTN_W = 320,
+        BTN_H = 40,
+        GAP = 10,
+        TITLE_H = 56;
       const n = 3;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
@@ -172,7 +190,9 @@ test.describe('Issue #114 — P key toggles pheromone overlay', () => {
 });
 
 test.describe('Round-2 review — overlay observability stays coherent across transitions', () => {
-  test('Save/Load → Esc back to pause menu does NOT briefly publish activeOverlay = none', async ({ page }) => {
+  test('Save/Load → Esc back to pause menu does NOT briefly publish activeOverlay = none', async ({
+    page,
+  }) => {
     await bootGame(page);
     await page.keyboard.press('Escape');
     await page.waitForTimeout(100);
@@ -180,8 +200,12 @@ test.describe('Round-2 review — overlay observability stays coherent across tr
 
     // Open Save/Load (button index 1).
     const saveLoadRect = await page.evaluate(() => {
-      const CANVAS_W = 800, CANVAS_H = 592;
-      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const CANVAS_W = 800,
+        CANVAS_H = 592;
+      const BTN_W = 320,
+        BTN_H = 40,
+        GAP = 10,
+        TITLE_H = 56;
       const n = 4;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
@@ -214,14 +238,18 @@ test.describe('Round-2 review — overlay observability stays coherent across tr
 });
 
 test.describe('Round-2 review — keybinds gated on Playing phase', () => {
-  test('P pressed while pause menu is open does NOT flip the persisted setting', async ({ page }) => {
+  test('P pressed while pause menu is open does NOT flip the persisted setting', async ({
+    page,
+  }) => {
     await bootGame(page);
     // Verify default
     const before = await page.evaluate(() => {
       try {
         const raw = localStorage.getItem('subterrans:settings:v1');
         return raw === null ? true : (JSON.parse(raw).settings?.pheromoneOverlay ?? true);
-      } catch { return true; }
+      } catch {
+        return true;
+      }
     });
     expect(before).toBe(true);
 
@@ -238,7 +266,9 @@ test.describe('Round-2 review — keybinds gated on Playing phase', () => {
       try {
         const raw = localStorage.getItem('subterrans:settings:v1');
         return raw === null ? true : (JSON.parse(raw).settings?.pheromoneOverlay ?? true);
-      } catch { return true; }
+      } catch {
+        return true;
+      }
     });
     expect(after).toBe(true);
   });
@@ -253,8 +283,12 @@ test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () =>
 
     // Save/Load is the 2nd button (index 1) in the main menu.
     const saveLoadRect = await page.evaluate(() => {
-      const CANVAS_W = 800, CANVAS_H = 592;
-      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const CANVAS_W = 800,
+        CANVAS_H = 592;
+      const BTN_W = 320,
+        BTN_H = 40,
+        GAP = 10,
+        TITLE_H = 56;
       const n = 4;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
@@ -267,7 +301,9 @@ test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () =>
     expect(await activeOverlay(page)).toBe('save-load');
   });
 
-  test('clicking Delete once on a fresh save arms the confirm; second click commits (no one-click destruction)', async ({ page }) => {
+  test('clicking Delete once on a fresh save arms the confirm; second click commits (no one-click destruction)', async ({
+    page,
+  }) => {
     await bootGame(page);
     // Manually populate localStorage with a fresh save so Delete is enabled.
     await page.evaluate(() => {
@@ -276,11 +312,31 @@ test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () =>
         seed: 1,
         inputLog: [],
         snapshot: {
-          tick: 1, rngState: 1, nextEntityId: 0, commandQueue: [],
-          ants: { count: 0, posX: [], posY: [], colonyId: [], task: [], subTask: [],
-                  speed: [], foodCarrying: [], starvationTimer: [], age: [], alive: [],
-                  lifespan: [], zone: [], digTileX: [], digTileY: [], digTicksRemaining: [],
-                  targetPosX: [], targetPosY: [], targetSet: [] },
+          tick: 1,
+          rngState: 1,
+          nextEntityId: 0,
+          commandQueue: [],
+          ants: {
+            count: 0,
+            posX: [],
+            posY: [],
+            colonyId: [],
+            task: [],
+            subTask: [],
+            speed: [],
+            foodCarrying: [],
+            starvationTimer: [],
+            age: [],
+            alive: [],
+            lifespan: [],
+            zone: [],
+            digTileX: [],
+            digTileY: [],
+            digTicksRemaining: [],
+            targetPosX: [],
+            targetPosY: [],
+            targetSet: [],
+          },
           colonies: {},
           pheromoneGrids: {},
           surface: { width: 1, height: 1, data: [0] },
@@ -300,7 +356,10 @@ test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () =>
     });
     // Boot lands on SavePrompt — click Continue to enter Playing.
     // SAVE_PROMPT_CONTINUE_RECT = { x: 300, y: 280, w: 120, h: 32 }
-    await page.locator('canvas').first().click({ position: { x: 360, y: 296 } });
+    await page
+      .locator('canvas')
+      .first()
+      .click({ position: { x: 360, y: 296 } });
     await page.waitForTimeout(150);
     // (Continue may fall back to bootFresh on the synthetic envelope —
     // either way we're now in Playing without a SavePrompt.)
@@ -315,7 +374,45 @@ test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () =>
     await page.evaluate(() => {
       const raw = localStorage.getItem('subterrans:save:v3');
       if (raw === null) {
-        const env = { version: 3, seed: 1, inputLog: [], snapshot: { tick: 1, rngState: 1, nextEntityId: 0, commandQueue: [], ants: { count: 0, posX: [], posY: [], colonyId: [], task: [], subTask: [], speed: [], foodCarrying: [], starvationTimer: [], age: [], alive: [], lifespan: [], zone: [], digTileX: [], digTileY: [], digTicksRemaining: [], targetPosX: [], targetPosY: [], targetSet: [] }, colonies: {}, pheromoneGrids: {}, surface: { width: 1, height: 1, data: [0] }, undergroundGrids: {}, foodPiles: [], pendingChambers: {} }, savedAtMs: Date.now() };
+        const env = {
+          version: 3,
+          seed: 1,
+          inputLog: [],
+          snapshot: {
+            tick: 1,
+            rngState: 1,
+            nextEntityId: 0,
+            commandQueue: [],
+            ants: {
+              count: 0,
+              posX: [],
+              posY: [],
+              colonyId: [],
+              task: [],
+              subTask: [],
+              speed: [],
+              foodCarrying: [],
+              starvationTimer: [],
+              age: [],
+              alive: [],
+              lifespan: [],
+              zone: [],
+              digTileX: [],
+              digTileY: [],
+              digTicksRemaining: [],
+              targetPosX: [],
+              targetPosY: [],
+              targetSet: [],
+            },
+            colonies: {},
+            pheromoneGrids: {},
+            surface: { width: 1, height: 1, data: [0] },
+            undergroundGrids: {},
+            foodPiles: [],
+            pendingChambers: {},
+          },
+          savedAtMs: Date.now(),
+        };
         localStorage.setItem('subterrans:save:v3', JSON.stringify(env));
       }
     });
@@ -325,7 +422,10 @@ test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () =>
     await page.waitForTimeout(100);
     expect(await activeOverlay(page)).toBe('pause-menu');
     // Save/Load row.
-    await page.locator('canvas').first().click({ position: { x: 400, y: 312 } });
+    await page
+      .locator('canvas')
+      .first()
+      .click({ position: { x: 400, y: 312 } });
     await page.waitForTimeout(150);
     expect(await activeOverlay(page)).toBe('save-load');
 
@@ -335,13 +435,19 @@ test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () =>
     const deleteX = (800 - 280) / 2 + 280 / 2;
 
     // First click — arms confirm (save still present).
-    await page.locator('canvas').first().click({ position: { x: deleteX, y: deleteY } });
+    await page
+      .locator('canvas')
+      .first()
+      .click({ position: { x: deleteX, y: deleteY } });
     await page.waitForTimeout(150);
     const stillThere = await page.evaluate(() => localStorage.getItem('subterrans:save:v3'));
     expect(stillThere).not.toBeNull();
 
     // Second click — commits delete.
-    await page.locator('canvas').first().click({ position: { x: deleteX, y: deleteY } });
+    await page
+      .locator('canvas')
+      .first()
+      .click({ position: { x: deleteX, y: deleteY } });
     await page.waitForTimeout(150);
     const gone = await page.evaluate(() => localStorage.getItem('subterrans:save:v3'));
     expect(gone).toBeNull();
@@ -349,13 +455,17 @@ test.describe('Issue #115 — Save/Load dialog reachable from pause menu', () =>
 });
 
 test.describe('Round-6 (Codex P2) — pheromone toggle survives degraded storage', () => {
-  test('menu-clicked toggle keeps alternating when localStorage.setItem is blocked', async ({ page }) => {
+  test('menu-clicked toggle keeps alternating when localStorage.setItem is blocked', async ({
+    page,
+  }) => {
     await bootGame(page);
 
     // Simulate quota-exceeded / private-mode: setItem throws. Reading is
     // unaffected — only the write path is blocked.
     await page.evaluate(() => {
-      window.localStorage.setItem = () => { throw new Error('QuotaExceeded (simulated)'); };
+      window.localStorage.setItem = () => {
+        throw new Error('QuotaExceeded (simulated)');
+      };
     });
 
     // Open pause menu → Settings sub-page. Stay there for the entire test
@@ -364,8 +474,12 @@ test.describe('Round-6 (Codex P2) — pheromone toggle survives degraded storage
     await page.keyboard.press('Escape');
     await page.waitForTimeout(100);
     const settingsRect = await page.evaluate(() => {
-      const CANVAS_W = 800, CANVAS_H = 592;
-      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const CANVAS_W = 800,
+        CANVAS_H = 592;
+      const BTN_W = 320,
+        BTN_H = 40,
+        GAP = 10,
+        TITLE_H = 56;
       const n = 4;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
@@ -378,8 +492,12 @@ test.describe('Round-6 (Codex P2) — pheromone toggle survives degraded storage
 
     // Pheromone toggle is index 0 on the Settings sub-page.
     const toggleClickPos = await page.evaluate(() => {
-      const CANVAS_W = 800, CANVAS_H = 592;
-      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const CANVAS_W = 800,
+        CANVAS_H = 592;
+      const BTN_W = 320,
+        BTN_H = 40,
+        GAP = 10,
+        TITLE_H = 56;
       const n = 3;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
@@ -409,9 +527,9 @@ test.describe('Round-6 (Codex P2) — pheromone toggle survives degraded storage
     // recomputes from DEFAULT_SETTINGS = {pheromoneOverlay: true}, so the
     // label always ends at "OFF" after the first click and never flips
     // back. Post-fix: in-mem state alternates regardless of storage.
-    expect(before.equals(afterOne)).toBe(false);       // 1 click changed it
-    expect(afterOne.equals(afterTwo)).toBe(false);     // 2nd click changed it back
-    expect(before.equals(afterTwo)).toBe(true);        // round trip
+    expect(before.equals(afterOne)).toBe(false); // 1 click changed it
+    expect(afterOne.equals(afterTwo)).toBe(false); // 2nd click changed it back
+    expect(before.equals(afterTwo)).toBe(true); // round trip
   });
 });
 
@@ -423,8 +541,12 @@ test.describe('Settings — Speed cycle row (UAT)', () => {
     await page.keyboard.press('Escape');
     await page.waitForTimeout(100);
     const settingsRect = await page.evaluate(() => {
-      const CANVAS_W = 800, CANVAS_H = 592;
-      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const CANVAS_W = 800,
+        CANVAS_H = 592;
+      const BTN_W = 320,
+        BTN_H = 40,
+        GAP = 10,
+        TITLE_H = 56;
       const n = 4;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
@@ -438,8 +560,12 @@ test.describe('Settings — Speed cycle row (UAT)', () => {
     // On Settings page: [pheromone-toggle (i=0), speed-cycle (i=1), back (i=2)].
     // Compute rect for i=1.
     const speedRect = await page.evaluate(() => {
-      const CANVAS_W = 800, CANVAS_H = 592;
-      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const CANVAS_W = 800,
+        CANVAS_H = 592;
+      const BTN_W = 320,
+        BTN_H = 40,
+        GAP = 10,
+        TITLE_H = 56;
       const n = 3;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
@@ -453,9 +579,12 @@ test.describe('Settings — Speed cycle row (UAT)', () => {
     // baseline — only sanity-checking that consecutive clicks change the
     // rendered text region (any change suffices: 1×→2×→4× all differ).
     const sampleLabel = async () => {
-      return await page.locator('canvas').first().screenshot({
-        clip: { x: speedRect.x - 60, y: speedRect.y - 8, width: 120, height: 16 },
-      });
+      return await page
+        .locator('canvas')
+        .first()
+        .screenshot({
+          clip: { x: speedRect.x - 60, y: speedRect.y - 8, width: 120, height: 16 },
+        });
     };
 
     const at1x = await sampleLabel();
@@ -525,7 +654,9 @@ test.describe('Pheromone overlay actually renders (UAT P1 — pre-existing draw-
 });
 
 test.describe('Round-5 (Codex P1) — Save Now respects autosaveSuspended', () => {
-  test('Save Now is a no-op when bootFromSave preserved a future-build save (does NOT overwrite the recoverable bytes)', async ({ page }) => {
+  test('Save Now is a no-op when bootFromSave preserved a future-build save (does NOT overwrite the recoverable bytes)', async ({
+    page,
+  }) => {
     // Bootstrap: populate localStorage with a future-sim save BEFORE the
     // page loads. bootFromSave will deserialize, catch FutureSimVersionError,
     // and set autosaveSuspended = true. We then verify Save Now refuses to
@@ -557,10 +688,26 @@ test.describe('Round-5 (Codex P1) — Save Now respects autosaveSuspended', () =
           nextEntityId: 0,
           simVersion: 99999, // > LATEST → FutureSimVersionError on bootFromSave
           commandQueue: [],
-          ants: { count: 0, posX: [], posY: [], colonyId: [], task: [], subTask: [],
-                  speed: [], foodCarrying: [], starvationTimer: [], age: [], alive: [],
-                  lifespan: [], zone: [], digTileX: [], digTileY: [], digTicksRemaining: [],
-                  targetPosX: [], targetPosY: [] },
+          ants: {
+            count: 0,
+            posX: [],
+            posY: [],
+            colonyId: [],
+            task: [],
+            subTask: [],
+            speed: [],
+            foodCarrying: [],
+            starvationTimer: [],
+            age: [],
+            alive: [],
+            lifespan: [],
+            zone: [],
+            digTileX: [],
+            digTileY: [],
+            digTicksRemaining: [],
+            targetPosX: [],
+            targetPosY: [],
+          },
           colonies: {},
           pheromoneGrids: {},
           surface: { width: 1, height: 1, data: [0] },
@@ -577,16 +724,22 @@ test.describe('Round-5 (Codex P1) — Save Now respects autosaveSuspended', () =
     // Reload — boot path now sees the future-sim save, SavePrompt shows.
     await page.reload();
     await page.locator('canvas').first().waitFor({ state: 'attached' });
-    await page.waitForFunction(() => {
-      const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
-      return ui !== undefined && ui.activeOverlay === 'save-prompt';
-    }, { timeout: 5_000 });
+    await page.waitForFunction(
+      () => {
+        const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
+        return ui !== undefined && ui.activeOverlay === 'save-prompt';
+      },
+      { timeout: 5_000 },
+    );
 
     // Click Continue → bootFromSave → catches FutureSimVersionError →
     // bootFresh + autosaveSuspended = true. The preserved bytes stay in
     // localStorage; the running game is now a fresh scenario.
     // SAVE_PROMPT_CONTINUE_RECT = { x: 300, y: 280, w: 120, h: 32 }
-    await page.locator('canvas').first().click({ position: { x: 360, y: 296 } });
+    await page
+      .locator('canvas')
+      .first()
+      .click({ position: { x: 360, y: 296 } });
     await page.waitForFunction(() => {
       const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
       return ui !== undefined && ui.activeOverlay === 'none';
@@ -600,8 +753,12 @@ test.describe('Round-5 (Codex P1) — Save Now respects autosaveSuspended', () =
     await page.keyboard.press('Escape');
     await page.waitForTimeout(100);
     const saveLoadRect = await page.evaluate(() => {
-      const CANVAS_W = 800, CANVAS_H = 592;
-      const BTN_W = 320, BTN_H = 40, GAP = 10, TITLE_H = 56;
+      const CANVAS_W = 800,
+        CANVAS_H = 592;
+      const BTN_W = 320,
+        BTN_H = 40,
+        GAP = 10,
+        TITLE_H = 56;
       const n = 4;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
@@ -611,13 +768,20 @@ test.describe('Round-5 (Codex P1) — Save Now respects autosaveSuspended', () =
     });
     await page.locator('canvas').first().click({ position: saveLoadRect });
     await page.waitForTimeout(150);
-    expect(await page.evaluate(() => (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui?.activeOverlay)).toBe('save-load');
+    expect(
+      await page.evaluate(
+        () => (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui?.activeOverlay,
+      ),
+    ).toBe('save-load');
 
     // Click Save Now (button index 1 in the dialog, BTN_W=280, BTN_H=36, GAP=8).
     // firstY = DIALOG_INFO_Y(152) + DIALOG_INFO_TO_BUTTONS_GAP(24) = 176.
     const saveNowY = 176 + 1 * (36 + 8) + 36 / 2;
     const saveNowX = (800 - 280) / 2 + 280 / 2;
-    await page.locator('canvas').first().click({ position: { x: saveNowX, y: saveNowY } });
+    await page
+      .locator('canvas')
+      .first()
+      .click({ position: { x: saveNowX, y: saveNowY } });
     await page.waitForTimeout(200);
 
     // The preserved bytes MUST be unchanged. Pre-fix this overwrote the

--- a/tests/phase-09-session.spec.ts
+++ b/tests/phase-09-session.spec.ts
@@ -43,10 +43,23 @@ const MINIMAL_SAVE_FIXTURE = {
     nextEntityId: 0,
     commandQueue: [],
     ants: {
-      posX: [], posY: [], colonyId: [], task: [], subTask: [], speed: [],
-      foodCarrying: [], starvationTimer: [], age: [], alive: [], lifespan: [],
-      zone: [], digTileX: [], digTileY: [], digTicksRemaining: [],
-      targetPosX: [], targetPosY: [],
+      posX: [],
+      posY: [],
+      colonyId: [],
+      task: [],
+      subTask: [],
+      speed: [],
+      foodCarrying: [],
+      starvationTimer: [],
+      age: [],
+      alive: [],
+      lifespan: [],
+      zone: [],
+      digTileX: [],
+      digTileY: [],
+      digTicksRemaining: [],
+      targetPosX: [],
+      targetPosY: [],
       // Phase 09.1 Chunk 0 — grid-of-occupancy byte (new SoA field). Empty
       // array matches the empty ants fixture; deserializeWorldState must
       // accept the field on round-trip.
@@ -68,10 +81,10 @@ async function clearSave(page: Page): Promise<void> {
 
 async function seedSave(page: Page, fixture: unknown): Promise<void> {
   await page.goto('/');
-  await page.evaluate(
-    ([key, json]) => window.localStorage.setItem(key as string, json as string),
-    [SAVE_KEY, JSON.stringify(fixture)] as const,
-  );
+  await page.evaluate(([key, json]) => window.localStorage.setItem(key as string, json as string), [
+    SAVE_KEY,
+    JSON.stringify(fixture),
+  ] as const);
 }
 
 test.describe('Phase 9 — SCEN-01 fresh boot', () => {
@@ -79,7 +92,9 @@ test.describe('Phase 9 — SCEN-01 fresh boot', () => {
     page,
   }) => {
     const consoleErrors: string[] = [];
-    page.on('console', (m) => { if (errorFilter(m)) consoleErrors.push(m.text()); });
+    page.on('console', (m) => {
+      if (errorFilter(m)) consoleErrors.push(m.text());
+    });
     page.on('pageerror', (e) => consoleErrors.push(e.message));
 
     await clearSave(page);
@@ -91,31 +106,24 @@ test.describe('Phase 9 — SCEN-01 fresh boot', () => {
 
     // SavePrompt overlay MUST NOT render when there is no save.
     // Canvas-drawn; observe via the __phase9_ui hook exported by Plan 09-06.
-    await expect
-      .poll(() => getActiveOverlay(page), { timeout: 5_000 })
-      .toBe('none');
+    await expect.poll(() => getActiveOverlay(page), { timeout: 5_000 }).toBe('none');
 
     // No runtime errors during fresh boot.
     expect(consoleErrors, consoleErrors.join('\n')).toHaveLength(0);
   });
 
-  test('corrupted save falls through to fresh boot (hasSave returns false)', async ({
-    page,
-  }) => {
+  test('corrupted save falls through to fresh boot (hasSave returns false)', async ({ page }) => {
     await page.goto('/');
-    await page.evaluate(
-      ([key]) => window.localStorage.setItem(key as string, 'not-valid-json'),
-      [SAVE_KEY] as const,
-    );
+    await page.evaluate(([key]) => window.localStorage.setItem(key as string, 'not-valid-json'), [
+      SAVE_KEY,
+    ] as const);
     await page.reload();
 
     const canvas = page.locator('canvas').first();
     await canvas.waitFor({ state: 'attached', timeout: 10_000 });
     await expect(canvas).toBeVisible();
     // Malformed JSON → loadSave returns null → no overlay.
-    await expect
-      .poll(() => getActiveOverlay(page), { timeout: 5_000 })
-      .toBe('none');
+    await expect.poll(() => getActiveOverlay(page), { timeout: 5_000 }).toBe('none');
   });
 });
 
@@ -128,9 +136,7 @@ test.describe('Phase 9 — SCEN-04 save-prompt flow', () => {
 
     // Overlay renders — proves hasSave() + loadSave() accepted the envelope shape.
     // Canvas-drawn; observe via the __phase9_ui hook exported by Plan 09-06.
-    await expect
-      .poll(() => getActiveOverlay(page), { timeout: 5_000 })
-      .toBe('save-prompt');
+    await expect.poll(() => getActiveOverlay(page), { timeout: 5_000 }).toBe('save-prompt');
 
     // SavePrompt buttons are Phaser.GameObjects.Text rendered to canvas — NOT DOM.
     // Playwright cannot reliably query canvas text. Click via canvas-relative
@@ -143,9 +149,7 @@ test.describe('Phase 9 — SCEN-04 save-prompt flow', () => {
     await page.mouse.click(box.x + R.x + R.w / 2, box.y + R.y + R.h / 2);
 
     // Overlay dismissed — hook flips back to 'none'.
-    await expect
-      .poll(() => getActiveOverlay(page), { timeout: 5_000 })
-      .toBe('none');
+    await expect.poll(() => getActiveOverlay(page), { timeout: 5_000 }).toBe('none');
 
     // Canvas still up (no crash-on-load — the minimal snapshot was accepted by deserializeWorldState).
     await expect(page.locator('canvas').first()).toBeVisible();
@@ -154,15 +158,11 @@ test.describe('Phase 9 — SCEN-04 save-prompt flow', () => {
     // asserting loaded-state richness would require an in-browser save helper which no plan exposes.
   });
 
-  test('seeded save → SavePrompt "New Game" clears save and boots fresh', async ({
-    page,
-  }) => {
+  test('seeded save → SavePrompt "New Game" clears save and boots fresh', async ({ page }) => {
     await seedSave(page, MINIMAL_SAVE_FIXTURE);
     await page.reload();
 
-    await expect
-      .poll(() => getActiveOverlay(page), { timeout: 5_000 })
-      .toBe('save-prompt');
+    await expect.poll(() => getActiveOverlay(page), { timeout: 5_000 }).toBe('save-prompt');
 
     const canvas2 = page.locator('canvas').first();
     const box2 = await canvas2.boundingBox();
@@ -171,9 +171,7 @@ test.describe('Phase 9 — SCEN-04 save-prompt flow', () => {
     await page.mouse.click(box2.x + R2.x + R2.w / 2, box2.y + R2.y + R2.h / 2);
 
     // Overlay dismissed; localStorage save deleted by deleteSave().
-    await expect
-      .poll(() => getActiveOverlay(page), { timeout: 5_000 })
-      .toBe('none');
+    await expect.poll(() => getActiveOverlay(page), { timeout: 5_000 }).toBe('none');
     const stored = await page.evaluate(
       (key) => window.localStorage.getItem(key as string),
       SAVE_KEY,
@@ -204,7 +202,9 @@ test.describe('Phase 09.1 Chunk 2 — enemy underground toggle', () => {
     //   X → flip back → HUD reads "Your Colony"
     // and asserts no console errors fire during the sequence.
     const consoleErrors: string[] = [];
-    page.on('console', (m) => { if (errorFilter(m)) consoleErrors.push(m.text()); });
+    page.on('console', (m) => {
+      if (errorFilter(m)) consoleErrors.push(m.text());
+    });
     page.on('pageerror', (e) => consoleErrors.push(e.message));
 
     await clearSave(page);
@@ -226,15 +226,22 @@ test.describe('Phase 09.1 Chunk 2 — enemy underground toggle', () => {
     // Phase 08-04 decision (JustDown). Poll the hook for the label going
     // truthy as a proxy for "UIScene has run at least one update frame
     // since boot", then press Tab.
-    await expect.poll(
-      async () => {
-        const v = await page.evaluate(() => (window as unknown as {
-          __phase9_ui?: { activeUndergroundLabel?: string };
-        }).__phase9_ui?.activeUndergroundLabel);
-        return v ?? 'unset';
-      },
-      { timeout: 5_000 },
-    ).toBe('Your Colony');
+    await expect
+      .poll(
+        async () => {
+          const v = await page.evaluate(
+            () =>
+              (
+                window as unknown as {
+                  __phase9_ui?: { activeUndergroundLabel?: string };
+                }
+              ).__phase9_ui?.activeUndergroundLabel,
+          );
+          return v ?? 'unset';
+        },
+        { timeout: 5_000 },
+      )
+      .toBe('Your Colony');
     await page.keyboard.press('Tab');
     await page.waitForTimeout(300);
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -99,7 +99,9 @@ test.describe('Phase 8 smoke — boot, toggle, pan', () => {
     });
   });
 
-  test('Space + left-drag pans the surface camera without error (Phase 8.5 primary gesture)', async ({ page }) => {
+  test('Space + left-drag pans the surface camera without error (Phase 8.5 primary gesture)', async ({
+    page,
+  }) => {
     const consoleErrors: string[] = [];
     page.on('console', (msg) => {
       if (errorFilter(msg)) consoleErrors.push(msg.text());

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,9 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 // playtrace upload module (issue #122) as the `gameVersion` field on the
 // submission envelope — sourced from package.json rather than hand-maintained
 // so version bumps flow through to telemetry automatically.
-const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as { version: string };
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
+  version: string;
+};
 
 /**
  * Issue #122 — dev-server mock for the playtrace upload endpoint.
@@ -37,84 +39,95 @@ const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 
 const playtraceMockPlugin = (): Plugin => ({
   name: 'subterrans-playtrace-mock',
   configureServer(server) {
-    server.middlewares.use('/api/playtrace', (req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) => {
-      if (req.method !== 'POST') {
-        // Let the dev server's default 404 handle GET/HEAD/etc.
-        next();
-        return;
-      }
-      // Sanity cap on the mock's incoming body — dev-only, but a runaway
-      // client (or a misconfigured browser-side test) could otherwise OOM
-      // the dev server. 10 MB is comfortably above the production 5 MB
-      // gzipped cap, so legitimate submissions always fit.
-      const MAX_MOCK_BODY = 10 * 1024 * 1024;
-      const chunks: Buffer[] = [];
-      let received = 0;
-      let oversized = false;
-      req.on('data', (chunk: Buffer) => {
-        received += chunk.length;
-        if (received > MAX_MOCK_BODY) {
-          if (!oversized) {
-            oversized = true;
-            // eslint-disable-next-line no-console
-            console.warn(`[playtrace-mock] body exceeded ${MAX_MOCK_BODY} bytes — discarding`);
-            res.statusCode = 413;
-            res.end('Payload Too Large');
-            req.destroy();
-          }
+    server.middlewares.use(
+      '/api/playtrace',
+      (req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) => {
+        if (req.method !== 'POST') {
+          // Let the dev server's default 404 handle GET/HEAD/etc.
+          next();
           return;
         }
-        chunks.push(chunk);
-      });
-      req.on('end', () => {
-        if (oversized) return; // response already sent
-        try {
-          const raw = Buffer.concat(chunks);
-          let envelope: Record<string, unknown> = {};
-          let parseError: string | null = null;
-          // The wire format is gzip-encoded JSON. Decompress + parse, but
-          // tolerate parse failures so the mock surfaces *what* the client
-          // sent even when the JSON is malformed — diagnosing a bad
-          // serialization is the whole point of having this middleware.
-          try {
-            const decompressed = gunzipSync(raw);
-            envelope = JSON.parse(decompressed.toString('utf8')) as Record<string, unknown>;
-          } catch (err) {
-            parseError = err instanceof Error ? err.message : String(err);
+        // Sanity cap on the mock's incoming body — dev-only, but a runaway
+        // client (or a misconfigured browser-side test) could otherwise OOM
+        // the dev server. 10 MB is comfortably above the production 5 MB
+        // gzipped cap, so legitimate submissions always fit.
+        const MAX_MOCK_BODY = 10 * 1024 * 1024;
+        const chunks: Buffer[] = [];
+        let received = 0;
+        let oversized = false;
+        req.on('data', (chunk: Buffer) => {
+          received += chunk.length;
+          if (received > MAX_MOCK_BODY) {
+            if (!oversized) {
+              oversized = true;
+              // eslint-disable-next-line no-console
+              console.warn(`[playtrace-mock] body exceeded ${MAX_MOCK_BODY} bytes — discarding`);
+              res.statusCode = 413;
+              res.end('Payload Too Large');
+              req.destroy();
+            }
+            return;
           }
-          const survey = envelope['survey'] as Record<string, unknown> | undefined;
-          const freeText = typeof survey?.['freeText'] === 'string' ? survey['freeText'] as string : '';
-          const freeTextPreview = freeText.length > 80 ? `${freeText.slice(0, 80)}…` : freeText;
-          // One-line summary keeps the dev-server log readable. The full
-          // envelope is also logged below for offline inspection.
-          // eslint-disable-next-line no-console
-          console.log(
-            `[playtrace-mock] received: sessionId=${envelope['sessionId'] ?? '?'} `
-            + `outcome=${envelope['outcome'] ?? '?'} `
-            + `gzippedBytes=${raw.length} `
-            + `rating=${survey?.['rating'] ?? '?'} `
-            + `brokenFlag=${survey?.['brokenFlag'] ?? '?'} `
-            + `hasSnapshot=${envelope['snapshot'] !== null} `
-            + `freeText=${JSON.stringify(freeTextPreview)}`
-            + (parseError !== null ? ` PARSE_ERROR=${parseError}` : ''),
-          );
-          // Full envelope dump (without the snapshot payload — the snapshot
-          // is large and noisy in the terminal; if you need it, change
-          // `null` → the actual snapshot block).
-          // eslint-disable-next-line no-console
-          console.log('[playtrace-mock] envelope:', JSON.stringify({ ...envelope, snapshot: envelope['snapshot'] === null ? null : '<elided>' }, null, 2));
+          chunks.push(chunk);
+        });
+        req.on('end', () => {
+          if (oversized) return; // response already sent
+          try {
+            const raw = Buffer.concat(chunks);
+            let envelope: Record<string, unknown> = {};
+            let parseError: string | null = null;
+            // The wire format is gzip-encoded JSON. Decompress + parse, but
+            // tolerate parse failures so the mock surfaces *what* the client
+            // sent even when the JSON is malformed — diagnosing a bad
+            // serialization is the whole point of having this middleware.
+            try {
+              const decompressed = gunzipSync(raw);
+              envelope = JSON.parse(decompressed.toString('utf8')) as Record<string, unknown>;
+            } catch (err) {
+              parseError = err instanceof Error ? err.message : String(err);
+            }
+            const survey = envelope['survey'] as Record<string, unknown> | undefined;
+            const freeText =
+              typeof survey?.['freeText'] === 'string' ? (survey['freeText'] as string) : '';
+            const freeTextPreview = freeText.length > 80 ? `${freeText.slice(0, 80)}…` : freeText;
+            // One-line summary keeps the dev-server log readable. The full
+            // envelope is also logged below for offline inspection.
+            // eslint-disable-next-line no-console
+            console.log(
+              `[playtrace-mock] received: sessionId=${envelope['sessionId'] ?? '?'} ` +
+                `outcome=${envelope['outcome'] ?? '?'} ` +
+                `gzippedBytes=${raw.length} ` +
+                `rating=${survey?.['rating'] ?? '?'} ` +
+                `brokenFlag=${survey?.['brokenFlag'] ?? '?'} ` +
+                `hasSnapshot=${envelope['snapshot'] !== null} ` +
+                `freeText=${JSON.stringify(freeTextPreview)}` +
+                (parseError !== null ? ` PARSE_ERROR=${parseError}` : ''),
+            );
+            // Full envelope dump (without the snapshot payload — the snapshot
+            // is large and noisy in the terminal; if you need it, change
+            // `null` → the actual snapshot block).
+            // eslint-disable-next-line no-console
+            console.log(
+              '[playtrace-mock] envelope:',
+              JSON.stringify(
+                { ...envelope, snapshot: envelope['snapshot'] === null ? null : '<elided>' },
+                null,
+                2,
+              ),
+            );
 
-          res.statusCode = 202;
-          res.setHeader('Content-Type', 'application/json');
-          res.end(JSON.stringify({ accepted: true, sessionId: envelope['sessionId'] ?? null }));
-        } catch (err) {
-          // eslint-disable-next-line no-console
-          console.error('[playtrace-mock] handler error:', err);
-          res.statusCode = 500;
-          res.end('mock middleware error');
-        }
-      });
-    });
+            res.statusCode = 202;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ accepted: true, sessionId: envelope['sessionId'] ?? null }));
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.error('[playtrace-mock] handler error:', err);
+            res.statusCode = 500;
+            res.end('mock middleware error');
+          }
+        });
+      },
+    );
   },
 });
 

--- a/vite.lib.config.ts
+++ b/vite.lib.config.ts
@@ -27,7 +27,9 @@ import ts from 'typescript';
 // the playtrace upload module (issue #122) can report `gameVersion` on the
 // submission envelope. Same source-of-truth as the standalone build's
 // vite.config.ts; keeping the two configs in sync is a manual review check.
-const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as { version: string };
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
+  version: string;
+};
 
 /** Emit dist-lib/manifest.json after the bundle is written, so the website
  *  deploy can read `entry` and inject the right hashed <script src=…>.
@@ -44,7 +46,7 @@ const manifestPlugin = (): Plugin => ({
     if (entries.length !== 1) {
       throw new Error(
         `subterrans-lib-manifest: expected exactly 1 entry chunk, found ${entries.length}. ` +
-        `Library build assumes a single ESM entry — check vite.lib.config.ts lib.entry.`,
+          `Library build assumes a single ESM entry — check vite.lib.config.ts lib.entry.`,
       );
     }
     const entry = entries[0];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,9 @@ import { readFileSync } from 'node:fs';
 // Mirror the build-time __APP_VERSION__ define from vite.config.ts so the
 // playtrace upload module (issue #122) can read it under Vitest the same
 // way it will at runtime in production. Same package.json source-of-truth.
-const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as { version: string };
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
+  version: string;
+};
 
 export default defineConfig({
   define: {


### PR DESCRIPTION
## Summary

PR A of a two-PR formatting initiative. Adds **Prettier 3.8.3** and runs a one-time repo-wide normalization. **Pure formatting — no logic, behavior, or `simVersion` changes.**

`npm run verify` is green after the reformat: eslint, `tsc --noEmit`, sim-boundary + asset-path guards, and **2290 tests across 77 files** all pass.

## What changed

**Tooling**
- `.prettierrc.json` — `singleQuote`, `semi`, `tabWidth: 2`, `trailingComma: "all"`, `printWidth: 100`. Chosen to match the prevailing style (src was already single-quote/semicolon/2-space/trailing-comma) so the diff is minimal-churn rather than a style flip.
- `.prettierignore` — `node_modules`, `dist`/`dist-lib`/`build`, `coverage`, `test-results`, `playwright-report`, `assets/`, `public/`, `package-lock.json`.
- `package.json` scripts — `format` (`prettier --write .`, repo-wide on demand), `format:check` (`prettier --check src/`); `format:check` wired into `verify`.
- **`eslint-config-prettier` intentionally NOT added** — the flat config has only `@typescript-eslint/recommended` + the sim-safety rules and **zero** formatting/stylistic rules, so there's no ESLint/Prettier conflict to disable. Confirmed clean.

**The reformat** — 168 files, whitespace-only. The internal review verified (whitespace-ignored + word-level diffs across `save.ts`, `ant-system.ts`, `tick.ts`, `combat.ts`, `spider.ts`, `eslint.config.ts`, etc.) that no numeric literals, identifiers, operators, regex selectors, array contents, or object properties were altered.

**Three sim test files** needed manual touch-ups where Prettier's wrapping displaced an `// eslint-disable-next-line` off the line it suppressed (each a deliberate float/division test input):
- `sim/ai-state.test.ts`, `sim/tick.test.ts` — relocated to a trailing `// eslint-disable-line` on the actual violation line.
- `sim/ant/ant-system.test.ts` — wrapped a multi-line `expect` in `/* eslint-disable */ … /* eslint-enable */`.

All three forms were verified **Prettier-stable** (they won't re-break on the next `format`).

## Format-gate scope (decided)

`format` writes repo-wide (so docs/config can be normalized on demand — and were, once, in this PR), but the **`format:check` gate that `verify` runs is scoped to `src/`**. Rationale: `verify` shouldn't halt on an unrelated doc/config formatting nit. (CI does not run `verify`, so this only affects local ergonomics regardless.)

## Risk

Mechanical. The 2290-test suite passing post-reformat is the determinism/behavior safety check. No `simVersion` bump (no sim algorithm or field changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)