### PR TITLE
chore: add type-aware ESLint layer (recommended-type-checked)

### DIFF
--- a/eslint.typecheck.config.ts
+++ b/eslint.typecheck.config.ts
@@ -1,0 +1,63 @@
+// code/eslint.typecheck.config.ts
+// Type-aware ESLint layer (typescript-eslint `recommended-type-checked`).
+//
+// Kept SEPARATE from eslint.config.ts on purpose. The fast config is what
+// `npm run lint` and the per-edit sim-boundary hook run; adding type-aware
+// rules there would rebuild the TS program on every single edit (seconds of
+// latency per save). This config builds the program once and is gated only in
+// `npm run lint:types`, `npm run verify`, and CI — where latency is fine.
+//
+// Scope note: this config intentionally does NOT re-declare the sim-safety
+// rules (Phaser/wall-clock/float bans, mutation guard) — eslint.config.ts owns
+// those and owns disable-directive usage reporting. We turn
+// reportUnusedDisableDirectives off here so the sim-rule disable comments (e.g.
+// `// eslint-disable-line no-restricted-syntax`) aren't falsely flagged as
+// unused by a config that never loaded those rules.
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: { '@typescript-eslint': tseslint },
+    linterOptions: { reportUnusedDisableDirectives: 'off' },
+    rules: {
+      ...tseslint.configs['recommended-type-checked'].rules,
+      // Mirror eslint.config.ts: `_`-prefixed identifiers are intentionally unused.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+  {
+    // Test files legitimately use `any` (JSON.parse round-trips, deliberately
+    // malformed validation inputs, loose mocks/spies) and loose async (mock
+    // handlers typed `async` to match a Promise-returning signature without
+    // awaiting). Enforcing the `any`-flow and async-shape rules here would mean
+    // contorting fixtures for no shipped-code benefit. The genuine bug-catchers
+    // (no-floating-promises, no-misused-promises, await-thenable) stay ON
+    // everywhere — only the low-value-in-tests rules are relaxed.
+    files: ['src/**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/require-await': 'off',
+      '@typescript-eslint/unbound-method': 'off',
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
+    "lint:types": "eslint --config eslint.typecheck.config.ts src/",
     "format": "prettier --write .",
     "format:check": "prettier --check src/",
-    "verify": "npm run format:check && npm run lint && npm run typecheck && bash scripts/check-sim-boundary.sh && bash scripts/check-asset-paths.sh && npm run test"
+    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run lint:types && bash scripts/check-sim-boundary.sh && bash scripts/check-asset-paths.sh && npm run test"
   },
   "dependencies": {
     "phaser": "^3.90.0"

--- a/src/input/surface-input.ts
+++ b/src/input/surface-input.ts
@@ -92,7 +92,7 @@ export function isEmptySurfaceTile(world: WorldState, tileX: number, tileY: numb
 
   // Check not a colony entrance — iterate colonies via Object.keys (ADR-0006)
   for (const key of Object.keys(world.colonies)) {
-    const colony = world.colonies[Number(key) as ColonyId];
+    const colony = world.colonies[Number(key)];
     if (colony === undefined) continue;
     for (const entrance of colony.entrances) {
       if (entrance.surfaceTileX === tileX && entrance.surfaceTileY === tileY) return false;
@@ -135,7 +135,7 @@ export function isForeignColonyEntrance(
   if (tileX < 0 || tileY < 0) return false;
   if (tileX >= world.surface.width || tileY >= world.surface.height) return false;
   for (const key of Object.keys(world.colonies)) {
-    const cid = Number(key) as ColonyId;
+    const cid = Number(key);
     if (cid === ownColonyId) continue;
     const colony = world.colonies[cid];
     if (colony === undefined) continue;

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -70,7 +70,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       ] as const;
       for (const f of fields) {
         expect(Array.isArray(s.ants[f])).toBe(true);
-        expect(s.ants[f]!.length).toBeGreaterThan(0);
+        expect(s.ants[f].length).toBeGreaterThan(0);
       }
     });
     it('serializes every Uint8Array grid .data as number[]', () => {
@@ -893,7 +893,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // wrote out for a fresh scenario.
       const w = createScenario(42);
       const s = serializeWorldState(w);
-      const latest = s.simVersion!;
+      const latest = s.simVersion;
       const out = deserializeWorldState(s);
       expect(out.simVersion).toBe(latest);
     });
@@ -941,7 +941,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // LATEST_SIM_VERSION is whatever the current sim writes for a fresh
       // scenario; the value is captured here to keep the test version-agnostic.
       const w = createScenario(42);
-      const latest = serializeWorldState(w).simVersion!;
+      const latest = serializeWorldState(w).simVersion;
       const snapshot = makeSavedSnapshot((s) => {
         s.simVersion = latest + 1;
       });

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -45,7 +45,6 @@ import {
   PLAYER_COLONY_ID,
 } from '../sim/constants.js';
 import { FP_SHIFT } from '../sim/fixed.js';
-import { ChamberType } from '../sim/enums.js';
 import { CHAMBER_DIMENSIONS } from '../sim/colony/chamber.js';
 
 // SAVE_FORMAT_VERSION is bumped on any breaking change to the on-disk shape
@@ -208,7 +207,7 @@ function validateChamberRecord(ch: unknown, label: string): void {
   ) {
     throw new Error(`Invalid ${label}.chamberType: ${String(c.chamberType)}`);
   }
-  const dims = CHAMBER_DIMENSIONS[c.chamberType as ChamberType];
+  const dims = CHAMBER_DIMENSIONS[c.chamberType];
   if (c.width !== dims.width || c.height !== dims.height) {
     throw new Error(
       `Invalid ${label} dims for type ${c.chamberType}: ` +
@@ -270,7 +269,7 @@ function validatePendingChamber(pc: unknown, label: string): void {
   if (!isTileCoord(p.anchorTileY, UNDERGROUND_GRID_HEIGHT)) {
     throw new Error(`Invalid ${label}.anchorTileY: ${String(p.anchorTileY)}`);
   }
-  const dims = CHAMBER_DIMENSIONS[p.chamberType as ChamberType];
+  const dims = CHAMBER_DIMENSIONS[p.chamberType];
   if (p.width !== dims.width || p.height !== dims.height) {
     throw new Error(
       `Invalid ${label} dims for type ${p.chamberType}: ` +
@@ -847,9 +846,7 @@ function deserializeAIStateArray(s: SerializedWorldState): AIStateRecord[] {
   for (let i = 0; i < raw.length; i++) {
     const r = raw[i]!;
     if (r === null || typeof r !== 'object') continue;
-    const fightIds = Array.isArray(r.operationFighterIds)
-      ? (r.operationFighterIds as number[])
-      : [];
+    const fightIds = Array.isArray(r.operationFighterIds) ? r.operationFighterIds : [];
     const buf = new Int32Array(AI_MAX_OPERATION_FIGHTERS).fill(-1);
     const copyLen = Math.min(fightIds.length, AI_MAX_OPERATION_FIGHTERS);
     for (let j = 0; j < copyLen; j++) {
@@ -1124,7 +1121,7 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     if (!/^-?\d+$/.test(cidStr)) {
       throw new Error(`Invalid colonies key: ${cidStr}`);
     }
-    colonies[Number(cidStr) as ColonyId] = deserializeColony(sc);
+    colonies[Number(cidStr)] = deserializeColony(sc);
   }
   const undergroundGrids: Record<ColonyId, UndergroundGrid> = {};
   for (const [cidStr, sg] of Object.entries(s.undergroundGrids)) {
@@ -1138,7 +1135,7 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
       UNDERGROUND_GRID_HEIGHT,
       `undergroundGrids[${cidStr}]`,
     );
-    undergroundGrids[Number(cidStr) as ColonyId] = deserializeUndergroundGrid(sg);
+    undergroundGrids[Number(cidStr)] = deserializeUndergroundGrid(sg);
   }
   const pheromoneGrids: Record<string, PheromoneGrid> = {};
   for (const [key, sg] of Object.entries(s.pheromoneGrids)) {

--- a/src/render/ai-controller.test.ts
+++ b/src/render/ai-controller.test.ts
@@ -56,7 +56,7 @@ function makeWorld(tick = 0): WorldState {
 
 /** Add a colony (with Phase 3 extension fields) to world.colonies. */
 function addColony(world: WorldState, colonyId: ColonyId, queenEntityId: number): ColonyRecord {
-  const colony = createColonyRecord(colonyId, queenEntityId) as ColonyRecord;
+  const colony = createColonyRecord(colonyId, queenEntityId);
   colony.entrances = [];
   colony.rallyPoint = null;
   colony.digFlowFieldDirty = false;

--- a/src/render/chamber-shape.ts
+++ b/src/render/chamber-shape.ts
@@ -263,7 +263,7 @@ function clampAmplitude(requested: number, w: number, h: number): number {
 }
 
 function computeWaveNodes(chamberSeedValue: number, ampPx: number): number[] {
-  const nodes: number[] = new Array(NUM_WAVE_NODES);
+  const nodes: number[] = new Array<number>(NUM_WAVE_NODES);
   if (ampPx <= 0) {
     nodes.fill(0);
     return nodes;

--- a/src/render/game-scene-logic.ts
+++ b/src/render/game-scene-logic.ts
@@ -42,7 +42,7 @@ export function decideBootMode(hasSaveFn: () => boolean): 'prompt' | 'fresh' {
  */
 export function deriveAIColonyIds(world: WorldState, playerColonyId: ColonyId): ColonyId[] {
   return Object.keys(world.colonies)
-    .map((key) => Number(key) as ColonyId)
+    .map((key) => Number(key))
     .filter((cid) => cid !== playerColonyId)
     .sort((a, b) => a - b);
 }

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -286,7 +286,7 @@ export class GameScene extends Phaser.Scene {
     // or non-string registry value means GameScene was instantiated outside
     // mount() (e.g. ad-hoc test harness, hand-built Phaser.Game) — fail loud
     // rather than letting `String(undefined)` produce 404s on every sprite.
-    const assetsBaseRaw = this.registry.get('assetsBase');
+    const assetsBaseRaw: unknown = this.registry.get('assetsBase');
     if (typeof assetsBaseRaw !== 'string' || assetsBaseRaw.length === 0) {
       throw new Error(
         'GameScene.preload: assetsBase registry value missing or invalid. ' +
@@ -331,7 +331,7 @@ export class GameScene extends Phaser.Scene {
     // main.ts in callbacks.preBoot). Treat any non-string value as "feature
     // off" so a programming error in main.ts doesn't accidentally turn the
     // overlay on with an undefined endpoint and 404 the submission.
-    const endpointRaw = this.registry.get('playtraceEndpoint');
+    const endpointRaw: unknown = this.registry.get('playtraceEndpoint');
     // Trim whitespace so a templated env var that resolved to spaces
     // is treated as feature-off here too. main.ts normalizes at the
     // boundary; this is defense-in-depth for the registry value.

--- a/src/render/playtrace-upload.test.ts
+++ b/src/render/playtrace-upload.test.ts
@@ -421,7 +421,7 @@ describe('cancelInFlightUpload', () => {
     });
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((_url, init) => {
       return new Promise<Response>((_resolve, reject) => {
-        const signal = (init as RequestInit | undefined)?.signal;
+        const signal = init?.signal;
         if (signal !== undefined && signal !== null) {
           signal.addEventListener('abort', () => {
             reject(new DOMException('Aborted', 'AbortError'));

--- a/src/sim/ant/ant-system.test.ts
+++ b/src/sim/ant/ant-system.test.ts
@@ -557,7 +557,7 @@ describe('tickAntMovement', () => {
     // Ant's tile: x = (maxX - 2) >> FP_SHIFT = SURFACE_GRID_WIDTH - 1 (rightmost column)
     // Neighbor to the right is out of bounds → phGet returns 0 there
     // So instead place strong pheromone at tile below and ensure movement stays in bounds
-    const tileY = (world.ants.posY[antId]! >> FP_SHIFT) + 1;
+    const tileY = (world.ants.posY[antId] >> FP_SHIFT) + 1;
     phSet(grid, SURFACE_GRID_WIDTH - 1, tileY, 1000);
 
     // Use seed 0 — exploit branch likely, moves toward strong neighbor
@@ -3655,7 +3655,7 @@ describe('tickAntMovement — wander fallback', () => {
       const rng = new Rng(seed);
       tickAntMovement(world, rng, digFlowFields);
       const moved = world.ants.posX[antId] !== posXBefore || world.ants.posY[antId] !== posYBefore;
-      const pausedThisTick = world.ants.searchPauseTicks[antId]! > 0;
+      const pausedThisTick = world.ants.searchPauseTicks[antId] > 0;
       if (moved || pausedThisTick) movedOrPausedCount += 1;
       if (!pausedThisTick) {
         nonPausedSeedsTotal += 1;
@@ -6928,14 +6928,14 @@ describe('issue #42 — surface SearchingFood no-revisit rule (v6)', () => {
     const digFlowFields = createDigFlowFields();
     for (let t = 0; t < 20; t++) {
       tickAntMovement(world, rng, digFlowFields);
-      const tx = world.ants.posX[antId]! >> FP_SHIFT;
-      const ty = world.ants.posY[antId]! >> FP_SHIFT;
+      const tx = world.ants.posX[antId] >> FP_SHIFT;
+      const ty = world.ants.posY[antId] >> FP_SHIFT;
       visitedTiles.add(`${tx},${ty}`);
       // Hard requirement: never enter an OOB tile (y must never be
       // < 0 even at sub-tile precision). Surface clamp at the call
       // boundary should already enforce this; assert so the test
       // catches any future passability change that lifts the clamp.
-      expect(world.ants.posY[antId]!).toBeGreaterThanOrEqual(0);
+      expect(world.ants.posY[antId]).toBeGreaterThanOrEqual(0);
     }
     // The ant must have crossed at least one tile boundary in 20
     // ticks — without the bounds check the picker would pin it at
@@ -7700,8 +7700,8 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
 
     tickLifecycleTransitions(world, colony);
     // Larva promoted to worker; entity id preserved.
-    expect(world.colonies[COLONY_ID]!.workers).toContain(larvaId);
-    expect(world.colonies[COLONY_ID]!.larvae).not.toContain(larvaId);
+    expect(world.colonies[COLONY_ID].workers).toContain(larvaId);
+    expect(world.colonies[COLONY_ID].larvae).not.toContain(larvaId);
     // Carry slot dropped on both ends.
     expect(world.ants.carryingBroodId[nurseId]).toBe(-1);
     expect(world.ants.carriedBy[larvaId]).toBe(-1);
@@ -7711,8 +7711,8 @@ describe('tickLifecycleTransitions — v10 larva→worker drops carry (#17 phase
     // New worker stays at the carrier's tile (8, 7), NOT the larva's
     // pre-carry tile (5, 5). This proves lifecycle promotion does not
     // teleport the new worker.
-    expect(world.ants.posX[larvaId]! >> FP_SHIFT).toBe(8);
-    expect(world.ants.posY[larvaId]! >> FP_SHIFT).toBe(7);
+    expect(world.ants.posX[larvaId] >> FP_SHIFT).toBe(8);
+    expect(world.ants.posY[larvaId] >> FP_SHIFT).toBe(7);
   });
 
   it('egg→larva mid-carry: carry stays attached (entity id preserved)', async () => {
@@ -8060,7 +8060,7 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
     ugSet(underground, 3, 4, UndergroundTileState.Open); // South — alternate
     // (2,3) and (3,2) remain Solid — no other alternates
 
-    const colonyId = world.ants.colonyId[antId]! as number;
+    const colonyId = world.ants.colonyId[antId]!;
     const colony = world.colonies[colonyId]!;
     // Place FoodStorage chamber at (4, 3) to seed the food flow field East.
     colony.chambers.push({
@@ -8109,7 +8109,7 @@ describe('tickAntMovement — V14 underground CarryingFood no-revisit guard', ()
     ugSet(underground, 4, 3, UndergroundTileState.Open); // East — will be poisoned
     // (2,3), (3,2), (3,4) remain Solid
 
-    const colonyId = world.ants.colonyId[antId]! as number;
+    const colonyId = world.ants.colonyId[antId]!;
     const colony = world.colonies[colonyId]!;
     colony.chambers.push({
       chamberId: 101,
@@ -8439,7 +8439,7 @@ describe('Nursery brood deposit — capacity-aware spread, real pipeline (#173, 
       world.ants.carriedBy[broodId] = nurseId;
       for (let t = 0; t < maxTicks; t++) {
         step();
-        if (world.ants.carriedBy[broodId]! < 0) return broodId; // deposited
+        if (world.ants.carriedBy[broodId] < 0) return broodId; // deposited
       }
       return broodId;
     }

--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -2086,7 +2086,7 @@ export function updateFightAntTargets(world: WorldState): void {
     if (ants.alive[id] !== 1) continue;
     if (ants.task[id] !== AntTask.Fighting) continue;
 
-    const colonyId = ants.colonyId[id]! as ReturnType<typeof Number>;
+    const colonyId = ants.colonyId[id]!;
     const colony = world.colonies[colonyId as unknown as keyof typeof world.colonies];
     if (colony === undefined) continue;
 
@@ -2734,8 +2734,8 @@ export function tickExcursionBoundary(world: WorldState): void {
           grid,
           tileX,
           tileY,
-          ants.searchPrevTileX[id]!,
-          ants.searchPrevTileY[id]!,
+          ants.searchPrevTileX[id],
+          ants.searchPrevTileY[id],
         );
       }
     }
@@ -4546,8 +4546,8 @@ export function tickAntMovement(
               tileX,
               tileY,
               rng,
-              ants.searchPrevTileX[id]!,
-              ants.searchPrevTileY[id]!,
+              ants.searchPrevTileX[id],
+              ants.searchPrevTileY[id],
             );
             if (dir.dx !== 0 || dir.dy !== 0) {
               dx = dir.dx;

--- a/src/sim/colony/colony-system.ts
+++ b/src/sim/colony/colony-system.ts
@@ -645,7 +645,7 @@ export function tickDeadDiggerCleanup(world: WorldState): void {
     // grid. IF FUTURE INVASION EXTENDS TO DIGGERS (cross-grid digging), switch
     // this read to `ants.currentGridColonyId[id]` so the stale BeingDug tile
     // is cleared in the grid where the dig was actually claimed.
-    const cid = world.ants.colonyId[id]! as ColonyId;
+    const cid = world.ants.colonyId[id]!;
     const ug = world.undergroundGrids[cid];
     if (!ug) continue;
     if (ugGet(ug, dtx, dty) === UndergroundTileState.BeingDug) {

--- a/src/sim/combat-cross-grid.test.ts
+++ b/src/sim/combat-cross-grid.test.ts
@@ -134,8 +134,8 @@ function buildCrossGridWorld(seed = 1, queenTileX = 5, queenTileY = 5): CrossGri
     zone: Zone.Underground,
   });
   world.ants.currentGridColonyId[playerAntId] = ENEMY_COLONY_ID;
-  world.colonies[PLAYER_COLONY_ID]!.workers.push(playerAntId);
-  world.colonies[PLAYER_COLONY_ID]!.workerCount += 1;
+  world.colonies[PLAYER_COLONY_ID].workers.push(playerAntId);
+  world.colonies[PLAYER_COLONY_ID].workerCount += 1;
 
   return { world, playerAntId, enemyQueenId };
 }
@@ -241,8 +241,8 @@ describe('combat cross-grid — tile-key gridColonyId extension (REQ-C4)', () =>
       zone: Zone.Underground,
     });
     world.ants.currentGridColonyId[antA] = PLAYER_COLONY_ID;
-    world.colonies[PLAYER_COLONY_ID]!.workers.push(antA);
-    world.colonies[PLAYER_COLONY_ID]!.workerCount += 1;
+    world.colonies[PLAYER_COLONY_ID].workers.push(antA);
+    world.colonies[PLAYER_COLONY_ID].workerCount += 1;
 
     // Ant B: enemy-colony ant in the ENEMY grid at (7,7) Underground.
     const antB = allocateEntityId(world);
@@ -257,8 +257,8 @@ describe('combat cross-grid — tile-key gridColonyId extension (REQ-C4)', () =>
       zone: Zone.Underground,
     });
     world.ants.currentGridColonyId[antB] = ENEMY_COLONY_ID;
-    world.colonies[ENEMY_COLONY_ID]!.workers.push(antB);
-    world.colonies[ENEMY_COLONY_ID]!.workerCount += 1;
+    world.colonies[ENEMY_COLONY_ID].workers.push(antB);
+    world.colonies[ENEMY_COLONY_ID].workerCount += 1;
 
     // MANDATORY t=0 precondition assertions -----------------------------------
     expect(world.ants.alive[antA]).toBe(1);
@@ -284,7 +284,7 @@ describe('combat cross-grid — tile-key gridColonyId extension (REQ-C4)', () =>
     expect(world.ants.alive[antA]).toBe(1);
     expect(world.ants.alive[antB]).toBe(1);
     // Neither colony scored a kill.
-    expect(world.colonies[PLAYER_COLONY_ID]!.killCount).toBe(0);
-    expect(world.colonies[ENEMY_COLONY_ID]!.killCount).toBe(0);
+    expect(world.colonies[PLAYER_COLONY_ID].killCount).toBe(0);
+    expect(world.colonies[ENEMY_COLONY_ID].killCount).toBe(0);
   });
 });

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -132,8 +132,8 @@ export function detectAndResolveCombat(world: WorldState, _rng: Rng): void {
   //     continue their windup. (Codex P1.)
   const spider = world.spider;
   const v23Spider = spider !== null && world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO;
-  const spiderTileX = v23Spider ? spider!.posX >> FP_SHIFT : -1;
-  const spiderTileY = v23Spider ? spider!.posY >> FP_SHIFT : -1;
+  const spiderTileX = v23Spider ? spider.posX >> FP_SHIFT : -1;
+  const spiderTileY = v23Spider ? spider.posY >> FP_SHIFT : -1;
   for (let i = 0; i < count; i++) {
     if (ants.alive[i] !== 1) continue;
     if (ants.combatOpponentId[i] === -2) {
@@ -207,7 +207,7 @@ function applyDamage(world: WorldState, antIdx: number, damage: number): boolean
     ants.homeGroundBonusHp[antIdx] = 0;
   }
   ants.hp[antIdx] = ants.hp[antIdx]! - damage;
-  return ants.hp[antIdx]! <= 0;
+  return ants.hp[antIdx] <= 0;
 }
 
 /**
@@ -224,7 +224,7 @@ function strikeDamage(world: WorldState, antId: number, strikes: boolean): numbe
       : COMBAT_DAMAGE_BASE;
   }
   // Non-fighters retaliate with reduced damage.
-  const cid = ants.colonyId[antId]! as ColonyId;
+  const cid = ants.colonyId[antId]!;
   const colony = world.colonies[cid];
   if (colony == null) return 0;
   if (colony.queenEntityId === antId) return COMBAT_DAMAGE_QUEEN;
@@ -356,8 +356,8 @@ function resolveCombatOnTile_v16(
 
   // Kill dead ants. Event ordering: combat_kill emitted first (in killAnt),
   // then queen_death (in checkQueenDeath after this resolver returns).
-  if (bDies) killAnt(world, antB, cidA as ColonyId, antA, 'Ant');
-  if (aDies) killAnt(world, antA, cidB as ColonyId, antB, 'Ant');
+  if (bDies) killAnt(world, antB, cidA, antA, 'Ant');
+  if (aDies) killAnt(world, antA, cidB, antB, 'Ant');
 
   // After a kill, clear the survivor's opponent tracking so the next encounter
   // is detected as a new pairing (triggering proper windup and home-ground bonus
@@ -402,10 +402,10 @@ export function killAnt(
     ants.carriedBy[antIndex] = -1;
   }
 
-  const victimColonyId = ants.colonyId[antIndex]! as ColonyId;
+  const victimColonyId = ants.colonyId[antIndex]!;
   const tileX = ants.posX[antIndex]! >> FP_SHIFT;
   const tileY = ants.posY[antIndex]! >> FP_SHIFT;
-  const currentGridColonyId = ants.currentGridColonyId[antIndex]! as ColonyId;
+  const currentGridColonyId = ants.currentGridColonyId[antIndex]!;
 
   // Emit combat_kill event and write queen death context.
   const victimColony = world.colonies[victimColonyId];
@@ -459,7 +459,7 @@ export function killAnt(
     const enemyAI = world.aiState[_ai]!;
     if (enemyAI.operationKind === 'None') continue;
     const aiColId = enemyAI.colonyId;
-    const victimColId = ants.colonyId[antIndex]! as ColonyId;
+    const victimColId = ants.colonyId[antIndex]!;
     // operationAttackerDeaths: victim is a committed-cohort AI fighter.
     if (
       victimColId === aiColId &&

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -106,7 +106,7 @@ function serializeWorldState(w: WorldState): string {
       .sort()
       .reduce(
         (acc, k) => {
-          const c = w.colonies[Number(k) as ColonyId]!;
+          const c = w.colonies[Number(k)]!;
           acc[k] = {
             colonyId: c.colonyId,
             queenEntityId: c.queenEntityId,
@@ -148,7 +148,7 @@ function serializeWorldState(w: WorldState): string {
       .sort()
       .reduce(
         (acc, k) => {
-          const g = w.undergroundGrids[Number(k) as ColonyId]!;
+          const g = w.undergroundGrids[Number(k)]!;
           acc[k] = { width: g.width, height: g.height, data: Array.from(g.data) };
           return acc;
         },
@@ -195,9 +195,9 @@ function buildWorld(seed: number): { world: WorldState; queenId: number; colonyI
   // into the pool would collapse to 2048 on the first reconcile and starve
   // the queen well before Test 6's pipeline completes. Spread the head-start
   // across 20 chambers (5000fp each, all under FOOD_CHAMBER_CAPACITY=5120).
-  world.colonies[1]!.foodStored = 0;
+  world.colonies[1].foodStored = 0;
   for (let i = 0; i < 20; i++) {
-    world.colonies[1]!.chambers.push({
+    world.colonies[1].chambers.push({
       chamberId: 1000 + i,
       chamberType: ChamberType.FoodStorage,
       foodStored: 5000,
@@ -217,7 +217,7 @@ function buildWorld(seed: number): { world: WorldState; queenId: number; colonyI
   // flip her zone to Underground so the pipeline is unblocked without having
   // to simulate relocation via entrances (Test 6 has no entrances or
   // underground grid — it's a behavior-free lifecycle harness).
-  world.colonies[1]!.chambers.push({
+  world.colonies[1].chambers.push({
     chamberId: 1100,
     chamberType: ChamberType.Queen,
     foodStored: 0,
@@ -226,7 +226,7 @@ function buildWorld(seed: number): { world: WorldState; queenId: number; colonyI
     width: 2,
     height: 2,
   });
-  world.colonies[1]!.chambers.push({
+  world.colonies[1].chambers.push({
     chamberId: 1101,
     chamberType: ChamberType.Nursery,
     foodStored: 0,
@@ -237,10 +237,10 @@ function buildWorld(seed: number): { world: WorldState; queenId: number; colonyI
   });
   world.ants.zone[queenId] = 1; // Zone.Underground — Gate 6 precondition
   // Phase 3 PRD §2a caller-side extension fields (factory does not set these):
-  world.colonies[1]!.entrances = [];
-  world.colonies[1]!.rallyPoint = null;
-  world.colonies[1]!.digFlowFieldDirty = false;
-  world.colonies[1]!.foodFlowFieldDirty = false;
+  world.colonies[1].entrances = [];
+  world.colonies[1].rallyPoint = null;
+  world.colonies[1].digFlowFieldDirty = false;
+  world.colonies[1].foodFlowFieldDirty = false;
   world.pheromoneGrids[pheromoneGridKey(1, PheromoneType.FoodTrail, 'surface')] =
     createPheromoneGrid(64, 64);
   return { world, queenId, colonyId: 1 as ColonyId };
@@ -482,8 +482,8 @@ describe('Phase 6 SC 2: starvation cascade', () => {
       lifespan: WORKER_LIFESPAN_TICKS,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
-    world.colonies[1]!.foodStored = 0; // no food — queen cannot eat
-    world.colonies[1]!.queenStarvationTimer = STARVATION_GRACE_TICKS; // timer at full grace
+    world.colonies[1].foodStored = 0; // no food — queen cannot eat
+    world.colonies[1].queenStarvationTimer = STARVATION_GRACE_TICKS; // timer at full grace
 
     // Run STARVATION_GRACE_TICKS + 1 ticks — timer decrements by 1 each tick until <= 0 → death
     for (let t = 0; t < STARVATION_GRACE_TICKS + 1; t++) {
@@ -491,7 +491,7 @@ describe('Phase 6 SC 2: starvation cascade', () => {
     }
 
     expect(world.ants.alive[queenId]).toBe(0);
-    expect(world.colonies[1]!.defeated).toBe(true);
+    expect(world.colonies[1].defeated).toBe(true);
   });
 });
 
@@ -514,7 +514,7 @@ describe('Phase 6 SC 3: pheromone deposit on traversed cells', () => {
       lifespan: WORKER_LIFESPAN_TICKS,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
-    world.colonies[1]!.foodStored = 100000;
+    world.colonies[1].foodStored = 100000;
 
     const workerId = allocateEntityId(world);
     initAnt(world.ants, workerId, {
@@ -527,8 +527,8 @@ describe('Phase 6 SC 3: pheromone deposit on traversed cells', () => {
       lifespan: WORKER_LIFESPAN_TICKS,
     });
     world.ants.foodCarrying[workerId] = 512; // carrying food — deposit rule activates
-    world.colonies[1]!.workers.push(workerId);
-    world.colonies[1]!.workerCount = 1;
+    world.colonies[1].workers.push(workerId);
+    world.colonies[1].workerCount = 1;
 
     const gridKey = pheromoneGridKey(1, PheromoneType.FoodTrail, 'surface');
     const foodGrid = createPheromoneGrid(64, 64);
@@ -560,7 +560,7 @@ describe('Phase 6 SC 4: CTRL-04 one-tick immediate allocation', () => {
       lifespan: WORKER_LIFESPAN_TICKS,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
-    world.colonies[1]!.foodStored = 100000;
+    world.colonies[1].foodStored = 100000;
 
     // Add 10 workers (all Idle — no brood)
     for (let i = 0; i < 10; i++) {
@@ -572,18 +572,18 @@ describe('Phase 6 SC 4: CTRL-04 one-tick immediate allocation', () => {
         task: AntTask.Idle,
         subTask: 0,
       });
-      world.colonies[1]!.workers.push(wid);
-      world.colonies[1]!.workerCount += 1;
+      world.colonies[1].workers.push(wid);
+      world.colonies[1].workerCount += 1;
     }
 
     // Set initial targetRatio → forage:10 (all 10 workers allocated to forage)
-    world.colonies[1]!.targetRatio.forage = 10;
-    world.colonies[1]!.targetRatio.fight = 0;
+    world.colonies[1].targetRatio.forage = 10;
+    world.colonies[1].targetRatio.fight = 0;
 
     // Tick 0 (no commands): allocation reflects forage:10 ratio
     tick(world, []);
-    expect(world.colonies[1]!.computedAllocation.forage).toBe(10);
-    expect(world.colonies[1]!.computedAllocation.dig).toBe(0);
+    expect(world.colonies[1].computedAllocation.forage).toBe(10);
+    expect(world.colonies[1].computedAllocation.dig).toBe(0);
 
     // Tick 1: issue SetBehaviorRatio pivoting forage↔fight (Phase 10 CTRL-01': dig is auto-assigned per CTRL-06)
     const cmd: SimCommand = {
@@ -596,9 +596,9 @@ describe('Phase 6 SC 4: CTRL-04 one-tick immediate allocation', () => {
 
     // The new ratio takes effect in the SAME tick the command is issued (CTRL-04).
     // NOT in the "next tick after this one".
-    expect(world.colonies[1]!.computedAllocation.forage).toBe(0);
-    expect(world.colonies[1]!.computedAllocation.dig).toBe(0);
-    expect(world.colonies[1]!.computedAllocation.fight).toBe(10);
+    expect(world.colonies[1].computedAllocation.forage).toBe(0);
+    expect(world.colonies[1].computedAllocation.dig).toBe(0);
+    expect(world.colonies[1].computedAllocation.fight).toBe(10);
   });
 });
 
@@ -660,13 +660,13 @@ describe('No-allocation invariant: object identity in steady state', () => {
       lifespan: WORKER_LIFESPAN_TICKS,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
-    world.colonies[1]!.foodStored = 100000;
+    world.colonies[1].foodStored = 100000;
 
     // 10 warm-up ticks to stabilize
     for (let i = 0; i < 10; i++) tick(world, []);
 
     // Capture object references after warmup
-    const colony = world.colonies[1]!;
+    const colony = world.colonies[1];
     const targetRatioRef = colony.targetRatio;
     const computedAllocationRef = colony.computedAllocation;
     const taskCensusRef = colony.taskCensus;

--- a/src/sim/game-over.test.ts
+++ b/src/sim/game-over.test.ts
@@ -154,7 +154,7 @@ function makeV22WorldWith2Colonies(
     subTask: 0,
     speed: 0,
   });
-  const c1 = createColonyRecord(playerColonyId as ColonyId, queen1);
+  const c1 = createColonyRecord(playerColonyId, queen1);
   c1.entrances = [];
   c1.rallyPoint = null;
   c1.digFlowFieldDirty = false;
@@ -169,7 +169,7 @@ function makeV22WorldWith2Colonies(
     subTask: 0,
     speed: 0,
   });
-  const c2 = createColonyRecord(aiColonyId as ColonyId, queen2);
+  const c2 = createColonyRecord(aiColonyId, queen2);
   c2.entrances = [];
   c2.rallyPoint = null;
   c2.digFlowFieldDirty = false;
@@ -178,7 +178,7 @@ function makeV22WorldWith2Colonies(
   const addWorker = (colonyId: number): number => {
     const id = allocateEntityId(world);
     initAnt(world.ants, id, {
-      colonyId: colonyId as ColonyId,
+      colonyId: colonyId,
       posX: 1,
       posY: 1,
       task: AntTask.Idle,

--- a/src/sim/game-over.ts
+++ b/src/sim/game-over.ts
@@ -74,7 +74,7 @@ export function checkQueenDeath(world: WorldState, playerColonyId?: ColonyId): G
       const id = Number(key);
       if (id < minId) minId = id;
     }
-    playerCid = minId as ColonyId;
+    playerCid = minId;
   }
 
   const playerColony = world.colonies[playerCid];
@@ -93,7 +93,7 @@ export function checkQueenDeath(world: WorldState, playerColonyId?: ColonyId): G
   let otherColonyCount = 0;
   for (const key in world.colonies) {
     if (!Object.hasOwn(world.colonies, key)) continue;
-    const cid = Number(key) as ColonyId;
+    const cid = Number(key);
     if (cid === playerCid) continue;
     otherColonyCount += 1;
     const colony = world.colonies[cid]!;
@@ -109,7 +109,7 @@ export function checkQueenDeath(world: WorldState, playerColonyId?: ColonyId): G
   const anyOtherAlive = (() => {
     for (const key in world.colonies) {
       if (!Object.hasOwn(world.colonies, key)) continue;
-      const cid = Number(key) as ColonyId;
+      const cid = Number(key);
       if (cid === playerCid) continue;
       const colony = world.colonies[cid]!;
       if (isQueenAlive(world, colony)) return true;
@@ -242,7 +242,7 @@ export function checkTiebreaks(world: WorldState, playerColonyId: ColonyId): Gam
   let aiColony: ColonyRecord | null = null;
   for (const key in world.colonies) {
     if (!Object.hasOwn(world.colonies, key)) continue;
-    const cid = Number(key) as ColonyId;
+    const cid = Number(key);
     if (cid === playerColonyId) continue;
     const col = world.colonies[cid]!;
     if (world.ants.alive[col.queenEntityId] !== 1) return GameOutcome.None; // AI queen dead → not a tiebreak

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -126,7 +126,7 @@ function placeFighter(
 }
 
 // Hunger value (Normal tier) that puts a V23 spider over the hungry threshold.
-const HUNGRY_TICKS = SPIDER_HUNGER_THRESHOLD_TICKS[1]!;
+const HUNGRY_TICKS = SPIDER_HUNGER_THRESHOLD_TICKS[1];
 
 // ---------------------------------------------------------------------------
 // State transition tests
@@ -157,10 +157,10 @@ describe('tickSpider', () => {
       placeWorker(world, spiderTileX + 2, spiderTileY);
 
       tickSpider(world);
-      expect(world.spider!.state).toBe('Hunting');
-      expect(world.spider!.huntStartTick).toBe(0);
-      expect(world.spider!.huntTargetTileX).toBe(spiderTileX + 2);
-      expect(world.spider!.huntTargetTileY).toBe(spiderTileY);
+      expect(world.spider.state).toBe('Hunting');
+      expect(world.spider.huntStartTick).toBe(0);
+      expect(world.spider.huntTargetTileX).toBe(spiderTileX + 2);
+      expect(world.spider.huntTargetTileY).toBe(spiderTileY);
     });
 
     it('stays Patrolling when no workers in range', () => {
@@ -169,7 +169,7 @@ describe('tickSpider', () => {
       world.spider.nextHuntTick = 0;
       // No workers placed
       tickSpider(world);
-      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider.state).toBe('Patrolling');
     });
 
     it('stays Patrolling when tick < nextHuntTick even with workers present', () => {
@@ -182,7 +182,7 @@ describe('tickSpider', () => {
       placeWorker(world, spiderTileX + 2, spiderTileY);
 
       tickSpider(world);
-      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider.state).toBe('Patrolling');
     });
   });
 
@@ -198,9 +198,9 @@ describe('tickSpider', () => {
       world.tick = SPIDER_TELEGRAPH_TICKS;
 
       tickSpider(world);
-      expect(world.spider!.state).toBe('Striking');
-      expect(world.spider!.strikeStartTick).toBe(SPIDER_TELEGRAPH_TICKS);
-      expect(world.spider!.killsThisStrike).toBe(0);
+      expect(world.spider.state).toBe('Striking');
+      expect(world.spider.strikeStartTick).toBe(SPIDER_TELEGRAPH_TICKS);
+      expect(world.spider.killsThisStrike).toBe(0);
     });
 
     it('stays Hunting before SPIDER_TELEGRAPH_TICKS', () => {
@@ -214,7 +214,7 @@ describe('tickSpider', () => {
       world.tick = SPIDER_TELEGRAPH_TICKS - 1;
 
       tickSpider(world);
-      expect(world.spider!.state).toBe('Hunting');
+      expect(world.spider.state).toBe('Hunting');
     });
   });
 
@@ -231,9 +231,9 @@ describe('tickSpider', () => {
       world.tick = SPIDER_STRIKE_TICKS;
 
       tickSpider(world);
-      expect(world.spider!.state).toBe('Feeding');
-      expect(world.spider!.feedingStartTick).toBe(SPIDER_STRIKE_TICKS);
-      expect(world.spider!.hungerTicks).toBe(0); // reset on Feeding entry
+      expect(world.spider.state).toBe('Feeding');
+      expect(world.spider.feedingStartTick).toBe(SPIDER_STRIKE_TICKS);
+      expect(world.spider.hungerTicks).toBe(0); // reset on Feeding entry
     });
   });
 
@@ -250,9 +250,9 @@ describe('tickSpider', () => {
       world.tick = SPIDER_STRIKE_TICKS;
 
       tickSpider(world);
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.nextHuntTick).toBe(SPIDER_STRIKE_TICKS + SPIDER_HUNT_INTERVAL_TICKS);
-      expect(world.spider!.huntTargetTileX).toBe(-1);
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.nextHuntTick).toBe(SPIDER_STRIKE_TICKS + SPIDER_HUNT_INTERVAL_TICKS);
+      expect(world.spider.huntTargetTileX).toBe(-1);
     });
 
     it('clears stale -2 combatOpponentId sentinels on Striking → Patrolling exit', () => {
@@ -271,7 +271,7 @@ describe('tickSpider', () => {
       world.tick = SPIDER_STRIKE_TICKS;
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider.state).toBe('Patrolling');
       expect(world.ants.combatOpponentId[antId]).toBe(-1);
     });
   });
@@ -288,8 +288,8 @@ describe('tickSpider', () => {
       world.tick = SPIDER_FEEDING_TICKS;
 
       tickSpider(world);
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.nextHuntTick).toBe(SPIDER_FEEDING_TICKS + SPIDER_HUNT_INTERVAL_TICKS);
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.nextHuntTick).toBe(SPIDER_FEEDING_TICKS + SPIDER_HUNT_INTERVAL_TICKS);
     });
   });
 
@@ -303,7 +303,7 @@ describe('tickSpider', () => {
       world.spider = makeSpider({ state: 'Patrolling', hungerTicks: 10 });
       world.tick = 0;
       tickSpider(world);
-      expect(world.spider!.hungerTicks).toBe(11);
+      expect(world.spider.hungerTicks).toBe(11);
     });
 
     it('does not accrue hungerTicks while Feeding', () => {
@@ -315,7 +315,7 @@ describe('tickSpider', () => {
       });
       world.tick = 1;
       tickSpider(world);
-      expect(world.spider!.hungerTicks).toBe(50); // unchanged
+      expect(world.spider.hungerTicks).toBe(50); // unchanged
     });
 
     it('resets hungerTicks on Feeding entry from Striking', () => {
@@ -330,8 +330,8 @@ describe('tickSpider', () => {
       });
       world.tick = SPIDER_STRIKE_TICKS;
       tickSpider(world);
-      expect(world.spider!.state).toBe('Feeding');
-      expect(world.spider!.hungerTicks).toBe(0);
+      expect(world.spider.state).toBe('Feeding');
+      expect(world.spider.hungerTicks).toBe(0);
     });
   });
 
@@ -351,8 +351,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
       // After increment: hungerTicks = SPIDER_HUNGER_MAX_TICKS[1]; triggers rampaging.
-      expect(world.spider!.state).toBe('Rampaging');
-      expect(world.spider!.rampageKillsThisRampage).toBe(0);
+      expect(world.spider.state).toBe('Rampaging');
+      expect(world.spider.rampageKillsThisRampage).toBe(0);
     });
   });
 
@@ -376,17 +376,17 @@ describe('tickSpider', () => {
       world.tick = 0;
 
       tickSpider(world);
-      expect(world.spider!.state).toBe('Rampaging');
+      expect(world.spider.state).toBe('Rampaging');
       expect(
-        world.spider!.rampageTargetColonyId === PLAYER_COLONY_ID ||
-          world.spider!.rampageTargetColonyId === ENEMY_COLONY_ID,
+        world.spider.rampageTargetColonyId === PLAYER_COLONY_ID ||
+          world.spider.rampageTargetColonyId === ENEMY_COLONY_ID,
       ).toBe(true);
 
       // Transition to Feeding via kill quota — target should be cleared.
-      world.spider!.rampageKillsThisRampage = SPIDER_RAMPAGE_KILL_QUOTA;
+      world.spider.rampageKillsThisRampage = SPIDER_RAMPAGE_KILL_QUOTA;
       tickSpider(world);
-      expect(world.spider!.state).toBe('Feeding');
-      expect(world.spider!.rampageTargetColonyId).toBe(-1);
+      expect(world.spider.state).toBe('Feeding');
+      expect(world.spider.rampageTargetColonyId).toBe(-1);
     });
 
     it('always targets a valid colony (not -1) when both colonies exist', () => {
@@ -409,7 +409,7 @@ describe('tickSpider', () => {
         });
         world.tick = seed * 100;
         tickSpider(world);
-        expect(world.spider!.rampageTargetColonyId).toBeGreaterThan(0);
+        expect(world.spider.rampageTargetColonyId).toBeGreaterThan(0);
       }
     });
 
@@ -435,7 +435,7 @@ describe('tickSpider', () => {
         });
         world.tick = tick * 37; // vary tick to get different hash values
         tickSpider(world);
-        chosen.add(world.spider!.rampageTargetColonyId);
+        chosen.add(world.spider.rampageTargetColonyId);
       }
       // Both colonies should appear at least once across 50 rampages.
       expect(chosen.has(PLAYER_COLONY_ID)).toBe(true);
@@ -565,7 +565,7 @@ describe('tickSpider', () => {
       world.tick = 20;
 
       tickSpider(world);
-      expect(world.spider!.hp).toBe(41);
+      expect(world.spider.hp).toBe(41);
     });
 
     it('does not exceed SPIDER_HP_FULL', () => {
@@ -578,7 +578,7 @@ describe('tickSpider', () => {
       world.tick = 20;
 
       tickSpider(world);
-      expect(world.spider!.hp).toBe(SPIDER_HP_FULL);
+      expect(world.spider.hp).toBe(SPIDER_HP_FULL);
     });
   });
 
@@ -596,8 +596,8 @@ describe('tickSpider', () => {
       world.tick = 100;
 
       tickSpider(world);
-      expect(world.spider!.state).toBe('Feeding');
-      expect(world.spider!.hungerTicks).toBe(0);
+      expect(world.spider.state).toBe('Feeding');
+      expect(world.spider.hungerTicks).toBe(0);
     });
   });
 
@@ -617,8 +617,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
     });
 
     it('a hungry spider enters Chasing for the nearest surface ant within trigger radius', () => {
@@ -637,9 +637,9 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Chasing');
-      expect(world.spider!.chaseTargetAntId).toBe(antId);
-      expect(world.spider!.chaseStartTick).toBe(world.tick);
+      expect(world.spider.state).toBe('Chasing');
+      expect(world.spider.chaseTargetAntId).toBe(antId);
+      expect(world.spider.chaseStartTick).toBe(world.tick);
       const evt = world.events.find((e) => e.type === 'spider_chase_start');
       expect(evt).toBeDefined();
     });
@@ -661,8 +661,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Chasing');
-      expect(world.spider!.chaseTargetAntId).toBe(near);
+      expect(world.spider.state).toBe('Chasing');
+      expect(world.spider.chaseTargetAntId).toBe(near);
     });
 
     it('does NOT chase an ant just outside the trigger radius (camps an entrance instead)', () => {
@@ -680,8 +680,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).not.toBe('Chasing');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider.state).not.toBe('Chasing');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
     });
 
     it('does NOT chase under a pre-V23 (V22) world — old-replay guard', () => {
@@ -695,8 +695,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
     });
 
     it('chase takes precedence over entrance-camping when hungry', () => {
@@ -714,7 +714,7 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Chasing');
+      expect(world.spider.state).toBe('Chasing');
     });
 
     it('excludes the queen from chase targets', () => {
@@ -738,8 +738,8 @@ describe('tickSpider', () => {
       tickSpider(world);
 
       // Only the queen is in range and queens are excluded → no chase.
-      expect(world.spider!.state).not.toBe('Chasing');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider.state).not.toBe('Chasing');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
     });
   });
 
@@ -750,7 +750,7 @@ describe('tickSpider', () => {
       world.spider = makeSpider({ state: 'Patrolling', hungerTicks: 10 });
       world.tick = SPIDER_GRACE_TICKS - 1;
       tickSpider(world);
-      expect(world.spider!.hungerTicks).toBe(10); // frozen during grace
+      expect(world.spider.hungerTicks).toBe(10); // frozen during grace
     });
 
     it('resumes hunger accrual at the grace boundary', () => {
@@ -759,7 +759,7 @@ describe('tickSpider', () => {
       world.spider = makeSpider({ state: 'Patrolling', hungerTicks: 10 });
       world.tick = SPIDER_GRACE_TICKS;
       tickSpider(world);
-      expect(world.spider!.hungerTicks).toBe(11);
+      expect(world.spider.hungerTicks).toBe(11);
     });
 
     it('stays dormant — no chase — on the last grace tick even with prey in range', () => {
@@ -779,9 +779,9 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.hungerTicks).toBe(HUNGRY_TICKS - 1); // no accrual → never crosses
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider.hungerTicks).toBe(HUNGRY_TICKS - 1); // no accrual → never crosses
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
     });
 
     it('stays dormant during grace even when hunger already exceeds the threshold (e.g. a loaded save)', () => {
@@ -802,9 +802,9 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
-      expect(world.spider!.hungerTicks).toBe(HUNGRY_TICKS + 100); // frozen during grace
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
+      expect(world.spider.hungerTicks).toBe(HUNGRY_TICKS + 100); // frozen during grace
     });
 
     it('wakes and chases once the grace window ends', () => {
@@ -824,8 +824,8 @@ describe('tickSpider', () => {
       tickSpider(world);
 
       // Accrual resumes → crosses the hungry threshold → opportunistic chase fires.
-      expect(world.spider!.state).toBe('Chasing');
-      expect(world.spider!.chaseTargetAntId).toBe(antId);
+      expect(world.spider.state).toBe('Chasing');
+      expect(world.spider.chaseTargetAntId).toBe(antId);
     });
   });
 
@@ -844,9 +844,9 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Chasing');
-      expect(world.spider!.chaseTargetAntId).toBe(fighterId);
-      expect(world.spider!.chaseStartTick).toBe(world.tick);
+      expect(world.spider.state).toBe('Chasing');
+      expect(world.spider.chaseTargetAntId).toBe(fighterId);
+      expect(world.spider.chaseStartTick).toBe(world.tick);
     });
 
     it('picks the nearest attacking fighter when several are in range', () => {
@@ -861,8 +861,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Chasing');
-      expect(world.spider!.chaseTargetAntId).toBe(near);
+      expect(world.spider.state).toBe('Chasing');
+      expect(world.spider.chaseTargetAntId).toBe(near);
     });
 
     it('ignores a non-fighter worker within defense radius (only bites back attackers)', () => {
@@ -876,8 +876,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
     });
 
     it('does NOT self-defend an attacker outside the defense radius', () => {
@@ -891,8 +891,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
     });
 
     it('does NOT self-defend under a pre-V23 (V22) world — old-replay guard', () => {
@@ -906,8 +906,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
     });
 
     it('a Rampaging spider under attack abandons the camp and Chases the attacker', () => {
@@ -928,9 +928,9 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Chasing');
-      expect(world.spider!.chaseTargetAntId).toBe(fighterId);
-      expect(world.spider!.rampageTargetColonyId).toBe(-1);
+      expect(world.spider.state).toBe('Chasing');
+      expect(world.spider.chaseTargetAntId).toBe(fighterId);
+      expect(world.spider.rampageTargetColonyId).toBe(-1);
       const evt = world.events.find((e) => e.type === 'spider_rampage_end');
       expect(evt).toBeDefined();
       if (evt?.type === 'spider_rampage_end') {
@@ -962,8 +962,8 @@ describe('tickSpider', () => {
 
       // Holds the gate: combat catches the pinned descender this tick; the spider does
       // not chase the attacker off the entrance (which would let the descender escape).
-      expect(world.spider!.state).toBe('Rampaging');
-      expect(world.spider!.rampageTargetColonyId).toBe(PLAYER_COLONY_ID);
+      expect(world.spider.state).toBe('Rampaging');
+      expect(world.spider.rampageTargetColonyId).toBe(PLAYER_COLONY_ID);
     });
 
     it('still self-defends when only the enemy QUEEN sits on the camped entrance (queen does not hold the gate)', () => {
@@ -992,9 +992,9 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Chasing');
-      expect(world.spider!.chaseTargetAntId).toBe(fighterId);
-      expect(world.spider!.rampageTargetColonyId).toBe(-1);
+      expect(world.spider.state).toBe('Chasing');
+      expect(world.spider.chaseTargetAntId).toBe(fighterId);
+      expect(world.spider.rampageTargetColonyId).toBe(-1);
     });
   });
 
@@ -1122,8 +1122,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Chasing');
-      expect(world.spider!.posX).toBe((sx << FP_SHIFT) + SPIDER_SPEED); // moved +X toward target
+      expect(world.spider.state).toBe('Chasing');
+      expect(world.spider.posX).toBe((sx << FP_SHIFT) + SPIDER_SPEED); // moved +X toward target
     });
 
     it('a chase catch (killedThisTick) with no fighter adjacent → Feeding, hunger reset', () => {
@@ -1148,9 +1148,9 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Feeding');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
-      expect(world.spider!.hungerTicks).toBe(0);
+      expect(world.spider.state).toBe('Feeding');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
+      expect(world.spider.hungerTicks).toBe(0);
       const evt = world.events.find((e) => e.type === 'spider_feed_start');
       expect(evt).toBeDefined();
       // The chase episode is closed before Feeding so start/end pairs aren't dangling.
@@ -1176,9 +1176,9 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
-      expect(world.spider!.hungerTicks).toBe(501); // accrued +1, not reset
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
+      expect(world.spider.hungerTicks).toBe(501); // accrued +1, not reset
       // Target died from another source (no killedThisTick) → 'lost', not 'kill',
       // so chase-success telemetry isn't credited a phantom spider kill.
       const evt = world.events.find((e) => e.type === 'spider_chase_end');
@@ -1211,7 +1211,7 @@ describe('tickSpider', () => {
       tickSpider(world);
 
       // Out of Feeding (fighter adjacent) but a real spider kill → 'kill'.
-      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider.state).toBe('Patrolling');
       const evt = world.events.find((e) => e.type === 'spider_chase_end');
       expect(evt).toBeDefined();
       if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('kill');
@@ -1231,8 +1231,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
       const evt = world.events.find((e) => e.type === 'spider_chase_end');
       if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('escape');
     });
@@ -1250,8 +1250,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.chaseTargetAntId).toBe(-1);
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.chaseTargetAntId).toBe(-1);
       const evt = world.events.find((e) => e.type === 'spider_chase_end');
       if (evt?.type === 'spider_chase_end') expect(evt.payload.outcome).toBe('leash');
     });
@@ -1270,8 +1270,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).not.toBe('Retreating');
-      expect(world.spider!.state).toBe('Chasing'); // still pursuing its live target
+      expect(world.spider.state).not.toBe('Retreating');
+      expect(world.spider.state).toBe('Chasing'); // still pursuing its live target
     });
 
     it('emits spider_chase_end(killed) when the spider dies mid-chase', () => {
@@ -1305,9 +1305,9 @@ describe('tickSpider', () => {
       const beforeX = world.spider.posX;
       const beforeY = world.spider.posY;
       tickSpider(world);
-      expect(world.spider!.posX).toBe(beforeX);
-      expect(world.spider!.posY).toBe(beforeY);
-      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider.posX).toBe(beforeX);
+      expect(world.spider.posY).toBe(beforeY);
+      expect(world.spider.state).toBe('Patrolling');
     });
 
     it('writes no scatter reticle while meandering', () => {
@@ -1336,8 +1336,8 @@ describe('tickSpider', () => {
       for (let t = 0; t < 2000; t++) {
         world.tick = t;
         tickSpider(world);
-        const tx = world.spider!.posX >> FP_SHIFT;
-        const ty = world.spider!.posY >> FP_SHIFT;
+        const tx = world.spider.posX >> FP_SHIFT;
+        const ty = world.spider.posY >> FP_SHIFT;
         const d = Math.abs(tx - lairX) + Math.abs(ty - lairY);
         if (d > maxDist) maxDist = d;
       }
@@ -1368,8 +1368,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.hungerTicks).toBe(0);
-      expect(world.spider!.state).not.toBe('Feeding');
+      expect(world.spider.hungerTicks).toBe(0);
+      expect(world.spider.state).not.toBe('Feeding');
     });
 
     it('kill with no fighter adjacent → Feeding, feedAwayTile ~10 tiles from kill, hunger reset', () => {
@@ -1391,10 +1391,10 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Feeding');
-      expect(world.spider!.hungerTicks).toBe(0);
-      const fx = world.spider!.feedAwayTileX;
-      const fy = world.spider!.feedAwayTileY;
+      expect(world.spider.state).toBe('Feeding');
+      expect(world.spider.hungerTicks).toBe(0);
+      const fx = world.spider.feedAwayTileX;
+      const fy = world.spider.feedAwayTileY;
       const dist = Math.abs(fx - sx) + Math.abs(fy - sy);
       expect(dist).toBe(SPIDER_FEED_RETREAT_TILES);
       // The hunt/strike episode is closed before Feeding (no dangling start/end pair).
@@ -1424,9 +1424,9 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Feeding');
-      const fx = world.spider!.feedAwayTileX;
-      const fy = world.spider!.feedAwayTileY;
+      expect(world.spider.state).toBe('Feeding');
+      const fx = world.spider.feedAwayTileX;
+      const fy = world.spider.feedAwayTileY;
       // In-bounds, full retreat distance, and reflected inward (away from the
       // edge) rather than clamped onto the kill tile.
       expect(fx).toBeGreaterThanOrEqual(0);
@@ -1457,9 +1457,9 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Feeding');
-      const fx = world.spider!.feedAwayTileX;
-      const fy = world.spider!.feedAwayTileY;
+      expect(world.spider.state).toBe('Feeding');
+      const fx = world.spider.feedAwayTileX;
+      const fy = world.spider.feedAwayTileY;
       expect(fy).toBeGreaterThanOrEqual(0);
       expect(fy).toBeLessThanOrEqual(SURFACE_GRID_HEIGHT - 1);
       expect(Math.abs(fx - kx) + Math.abs(fy - ky)).toBe(SPIDER_FEED_RETREAT_TILES);
@@ -1487,9 +1487,9 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Feeding');
-      const fx = world.spider!.feedAwayTileX;
-      const fy = world.spider!.feedAwayTileY;
+      expect(world.spider.state).toBe('Feeding');
+      const fx = world.spider.feedAwayTileX;
+      const fy = world.spider.feedAwayTileY;
       expect(fx).toBeGreaterThanOrEqual(0);
       expect(fx).toBeLessThanOrEqual(SURFACE_GRID_WIDTH - 1);
       expect(fy).toBeGreaterThanOrEqual(0);
@@ -1518,7 +1518,7 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Feeding');
+      expect(world.spider.state).toBe('Feeding');
       const rampageEnd = world.events.find((e) => e.type === 'spider_rampage_end');
       expect(rampageEnd).toBeDefined();
       if (rampageEnd?.type === 'spider_rampage_end') {
@@ -1553,8 +1553,8 @@ describe('tickSpider', () => {
       // Healed by roughly SPIDER_FEED_TICKS / interval HP (within 2 of target).
       // eslint-disable-next-line no-restricted-syntax -- test-only expected-count math; both operands are constants, result is floored
       const expectedHeal = Math.floor(SPIDER_FEED_TICKS / SPIDER_FEED_HEAL_INTERVAL_TICKS);
-      expect(world.spider!.hp).toBeGreaterThanOrEqual(startHp + expectedHeal - 2);
-      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider.hp).toBeGreaterThanOrEqual(startHp + expectedHeal - 2);
+      expect(world.spider.state).toBe('Patrolling');
     });
 
     it('a fighter reaching the feeding spider interrupts the heal → Patrolling', () => {
@@ -1576,7 +1576,7 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider.state).toBe('Patrolling');
       const evt = world.events.find((e) => e.type === 'spider_feed_end');
       if (evt?.type === 'spider_feed_end') expect(evt.payload.outcome).toBe('interrupted');
     });
@@ -1597,8 +1597,8 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
-      expect(world.spider!.rampageTargetColonyId).toBe(-1);
+      expect(world.spider.state).toBe('Patrolling');
+      expect(world.spider.rampageTargetColonyId).toBe(-1);
     });
 
     it('Rampaging leashes back to Patrolling after SPIDER_RAMPAGE_MAX_TICKS', () => {
@@ -1614,7 +1614,7 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider.state).toBe('Patrolling');
     });
 
     it('normalizes a loaded Retreating state to Patrolling on the first V23 tick', () => {
@@ -1625,7 +1625,7 @@ describe('tickSpider', () => {
 
       tickSpider(world);
 
-      expect(world.spider!.state).toBe('Patrolling');
+      expect(world.spider.state).toBe('Patrolling');
     });
   });
 });

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -1086,7 +1086,7 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
 
   switch (spider.state) {
     case 'Patrolling': {
-      const hungry = !inGrace && spider.hungerTicks >= SPIDER_HUNGER_THRESHOLD_TICKS[tier]!;
+      const hungry = !inGrace && spider.hungerTicks >= SPIDER_HUNGER_THRESHOLD_TICKS[tier];
       if (hungry) {
         // Precedence: (a) opportunistic chase of a lone ant; (b) telegraphed
         // density hunt (when off cooldown and a dense tile exists); (c) camp a

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -67,7 +67,7 @@ function makeWorldWithColony(seed: number = 42): {
     lifespan: WORKER_LIFESPAN_TICKS,
   });
   world.colonies[1] = createColonyRecord(1, queenId);
-  world.colonies[1]!.foodStored = 10000;
+  world.colonies[1].foodStored = 10000;
   return { world, colonyId: 1 as ColonyId, queenId };
 }
 
@@ -986,7 +986,7 @@ describe('Pheromone step ordering', () => {
 
     // Deposit ran first (added FOOD_TRAIL_DEPOSIT_V14), then decay reduced it.
     // Result must be > 0 (not zero) and <= FOOD_TRAIL_DEPOSIT_V14.
-    const val = phGet(world.pheromoneGrids[gridKey]!, 3, 3);
+    const val = phGet(world.pheromoneGrids[gridKey], 3, 3);
     expect(val).toBeGreaterThan(0);
     expect(val).toBeLessThanOrEqual(FOOD_TRAIL_DEPOSIT_V14);
   });
@@ -1043,7 +1043,7 @@ describe('Tick writeback and return', () => {
       speed: 0,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
-    world.colonies[1]!.foodStored = 10000;
+    world.colonies[1].foodStored = 10000;
 
     // Add a forager so movement uses rng
     for (let i = 0; i < 3; i++) {
@@ -1055,8 +1055,8 @@ describe('Tick writeback and return', () => {
         task: AntTask.Foraging,
         subTask: ForagingSubState.SearchingFood,
       });
-      world.colonies[1]!.workers.push(wid);
-      world.colonies[1]!.workerCount += 1;
+      world.colonies[1].workers.push(wid);
+      world.colonies[1].workerCount += 1;
     }
     const gridKey = pheromoneGridKey(1 as ColonyId, PheromoneType.FoodTrail, 'surface');
     world.pheromoneGrids[gridKey] = createPheromoneGrid(64, 64);
@@ -1108,7 +1108,7 @@ describe('Multi-colony iteration', () => {
       speed: 0,
     });
     world.colonies[1] = createColonyRecord(1, q1);
-    world.colonies[1]!.foodStored = 5000;
+    world.colonies[1].foodStored = 5000;
 
     // Colony 2
     const q2 = allocateEntityId(world);
@@ -1121,7 +1121,7 @@ describe('Multi-colony iteration', () => {
       speed: 0,
     });
     world.colonies[2] = createColonyRecord(2, q2);
-    world.colonies[2]!.foodStored = 5000;
+    world.colonies[2].foodStored = 5000;
 
     // Add 2 workers to each colony
     for (let i = 0; i < 2; i++) {
@@ -1133,8 +1133,8 @@ describe('Multi-colony iteration', () => {
         task: AntTask.Foraging,
         subTask: ForagingSubState.SearchingFood,
       });
-      world.colonies[1]!.workers.push(w1);
-      world.colonies[1]!.workerCount += 1;
+      world.colonies[1].workers.push(w1);
+      world.colonies[1].workerCount += 1;
 
       const w2 = allocateEntityId(world);
       initAnt(world.ants, w2, {
@@ -1144,19 +1144,19 @@ describe('Multi-colony iteration', () => {
         task: AntTask.Foraging,
         subTask: ForagingSubState.SearchingFood,
       });
-      world.colonies[2]!.workers.push(w2);
-      world.colonies[2]!.workerCount += 1;
+      world.colonies[2].workers.push(w2);
+      world.colonies[2].workerCount += 1;
     }
 
     tick(world, []);
 
     // Both colonies consumed food (queen fed)
-    expect(world.colonies[1]!.foodStored).toBe(5000 - QUEEN_FOOD_PER_TICK);
-    expect(world.colonies[2]!.foodStored).toBe(5000 - QUEEN_FOOD_PER_TICK);
+    expect(world.colonies[1].foodStored).toBe(5000 - QUEEN_FOOD_PER_TICK);
+    expect(world.colonies[2].foodStored).toBe(5000 - QUEEN_FOOD_PER_TICK);
     // Both colonies have populated task census
     // (2 mid-cycle foragers each → census forage = 2)
-    expect(world.colonies[1]!.taskCensus.forage).toBe(2);
-    expect(world.colonies[2]!.taskCensus.forage).toBe(2);
+    expect(world.colonies[1].taskCensus.forage).toBe(2);
+    expect(world.colonies[2].taskCensus.forage).toBe(2);
   });
 });
 
@@ -1256,11 +1256,11 @@ describe('Phase 7: MarkDigTile command processing', () => {
       subTask: 0,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
-    world.colonies[1]!.foodStored = 10000;
+    world.colonies[1].foodStored = 10000;
     // Phase 3 extension fields required by tick.ts
-    world.colonies[1]!.entrances = [];
-    world.colonies[1]!.rallyPoint = null;
-    world.colonies[1]!.digFlowFieldDirty = false;
+    world.colonies[1].entrances = [];
+    world.colonies[1].rallyPoint = null;
+    world.colonies[1].digFlowFieldDirty = false;
     world.undergroundGrids[1] = createUndergroundGrid(
       UNDERGROUND_GRID_WIDTH,
       UNDERGROUND_GRID_HEIGHT,
@@ -1455,7 +1455,7 @@ describe('Phase 7: MarkDigTile command processing', () => {
       { type: 'MarkFoodPile', colonyId: colonyA, tileX: 10, tileY: 10, issuedAtTick: 0 },
     ]);
     expect(world.colonies[colonyA]!.priorityFoodPileId).toBe(7);
-    expect(world.colonies[colonyB]!.priorityFoodPileId).toBeNull();
+    expect(world.colonies[colonyB].priorityFoodPileId).toBeNull();
   });
 
   // Test P7-7: PlaceChamber creates PendingChamber with correct dimensions; footprint tiles marked
@@ -1482,7 +1482,7 @@ describe('Phase 7: MarkDigTile command processing', () => {
     const pcKey = `${colonyId}:10:10`;
     expect(world.pendingChambers[pcKey]).toBeDefined();
     const pc = world.pendingChambers[pcKey]!;
-    const dims = CHAMBER_DIMENSIONS[ChamberType.Queen]!;
+    const dims = CHAMBER_DIMENSIONS[ChamberType.Queen];
     expect(pc.width).toBe(dims.width);
     expect(pc.height).toBe(dims.height);
     expect(pc.chamberType).toBe(ChamberType.Queen);
@@ -1556,7 +1556,7 @@ describe('Phase 7: MarkDigTile command processing', () => {
   // Test P7-9: PlaceChamber rejected if out of bounds
   it('Test P7-9: PlaceChamber rejected if out of bounds', () => {
     const { world, colonyId } = makeWorldWithUnderground();
-    const dims = CHAMBER_DIMENSIONS[ChamberType.Queen]!;
+    const dims = CHAMBER_DIMENSIONS[ChamberType.Queen];
     const cmd: SimCommand = {
       type: 'PlaceChamber',
       colonyId,
@@ -1644,7 +1644,7 @@ describe('Phase 7: MarkDigTile command processing', () => {
   // ---------------------------------------------------------------------------
 
   function setupPendingQueenAt(world: WorldState, colonyId: ColonyId, ax: number, ay: number) {
-    const dims = CHAMBER_DIMENSIONS[ChamberType.Queen]!;
+    const dims = CHAMBER_DIMENSIONS[ChamberType.Queen];
     const underground = world.undergroundGrids[colonyId]!;
     // Mark the entire footprint, mirroring what PlaceChamber does.
     for (let dy = 0; dy < dims.height; dy++) {
@@ -1729,7 +1729,7 @@ describe('Phase 7: MarkDigTile command processing', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     const { pcKey: keyA } = setupPendingQueenAt(world, colonyId, 20, 5);
     // Place a second pending chamber far from A.
-    const dims = CHAMBER_DIMENSIONS[ChamberType.Nursery]!;
+    const dims = CHAMBER_DIMENSIONS[ChamberType.Nursery];
     const bx = 60,
       by = 20;
     const underground = world.undergroundGrids[colonyId]!;
@@ -1763,7 +1763,7 @@ describe('Phase 7: MarkDigTile command processing', () => {
   it('Issue #54 (v9): cross-colony — cancel in colony A leaves colony B pending chamber intact', () => {
     const { world, colonyId: colonyA } = makeWorldWithUnderground();
     // Set up a sibling colony B with its own underground grid.
-    const colonyB = (colonyA + 1) as ColonyId;
+    const colonyB = colonyA + 1;
     const queenB = allocateEntityId(world);
     initAnt(world.ants, queenB, {
       colonyId: colonyB,
@@ -1773,9 +1773,9 @@ describe('Phase 7: MarkDigTile command processing', () => {
       subTask: 0,
     });
     world.colonies[colonyB] = createColonyRecord(colonyB, queenB);
-    world.colonies[colonyB]!.entrances = [];
-    world.colonies[colonyB]!.rallyPoint = null;
-    world.colonies[colonyB]!.digFlowFieldDirty = false;
+    world.colonies[colonyB].entrances = [];
+    world.colonies[colonyB].rallyPoint = null;
+    world.colonies[colonyB].digFlowFieldDirty = false;
     world.undergroundGrids[colonyB] = createUndergroundGrid(
       UNDERGROUND_GRID_WIDTH,
       UNDERGROUND_GRID_HEIGHT,
@@ -1831,7 +1831,7 @@ describe('Phase 7: MarkDigTile command processing', () => {
     // benefits, since checkPendingChambers' all-Open promotion gate is the
     // shared mechanism that orphans the entry.
     const { world, colonyId } = makeWorldWithUnderground();
-    const dims = CHAMBER_DIMENSIONS[ChamberType.Nursery]!;
+    const dims = CHAMBER_DIMENSIONS[ChamberType.Nursery];
     const ax = 30,
       ay = 8;
     const underground = world.undergroundGrids[colonyId]!;
@@ -1871,10 +1871,10 @@ describe('Phase 7: Step ordering tests', () => {
       subTask: 0,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
-    world.colonies[1]!.foodStored = 10000;
-    world.colonies[1]!.entrances = [];
-    world.colonies[1]!.rallyPoint = null;
-    world.colonies[1]!.digFlowFieldDirty = false;
+    world.colonies[1].foodStored = 10000;
+    world.colonies[1].entrances = [];
+    world.colonies[1].rallyPoint = null;
+    world.colonies[1].digFlowFieldDirty = false;
     world.undergroundGrids[1] = createUndergroundGrid(
       UNDERGROUND_GRID_WIDTH,
       UNDERGROUND_GRID_HEIGHT,
@@ -1902,7 +1902,7 @@ describe('Phase 7: Step ordering tests', () => {
   it('Test P7-14: step 11 checkPendingChambers promotes fully-open PendingChamber to ChamberRecord', () => {
     const { world, colonyId } = makeWorldWithUnderground();
     const underground = world.undergroundGrids[colonyId]!;
-    const dims = CHAMBER_DIMENSIONS[ChamberType.Nursery]!;
+    const dims = CHAMBER_DIMENSIONS[ChamberType.Nursery];
     const ax = 20,
       ay = 5;
     // Pre-open all footprint tiles
@@ -2168,7 +2168,7 @@ describe('Phase 7: Integration tests', () => {
     const colony = world.colonies[colonyId]!;
 
     const chamberType = ChamberType.FoodStorage;
-    const dims = CHAMBER_DIMENSIONS[chamberType]!;
+    const dims = CHAMBER_DIMENSIONS[chamberType];
     const ax = 30,
       ay = 10;
 
@@ -2262,10 +2262,10 @@ describe('Regression: reviewer P1 fixes', () => {
       subTask: 0,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
-    world.colonies[1]!.foodStored = 10000;
-    world.colonies[1]!.entrances = [];
-    world.colonies[1]!.rallyPoint = null;
-    world.colonies[1]!.digFlowFieldDirty = false;
+    world.colonies[1].foodStored = 10000;
+    world.colonies[1].entrances = [];
+    world.colonies[1].rallyPoint = null;
+    world.colonies[1].digFlowFieldDirty = false;
     world.undergroundGrids[1] = createUndergroundGrid(
       UNDERGROUND_GRID_WIDTH,
       UNDERGROUND_GRID_HEIGHT,
@@ -2708,11 +2708,11 @@ describe('Regression: reviewer P1 fixes', () => {
     const queen2 = allocateEntityId(world);
     initAnt(world.ants, queen2, { colonyId: 2, posX: 0, posY: 0, task: AntTask.Idle, subTask: 0 });
     world.colonies[2] = createColonyRecord(2, queen2);
-    world.colonies[2]!.entrances = [
+    world.colonies[2].entrances = [
       { entranceId: 999, surfaceTileX: 50, surfaceTileY: 0, isOpen: true },
     ];
-    world.colonies[2]!.rallyPoint = null;
-    world.colonies[2]!.digFlowFieldDirty = false;
+    world.colonies[2].rallyPoint = null;
+    world.colonies[2].digFlowFieldDirty = false;
     world.undergroundGrids[2] = createUndergroundGrid(
       UNDERGROUND_GRID_WIDTH,
       UNDERGROUND_GRID_HEIGHT,
@@ -2751,8 +2751,8 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
       subTask: 0,
     });
     world.colonies[1] = createColonyRecord(1, queenId);
-    world.colonies[1]!.foodStored = 10000;
-    world.colonies[1]!.entrances = [
+    world.colonies[1].foodStored = 10000;
+    world.colonies[1].entrances = [
       {
         entranceId: 999,
         surfaceTileX: entranceX,
@@ -2760,8 +2760,8 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
         isOpen: true,
       },
     ];
-    world.colonies[1]!.rallyPoint = null;
-    world.colonies[1]!.digFlowFieldDirty = false;
+    world.colonies[1].rallyPoint = null;
+    world.colonies[1].digFlowFieldDirty = false;
     const ug = createUndergroundGrid(UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
     world.undergroundGrids[1] = ug;
     return { world, colonyId: 1 as ColonyId, ug, entranceX };
@@ -2845,7 +2845,7 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     };
     tick(world, [cmd]);
     // Every Solid footprint tile should be Marked now.
-    const dims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage]!;
+    const dims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage];
     for (let dy = 0; dy < dims.height; dy++) {
       for (let dx = 0; dx < dims.width; dx++) {
         const state = ugGet(ug, entranceX + dx, 10 + dy);
@@ -2909,7 +2909,7 @@ describe('PlaceChamber v5 — chamber on Marked tiles (issue #38)', () => {
     tick(world, [cmd]);
     expect(world.pendingChambers[`${colonyId}:${entranceX}:10`]).toBeDefined();
     // Manually open the footprint (simulating excavation complete) and tick.
-    const dims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage]!;
+    const dims = CHAMBER_DIMENSIONS[ChamberType.FoodStorage];
     for (let dy = 0; dy < dims.height; dy++) {
       for (let dx = 0; dx < dims.width; dx++) {
         ug.data[(10 + dy) * UNDERGROUND_GRID_WIDTH + (entranceX + dx)] = UndergroundTileState.Open;
@@ -2982,10 +2982,10 @@ function makeTwoColonyWorld(): {
     lifespan: WORKER_LIFESPAN_TICKS,
   });
   world.colonies[1] = createColonyRecord(1, playerQueenId);
-  world.colonies[1]!.foodStored = 100000;
-  world.colonies[1]!.entrances = [];
-  world.colonies[1]!.rallyPoint = null;
-  world.colonies[1]!.digFlowFieldDirty = false;
+  world.colonies[1].foodStored = 100000;
+  world.colonies[1].entrances = [];
+  world.colonies[1].rallyPoint = null;
+  world.colonies[1].digFlowFieldDirty = false;
 
   // Enemy colony (ID=2)
   const enemyQueenId = allocateEntityId(world);
@@ -2999,10 +2999,10 @@ function makeTwoColonyWorld(): {
     lifespan: WORKER_LIFESPAN_TICKS,
   });
   world.colonies[2] = createColonyRecord(2, enemyQueenId);
-  world.colonies[2]!.foodStored = 100000;
-  world.colonies[2]!.entrances = [];
-  world.colonies[2]!.rallyPoint = null;
-  world.colonies[2]!.digFlowFieldDirty = false;
+  world.colonies[2].foodStored = 100000;
+  world.colonies[2].entrances = [];
+  world.colonies[2].rallyPoint = null;
+  world.colonies[2].digFlowFieldDirty = false;
 
   return {
     world,

--- a/src/sim/types.test.ts
+++ b/src/sim/types.test.ts
@@ -399,10 +399,10 @@ describe('WorldState', () => {
       it('colony creation: dst gains colony with correct scalar fields after copy', () => {
         src.colonies[1] = createColonyRecord(1, 42);
         // Phase 3 PRD §2a caller-side init (required before copyWorldState reads these fields)
-        src.colonies[1]!.entrances = [];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = false;
-        src.colonies[1]!.foodStored = 500;
+        src.colonies[1].entrances = [];
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = false;
+        src.colonies[1].foodStored = 500;
         copyWorldState(src, dst);
         expect(dst.colonies[1]).toBeDefined();
         expect(dst.colonies[1]!.foodStored).toBe(500);
@@ -412,9 +412,9 @@ describe('WorldState', () => {
       it('colony deletion propagation: colony removed from src is removed from dst on next copy', () => {
         src.colonies[2] = createColonyRecord(2, 50);
         // Phase 3 PRD §2a caller-side init
-        src.colonies[2]!.entrances = [];
-        src.colonies[2]!.rallyPoint = null;
-        src.colonies[2]!.digFlowFieldDirty = false;
+        src.colonies[2].entrances = [];
+        src.colonies[2].rallyPoint = null;
+        src.colonies[2].digFlowFieldDirty = false;
         copyWorldState(src, dst);
         expect(dst.colonies[2]).toBeDefined();
         delete src.colonies[2];
@@ -425,25 +425,25 @@ describe('WorldState', () => {
       it('colony bucket arrays independence: workers array values copied but not same reference', () => {
         src.colonies[1] = createColonyRecord(1, 10);
         // Phase 3 PRD §2a caller-side init
-        src.colonies[1]!.entrances = [];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = false;
-        src.colonies[1]!.workers = [10, 20, 30];
+        src.colonies[1].entrances = [];
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = false;
+        src.colonies[1].workers = [10, 20, 30];
         copyWorldState(src, dst);
         expect(dst.colonies[1]!.workers).toEqual([10, 20, 30]);
-        expect(dst.colonies[1]!.workers).not.toBe(src.colonies[1]!.workers);
+        expect(dst.colonies[1]!.workers).not.toBe(src.colonies[1].workers);
       });
 
       it('nested plain-object reuse: targetRatio object identity preserved through copy (zero-alloc steady state)', () => {
         src.colonies[1] = createColonyRecord(1, 10);
         // Phase 3 PRD §2a caller-side init
-        src.colonies[1]!.entrances = [];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = false;
+        src.colonies[1].entrances = [];
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = false;
         copyWorldState(src, dst);
         const beforeRatio = dst.colonies[1]!.targetRatio;
         // Mutate src ratio, then copy again
-        src.colonies[1]!.targetRatio.forage = 5;
+        src.colonies[1].targetRatio.forage = 5;
         copyWorldState(src, dst);
         // Same object reference — field-by-field copy, not spread
         expect(dst.colonies[1]!.targetRatio).toBe(beforeRatio);
@@ -454,10 +454,10 @@ describe('WorldState', () => {
       it('taskCensus shape preserved through copy: 4 fields (nurse, forage, dig, fight) — no idle', () => {
         src.colonies[1] = createColonyRecord(1, 10);
         // Phase 3 PRD §2a caller-side init
-        src.colonies[1]!.entrances = [];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = false;
-        src.colonies[1]!.taskCensus = { nurse: 2, forage: 3, dig: 1, fight: 0 };
+        src.colonies[1].entrances = [];
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = false;
+        src.colonies[1].taskCensus = { nurse: 2, forage: 3, dig: 1, fight: 0 };
         copyWorldState(src, dst);
         const keys = Object.keys(dst.colonies[1]!.taskCensus).sort();
         expect(keys).toEqual(['dig', 'fight', 'forage', 'nurse']);
@@ -479,17 +479,17 @@ describe('WorldState', () => {
 
       it('pheromone grid round trip: cell value copied correctly', () => {
         src.pheromoneGrids['1:0:surface'] = createPheromoneGrid(16, 16);
-        phSet(src.pheromoneGrids['1:0:surface']!, 3, 3, 77);
+        phSet(src.pheromoneGrids['1:0:surface'], 3, 3, 77);
         copyWorldState(src, dst);
         expect(phGet(dst.pheromoneGrids['1:0:surface']!, 3, 3)).toBe(77);
       });
 
       it('pheromone grid data independence: mutating src after copy does not affect dst', () => {
         src.pheromoneGrids['1:0:surface'] = createPheromoneGrid(16, 16);
-        phSet(src.pheromoneGrids['1:0:surface']!, 3, 3, 77);
+        phSet(src.pheromoneGrids['1:0:surface'], 3, 3, 77);
         copyWorldState(src, dst);
         // Mutate src AFTER copy — dst must remain unchanged
-        phSet(src.pheromoneGrids['1:0:surface']!, 3, 3, 999);
+        phSet(src.pheromoneGrids['1:0:surface'], 3, 3, 999);
         expect(phGet(dst.pheromoneGrids['1:0:surface']!, 3, 3)).toBe(77);
       });
 
@@ -527,7 +527,7 @@ describe('WorldState', () => {
 
       it('undergroundGrids: add grid to src, copy, verify dst has it', () => {
         src.undergroundGrids[1] = createUndergroundGrid(128, 64);
-        src.undergroundGrids[1]!.data[0] = 5;
+        src.undergroundGrids[1].data[0] = 5;
         copyWorldState(src, dst);
         expect(dst.undergroundGrids[1]).toBeDefined();
         expect(dst.undergroundGrids[1]!.data[0]).toBe(5);
@@ -535,9 +535,9 @@ describe('WorldState', () => {
 
       it('undergroundGrids: mutate src grid after copy, verify dst unchanged', () => {
         src.undergroundGrids[1] = createUndergroundGrid(128, 64);
-        src.undergroundGrids[1]!.data[0] = 5;
+        src.undergroundGrids[1].data[0] = 5;
         copyWorldState(src, dst);
-        src.undergroundGrids[1]!.data[0] = 99;
+        src.undergroundGrids[1].data[0] = 99;
         expect(dst.undergroundGrids[1]!.data[0]).toBe(5);
       });
 
@@ -673,9 +673,9 @@ describe('WorldState', () => {
       it('new-colony fallback patches Phase 3 defaults: entrances=[], rallyPoint=null, digFlowFieldDirty=false before extension copy', () => {
         // src has colony 1 with default Phase 3 fields; dst has no colony 1 yet
         src.colonies[1] = createColonyRecord(1, 42);
-        src.colonies[1]!.entrances = [];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = false;
+        src.colonies[1].entrances = [];
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = false;
         copyWorldState(src, dst);
         expect(dst.colonies[1]).toBeDefined();
         expect(Array.isArray(dst.colonies[1]!.entrances)).toBe(true);
@@ -685,11 +685,11 @@ describe('WorldState', () => {
 
       it('copies colony.entrances: add entrance to src colony, copy, verify', () => {
         src.colonies[1] = createColonyRecord(1, 42);
-        src.colonies[1]!.entrances = [
+        src.colonies[1].entrances = [
           { entranceId: 1, surfaceTileX: 10, surfaceTileY: 64, isOpen: true },
         ];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = false;
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = false;
         copyWorldState(src, dst);
         expect(dst.colonies[1]!.entrances.length).toBe(1);
         expect(dst.colonies[1]!.entrances[0]!.surfaceTileX).toBe(10);
@@ -698,65 +698,65 @@ describe('WorldState', () => {
 
       it('copies colony.entrances: shrink src entrances array, copy, verify dst shrunk', () => {
         src.colonies[1] = createColonyRecord(1, 42);
-        src.colonies[1]!.entrances = [
+        src.colonies[1].entrances = [
           { entranceId: 1, surfaceTileX: 10, surfaceTileY: 64, isOpen: false },
           { entranceId: 2, surfaceTileX: 20, surfaceTileY: 64, isOpen: false },
         ];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = false;
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = false;
         copyWorldState(src, dst);
         expect(dst.colonies[1]!.entrances.length).toBe(2);
-        src.colonies[1]!.entrances.pop();
+        src.colonies[1].entrances.pop();
         copyWorldState(src, dst);
         expect(dst.colonies[1]!.entrances.length).toBe(1);
       });
 
       it('copies colony.rallyPoint: null → object → object-update → null transitions', () => {
         src.colonies[1] = createColonyRecord(1, 42);
-        src.colonies[1]!.entrances = [];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = false;
+        src.colonies[1].entrances = [];
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = false;
 
         // null → null
         copyWorldState(src, dst);
         expect(dst.colonies[1]!.rallyPoint).toBeNull();
 
         // null → object
-        src.colonies[1]!.rallyPoint = { tileX: 5, tileY: 10 };
+        src.colonies[1].rallyPoint = { tileX: 5, tileY: 10 };
         copyWorldState(src, dst);
         expect(dst.colonies[1]!.rallyPoint).toEqual({ tileX: 5, tileY: 10 });
 
         // object → object update (same reference in dst)
         const prevRef = dst.colonies[1]!.rallyPoint;
-        src.colonies[1]!.rallyPoint = { tileX: 7, tileY: 12 };
+        src.colonies[1].rallyPoint = { tileX: 7, tileY: 12 };
         copyWorldState(src, dst);
         expect(dst.colonies[1]!.rallyPoint).toEqual({ tileX: 7, tileY: 12 });
         expect(dst.colonies[1]!.rallyPoint).toBe(prevRef); // object identity preserved
 
         // object → null
-        src.colonies[1]!.rallyPoint = null;
+        src.colonies[1].rallyPoint = null;
         copyWorldState(src, dst);
         expect(dst.colonies[1]!.rallyPoint).toBeNull();
       });
 
       it('copies colony.digFlowFieldDirty: true/false transitions', () => {
         src.colonies[1] = createColonyRecord(1, 42);
-        src.colonies[1]!.entrances = [];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = true;
+        src.colonies[1].entrances = [];
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = true;
         copyWorldState(src, dst);
         expect(dst.colonies[1]!.digFlowFieldDirty).toBe(true);
 
-        src.colonies[1]!.digFlowFieldDirty = false;
+        src.colonies[1].digFlowFieldDirty = false;
         copyWorldState(src, dst);
         expect(dst.colonies[1]!.digFlowFieldDirty).toBe(false);
       });
 
       it('entrances array independence: pushing to dst does not affect src', () => {
         src.colonies[1] = createColonyRecord(1, 42);
-        src.colonies[1]!.entrances = [];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = false;
+        src.colonies[1].entrances = [];
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = false;
         copyWorldState(src, dst);
         dst.colonies[1]!.entrances.push({
           entranceId: 99,
@@ -764,45 +764,45 @@ describe('WorldState', () => {
           surfaceTileY: 64,
           isOpen: false,
         });
-        expect(src.colonies[1]!.entrances.length).toBe(0);
+        expect(src.colonies[1].entrances.length).toBe(0);
       });
 
       it('copyWorldState round-trips killCount', () => {
         src.colonies[1] = createColonyRecord(1, 42);
-        src.colonies[1]!.entrances = [];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = false;
-        src.colonies[1]!.killCount = 5;
+        src.colonies[1].entrances = [];
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = false;
+        src.colonies[1].killCount = 5;
 
         dst.colonies[1] = createColonyRecord(1, 42);
-        dst.colonies[1]!.entrances = [];
-        dst.colonies[1]!.rallyPoint = null;
-        dst.colonies[1]!.digFlowFieldDirty = false;
-        dst.colonies[1]!.killCount = 99;
+        dst.colonies[1].entrances = [];
+        dst.colonies[1].rallyPoint = null;
+        dst.colonies[1].digFlowFieldDirty = false;
+        dst.colonies[1].killCount = 99;
 
         copyWorldState(src, dst);
-        expect(dst.colonies[1]!.killCount).toBe(5);
+        expect(dst.colonies[1].killCount).toBe(5);
       });
 
       it('copyWorldState round-trips priorityFoodPileId (both a concrete id and null)', () => {
         src.colonies[1] = createColonyRecord(1, 42);
-        src.colonies[1]!.entrances = [];
-        src.colonies[1]!.rallyPoint = null;
-        src.colonies[1]!.digFlowFieldDirty = false;
-        src.colonies[1]!.priorityFoodPileId = 7;
+        src.colonies[1].entrances = [];
+        src.colonies[1].rallyPoint = null;
+        src.colonies[1].digFlowFieldDirty = false;
+        src.colonies[1].priorityFoodPileId = 7;
 
         dst.colonies[1] = createColonyRecord(1, 42);
-        dst.colonies[1]!.entrances = [];
-        dst.colonies[1]!.rallyPoint = null;
-        dst.colonies[1]!.digFlowFieldDirty = false;
-        dst.colonies[1]!.priorityFoodPileId = 99;
+        dst.colonies[1].entrances = [];
+        dst.colonies[1].rallyPoint = null;
+        dst.colonies[1].digFlowFieldDirty = false;
+        dst.colonies[1].priorityFoodPileId = 99;
 
         copyWorldState(src, dst);
-        expect(dst.colonies[1]!.priorityFoodPileId).toBe(7);
+        expect(dst.colonies[1].priorityFoodPileId).toBe(7);
 
-        src.colonies[1]!.priorityFoodPileId = null;
+        src.colonies[1].priorityFoodPileId = null;
         copyWorldState(src, dst);
-        expect(dst.colonies[1]!.priorityFoodPileId).toBeNull();
+        expect(dst.colonies[1].priorityFoodPileId).toBeNull();
       });
     });
   }); // end describe('copyWorldState')

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -809,7 +809,7 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
     if (!(colonyId in dst.colonies)) {
       dst.colonies[colonyId] = createColonyRecord(s.colonyId, s.queenEntityId);
       // Phase 3 PRD §2a caller-side extension defaults (factory does not set these):
-      const fresh = dst.colonies[colonyId]!;
+      const fresh = dst.colonies[colonyId];
       fresh.entrances = [];
       fresh.rallyPoint = null;
       fresh.digFlowFieldDirty = false;


### PR DESCRIPTION
## Summary

PR B of two. Adds typescript-eslint **`recommended-type-checked`** as a type-aware lint gate, catching `any`-leakage, unawaited promises, and redundant assertions the non-type-aware config can't see.

`npm run verify` is green including the new gate; **2290 tests pass**.

> **Stacked on #184 (Prettier).** Base is `chore/add-prettier` so this diff shows *only* the type-check changes. After #184 merges I'll retarget this to `main`.

## Architecture — a separate config, on purpose

`eslint.typecheck.config.ts` is **not** merged into `eslint.config.ts`. The fast config is what `npm run lint` *and the per-edit sim-boundary hook* run; type-aware linting rebuilds the TS program (seconds) per invocation, so folding it in would add that latency to **every edit**. Instead it's gated only in `npm run lint:types` → `verify` → CI.

- `parserOptions.projectService` against the project tsconfig (`strict`, `noUncheckedIndexedAccess` already on).
- Carries over `eslint.config.ts`'s `^_`-ignore for `no-unused-vars`.

## Findings resolved

**335 redundant type assertions auto-removed** (`eslint --fix`). Safe by construction — the rule only flags assertions `tsc` proves are no-ops (`EntityId`/`ColonyId` are plain `number` aliases, so the brand-looking casts were pure noise). `tsc --noEmit` + the full suite confirm no behavior change.

**4 production type-safety fixes** (hand-written, not suppressed):
| File | Fix |
|------|-----|
| `platform/save.ts` | drop now-unused `ChamberType` import (its `as` cast was auto-removed) |
| `render/chamber-shape.ts` | `new Array<number>(n)` — bare `new Array(n)` is `any[]` |
| `render/game-scene.ts` (×2) | type Phaser `registry.get()` reads as `unknown`; existing `typeof === 'string'` guards narrow them |

## Policy decision for reviewers

The `no-unsafe-*` / `require-await` / `unbound-method` family is **relaxed for `*.test.ts`** (documented in-config). Tests legitimately use `any` (JSON.parse round-trips, deliberately-malformed validation inputs, loose mocks) and loose async. Enforcing there means contorting fixtures for no shipped-code benefit. The genuine bug-catchers — `no-floating-promises`, `no-misused-promises`, `await-thenable` — stay **ON everywhere** and found **zero** violations.

## Risk

No `simVersion` impact. The assertion removals are `tsc`-verified no-ops; the 2290-test suite passing is the behavior safety check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)