### PR TITLE
fix(save): preserve future-build saves on fresh boot (#196)

### DIFF
--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -12,6 +12,7 @@ import {
   tickAutosave,
   manualSave,
   hasIncompatibleSave,
+  classifySaveCompatibility,
   getSaveInfo,
   parseSaveFile,
   FutureSimVersionError,
@@ -1794,6 +1795,76 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         }),
       );
       expect(hasIncompatibleSave()).toBe(true);
+    });
+  });
+
+  describe('Issue #196 — classifySaveCompatibility (three-way verdict)', () => {
+    // The boot path (game-scene decideBootMode) relies on this verdict to arm
+    // autosaveSuspended ONLY for the recoverable future-build case and to leave
+    // corrupt saves overwriting freely. hasIncompatibleSave() collapses both
+    // incompatible verdicts to a single boolean, so these tests are the only
+    // direct guard that the future-vs-corrupt split is wired correctly — a
+    // refactor that swapped the two branches would otherwise stay green.
+    it("returns 'none' when localStorage is empty", () => {
+      expect(classifySaveCompatibility()).toBe('none');
+    });
+
+    it("returns 'compatible' for a freshly-written current-format save", () => {
+      manualSave(42, [], createScenario(42));
+      expect(classifySaveCompatibility()).toBe('compatible');
+    });
+
+    it("returns 'incompatible-future' when simVersion exceeds LATEST (recoverable → suspend autosave)", async () => {
+      const { LATEST_SIM_VERSION } = await import('../sim/types.js');
+      const snap = serializeWorldState(createScenario(7));
+      snap.simVersion = LATEST_SIM_VERSION + 1;
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({ version: SAVE_FORMAT_VERSION, seed: 7, inputLog: [], snapshot: snap }),
+      );
+      expect(classifySaveCompatibility()).toBe('incompatible-future');
+    });
+
+    it("returns 'incompatible-corrupt' when simVersion is below MIN_ACCEPTED (tampered down → overwrite freely)", async () => {
+      // The load-bearing distinction from the future case above: a sub-MIN
+      // save is NOT recoverable, so boot must NOT suspend autosave for it.
+      const { LEGACY_SIM_VERSION } = await import('../sim/types.js');
+      const snap = serializeWorldState(createScenario(7));
+      snap.simVersion = LEGACY_SIM_VERSION - 1;
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({ version: SAVE_FORMAT_VERSION, seed: 7, inputLog: [], snapshot: snap }),
+      );
+      expect(classifySaveCompatibility()).toBe('incompatible-corrupt');
+    });
+
+    it("returns 'incompatible-corrupt' for a stale save-format envelope (parseSaveFile throws)", () => {
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({ version: 2, seed: 1, inputLog: [], snapshot: {} }),
+      );
+      expect(classifySaveCompatibility()).toBe('incompatible-corrupt');
+    });
+
+    it("returns 'incompatible-corrupt' for malformed JSON", () => {
+      window.localStorage.setItem(SAVE_KEY, '{not-json');
+      expect(classifySaveCompatibility()).toBe('incompatible-corrupt');
+    });
+
+    it("returns 'incompatible-corrupt' when snapshot is null (parseable envelope, garbage payload)", () => {
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({ version: SAVE_FORMAT_VERSION, seed: 1, inputLog: [], snapshot: null }),
+      );
+      expect(classifySaveCompatibility()).toBe('incompatible-corrupt');
+    });
+
+    it("returns 'incompatible-corrupt' when the snapshot deserialize throws (empty object, missing fields)", () => {
+      window.localStorage.setItem(
+        SAVE_KEY,
+        JSON.stringify({ version: SAVE_FORMAT_VERSION, seed: 1, inputLog: [], snapshot: {} }),
+      );
+      expect(classifySaveCompatibility()).toBe('incompatible-corrupt');
     });
   });
 

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -1470,6 +1470,62 @@ export function manualSave(
   }
 }
 
+/**
+ * Issue #196 — three-way compatibility verdict for the save currently in
+ * localStorage. Distinguishes a recoverable future-build save from definitive
+ * corruption so the boot path can preserve the former (suspend autosave so the
+ * bytes survive for recovery on a newer build) while letting the latter be
+ * overwritten freely.
+ *
+ *   - 'none'                 — no bytes under SAVE_KEY (or storage unreadable)
+ *   - 'compatible'           — parses AND deserializes on this build (loadable)
+ *   - 'incompatible-future'  — parses but `snapshot.simVersion > LATEST`
+ *                              (FutureSimVersionError): a NEWER build wrote it;
+ *                              the bytes are intact and recoverable on that build
+ *   - 'incompatible-corrupt' — any other failure (envelope parse error,
+ *                              non-object snapshot, tampered/missing fields,
+ *                              `simVersion < MIN`): not loadable by any build
+ *
+ * Mirrors the classification `bootFromSave` already performs on the Continue
+ * path (FutureSimVersionError vs plain Error) so the fresh-boot path can make
+ * the same recoverable-vs-corrupt decision at boot time.
+ */
+export type SaveCompatibility =
+  | 'none'
+  | 'compatible'
+  | 'incompatible-future'
+  | 'incompatible-corrupt';
+
+export function classifySaveCompatibility(): SaveCompatibility {
+  let raw: string | null;
+  try {
+    purgeLegacySaves();
+    raw = localStorage.getItem(SAVE_KEY);
+  } catch {
+    return 'none';
+  }
+  if (raw === null) return 'none';
+  let file: SaveFile;
+  try {
+    file = parseSaveFile(raw);
+  } catch {
+    return 'incompatible-corrupt';
+  }
+  // parseSaveFile validates the envelope only; the snapshot can be null / a
+  // non-object on a tampered envelope. Reject before the deserialize attempt.
+  const snapshot = file.snapshot as unknown;
+  if (snapshot === null || typeof snapshot !== 'object') return 'incompatible-corrupt';
+  // The canonical compatibility boundary: a full deserialize. FutureSimVersionError
+  // is the one recoverable failure (newer build wrote it); every other throw is
+  // corruption this build (or any build) cannot load.
+  try {
+    deserializeWorldState(file.snapshot);
+    return 'compatible';
+  } catch (err) {
+    return err instanceof FutureSimVersionError ? 'incompatible-future' : 'incompatible-corrupt';
+  }
+}
+
 /** Issue #115 — true iff bytes exist under SAVE_KEY but this build cannot
  *  load them. Three categories of incompatibility:
  *    1. envelope parse fails (wrong save format version, malformed JSON,
@@ -1495,46 +1551,16 @@ export function manualSave(
  *  prior "envelope-parse only" check that returned false for future-sim
  *  saves and enabled a Continue click that would silently lose the save. */
 export function hasIncompatibleSave(): boolean {
-  let raw: string | null;
-  try {
-    purgeLegacySaves();
-    raw = localStorage.getItem(SAVE_KEY);
-  } catch {
-    return false;
-  }
-  if (raw === null) return false;
-  let file: SaveFile;
-  try {
-    file = parseSaveFile(raw);
-  } catch {
-    return true;
-  }
-  // Codex round-3 P1: parseSaveFile only validates the envelope (version,
-  // seed, inputLog). `snapshot` itself can be `null` or any non-object on
-  // a tampered/malformed envelope. Reject the obviously-broken case before
-  // the deserialize attempt below so we don't waste an allocation on it.
-  const snapshot = file.snapshot as unknown;
-  if (snapshot === null || typeof snapshot !== 'object') return true;
-
-  // Round-4 (Rob's manual review of 6d840ef): the prior simVersion-only
-  // check left a UI-lie window for parseable envelopes whose snapshot is
-  // shape-valid at the top level but missing required deeper fields
-  // (e.g. `snapshot: {}`, or `simVersion: LEGACY_SIM_VERSION - 1`).
-  // Continue would look enabled; bootFromSave would then throw on
-  // deserialize and fall through to bootFresh. Align the dialog's
-  // compatibility boundary with the canonical one — attempt the full
-  // deserialize. Any throw (FutureSimVersionError, plain Error from
-  // tampered/missing-fields, etc.) means Continue would not actually
-  // load the save, so surface as incompatible.
+  // Issue #196 — delegate to the three-way classifier so this and the boot
+  // path share one compatibility boundary. Both incompatible verdicts
+  // (future + corrupt) mean Continue would not actually load the save, so
+  // the dialog surfaces them identically (its info line already does).
   //
-  // Cost: one full WorldState allocation per call. The dialog open path
-  // calls this once (cached for the render); user-initiated, infrequent.
-  try {
-    deserializeWorldState(file.snapshot);
-    return false;
-  } catch {
-    return true;
-  }
+  // Cost: one full WorldState allocation per call (the classifier's
+  // deserialize). The dialog open path calls this once (cached for the
+  // render); user-initiated, infrequent.
+  const verdict = classifySaveCompatibility();
+  return verdict === 'incompatible-future' || verdict === 'incompatible-corrupt';
 }
 
 /** Lightweight save summary surfaced in the Save/Load dialog's info line.

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -31,8 +31,7 @@ import { copyWorldState, type WorldState } from '../sim/types.js';
 import { tick, resetFlowFieldCaches } from '../sim/tick.js';
 import { createGameLoop, type GameLoop, MS_PER_TICK } from '../platform/game-loop.js';
 import {
-  hasSave,
-  hasIncompatibleSave,
+  classifySaveCompatibility,
   loadSave,
   deleteSave,
   tickAutosave,
@@ -459,10 +458,14 @@ export class GameScene extends Phaser.Scene {
     this.surfaceInputState = registerSurfaceInput(this, getWorld, this.viewState, getPrevWorld);
     this.undergroundInputState = registerUndergroundInput(this, getWorld, this.viewState);
 
-    // Phase 9 boot: check for existing save. If found and loadable, show
-    // SavePrompt overlay. Otherwise boot fresh (incompatible saves are
-    // silently skipped here; the new game's first autosave will overwrite them).
-    const bootMode = decideBootMode(() => hasSave() && !hasIncompatibleSave());
+    // Phase 9 boot: classify any existing save ONCE. A loadable ('compatible')
+    // save shows the Continue/New Game SavePrompt. Everything else boots fresh —
+    // but a future-build save ('incompatible-future': simVersion > LATEST) is
+    // recoverable on a newer build, so the fresh boot must NOT let autosave /
+    // Save Now overwrite its bytes (issue #196). Corrupt / absent saves get no
+    // such protection — the new game's first autosave overwrites them freely.
+    const saveCompat = classifySaveCompatibility();
+    const bootMode = decideBootMode(() => saveCompat === 'compatible');
     if (bootMode === 'prompt') {
       this.gamePhase = GamePhase.SavePrompt;
       const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
@@ -474,7 +477,10 @@ export class GameScene extends Phaser.Scene {
         },
       });
     } else {
-      this.showDifficultySelectThenBoot();
+      // issue #196 — preserve a recoverable future-build save by suspending
+      // autosave after the fresh boot (mirrors bootFromSave's
+      // FutureSimVersionError catch on the Continue path).
+      this.showDifficultySelectThenBoot(saveCompat === 'incompatible-future');
     }
 
     // Lifecycle signal — preload assets are loaded (we're in create()), the
@@ -732,11 +738,26 @@ export class GameScene extends Phaser.Scene {
   // S5 — show difficulty selector then boot. Used for every new-game path.
   // Sets gamePhase to SavePrompt so update() returns early (line ~913 guard)
   // before this.gameLoop is initialized by bootFresh → finishBoot.
-  private showDifficultySelectThenBoot(): void {
+  //
+  // preserveFutureSave (issue #196): true only when the fresh boot was chosen
+  // because the existing save is a recoverable future-build save
+  // (simVersion > LATEST). In that case, arm autosaveSuspended AFTER bootFresh
+  // so autosave + Save Now don't clobber the preserved bytes — mirroring
+  // bootFromSave's FutureSimVersionError catch on the Continue path. The flag
+  // MUST be set after bootFresh because resetSessionState (run inside it)
+  // clears it. Corrupt-save / explicit New Game callers pass false (default)
+  // and overwrite freely.
+  private showDifficultySelectThenBoot(preserveFutureSave = false): void {
     this.gamePhase = GamePhase.SavePrompt;
     const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
     uiScene.showDifficultySelectOverlay({
-      onSelect: (d) => this.bootFresh(d),
+      onSelect: (d) => {
+        this.bootFresh(d);
+        if (preserveFutureSave) {
+          // Set after bootFresh — resetSessionState clears the flag.
+          this.autosaveSuspended = true;
+        }
+      },
     });
   }
 

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -171,6 +171,7 @@ interface UIScenePhase9 {
     onContinue: () => void;
     onNewGame: () => void;
     onSaveNow: () => boolean;
+    onDelete: () => void;
     onBack: () => void;
   }): void;
   hideSaveLoadDialogOverlay(): void;
@@ -1174,6 +1175,14 @@ export class GameScene extends Phaser.Scene {
         // 15:33 the next time the player opens it, with no action of theirs.
         if (ok) this.lastAutosaveMs = performance.now();
         return ok;
+      },
+      onDelete: () => {
+        // Issue #196 (Codex P2): the dialog just deleted the save. If autosave
+        // was suspended to preserve a future-build save's bytes, that reason is
+        // gone now — clear the flag so the running fresh session can save and
+        // autosave normally again (otherwise onSaveNow keeps returning false and
+        // the autosave guard skips every write until a page reload).
+        this.autosaveSuspended = false;
       },
       onBack: () => {
         // Re-open the pause menu — gamePhase is still Paused, gameLoop is

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -284,6 +284,12 @@ export interface SaveLoadDialogCallbacks {
    *  success, false on storage failure. The dialog re-renders afterward so
    *  the info line picks up the new saved tick. */
   onSaveNow(): boolean;
+  /** Issue #196 — the player committed Delete on the existing save. The dialog
+   *  performs the actual `deleteSave()`; this notifies GameScene so it can
+   *  release any autosave suspension armed to protect a future-build save (the
+   *  bytes being protected are now gone, so the running session must be saveable
+   *  again). No-op when nothing was suspended. */
+  onDelete(): void;
   /** Close the dialog and return to the pause menu (no game-state change). */
   onBack(): void;
 }
@@ -1676,6 +1682,11 @@ export class UIScene extends Phaser.Scene {
           return;
         }
         deleteSave();
+        // Issue #196 — releasing the save means any autosave suspension that
+        // was protecting a future-build save's bytes is no longer warranted
+        // (the bytes are gone). Notify GameScene so the running fresh session
+        // can save / autosave again instead of staying frozen until reload.
+        cb?.onDelete();
         this.saveLoadDialogConfirming.delete = false;
         this.renderSaveLoadDialog();
         return;

--- a/tests/menu-and-dialog.spec.ts
+++ b/tests/menu-and-dialog.spec.ts
@@ -15,6 +15,14 @@ import { test, expect, type Page } from '@playwright/test';
 // Mirrors DIFFICULTY_NORMAL_RECT in ui-scene.ts.
 const DIFFICULTY_NORMAL_RECT = { x: 330, y: 260, w: 140, h: 40 } as const;
 
+// Canvas-local rects for the pause-menu "Save/Load" row (index 1 of 4) and the
+// Save/Load dialog's "Save Now" button (index 1). The playtrace feature is
+// forced off in playwright.config, so the pause menu has exactly 4 rows; these
+// mirror pause-menu-layout.ts / save-load-dialog-layout.ts. Inlined rather than
+// imported because those modules transitively pull in Phaser.
+const SAVE_LOAD_ROW_RECT = { x: 240, y: 279, w: 320, h: 40 } as const;
+const DIALOG_SAVE_NOW_RECT = { x: 260, y: 220, w: 280, h: 36 } as const;
+
 async function clickCanvasRect(
   page: Page,
   rect: { x: number; y: number; w: number; h: number },
@@ -74,6 +82,17 @@ async function activeOverlay(page: Page): Promise<string> {
   return await page.evaluate(() => {
     const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
     return ui?.activeOverlay ?? '<undefined>';
+  });
+}
+
+// The fresh-boot "Choose Difficulty" overlay and a real Continue/New Game
+// SavePrompt both report activeOverlay 'save-prompt'; __phase9_ui.bootScreen is
+// the discriminator ('difficulty-select' vs 'save-prompt'). Returns '<undefined>'
+// when the hook hasn't published yet so callers can poll for the value they want.
+async function bootScreen(page: Page): Promise<string> {
+  return await page.evaluate(() => {
+    const ui = (window as { __phase9_ui?: { bootScreen?: string } }).__phase9_ui;
+    return ui?.bootScreen ?? '<undefined>';
   });
 }
 
@@ -700,41 +719,57 @@ test.describe('Pheromone overlay actually renders (UAT P1 — pre-existing draw-
   });
 });
 
-test.describe('Round-5 (Codex P1) — Save Now respects autosaveSuspended', () => {
-  // QUARANTINED — blocked on GAME BUG #196 (not a test problem). This test guards
-  // a real data-loss protection: a future-build save (simVersion > LATEST) must
-  // survive on the older build so it can be recovered. Investigation (a real-save
-  // capture + simVersion bump, observed via Playwright) confirmed the protection
-  // is currently INERT: a future-sim save is treated as incompatible, so boot
-  // routes to a FRESH game (Choose Difficulty), `autosaveSuspended` is never
-  // armed, and Save Now overwrites the preserved bytes (observed simVersion
-  // 99999 → 26). Fixing that is a game-code change (out of scope for the #192
-  // test-fixture work) tracked in #196. Un-fixme this once #196 lands; the
-  // capture-a-real-save + bump-simVersion setup below is the right harness for it.
-  test.fixme('Save Now is a no-op when bootFromSave preserved a future-build save (does NOT overwrite the recoverable bytes)', async ({
+test.describe('Issue #196 — future-build save survives a fresh boot (Save Now does NOT overwrite it)', () => {
+  // A save written by a NEWER build (snapshot.simVersion > this build's
+  // LATEST_SIM_VERSION) is recoverable: the bytes are intact and a newer build
+  // can load them. On THIS (older) build the save is incompatible, so boot routes
+  // to a FRESH game ("Choose Difficulty") rather than a Continue/New Game prompt
+  // — but the preserved bytes MUST survive: neither autosave nor "Save Now" may
+  // overwrite them, so the player can recover by reloading on the newer build.
+  //
+  // Before #196 this protection was inert: hasIncompatibleSave() lumped the
+  // future-sim case in with corruption, decideBootMode fell through to a fresh
+  // game with autosaveSuspended = false (only bootFromSave's Continue path armed
+  // it, and the future-sim save never reached Continue), and Save Now overwrote
+  // the recoverable bytes (observed simVersion 99999 → 26). The fix classifies
+  // the incompatibility (incompatible-future vs -corrupt) and arms
+  // autosaveSuspended after the fresh boot for the future case only.
+  test('Save Now is a no-op after a future-build save routes boot to fresh (preserved bytes survive)', async ({
     page,
   }) => {
-    // Bootstrap: populate localStorage with a future-sim save BEFORE the
-    // page loads. bootFromSave will deserialize, catch FutureSimVersionError,
-    // and set autosaveSuspended = true. We then verify Save Now refuses to
-    // write so the preserved future-build bytes survive for recovery.
-    // Capture a REAL, current-format save envelope (rather than hand-crafting one
-    // that rots whenever the snapshot shape changes — the original cause of this
-    // test going stale), then bump its simVersion past LATEST so the next boot's
-    // bootFromSave throws FutureSimVersionError → autosaveSuspended = true.
+    // 1) Seed a REAL, current-format save by driving the live game through
+    //    Save Now (robust vs a hand-crafted fixture, which rots when the
+    //    snapshot shape changes — the original cause of #192).
     await bootGame(page); // fresh Normal game, Playing, autosave NOT suspended
-    // Save Now writes a valid envelope to localStorage. Open pause → Save/Load →
-    // Save Now (rects from pause-menu-layout.ts / save-load-dialog-layout.ts; the
-    // playtrace feature is forced off in playwright.config so the menu is 4 rows).
     await page.keyboard.press('Escape');
     await expect.poll(() => activeOverlay(page), { timeout: 5_000 }).toBe('pause-menu');
-    await clickCanvasRect(page, { x: 240, y: 279, w: 320, h: 40 }); // Save/Load row (index 1 of 4)
+    await clickCanvasRect(page, SAVE_LOAD_ROW_RECT);
     await expect.poll(() => activeOverlay(page), { timeout: 5_000 }).toBe('save-load');
-    await clickCanvasRect(page, { x: 260, y: 220, w: 280, h: 36 }); // Save Now (dialog index 1)
-    await page.waitForFunction(() => localStorage.getItem('subterrans:save:v3') !== null, {
-      timeout: 5_000,
-    });
-    // Mutate the captured envelope: simVersion > LATEST → future-build save.
+    // Clear the key IMMEDIATELY before the Save Now click so the post-click
+    // presence check can ONLY be satisfied by Save Now committing — not by a
+    // stale key or an autosave (the game is paused in the dialog, nothing else
+    // writes here).
+    await page.evaluate(() => localStorage.removeItem('subterrans:save:v3'));
+    await clickCanvasRect(page, DIALOG_SAVE_NOW_RECT);
+    // Tie success to a REAL current-format envelope (positive integer simVersion)
+    // so a misrouted click can't pass on garbage (defeats #192 silent masking).
+    await page.waitForFunction(
+      () => {
+        const raw = localStorage.getItem('subterrans:save:v3');
+        if (raw === null) return false;
+        try {
+          const v = (JSON.parse(raw) as { snapshot?: { simVersion?: unknown } }).snapshot
+            ?.simVersion;
+          return typeof v === 'number' && Number.isInteger(v) && v > 0;
+        } catch {
+          return false;
+        }
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
+
+    // 2) Bump the captured envelope's simVersion past LATEST → a future-build save.
     await page.evaluate(() => {
       const raw = localStorage.getItem('subterrans:save:v3');
       if (raw === null) throw new Error('expected a save after Save Now');
@@ -743,72 +778,56 @@ test.describe('Round-5 (Codex P1) — Save Now respects autosaveSuspended', () =
       localStorage.setItem('subterrans:save:v3', JSON.stringify(env));
     });
 
-    // Reload — boot path now sees the future-sim save, SavePrompt shows.
+    // 3) Reload. The future-build save is incompatible on this build, so boot
+    //    routes to a FRESH game — "Choose Difficulty", NOT a Continue/New Game
+    //    SavePrompt. bootScreen discriminates the two (both report activeOverlay
+    //    'save-prompt'); pin 'difficulty-select' so a regression that wrongly
+    //    showed a real Continue prompt (and let Continue silently lose the save)
+    //    can't pass silently.
     await page.reload();
     await page.locator('canvas').first().waitFor({ state: 'attached' });
-    await page.waitForFunction(
-      () => {
-        const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
-        return ui !== undefined && ui.activeOverlay === 'save-prompt';
-      },
-      { timeout: 5_000 },
-    );
+    await expect.poll(() => bootScreen(page), { timeout: 10_000 }).toBe('difficulty-select');
 
-    // Click Continue → bootFromSave → catches FutureSimVersionError →
-    // bootFresh + autosaveSuspended = true. The preserved bytes stay in
-    // localStorage; the running game is now a fresh scenario.
-    // SAVE_PROMPT_CONTINUE_RECT = { x: 300, y: 280, w: 120, h: 32 }
-    await page
-      .locator('canvas')
-      .first()
-      .click({ position: { x: 360, y: 296 } });
-    await page.waitForFunction(() => {
-      const ui = (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui;
-      return ui !== undefined && ui.activeOverlay === 'none';
-    });
+    // The recoverable bytes (simVersion 99999) must still be present at the boot
+    // screen — boot must not have deleted or overwritten them.
+    expect(
+      await page.evaluate(() => {
+        const raw = localStorage.getItem('subterrans:save:v3');
+        if (raw === null) return null;
+        return (JSON.parse(raw) as { snapshot: { simVersion: number } }).snapshot.simVersion;
+      }),
+    ).toBe(99999);
 
-    // Snapshot the preserved bytes BEFORE we touch the dialog.
+    // 4) Pick a difficulty → bootFresh → autosaveSuspended = true (issue #196).
+    await settleToPlaying(page);
+
+    // Snapshot the preserved bytes now the fresh game is running. (If autosave
+    // had fired and overwritten them, this would already be the fresh-session
+    // bytes — the final equality below still holds, so additionally assert the
+    // future simVersion survived into the running session.)
     const before = await page.evaluate(() => localStorage.getItem('subterrans:save:v3'));
     expect(before).not.toBeNull();
-
-    // Open pause menu → Save/Load.
-    await page.keyboard.press('Escape');
-    await page.waitForTimeout(100);
-    const saveLoadRect = await page.evaluate(() => {
-      const CANVAS_W = 800,
-        CANVAS_H = 592;
-      const BTN_W = 320,
-        BTN_H = 40,
-        GAP = 10,
-        TITLE_H = 56;
-      const n = 4;
-      const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
-      const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
-      const x = (CANVAS_W - BTN_W) / 2;
-      const slY = top + 1 * (BTN_H + GAP);
-      return { x: x + BTN_W / 2, y: slY + BTN_H / 2 };
-    });
-    await page.locator('canvas').first().click({ position: saveLoadRect });
-    await page.waitForTimeout(150);
     expect(
       await page.evaluate(
-        () => (window as { __phase9_ui?: { activeOverlay: string } }).__phase9_ui?.activeOverlay,
+        () =>
+          (JSON.parse(localStorage.getItem('subterrans:save:v3')!) as {
+            snapshot: { simVersion: number };
+          }).snapshot.simVersion,
       ),
-    ).toBe('save-load');
+    ).toBe(99999);
 
-    // Click Save Now (button index 1 in the dialog, BTN_W=280, BTN_H=36, GAP=8).
-    // firstY = DIALOG_INFO_Y(152) + DIALOG_INFO_TO_BUTTONS_GAP(24) = 176.
-    const saveNowY = 176 + 1 * (36 + 8) + 36 / 2;
-    const saveNowX = (800 - 280) / 2 + 280 / 2;
-    await page
-      .locator('canvas')
-      .first()
-      .click({ position: { x: saveNowX, y: saveNowY } });
+    // 5) Open pause → Save/Load → Save Now. With autosave suspended, Save Now
+    //    must be a no-op so the recoverable future-build bytes survive unchanged.
+    await page.keyboard.press('Escape');
+    await expect.poll(() => activeOverlay(page), { timeout: 5_000 }).toBe('pause-menu');
+    await clickCanvasRect(page, SAVE_LOAD_ROW_RECT);
+    await expect.poll(() => activeOverlay(page), { timeout: 5_000 }).toBe('save-load');
+    await clickCanvasRect(page, DIALOG_SAVE_NOW_RECT);
     await page.waitForTimeout(200);
 
-    // The preserved bytes MUST be unchanged. Pre-fix this overwrote the
-    // future-build save with the fresh-session bytes, silently destroying
-    // the recoverable save.
+    // 6) The preserved bytes MUST be unchanged. Pre-fix, Save Now overwrote the
+    //    future-build save with the fresh-session bytes (simVersion 99999 → 26),
+    //    silently destroying the recoverable save.
     const after = await page.evaluate(() => localStorage.getItem('subterrans:save:v3'));
     expect(after).toBe(before);
   });

--- a/tests/menu-and-dialog.spec.ts
+++ b/tests/menu-and-dialog.spec.ts
@@ -22,6 +22,9 @@ const DIFFICULTY_NORMAL_RECT = { x: 330, y: 260, w: 140, h: 40 } as const;
 // imported because those modules transitively pull in Phaser.
 const SAVE_LOAD_ROW_RECT = { x: 240, y: 279, w: 320, h: 40 } as const;
 const DIALOG_SAVE_NOW_RECT = { x: 260, y: 220, w: 280, h: 36 } as const;
+// Save/Load dialog "Delete Save" button (index 2 of 5: continue, save-now,
+// delete, new-game, back). firstButtonY 176 + 2*(36+8) = 264.
+const DIALOG_DELETE_RECT = { x: 260, y: 264, w: 280, h: 36 } as const;
 
 async function clickCanvasRect(
   page: Page,
@@ -830,5 +833,99 @@ test.describe('Issue #196 — future-build save survives a fresh boot (Save Now 
     //    silently destroying the recoverable save.
     const after = await page.evaluate(() => localStorage.getItem('subterrans:save:v3'));
     expect(after).toBe(before);
+  });
+
+  // Codex P2 (PR #198): the autosave suspension that protects a future-build
+  // save must be RELEASED when the player explicitly deletes that save via the
+  // dialog — otherwise the running fresh session can never save (onSaveNow
+  // returns false, autosave skips every write) until a page reload. The dialog
+  // performs deleteSave() itself; the fix wires an onDelete callback that clears
+  // autosaveSuspended on GameScene.
+  test('Deleting the preserved future-build save re-enables saving (suspension is released)', async ({
+    page,
+  }) => {
+    // Seed a real save, bump simVersion past LATEST, reload → fresh boot with
+    // autosave suspended (same setup as the test above).
+    await bootGame(page);
+    await page.keyboard.press('Escape');
+    await expect.poll(() => activeOverlay(page), { timeout: 5_000 }).toBe('pause-menu');
+    await clickCanvasRect(page, SAVE_LOAD_ROW_RECT);
+    await expect.poll(() => activeOverlay(page), { timeout: 5_000 }).toBe('save-load');
+    await page.evaluate(() => localStorage.removeItem('subterrans:save:v3'));
+    await clickCanvasRect(page, DIALOG_SAVE_NOW_RECT);
+    await page.waitForFunction(
+      () => {
+        const raw = localStorage.getItem('subterrans:save:v3');
+        if (raw === null) return false;
+        try {
+          const v = (JSON.parse(raw) as { snapshot?: { simVersion?: unknown } }).snapshot
+            ?.simVersion;
+          return typeof v === 'number' && Number.isInteger(v) && v > 0;
+        } catch {
+          return false;
+        }
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
+    await page.evaluate(() => {
+      const raw = localStorage.getItem('subterrans:save:v3');
+      if (raw === null) throw new Error('expected a save after Save Now');
+      const env = JSON.parse(raw) as { snapshot: { simVersion: number } };
+      env.snapshot.simVersion = 99999;
+      localStorage.setItem('subterrans:save:v3', JSON.stringify(env));
+    });
+    await page.reload();
+    await page.locator('canvas').first().waitFor({ state: 'attached' });
+    await expect.poll(() => bootScreen(page), { timeout: 10_000 }).toBe('difficulty-select');
+    await settleToPlaying(page); // pick difficulty → autosaveSuspended = true
+
+    // Open pause → Save/Load. The future-build save is still in storage and
+    // shows as incompatible; Delete is enabled.
+    await page.keyboard.press('Escape');
+    await expect.poll(() => activeOverlay(page), { timeout: 5_000 }).toBe('pause-menu');
+    await clickCanvasRect(page, SAVE_LOAD_ROW_RECT);
+    await expect.poll(() => activeOverlay(page), { timeout: 5_000 }).toBe('save-load');
+
+    // Sanity: while suspended, Save Now is a no-op (the future bytes survive).
+    await clickCanvasRect(page, DIALOG_SAVE_NOW_RECT);
+    await page.waitForTimeout(150);
+    expect(
+      await page.evaluate(() => {
+        const raw = localStorage.getItem('subterrans:save:v3');
+        return raw === null
+          ? null
+          : (JSON.parse(raw) as { snapshot: { simVersion: number } }).snapshot.simVersion;
+      }),
+    ).toBe(99999);
+
+    // Delete the save (two clicks: arm confirm, then commit). deleteSave() wipes
+    // the bytes AND onDelete() clears autosaveSuspended.
+    await clickCanvasRect(page, DIALOG_DELETE_RECT);
+    await page.waitForTimeout(120);
+    await clickCanvasRect(page, DIALOG_DELETE_RECT);
+    await page.waitForFunction(() => localStorage.getItem('subterrans:save:v3') === null, {
+      timeout: 5_000,
+    });
+
+    // Now Save Now must SUCCEED — the suspension is released, so the running
+    // fresh session writes a real current-format save (simVersion = LATEST,
+    // not the deleted 99999). Pre-fix this stayed null forever (until reload).
+    await clickCanvasRect(page, DIALOG_SAVE_NOW_RECT);
+    await page.waitForFunction(
+      () => {
+        const raw = localStorage.getItem('subterrans:save:v3');
+        if (raw === null) return false;
+        try {
+          const v = (JSON.parse(raw) as { snapshot?: { simVersion?: unknown } }).snapshot
+            ?.simVersion;
+          return typeof v === 'number' && Number.isInteger(v) && v > 0 && v !== 99999;
+        } catch {
+          return false;
+        }
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #196 — a save written by a **newer build** (`snapshot.simVersion > LATEST_SIM_VERSION`) was silently overwritten by autosave / "Save Now" on the older build, destroying recoverable bytes.

### Root cause
`hasIncompatibleSave()` (`src/platform/save.ts`) ran a full `deserializeWorldState` and returned `true` on **any** throw, including `FutureSimVersionError`. So `decideBootMode(() => hasSave() && !hasIncompatibleSave())` routed a future-sim save to a **fresh** boot (`showDifficultySelectThenBoot`) instead of the Continue/New Game `SavePrompt`. `autosaveSuspended` was only armed inside `bootFromSave`'s `FutureSimVersionError` catch — reached **only** via the SavePrompt's Continue — so for a future-sim save it never fired, and `bootFresh → resetSessionState` left it `false`. The preserve-future-save intent was inert at boot.

### Fix
- **`save.ts`** — new `classifySaveCompatibility(): 'none' | 'compatible' | 'incompatible-future' | 'incompatible-corrupt'` distinguishes a recoverable future-build save (`FutureSimVersionError`) from definitive corruption. `hasIncompatibleSave()` now delegates to it (behavior unchanged for the Save/Load dialog).
- **`game-scene.ts`** — boot classifies the save once; the fresh-boot branch arms `autosaveSuspended = true` after `bootFresh` **only** for `incompatible-future`, mirroring `bootFromSave`'s existing `FutureSimVersionError` catch. Corrupt saves still overwrite freely.
- **`tests/menu-and-dialog.spec.ts`** — un-quarantined the #196 regression test and re-derived it against the real fixed flow: seed a real captured save → bump `simVersion` past LATEST → reload → assert `bootScreen === 'difficulty-select'` (not a Continue prompt) → pick a difficulty → assert **Save Now is a no-op** (preserved future-sim bytes survive unchanged).

No `simVersion` bump — this is a boot/save-flow fix, not a sim algorithm/field change.

## Verification
- `npx playwright test tests/menu-and-dialog.spec.ts` → exit 0 (11 passed, the two #193 flaky tests remain quarantined). **Non-vacuous:** reverting only the source files makes the new test fail at the Save-Now assertion.
- `npm run verify` → exit 0 (prettier, eslint, tsc, lint:types, sim/asset guards, 2303 Vitest tests).
- Internal `ship-review` (base `main`): `passed: true`, 0 actionable / 0 advisory.

## UAT for the owner
Seed a "future-build" save (bump `snapshot.simVersion` past LATEST), confirm it **survives** a fresh boot **and** that Save Now / autosave no longer overwrite it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
