### PR TITLE
docs(ci): record coverage as intentionally local-only; close #188

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,16 @@ name: CI
 #            pins VITE_PLAYTRACE_ENDPOINT empty so the run is deterministic
 #            regardless of a developer's .env.local (see playwright.config.ts).
 #
-# Coverage (`npm run test:coverage`) is deliberately NOT gated here: the 80%
-# threshold passes, but v8 instrumentation on a 2-core runner pushes the long
-# simulation integration tests (ai-controller.integration, foraging-survival,
-# determinism) past their hard-coded timeouts, so the job fails on runtime, not
-# on coverage. `verify` already runs the same suite UN-instrumented and passes —
-# only the % enforcement is missing here. Tracked in issue #188.
+# Coverage (`npm run test:coverage`) is intentionally a LOCAL-ONLY pre-push tool,
+# by design — not a CI gate. The 80% thresholds pass, but v8 instrumentation on a
+# 2-core runner multiplies the long simulation integration tests
+# (ai-controller.integration, foraging-survival, determinism) several-fold past
+# their inline per-test timeouts, so the job fails on runtime, not on coverage. The
+# fix would mean scaling inline timeouts across ~11 test sites to absorb a flaky
+# instrumentation multiplier — permanent complexity for a redundant signal, since
+# `verify` already runs the identical suite UN-instrumented and gates correctness.
+# So coverage stays local (run it before pushing); CI gates correctness, not %.
+# Decision recorded in issue #188 (closed).
 
 on:
   pull_request:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Phase 1 targets web only. The architecture preserves portability for native wrap
 - **`src/sim/`**: Full test coverage. Every system function, every component store operation, every edge case. These are pure functions operating on data — they are trivially testable.
 - **`src/render/`, `src/input/`, `src/platform/`**: Smoke tests. Verify initialization, basic rendering, input translation.
 - **Deterministic replay tests**: A recorded input sequence + seed must always produce the same final world state. These tests catch non-determinism bugs.
-- **The full Vitest (unit/integration) suite runs in CI** on every push and PR via `verify` (`.github/workflows/ci.yml`). The coverage-% gate (`test:coverage`) and Playwright E2E are local-only for now, not CI-gated (see Building and Running; tracked in #188 and #186).
+- **The full Vitest (unit/integration) suite and the Playwright E2E suite both run in CI** on every push and PR via the `verify` and `e2e` jobs (`.github/workflows/ci.yml`). The coverage-% gate (`test:coverage`) is intentionally local-only by design — not CI-gated — because v8 instrumentation blows the long integration tests' timeouts on the CI runner while `verify` already gates the same suite un-instrumented (see Building and Running; decision in #188).
 
 ## Branching & PR Workflow
 
@@ -124,7 +124,7 @@ Use strong language deliberately — these are non-negotiable invariants of the 
 - Any new logic under `src/sim/` must ship with Vitest unit tests in the same PR. Untested sim code is a blocker, not a follow-up.
 - Changes to tick-order, command application, save format, or PRNG usage must include or update a deterministic replay test. If the PR claims "replay still works" without a test demonstrating it, ask for one.
 - Render/input/platform changes need at least a smoke test (initialization + one happy path). Full coverage is not required at those layers.
-- **80% coverage gate.** `npm run test:coverage` runs Vitest with v8 instrumentation and enforces global thresholds of 80% on statements / branches / functions / lines (see `vitest.config.ts`). Phaser scene files and `src/main.ts` are excluded from the gate because they are exercised by Playwright E2E, not unit tests. **Run `npm run test:coverage` and confirm the gate passes before pushing.** It is not part of `verify` — coverage instrumentation slows the suite to ~6 minutes and causes some long integration tests to hit their hard-coded timeouts, so keep it as a separate pre-push step rather than wiring it into the fast local loop. It is **not** CI-gated yet for that same timeout reason (the instrumented run blows those timeouts on the slower CI runner); bringing it into CI is tracked in #188.
+- **80% coverage gate.** `npm run test:coverage` runs Vitest with v8 instrumentation and enforces global thresholds of 80% on statements / branches / functions / lines (see `vitest.config.ts`). Phaser scene files and `src/main.ts` are excluded from the gate because they are exercised by Playwright E2E, not unit tests. **Run `npm run test:coverage` and confirm the gate passes before pushing.** It is not part of `verify` — coverage instrumentation slows the suite to ~6 minutes and causes some long integration tests to hit their hard-coded timeouts, so keep it as a separate pre-push step rather than wiring it into the fast local loop. It is intentionally **not** CI-gated (a deliberate decision, not a TODO): the instrumented run multiplies the long integration tests several-fold past their inline timeouts on the slower 2-core CI runner, and making it green would mean scaling per-test timeouts across ~11 sites to absorb a flaky multiplier — permanent complexity for a signal `verify` already covers un-instrumented. So coverage stays a local pre-push step. See #188 (closed) for the full rationale.
 
 ### Asset paths and build hygiene
 
@@ -146,7 +146,7 @@ npm run test:coverage  # Run Vitest with v8 coverage + 80% gate (run before push
 npm run test:e2e       # Run Playwright
 ```
 
-CI (`.github/workflows/ci.yml`) runs `verify` on every PR to `main` and on pushes to `main` — that includes the full Vitest suite (un-instrumented). Two suites are run locally only, **not** CI-gated yet: `test:coverage` (the 80% gate — v8 instrumentation pushes long integration tests past their timeouts on the CI runner, tracked in #188) and `test:e2e` (Playwright — fails headless, canvas/WebGL timeouts, tracked in #186).
+CI (`.github/workflows/ci.yml`) runs `verify` (the full Vitest suite, un-instrumented) and `e2e` (Playwright) on every PR to `main` and on pushes to `main`. One suite is run locally only, intentionally **not** CI-gated: `test:coverage` (the 80% gate — v8 instrumentation pushes long integration tests past their inline timeouts on the CI runner, so it stays a local pre-push step; decision in #188).
 
 ## Debugging snapshots (F9 exports)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Highlights:
 
    Prefixes we use: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`.
 
-4. **Run `npm run verify` before pushing.** CI runs the same gate on every PR (`.github/workflows/ci.yml`). The `test:coverage` (80%) and `test:e2e` suites are local-only for now — not CI-gated (tracked in #188 and #186) — so run them locally before pushing.
+4. **Run `npm run verify` before pushing.** CI runs the same gate on every PR (`.github/workflows/ci.yml`), alongside the `e2e` (Playwright) job. The `test:coverage` (80%) suite is intentionally local-only — not CI-gated, because v8 instrumentation blows the long integration tests' timeouts on the CI runner (decision in #188) — so run it locally before pushing.
 5. **Open a PR** against `main`. Fill out the PR template (summary + test plan).
 
 ## PR Review


### PR DESCRIPTION
## What & why

Closes #188 — but as a **decision-and-document**, not by wiring coverage into CI.

The 80% v8 coverage **thresholds pass**; the blocker is *runtime*. On a 2-core CI runner, v8 instrumentation multiplies the long simulation integration tests (`ai-controller.integration`, `foraging-survival`, `determinism`) several-fold past their **inline** per-test timeouts, so the job fails on timeout. I confirmed empirically that vitest's CLI `--testTimeout` does **not** override inline per-test timeouts, so there's no one-flag fix — making coverage green in CI would require scaling timeouts across **~11** integration-test sites (3 in `ai-controller.integration`, 7 in `determinism`, 1 in `foraging-excursion`) to absorb a flaky instrumentation multiplier. That's permanent complexity for a signal `verify` already provides by running the identical suite **un-instrumented** on every PR.

So the call (option C from the #188 discussion): **coverage stays a documented local pre-push tool, by design.** CI gates correctness, not coverage %.

## Changes (docs/comments only — no code or logic)

- **`.github/workflows/ci.yml`** — reframe the coverage comment from "broken in CI, tracked in #188" to "intentionally local-only by design", with the rationale.
- **`AGENTS.md`, `CONTRIBUTING.md`** — same reframing for the coverage gate.
- **Correct now-stale e2e wording**: the Playwright suite **is** CI-gated (the `e2e` job, landed with #186's fix), so the "local-only / not CI-gated / tracked in #186" text for it is removed. #186 is closed.

## Test plan

- `npm run verify` green locally (format:check, eslint, tsc, type-aware lint, sim/asset guards, 2311 unit/integration tests).
- No executable code changed — pure comments + markdown prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)