### PR TITLE
fix(sim): spider keeps a margin from map edges so its sprite stays on-screen (V26, #181)

### DIFF
--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -5,6 +5,7 @@ import {
   allocateEntityId,
   SIM_VERSION_V22_DIFFICULTY,
   SIM_VERSION_V23_SPIDER_AGGRO,
+  SIM_VERSION_V26_SPIDER_EDGE_MARGIN,
 } from './types.js';
 import { Rng } from './rng.js';
 import { createColonyRecord } from './colony/colony-store.js';
@@ -745,5 +746,123 @@ describe('sated meander self-defense (V23 Codex P2)', () => {
     detectAndResolveCombat(world, new Rng(world.rngState));
 
     expect(world.ants.combatOpponentId[worker]).toBe(-2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V26 (#181): combat boundary fold (margin-band catch).
+// The spider is clamped to [margin, size-1-margin] but ants reach the full grid.
+// When the spider sits on a boundary tile, the fold extends combat reach into the
+// margin band to prevent unreachable ants from making the outer ring a safe zone.
+// The stale-pass fold (detectAndResolveCombat) must mirror the resolver fold
+// (resolveSpiderCombatOnTile) exactly so margin-band ants stay paired and their
+// windup sentinels don't get cleared every tick, which would cause permanent stalemate.
+// ---------------------------------------------------------------------------
+
+describe('combat boundary fold (V26 #181)', () => {
+  function makeV26World(seed = 42): { world: WorldState; cid1: ColonyId; cid2: ColonyId } {
+    const r = makeWorldWith2Colonies(seed);
+    r.world.simVersion = SIM_VERSION_V26_SPIDER_EDGE_MARGIN;
+    return r;
+  }
+
+  it('spider Chasing at boundary tile (margin) catches ant in margin band beyond it', () => {
+    // V26: margin = 3, spider clamped to [3, 124]. Ant at tile 0 is in the margin band
+    // beyond the boundary. When spider sits at tile 3 (loX), ant at tile 0 matches via fold.
+    const { world, cid1 } = makeV26World();
+    const fighter = spawnFighter(world, cid1, 0, 10, Zone.Surface); // in margin band
+    const spider = placeSpider(world, 3, 10, 'Chasing'); // at boundary (loX)
+    spider.chaseTargetAntId = fighter;
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    // Ant should be paired with spider (sentinel -2) via the boundary fold.
+    expect(world.ants.combatOpponentId[fighter]).toBe(-2);
+  });
+
+  it('sentinel -2 survives the stale-pass fold when ant remains in margin band', () => {
+    // Regression guard: the stale-pass fold (lines 165-173 in combat.ts) must
+    // preserve -2 sentinels for margin-band ants still paired with a boundary spider.
+    // If the fold is missing or gated incorrectly, the sentinel clears every tick and
+    // the resolver restarts the windup forever (permanent stalemate).
+    const { world, cid1 } = makeV26World();
+    const fighter = spawnFighter(world, cid1, 0, 10, Zone.Surface); // margin band
+    placeSpider(world, 3, 10, 'Chasing'); // boundary (loX)
+
+    // Pre-arm the ant as if it's already paired from a prior tick.
+    world.ants.combatOpponentId[fighter] = -2;
+    world.ants.attackCooldown[fighter] = 3; // mid-windup
+
+    // Run the stale-pass: should preserve -2 because the fold treats the
+    // margin-band ant as on-tile.
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    // Sentinel should survive the fold and not be cleared.
+    expect(world.ants.combatOpponentId[fighter]).toBe(-2);
+  });
+
+  it('spider Chasing at right boundary (hiX) catches ant beyond the margin band', () => {
+    // Mirror test: spider at tile (124, Y) = hiX boundary, ant at tile (127, Y) = margin band.
+    // SURFACE_GRID_WIDTH = 128, so hiX = 128 - 1 - 3 = 124.
+    const { world, cid1 } = makeV26World();
+    const fighter = spawnFighter(world, cid1, 127, 10, Zone.Surface); // east margin band
+    const spider = placeSpider(world, 124, 10, 'Chasing'); // at east boundary (hiX)
+    spider.chaseTargetAntId = fighter;
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    // Should be paired via the fold.
+    expect(world.ants.combatOpponentId[fighter]).toBe(-2);
+  });
+
+  it('spider Chasing at top boundary (loY) catches ant beyond the margin band', () => {
+    // Y-axis boundary fold: spider at (10, 3) = loY, ant at (10, 0) = north margin band.
+    const { world, cid1 } = makeV26World();
+    const fighter = spawnFighter(world, cid1, 10, 0, Zone.Surface); // north margin band
+    const spider = placeSpider(world, 10, 3, 'Chasing'); // at north boundary (loY)
+    spider.chaseTargetAntId = fighter;
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    expect(world.ants.combatOpponentId[fighter]).toBe(-2);
+  });
+
+  it('passive state (Patrolling) does NOT fold the margin band (margin = 0)', () => {
+    // The fold is only active in pursuit states (Chasing/Striking/Rampaging).
+    // A passive Patrolling spider at the boundary should NOT catch margin-band ants.
+    const { world, cid1 } = makeV26World();
+    const fighter = spawnFighter(world, cid1, 0, 10, Zone.Surface); // margin band
+    placeSpider(world, 3, 10, 'Patrolling'); // boundary, but passive
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    // Without the fold in passive states, no pairing.
+    expect(world.ants.combatOpponentId[fighter]).toBe(-1);
+  });
+
+  it('pre-V26 (V25) does NOT fold: exact same-tile matching only', () => {
+    // Guard: boundary fold is V26-only. Pre-V26 worlds keep exact same-tile matching.
+    const r = makeWorldWith2Colonies();
+    r.world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO; // V25 or earlier
+    const fighter = spawnFighter(r.world, r.cid1, 0, 10, Zone.Surface); // margin band
+    placeSpider(r.world, 3, 10, 'Chasing'); // boundary
+
+    detectAndResolveCombat(r.world, new Rng(r.world.rngState));
+
+    // No pairing in pre-V26.
+    expect(r.world.ants.combatOpponentId[fighter]).toBe(-1);
+  });
+
+  it('interior spider at the same Y row as margin-band ant does NOT fold', () => {
+    // Fold only triggers when spider is ON a boundary tile. An interior spider
+    // that happens to share a row with a margin-band ant should not reach it.
+    const { world, cid1 } = makeV26World();
+    const fighter = spawnFighter(world, cid1, 0, 10, Zone.Surface); // margin band
+    placeSpider(world, 50, 10, 'Chasing'); // interior, not boundary
+
+    detectAndResolveCombat(world, new Rng(world.rngState));
+
+    // No pairing: spider is not on a boundary tile.
+    expect(world.ants.combatOpponentId[fighter]).toBe(-1);
   });
 });

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -17,7 +17,7 @@ import { Rng } from './rng.js';
 import { AntTask } from './enums.js';
 import { makeTileKey } from './tile-key.js';
 import type { WorldState, KillerKind, QueenDeathContext } from './types.js';
-import { SIM_VERSION_V23_SPIDER_AGGRO } from './types.js';
+import { SIM_VERSION_V23_SPIDER_AGGRO, SIM_VERSION_V26_SPIDER_EDGE_MARGIN } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 import type { Zone } from './terrain.js';
 import { FP_SHIFT } from './fixed.js';
@@ -31,6 +31,9 @@ import {
   COMBAT_DAMAGE_QUEEN,
   SPIDER_DAMAGE,
   SPIDER_SWARM_FIGHTER_THRESHOLD,
+  SPIDER_EDGE_MARGIN_TILES,
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
 } from './constants.js';
 import { isInCohort } from './ai-state.js';
 
@@ -134,14 +137,37 @@ export function detectAndResolveCombat(world: WorldState, _rng: Rng): void {
   const v23Spider = spider !== null && world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO;
   const spiderTileX = v23Spider ? spider.posX >> FP_SHIFT : -1;
   const spiderTileY = v23Spider ? spider.posY >> FP_SHIFT : -1;
+  // V26: mirror the boundary fold in resolveSpiderCombatOnTile (gated identically
+  // on V26 + an active pursuit state). When the spider is pinned on a boundary
+  // tile, the resolver folds the unreachable outer margin band into that tile and
+  // re-engages a margin-band ant — so this pass must treat that ant as on-tile too,
+  // or it would clear the ant's -2 windup sentinel every tick and the resolver
+  // would restart the windup forever (permanent stalemate). margin = 0 pre-V26 and
+  // in passive states, collapsing the fold to exact same-tile matching.
+  const v26EdgeStale =
+    v23Spider &&
+    world.simVersion >= SIM_VERSION_V26_SPIDER_EDGE_MARGIN &&
+    (spider.state === 'Chasing' || spider.state === 'Striking' || spider.state === 'Rampaging');
+  const staleMargin = v26EdgeStale ? SPIDER_EDGE_MARGIN_TILES : 0;
+  const staleLoX = staleMargin;
+  const staleHiX = SURFACE_GRID_WIDTH - 1 - staleMargin;
+  const staleLoY = staleMargin;
+  const staleHiY = SURFACE_GRID_HEIGHT - 1 - staleMargin;
   for (let i = 0; i < count; i++) {
     if (ants.alive[i] !== 1) continue;
     if (ants.combatOpponentId[i] === -2) {
       if (v23Spider) {
-        const onSpiderTile =
-          ants.zone[i] === 0 &&
-          ants.posX[i]! >> FP_SHIFT === spiderTileX &&
-          ants.posY[i]! >> FP_SHIFT === spiderTileY;
+        const ax = ants.posX[i]! >> FP_SHIFT;
+        const ay = ants.posY[i]! >> FP_SHIFT;
+        const matchX =
+          ax === spiderTileX ||
+          (spiderTileX === staleLoX && ax < staleLoX) ||
+          (spiderTileX === staleHiX && ax > staleHiX);
+        const matchY =
+          ay === spiderTileY ||
+          (spiderTileY === staleLoY && ay < staleLoY) ||
+          (spiderTileY === staleHiY && ay > staleHiY);
+        const onSpiderTile = ants.zone[i] === 0 && matchX && matchY;
         if (!onSpiderTile) ants.combatOpponentId[i] = -1;
       }
       continue;
@@ -531,6 +557,31 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
     else queenId1 = col.queenEntityId;
   }
 
+  // V26: the spider is clamped to [margin, size-1-margin] on both axes (edge
+  // margin so its 3-tile sprite can't clip off-screen), but ants reach the full
+  // grid. Without this, an ant pinned in the outer margin band shares no tile
+  // with the spider and is never caught — the outer ring would become a chase-
+  // proof safe zone. When the spider sits on a boundary tile, fold the outer
+  // band beyond it into that tile for combat: an ant at tile <= margin (when the
+  // spider is at tile == margin) or >= size-1-margin counts as on-tile on that
+  // axis. Pre-V26 keeps exact same-tile matching (margin = 0 makes both bands
+  // empty so only the boundary itself matches).
+  // The fold is only needed to keep a genuinely-pursued target catchable when the
+  // spider is pinned on a boundary tile during active pursuit. Restricting it to
+  // pursuit states (Chasing/Striking/Rampaging) avoids granting passive states
+  // (Patrolling/Hunting) a multi-tile combat reach into the margin band: a sated
+  // spider routinely meanders onto a boundary tile and would otherwise silently
+  // bite any ant sharing its row/column up to `margin` tiles away. In passive
+  // states margin = 0, so only exact same-tile matching applies (as pre-V26).
+  const v26Edge =
+    world.simVersion >= SIM_VERSION_V26_SPIDER_EDGE_MARGIN &&
+    (spider.state === 'Chasing' || spider.state === 'Striking' || spider.state === 'Rampaging');
+  const margin = v26Edge ? SPIDER_EDGE_MARGIN_TILES : 0;
+  const loX = margin;
+  const hiX = SURFACE_GRID_WIDTH - 1 - margin;
+  const loY = margin;
+  const hiY = SURFACE_GRID_HEIGHT - 1 - margin;
+
   const onTile = SPIDER_TILE_SCRATCH;
   onTile.length = 0;
   const count = ants.alive.length;
@@ -539,7 +590,13 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
     if (ants.zone[i] !== 0) continue; // surface only
     const ax = ants.posX[i]! >> FP_SHIFT;
     const ay = ants.posY[i]! >> FP_SHIFT;
-    if (ax !== spiderTileX || ay !== spiderTileY) continue;
+    // Per-axis match: exact tile, or — when the spider is pinned on the low/high
+    // boundary tile — the unreachable outer margin band beyond it.
+    const matchX =
+      ax === spiderTileX || (spiderTileX === loX && ax < loX) || (spiderTileX === hiX && ax > hiX);
+    const matchY =
+      ay === spiderTileY || (spiderTileY === loY && ay < loY) || (spiderTileY === hiY && ay > hiY);
+    if (!matchX || !matchY) continue;
     if (i === queenId0 || i === queenId1) continue; // skip queens
     onTile.push(i);
   }

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -883,3 +883,14 @@ export const SPIDER_FEED_HEAL_INTERVAL_TICKS = 10 as const;
  * it is surrounded. The spider moves at 2× ant speed, so a Chase reliably closes.
  */
 export const SPIDER_DEFENSE_TRIGGER_RADIUS = 6 as const;
+
+/**
+ * V26 (#181) — Minimum tile margin the spider keeps from every map edge, in all
+ * surface states (meander, hunt, chase, rampage, feed). The spider sprite is
+ * 48×48 px = 3 tiles (TILE_SIZE_PX=16) drawn centered on the spider position, so
+ * its half-extent is 1.5 tiles; a 3-tile margin keeps the full sprite — plus the
+ * health bar drawn above it — on the playfield instead of clipping off the edge
+ * when the spider chases/fights an ant into a corner. Gated on simVersion so pre-
+ * V26 saves replay the old to-the-edge movement byte-for-byte.
+ */
+export const SPIDER_EDGE_MARGIN_TILES = 3 as const;

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -947,8 +947,8 @@ describe('S3 V20: spider replay determinism (Hunting → Striking → Rampaging)
       // Lock the lair coordinates for seed 7777. If _placeSpider changes behaviour
       // (scan order, grid dimensions, etc.), this fails loudly rather than silently
       // breaking the distance safety bound used in the comment below.
-      expect(spider.lairTileX).toBe(57);
-      expect(spider.lairTileY).toBe(49);
+      expect(spider.lairTileX).toBe(62);
+      expect(spider.lairTileY).toBe(40);
       // Pin position to lair tile so moveTowardTile during Striking cannot drift the
       // spider relative to the workers' starting distance.
       spider.posX = spider.lairTileX << FP_SHIFT;
@@ -967,12 +967,13 @@ describe('S3 V20: spider replay determinism (Hunting → Striking → Rampaging)
       // NORMAL_TIER_INDEX=1 → threshold 1800. After Striking exits to Patrolling
       // hunger will be ≥1800, triggering an immediate Rampaging transition.
       // Safety: createScenario places STARTING_WORKERS=3 at PLAYER_START_X/Y (24,64) and
-      // ENEMY_START_X/Y (104,64). The lair is at (57,49); nearest colony workers start
-      // at Manhattan distance ≥48 tiles. The combined Hunting+Striking window is 200 ticks
+      // ENEMY_START_X/Y (104,64). The lair is at (62,40) (#181 margin-inset sampling);
+      // nearest colony workers start at Manhattan distance 62 tiles. The combined
+      // Hunting+Striking window is 200 ticks
       // (120+80); at WORKER_BASE_SPEED=0.5 tile/tick the theoretical straight-line coverage
-      // is 100 tiles — exceeding the 48-tile gap. However, Foraging ants follow pheromones
+      // is 100 tiles — exceeding the 62-tile gap. However, Foraging ants follow pheromones
       // and search randomly, not toward the spider lair; in practice they cannot reach
-      // (57,49) from (24,64) in 200 ticks of pheromone-guided wandering. The lair coord
+      // (62,40) from (24,64) in 200 ticks of pheromone-guided wandering. The lair coord
       // assertion on lines above will catch a future _placeSpider regression that places
       // the lair near a colony start before the margin narrows.
       spider.hungerTicks = SPIDER_HUNGER_MAX_TICKS[1];

--- a/src/sim/scenario.test.ts
+++ b/src/sim/scenario.test.ts
@@ -33,6 +33,7 @@ import {
   UNDERGROUND_GRID_WIDTH,
   UNDERGROUND_GRID_HEIGHT,
   ENTRANCE_SHAFT_DEPTH,
+  SPIDER_EDGE_MARGIN_TILES,
 } from './constants.js';
 
 describe('createScenario', () => {
@@ -568,6 +569,34 @@ describe('createScenario', () => {
         const chamberFood = colony.chambers.reduce((s, c) => s + c.foodStored, 0);
         const evidence = colony.foodStored > 0 || chamberFood > 0 || workersCarrying > 0;
         expect(evidence).toBe(true);
+      }
+    });
+  });
+
+  // #181 — The spider must spawn within the SPIDER_EDGE_MARGIN_TILES-inset interior
+  // so its centered 3-tile sprite is fully on-screen from tick 0, without relying on
+  // the runtime per-tick edge clamp to nudge it inward on the first tick.
+  describe('spider lair edge margin (#181)', () => {
+    const MIN = SPIDER_EDGE_MARGIN_TILES;
+    const MAX_X = SURFACE_GRID_WIDTH - 1 - SPIDER_EDGE_MARGIN_TILES;
+    const MAX_Y = SURFACE_GRID_HEIGHT - 1 - SPIDER_EDGE_MARGIN_TILES;
+
+    it('spawns the lair inside [margin, size-1-margin] on both axes across many seeds', () => {
+      // Sweep a spread of seeds: every spawned lair (and its derived position) must
+      // sit in the inset interior, never inside the margin band.
+      for (let seed = 0; seed < 200; seed++) {
+        const world = createScenario(seed);
+        const spider = world.spider;
+        expect(spider).not.toBeNull();
+        expect(spider!.lairTileX).toBeGreaterThanOrEqual(MIN);
+        expect(spider!.lairTileX).toBeLessThanOrEqual(MAX_X);
+        expect(spider!.lairTileY).toBeGreaterThanOrEqual(MIN);
+        expect(spider!.lairTileY).toBeLessThanOrEqual(MAX_Y);
+        // posX/posY are seeded from the lair tile, so they share the invariant.
+        expect(spider!.posX >> FP_SHIFT).toBeGreaterThanOrEqual(MIN);
+        expect(spider!.posX >> FP_SHIFT).toBeLessThanOrEqual(MAX_X);
+        expect(spider!.posY >> FP_SHIFT).toBeGreaterThanOrEqual(MIN);
+        expect(spider!.posY >> FP_SHIFT).toBeLessThanOrEqual(MAX_Y);
       }
     });
   });

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -50,6 +50,7 @@ import {
   COMBAT_HP_QUEEN,
   SPIDER_HP_FULL,
   SPIDER_TERRITORY_RADIUS_TILES,
+  SPIDER_EDGE_MARGIN_TILES,
   SPIDER_HUNT_INTERVAL_TICKS,
   QUEEN_EGG_INTERVAL_DIFFICULTY_NUMERATOR,
 } from './constants.js';
@@ -261,13 +262,23 @@ function _placeSpider(world: WorldState): SpiderState {
   let lairTileX = SURFACE_GRID_WIDTH >> 1;
   let lairTileY = SURFACE_GRID_HEIGHT >> 1;
 
+  // #181 — Sample the lair from the SPIDER_EDGE_MARGIN_TILES-inset interior
+  // [margin, size-1-margin] instead of the full [0, size-1] grid, so the spider
+  // never spawns inside the margin band the per-tick clamp (tickSpiderV23 step 6b)
+  // enforces during play. Without this the spider could spawn at the very edge and
+  // jump inward on its first tick. Scenario generation is unversioned (always
+  // LATEST, like the rest of createScenario), so no simVersion gate here — only the
+  // runtime movement clamp is gated, for save-replay determinism.
+  const spanX = SURFACE_GRID_WIDTH - 2 * SPIDER_EDGE_MARGIN_TILES;
+  const spanY = SURFACE_GRID_HEIGHT - 2 * SPIDER_EDGE_MARGIN_TILES;
+
   for (let attempt = 0; attempt < 1000; attempt++) {
     h = Math.imul(h ^ (h >>> 16), 0x85ebca6b) >>> 0;
     h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35) >>> 0;
     h ^= h >>> 16;
-    const tx = (h >>> 0) % SURFACE_GRID_WIDTH;
+    const tx = ((h >>> 0) % spanX) + SPIDER_EDGE_MARGIN_TILES;
     const h2 = Math.imul(h, 0x9e3779b9) >>> 0;
-    const ty = (h2 >>> 0) % SURFACE_GRID_HEIGHT;
+    const ty = ((h2 >>> 0) % spanY) + SPIDER_EDGE_MARGIN_TILES;
 
     // Check Manhattan distance from both colony starts
     const d1 =

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -8,6 +8,7 @@ import {
   SIM_VERSION_V20_SPIDER,
   SIM_VERSION_V22_DIFFICULTY,
   SIM_VERSION_V23_SPIDER_AGGRO,
+  SIM_VERSION_V26_SPIDER_EDGE_MARGIN,
 } from './types.js';
 import { tickSpider } from './spider.js';
 import { initAnt } from './ant/ant-store.js';
@@ -39,6 +40,7 @@ import {
   SURFACE_GRID_HEIGHT,
   PLAYER_COLONY_ID,
   ENEMY_COLONY_ID,
+  SPIDER_EDGE_MARGIN_TILES,
 } from './constants.js';
 import { FP_SHIFT } from './fixed.js';
 import { Zone } from './terrain.js';
@@ -1626,6 +1628,97 @@ describe('tickSpider', () => {
       tickSpider(world);
 
       expect(world.spider.state).toBe('Patrolling');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // #181 — Spider keeps a margin from map edges (V26) so its centered 3-tile
+  // sprite never renders off-screen while chasing an ant into a corner.
+  // -------------------------------------------------------------------------
+  describe('edge margin (#181)', () => {
+    const M = SPIDER_EDGE_MARGIN_TILES;
+
+    /**
+     * Stage a spider Chasing a stationary surface ant pinned at the west edge.
+     * The spider starts a handful of tiles inland on the same row, so it moves
+     * purely west (−X) toward the ant. Chase has no distance-escape (only
+     * dead/descended/leash), and we never run combat, so the chase persists for
+     * the whole window. Returns { world, tileXOf }.
+     */
+    function chaseTowardWestEdge(simVersion: number) {
+      const world = makeWorld();
+      world.simVersion = simVersion;
+      world.tick = 0;
+      const rowY = 32;
+      // Target ant at the very west edge; stays put (only tickSpider runs).
+      const antId = placeWorker(world, 0, rowY);
+      world.spider = makeSpider({
+        state: 'Chasing',
+        posX: (M + 5) << FP_SHIFT,
+        posY: rowY << FP_SHIFT,
+        chaseTargetAntId: antId,
+        chaseStartTick: 0,
+      });
+      const tileXOf = () => world.spider!.posX >> FP_SHIFT;
+      const tileYOf = () => world.spider!.posY >> FP_SHIFT;
+      return { world, tileXOf, tileYOf, rowY };
+    }
+
+    it('V26: spider chasing an ant at the west edge holds the margin (never reaches the edge)', () => {
+      const { world, tileXOf, tileYOf, rowY } = chaseTowardWestEdge(
+        SIM_VERSION_V26_SPIDER_EDGE_MARGIN,
+      );
+      // Precondition: started inland, actually Chasing the edge ant.
+      expect(world.spider!.state).toBe('Chasing');
+      expect(tileXOf()).toBe(M + 5);
+
+      // Drive enough ticks to traverse well past the edge had it been unclamped.
+      let minTileX = tileXOf();
+      for (let t = 0; t < 20; t++) {
+        tickSpider(world);
+        minTileX = Math.min(minTileX, tileXOf());
+        // Invariant every tick: never inside the margin band.
+        expect(tileXOf()).toBeGreaterThanOrEqual(M);
+      }
+      // It pressed up against the margin (settled exactly at it) and pursued
+      // purely along X (row unchanged), confirming it WANTED to go further west.
+      expect(minTileX).toBe(M);
+      expect(tileXOf()).toBe(M);
+      expect(tileYOf()).toBe(rowY);
+      expect(world.spider!.state).toBe('Chasing');
+    });
+
+    it('V23 control: same chase pins the spider against the west edge (pre-fix behavior)', () => {
+      const { world, tileXOf } = chaseTowardWestEdge(SIM_VERSION_V23_SPIDER_AGGRO);
+
+      for (let t = 0; t < 20; t++) tickSpider(world);
+
+      // Without the V26 clamp the spider reaches the ant's tile at the very edge.
+      expect(tileXOf()).toBe(0);
+    });
+
+    it('V26: chasing an ant into the NW corner clamps BOTH axes to the margin', () => {
+      const world = makeWorld();
+      world.simVersion = SIM_VERSION_V26_SPIDER_EDGE_MARGIN;
+      world.tick = 0;
+      const antId = placeWorker(world, 0, 0); // NW corner
+      world.spider = makeSpider({
+        state: 'Chasing',
+        posX: (M + 6) << FP_SHIFT,
+        posY: (M + 6) << FP_SHIFT,
+        chaseTargetAntId: antId,
+        chaseStartTick: 0,
+      });
+
+      const spider = world.spider;
+      for (let t = 0; t < 24; t++) {
+        tickSpider(world);
+        expect(spider.posX >> FP_SHIFT).toBeGreaterThanOrEqual(M);
+        expect(spider.posY >> FP_SHIFT).toBeGreaterThanOrEqual(M);
+      }
+      // Settled in the corner of the allowed region, margin off both edges.
+      expect(spider.posX >> FP_SHIFT).toBe(M);
+      expect(spider.posY >> FP_SHIFT).toBe(M);
     });
   });
 });

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -37,8 +37,9 @@ import {
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
   PHEROMONE_CAP,
+  SPIDER_EDGE_MARGIN_TILES,
 } from './constants.js';
-import { SIM_VERSION_V23_SPIDER_AGGRO } from './types.js';
+import { SIM_VERSION_V23_SPIDER_AGGRO, SIM_VERSION_V26_SPIDER_EDGE_MARGIN } from './types.js';
 import { FP_SHIFT } from './fixed.js';
 
 // HUNT_KEY_SHIFT: number of bits to shift Y to form a tile key (Y << SHIFT + X).
@@ -383,6 +384,22 @@ function moveTowardTile(spider: SpiderState, targetX: number, targetY: number): 
   if (spider.posX < 0) spider.posX = 0;
   if (spider.posX > maxX) spider.posX = maxX;
   if (spider.posY < 0) spider.posY = 0;
+  if (spider.posY > maxY) spider.posY = maxY;
+}
+
+// V26 (#181) — keep the spider SPIDER_EDGE_MARGIN_TILES from every map edge so its
+// 3-tile (48px) centered sprite never renders off the playfield while chasing/
+// fighting/meandering into a corner. Applied once after the movement switch, so it
+// tightens moveTowardTile's [0, max] clamp uniformly across all surface states.
+// Grid (128) is far larger than 2× the margin, so the min/max never cross.
+function clampSpiderWithinEdgeMargin(spider: SpiderState): void {
+  const minX = SPIDER_EDGE_MARGIN_TILES << FP_SHIFT;
+  const minY = SPIDER_EDGE_MARGIN_TILES << FP_SHIFT;
+  const maxX = (SURFACE_GRID_WIDTH - 1 - SPIDER_EDGE_MARGIN_TILES) << FP_SHIFT;
+  const maxY = (SURFACE_GRID_HEIGHT - 1 - SPIDER_EDGE_MARGIN_TILES) << FP_SHIFT;
+  if (spider.posX < minX) spider.posX = minX;
+  if (spider.posX > maxX) spider.posX = maxX;
+  if (spider.posY < minY) spider.posY = minY;
   if (spider.posY > maxY) spider.posY = maxY;
 }
 
@@ -1348,6 +1365,14 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
       }
       break;
     }
+  }
+
+  // 6b. Edge margin (#181, V26): hold the spider a few tiles off every map edge so
+  // its centered 3-tile sprite never clips off-screen when it chases/fights an ant
+  // into a corner. Runs after the movement switch (before pheromone seeding reads
+  // the position) so the deposited danger trail matches the clamped location.
+  if (world.simVersion >= SIM_VERSION_V26_SPIDER_EDGE_MARGIN) {
+    clampSpiderWithinEdgeMargin(spider);
   }
 
   // 7. Danger pheromone — all surface states (everything except Feeding).

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -978,22 +978,34 @@ function computeFeedAwayTile(world: WorldState, spider: SpiderState): void {
     if (ax >= ay) signX = dx > 0 ? 1 : -1;
     else signY = dy > 0 ? 1 : -1;
   }
-  spider.feedAwayTileX = feedRetreatCoord(kx, signX, SURFACE_GRID_WIDTH);
-  spider.feedAwayTileY = feedRetreatCoord(ky, signY, SURFACE_GRID_HEIGHT);
+  // V26: keep the feed destination inside the spider's reachable band so the
+  // edge-margin clamp (step 6b) can't strand the spider short of feedAwayTile —
+  // an exact-equality arrival gate against an unreachable margin-band tile would
+  // livelock Feeding (heal never starts). Pre-V26 the band is the full grid.
+  const margin =
+    world.simVersion >= SIM_VERSION_V26_SPIDER_EDGE_MARGIN ? SPIDER_EDGE_MARGIN_TILES : 0;
+  spider.feedAwayTileX = feedRetreatCoord(kx, signX, SURFACE_GRID_WIDTH, margin);
+  spider.feedAwayTileY = feedRetreatCoord(ky, signY, SURFACE_GRID_HEIGHT, margin);
 }
 
 // Retreat `SPIDER_FEED_RETREAT_TILES` from the kill coordinate along one axis.
-// If the preferred direction would exit the grid, reflect inward instead of
-// clamping to the edge — otherwise an edge kill collapses the endpoint onto (or
-// near) the kill tile, so the spider enters Feeding without actually moving away
-// and the post-kill chain-kill avoidance silently fails. The surface grid
-// (128) is far larger than 2× the retreat (20), so at least one direction is
-// always in-bounds; the trailing clamp only guards a hypothetically tiny grid.
-function feedRetreatCoord(k: number, sign: number, size: number): number {
+// If the preferred direction would exit the reachable band, reflect inward
+// instead of clamping to the edge — otherwise an edge kill collapses the
+// endpoint onto (or near) the kill tile, so the spider enters Feeding without
+// actually moving away and the post-kill chain-kill avoidance silently fails.
+// `margin` is the per-edge keep-out band (V26 edge-margin clamp; 0 pre-V26):
+// endpoints are confined to [margin, size-1-margin] so the feed target is always
+// reachable under the step-6b clamp (the exact-equality arrival gate otherwise
+// livelocks Feeding). The surface grid (128) is far larger than 2× the retreat
+// (20) plus 2× the margin (6), so at least one direction is always in-band; the
+// trailing clamp only guards a hypothetically tiny grid.
+function feedRetreatCoord(k: number, sign: number, size: number, margin: number): number {
+  const lo = margin;
+  const hi = size - 1 - margin;
   let end = k + sign * SPIDER_FEED_RETREAT_TILES;
-  if (end < 0 || end > size - 1) end = k - sign * SPIDER_FEED_RETREAT_TILES;
-  if (end < 0) end = 0;
-  if (end > size - 1) end = size - 1;
+  if (end < lo || end > hi) end = k - sign * SPIDER_FEED_RETREAT_TILES;
+  if (end < lo) end = lo;
+  if (end > hi) end = hi;
   return end;
 }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -324,7 +324,20 @@ export const SIM_VERSION_V24_NURSERY_CAPACITY = 24 as const;
  * simVersion >= V25) for byte-identical replay.
  */
 export const SIM_VERSION_V25_RALLY_RECALL = 25 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V25_RALLY_RECALL;
+/**
+ * V26 (#181) — Spider keeps a SPIDER_EDGE_MARGIN_TILES margin from every map edge
+ * in all surface states. Previously the V23 chase/combat (and meander/rampage)
+ * movement clamped the spider only to the grid bounds [0, max], so chasing an ant
+ * into a corner pinned the spider against the boundary and its 3-tile (48px)
+ * centered sprite rendered partly off the playfield (#176 had added inward
+ * reflection for the feed-retreat endpoint, but the chase path had no equivalent
+ * clamp). Under V26+ a single post-movement clamp tightens every surface state's
+ * position to [margin, max-margin] on both axes, so the full sprite always stays
+ * on-screen. Pre-V26 saves keep the to-the-edge movement (gated on simVersion >=
+ * V26) for byte-identical replay.
+ */
+export const SIM_VERSION_V26_SPIDER_EDGE_MARGIN = 26 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V26_SPIDER_EDGE_MARGIN;
 
 /**
  * S2 — AI colony state machine states.


### PR DESCRIPTION
## Summary

Fixes **#181** — during combat the spider chased fighter ants all the way to the map edge and its sprite rendered partially **off the playfield**. The V23 chase/combat movement only clamped the spider to the grid bounds `[0, max]`, so chasing an ant into a corner pinned it against the boundary; since the 48×48px (3-tile) sprite is drawn **centered** on the spider, half of it clipped off-screen.

## Fix

All keyed off a new `SPIDER_EDGE_MARGIN_TILES = 3` (sprite half-extent is 1.5 tiles, so 3 keeps the full sprite + health bar on-screen with headroom):

1. **Runtime clamp (V26, `SIM_VERSION_V26_SPIDER_EDGE_MARGIN`).** A post-movement clamp in `tickSpiderV23` tightens the spider's position to `[margin, max − margin]` on both axes, across every surface state. Runs before danger-pheromone seeding. Gated on `simVersion >= V26` for byte-identical pre-V26 replay.

2. **Spawn placement.** `_placeSpider` samples the lair from the margin-inset interior, so the spider is fully on-screen from tick 0 — no first-tick nudge. (Scenario gen is unversioned/always-LATEST, like the difficulty numerator, so no `simVersion` gate on the spawn formula.)

3. **Margin-band exploit closure (found in internal review).** Because the spider can no longer enter the outer margin ring but ants still can, the clamp alone would have created three issues, all fixed and V26-gated:
   - **Combat safe-zone** (`resolveSpiderCombatOnTile`): a boundary-pinned spider shares no tile with a margin-band ant → the edge becomes a chase-proof hideout. Folds the unreachable band beyond a boundary tile into that tile for combat matching, restricted to active pursuit (Chasing/Striking/Rampaging) so passive meandering gets no free reach.
   - **Windup-sentinel stalemate** (`detectAndResolveCombat` stale pass): the mirrored fold preserves the `-2` windup sentinel for a margin-band target, so the resolver doesn't restart the windup forever.
   - **Feeding livelock** (`feedRetreatCoord`): confines the post-kill feed destination to the reachable band so the exact-equality arrival gate fires and healing starts.

## Tests

- **Runtime (`spider.test.ts`):** chase holds at the margin (every tick), V23 control reaches the edge, NW-corner clamps both axes.
- **Spawn (`scenario.test.ts`):** 200-seed sweep — every lair lands in the inset interior.
- **Combat fold (`combat.test.ts`, 7 new):** boundary catches at low/high/top edges, windup-sentinel survival, and negative guards (passive state, pre-V26, interior spider).
- **Determinism (`determinism.test.ts`):** locked seed-7777 lair updated (57,49)→(62,40).

## Verification

`npm run verify` green — **2303 tests**, all guards clean. No `/`, floats, or wall-clock added to `src/sim/`. Internal adversarial review: 4 rounds to a clean pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)