### PR TITLE
fix(sim): foreign-grid recall keys on rally point, not fight ratio (V25, #174)

### DIFF
--- a/src/sim/ant/ant-system.ts
+++ b/src/sim/ant/ant-system.ts
@@ -36,6 +36,7 @@ import {
   type WorldState,
   SIM_VERSION_V23_SPIDER_AGGRO,
   SIM_VERSION_V24_NURSERY_CAPACITY,
+  SIM_VERSION_V25_RALLY_RECALL,
 } from '../types.js';
 import {
   SurfaceMovementEffect,
@@ -4597,8 +4598,16 @@ export function tickAntMovement(
         const ownColony = world.colonies[ownColonyId];
         // null colony is treated as NOT recalled (matches isRecallingFromForeign guard
         // in skipAscent) — missing colony record is a defensive fallback, not a recall.
+        // V25 (#174): recall keys on the rally point alone — a cleared rally means
+        // "come home". Pre-V25 also recalled on fight===0, which fought an explicit
+        // rally on the enemy entrance and bounced invaders at the shaft. Kept gated
+        // for byte-identical replay of pre-V25 saves. Must stay in lockstep with the
+        // ascent skipAscent predicate below (~line 5210).
         const isRecalling =
-          ownColony != null && (ownColony.targetRatio.fight === 0 || ownColony.rallyPoint == null);
+          ownColony != null &&
+          (world.simVersion >= SIM_VERSION_V25_RALLY_RECALL
+            ? ownColony.rallyPoint == null
+            : ownColony.targetRatio.fight === 0 || ownColony.rallyPoint == null);
 
         if (isRecalling) {
           // Recalled invader: navigate toward the nearest foreign entrance exit
@@ -5193,13 +5202,21 @@ export function tickAntMovement(
           //       which is also why the warp-home bug only surfaced on
           //       coincidental tileX alignment.
           const inOwnGrid = ants.currentGridColonyId[id] === ants.colonyId[id];
-          // Recalled invaders (fight ratio zeroed or rally cleared) must be able to
-          // exit the enemy underground, so skipAscent is cleared for them.
+          // Recalled invaders must be able to exit the enemy underground, so
+          // skipAscent is cleared for them. V25 (#174): recall keys on a cleared
+          // rally alone. Pre-V25 also recalled on fight===0, which made invaders
+          // ascend the moment they reached tileY=0 on the enemy entrance column
+          // even with a rally explicitly set there, producing a descend/ascend
+          // bounce. Kept gated for byte-identical replay. Must match the
+          // underground recall-navigation predicate above (~line 4600).
           const ownColonyForAscent = world.colonies[ants.colonyId[id]!];
           const isRecallingFromForeign =
             !inOwnGrid &&
             ownColonyForAscent != null &&
-            (ownColonyForAscent.targetRatio.fight === 0 || ownColonyForAscent.rallyPoint == null);
+            (world.simVersion >= SIM_VERSION_V25_RALLY_RECALL
+              ? ownColonyForAscent.rallyPoint == null
+              : ownColonyForAscent.targetRatio.fight === 0 ||
+                ownColonyForAscent.rallyPoint == null);
           const skipAscent = task === AntTask.Fighting && !inOwnGrid && !isRecallingFromForeign;
           if (!skipAscent) {
             const lookupColonyId = ants.currentGridColonyId[id]!;

--- a/src/sim/invasion-routing.test.ts
+++ b/src/sim/invasion-routing.test.ts
@@ -34,7 +34,12 @@
 import { describe, it, expect } from 'vitest';
 import { createScenario } from './scenario.js';
 import { tick } from './tick.js';
-import { allocateEntityId } from './types.js';
+import {
+  allocateEntityId,
+  LATEST_SIM_VERSION,
+  SIM_VERSION_V24_NURSERY_CAPACITY,
+  SIM_VERSION_V25_RALLY_RECALL,
+} from './types.js';
 import { initAnt } from './ant/ant-store.js';
 import { AntTask } from './enums.js';
 import { Zone, UndergroundTileState, ugSet } from './terrain.js';
@@ -317,5 +322,100 @@ describe('invasion-routing — Fighting ant descent-intent gate (REQ-C3)', () =>
     expect(world.ants.zone[playerAntId]).toBe(Zone.Surface);
     expect(world.ants.task[playerAntId]).toBe(AntTask.Foraging);
     expect(world.ants.currentGridColonyId[playerAntId]).toBe(PLAYER_COLONY_ID);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #174 — foreign-grid recall keys on the rally point, not the fight ratio.
+//
+// Repro: the player rallies fighters to an OPEN enemy entrance (an explicit
+// "invade here" command) but leaves the fight ratio at 0 ("don't make MORE
+// fighters"). Pre-V25, the `targetRatio.fight === 0` disjunct in the recall
+// predicate fired, so each invader ascended the instant it reached tileY=0 on
+// the enemy entrance column, then re-descended next tick — a descend/ascend
+// bounce that never let fighters commit inside the enemy colony.
+//
+// V25 keys recall on `rallyPoint == null` alone: with a rally still set, a
+// fight ratio of 0 no longer pulls existing fighters out. The control test
+// pins simVersion to V24 to lock in the pre-fix bounce as the version boundary.
+// ---------------------------------------------------------------------------
+describe('invasion-routing — foreign recall keys on rally, not fight ratio (#174)', () => {
+  const DESCENT_TICKS = 5;
+  // Window long enough to catch the period-≈2 descend/ascend bounce many times
+  // over (the bug surfaces within 1–2 ticks of fight=0), but short enough to
+  // stay inside the committed-Fighting state.
+  const HOLD_TICKS = 20;
+
+  /**
+   * Stage a player Fighter committed inside the enemy underground grid, with the
+   * rally still on the enemy entrance. Returns once descent is confirmed; the
+   * caller then zeroes the fight ratio and asserts hold-vs-bounce.
+   */
+  function descendCommittedInvader(seed = 4242) {
+    const ctx = buildInvasionWorld(seed);
+    const { world, playerAntId } = ctx;
+    world.ants.task[playerAntId] = AntTask.Fighting;
+    // buildInvasionWorld already set rally = enemy entrance and fight = 5, so the
+    // invader descends and commits rather than recalling on contact.
+    tickN(world, DESCENT_TICKS);
+    // Precondition: invader is underground in the ENEMY grid. If this fails the
+    // harness broke (descent never happened) — not the recall gate.
+    expect(world.ants.zone[playerAntId]).toBe(Zone.Underground);
+    expect(world.ants.currentGridColonyId[playerAntId]).toBe(ENEMY_COLONY_ID);
+    expect(world.ants.task[playerAntId]).toBe(AntTask.Fighting);
+    return ctx;
+  }
+
+  it('V25: invader HOLDS underground when rally is set and fight ratio drops to 0 (no bounce)', () => {
+    const { world, playerAntId, enemyEntTileX, enemyEntTileY } = descendCommittedInvader();
+
+    // Player stops reinforcing (fight → 0) but leaves the rally on the enemy
+    // entrance: "hold what you have inside, don't make more".
+    world.colonies[PLAYER_COLONY_ID]!.targetRatio.fight = 0;
+
+    // Preconditions for the gate under test.
+    expect(world.simVersion).toBe(LATEST_SIM_VERSION);
+    expect(world.simVersion).toBeGreaterThanOrEqual(SIM_VERSION_V25_RALLY_RECALL);
+    expect(world.colonies[PLAYER_COLONY_ID]!.rallyPoint).toEqual({
+      tileX: enemyEntTileX,
+      tileY: enemyEntTileY,
+    });
+    expect(world.colonies[PLAYER_COLONY_ID]!.targetRatio.fight).toBe(0);
+
+    // Act + assert: the invader must stay underground in the enemy grid for the
+    // whole window — never surfacing. Checking every tick catches the period-≈2
+    // bounce that the pre-V25 predicate produced.
+    for (let t = 0; t < HOLD_TICKS; t++) {
+      const cmds = world.commandQueue.splice(0);
+      tick(world, cmds);
+      expect(world.ants.zone[playerAntId]).toBe(Zone.Underground);
+    }
+    expect(world.ants.currentGridColonyId[playerAntId]).toBe(ENEMY_COLONY_ID);
+    // Still a committed fighter — fight=0 never demoted the existing invader
+    // (reassignment only promotes Idle ants; see tick.ts §10a).
+    expect(world.ants.task[playerAntId]).toBe(AntTask.Fighting);
+  });
+
+  it('V24 control: same scenario bounces the invader back to the surface (pre-fix behavior)', () => {
+    const { world, playerAntId } = descendCommittedInvader();
+    // Pin the sim to the pre-#174 version: recall still fires on fight===0.
+    world.simVersion = SIM_VERSION_V24_NURSERY_CAPACITY;
+    world.colonies[PLAYER_COLONY_ID]!.targetRatio.fight = 0;
+
+    expect(world.simVersion).toBeLessThan(SIM_VERSION_V25_RALLY_RECALL);
+
+    // Under V24 the fight===0 disjunct recalls the invader: it routes to the
+    // entrance exit and ascends. Confirm it reaches the Surface within the
+    // window — the exact bounce that V25 eliminates.
+    let surfaced = false;
+    for (let t = 0; t < HOLD_TICKS; t++) {
+      const cmds = world.commandQueue.splice(0);
+      tick(world, cmds);
+      if (world.ants.zone[playerAntId] === Zone.Surface) {
+        surfaced = true;
+        break;
+      }
+    }
+    expect(surfaced).toBe(true);
   });
 });

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -306,7 +306,25 @@ export const SIM_VERSION_V23_SPIDER_AGGRO = 23 as const;
  * deposit (gated on simVersion >= V24) for byte-identical replay.
  */
 export const SIM_VERSION_V24_NURSERY_CAPACITY = 24 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V24_NURSERY_CAPACITY;
+/**
+ * V25 (#174) — Foreign-colony recall keys on the rally point alone, not the
+ * fight ratio. Previously a Fighting invader inside an enemy grid was treated as
+ * "recalled" whenever EITHER `targetRatio.fight === 0` OR `rallyPoint == null`.
+ * So a player who set a rally on the enemy entrance (an explicit "invade here"
+ * command) but left the fight ratio at 0 (don't produce MORE fighters) saw the
+ * `fight === 0` disjunct fire: invaders navigated to the entrance and ascended
+ * the moment they hit tileY=0, then re-descended next tick — a descend/ascend
+ * oscillation that never let fighters commit inside the enemy colony.
+ * Under V25+: an invader is recalled only when its colony's `rallyPoint == null`
+ * (the rally was actually cleared). With a rally still set, `fight === 0` no
+ * longer pulls fighters out — existing fighters hold the invasion while no new
+ * ones are produced. Both gated predicates move together: the underground
+ * recall-navigation step (route to exit) and the ascent `skipAscent` clear.
+ * Pre-V25 saves keep the `fight === 0 || rallyPoint == null` predicate (gated on
+ * simVersion >= V25) for byte-identical replay.
+ */
+export const SIM_VERSION_V25_RALLY_RECALL = 25 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V25_RALLY_RECALL;
 
 /**
  * S2 — AI colony state machine states.


### PR DESCRIPTION
## Summary

Fixes **#174** — player Fighting ants rallied to an open enemy entrance bounced at the shaft (descend into the enemy colony → ascend back to the surface every other tick) whenever the **fight ratio was 0**, so fighters never committed to the invasion. The player's explicit "invade here" rally was being overridden by the recall heuristic.

## Root cause

The foreign-grid recall predicate appears in **two** places that must agree — the underground recall-navigation step (`ant-system.ts` ~4600, route to exit) and the ascent `skipAscent` clear (~5210). Both tested:

```ts
ownColony.targetRatio.fight === 0 || ownColony.rallyPoint == null
```

With a rally set on the enemy entrance but `fight === 0`, the `fight === 0` disjunct fired: every invader navigated to the entrance and ascended the instant it reached `tileY === 0` on the entrance column, then re-descended next tick. A long-lived bug from the V16 combat system (`59e74be`), **not** introduced by the V23 spider work (PR #172 only removed a `useGridColony` guard on these lines).

## Fix — V25 (`SIM_VERSION_V25_RALLY_RECALL`)

Recall now keys on **`rallyPoint == null` alone** (rally option 1 from the issue, chosen by Rob): a cleared rally means "come home". With a rally still set, `fight === 0` no longer pulls existing fighters out — they hold the invasion while no new fighters are produced (reassignment only promotes *Idle* ants, so existing Fighting invaders are never demoted; see `tick.ts` §10a).

Both predicates move together under the same gate — otherwise a `fight=0` invader would navigate to the exit but refuse to ascend, a different stuck state. Pre-V25 saves keep the `fight===0 || rallyPoint==null` predicate for **byte-identical replay**.

## Tests

`src/sim/invasion-routing.test.ts`, new describe block:
- **V25 (fix):** invader descends and commits, then `fight → 0` with rally still on the enemy entrance → **holds underground in the enemy grid for the full 20-tick window** (asserted every tick to catch the period-≈2 bounce), stays Fighting.
- **V24 control:** same scenario with `simVersion` pinned to V24 → reproduces the pre-fix ascent to the surface, locking the version boundary.

## Verification

`npm run verify` green locally — Prettier, eslint, `tsc`, type-aware lint, sim-boundary + asset-path guards, **2292 tests pass**. No `/` operator, floats, or wall-clock added to `src/sim/`.

## Sim-version / replay

`LATEST_SIM_VERSION` 24 → 25. New worlds get V25; existing saves stick at their stored version and replay the old recall behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)