### PR TITLE
fix(render): spider rampage popup fires every rampage; drop "tunnels" copy

### DIFF
--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -133,7 +133,7 @@ import {
 } from '../input/underground-input.js';
 import { hideContextMenu } from './context-menu-state.js';
 import { buildPlaytraceSummary, type GameOutcomeLabel } from './summary-builder.js';
-import { checkAndTrigger, resetCaptions } from './onboarding-captions.js';
+import { captionForEvent, checkAndTrigger, resetCaptions } from './onboarding-captions.js';
 import {
   triggerScreenEdgeFlash,
   triggerQueenDamagePulse,
@@ -690,16 +690,19 @@ export class GameScene extends Phaser.Scene {
         } else {
           triggerScreenEdgeFlash(this, 'right', CANVAS_W, CANVAS_H);
         }
-        // Caption #7: first AI invasion.
-        const captionText = checkAndTrigger('aiInvading');
+        // Caption #7: AI invasion (one-shot, via the event→caption policy).
+        const captionText = captionForEvent(ev.type);
         if (captionText && uiScene) {
           uiScene.showCaption(captionText, CANVAS_W / 2, 60);
         }
       }
 
       if (ev.type === 'spider_rampage_start') {
-        // Caption #8: first spider rampage.
-        const captionText = checkAndTrigger('spiderRampage');
+        // Spider rampage caption: fires on EVERY rampage, not just the first.
+        // The recurring-vs-one-shot decision lives in captionForEvent; the
+        // spider is surface-only now (#146/#176/#177) so the copy no longer
+        // mentions tunnels.
+        const captionText = captionForEvent(ev.type);
         if (captionText && uiScene) {
           uiScene.showCaption(captionText, CANVAS_W / 2, 60);
         }

--- a/src/render/onboarding-captions.test.ts
+++ b/src/render/onboarding-captions.test.ts
@@ -1,7 +1,13 @@
 // onboarding-captions.test.ts — S6 coverage for the first-occurrence caption registry.
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { checkAndTrigger, resetCaptions, triggered } from './onboarding-captions.js';
+import {
+  captionForEvent,
+  checkAndTrigger,
+  resetCaptions,
+  triggered,
+} from './onboarding-captions.js';
+import type { SimEvent } from '../sim/telemetry.js';
 
 // Always start each test with a clean slate.
 beforeEach(() => {
@@ -119,6 +125,76 @@ describe('checkAndTrigger — chamber type substitution', () => {
   it('substitution only happens on first trigger; second call still returns null', () => {
     checkAndTrigger('chamber', 'Queen');
     expect(checkAndTrigger('chamber', 'Nursery')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event → caption policy (captionForEvent)
+// ---------------------------------------------------------------------------
+
+describe('captionForEvent — recurring alerts fire every time', () => {
+  it('spider_rampage_start returns its caption on EVERY call (per-event dispatch)', () => {
+    const expected = 'The spider has gone hungry and is hunting on the surface.';
+    // Two separate rampage events must both produce the caption — this is the
+    // regression guard for #190 (rampage popup only fired on the first rampage).
+    expect(captionForEvent('spider_rampage_start')).toBe(expected);
+    expect(captionForEvent('spider_rampage_start')).toBe(expected);
+    // ...and again after many occurrences.
+    expect(captionForEvent('spider_rampage_start')).toBe(expected);
+  });
+
+  it('the spider rampage copy no longer mentions tunnels (#190)', () => {
+    const text = captionForEvent('spider_rampage_start');
+    expect(text).not.toBeNull();
+    expect(text?.toLowerCase()).not.toContain('tunnel');
+  });
+
+  it('recurring dispatch does not touch the one-shot triggered map', () => {
+    captionForEvent('spider_rampage_start');
+    captionForEvent('spider_rampage_start');
+    expect(triggered.has('spiderRampage')).toBe(false);
+  });
+});
+
+describe('captionForEvent — one-shot events fire once', () => {
+  it('invasion_start returns its caption once then null', () => {
+    expect(captionForEvent('invasion_start')).toBe('The enemy is attacking your hive.');
+    expect(captionForEvent('invasion_start')).toBeNull();
+  });
+
+  it('shares one-shot state with checkAndTrigger for the same CaptionKey', () => {
+    // invasion_start maps to the 'aiInvading' caption; once the event fires it,
+    // a direct checkAndTrigger('aiInvading') (the ai_state_transition
+    // belt-and-suspenders path) must be suppressed, and vice versa.
+    expect(captionForEvent('invasion_start')).not.toBeNull();
+    expect(checkAndTrigger('aiInvading')).toBeNull();
+
+    resetCaptions();
+
+    expect(checkAndTrigger('aiInvading')).not.toBeNull();
+    expect(captionForEvent('invasion_start')).toBeNull();
+  });
+});
+
+describe('captionForEvent — unknown / caption-less events', () => {
+  it('returns null for events with no caption', () => {
+    expect(captionForEvent('combat_kill')).toBeNull();
+    expect(captionForEvent('ai_state_transition')).toBeNull();
+    // Defensive runtime check: an event type outside the union (e.g. one that
+    // existed in an older save/telemetry stream) must still map to null. The
+    // cast is required because the signature now narrows to SimEvent['type'].
+    expect(captionForEvent('not_a_real_event' as SimEvent['type'])).toBeNull();
+  });
+});
+
+describe('captionForEvent vs checkAndTrigger — one-shot onboarding unaffected', () => {
+  it('genuine onboarding one-shots still fire exactly once', () => {
+    // Per-event recurring dispatch must not regress the one-shot onboarding tips.
+    for (const key of ['dig', 'chamber', 'foodMark', 'rally'] as const) {
+      resetCaptions();
+      expect(checkAndTrigger(key)).not.toBeNull();
+      expect(checkAndTrigger(key)).toBeNull();
+    }
   });
 });
 

--- a/src/render/onboarding-captions.ts
+++ b/src/render/onboarding-captions.ts
@@ -5,6 +5,8 @@
 // Reset on every new round (including same-seed rematch) so each session
 // starts fresh (Q6 DEFAULT_ACCEPTED).
 
+import type { SimEvent } from '../sim/telemetry.js';
+
 export type CaptionKey =
   | 'dig'
   | 'chamber'
@@ -25,7 +27,7 @@ const CAPTION_TEXTS: Record<CaptionKey, string> = {
   rally: 'Fighters will converge here.',
   spiderPriority: 'Your fighters are engaging the spider.',
   aiInvading: 'The enemy is attacking your hive.',
-  spiderRampage: 'The spider has gone hungry and is in the tunnels.',
+  spiderRampage: 'The spider has gone hungry and is hunting on the surface.',
   queenDamage: 'Your queen is in danger.',
   queenStarvation: 'Your queen is growing hungry.',
 };
@@ -52,4 +54,52 @@ export function checkAndTrigger(key: CaptionKey, textOverride?: string): string 
     return base.replace('[Chamber Type]', textOverride);
   }
   return base;
+}
+
+// ---------------------------------------------------------------------------
+// Event → caption policy
+// ---------------------------------------------------------------------------
+//
+// `captionForEvent` is the dispatch policy for captions driven by WorldState
+// events (`world.events`). It is keyed by the event `type` string — NOT by a
+// CaptionKey — so GameScene's event loop forwards each event type and shows
+// whatever caption (if any) comes back. The recurring-vs-one-shot decision
+// lives here rather than at the call site.
+//
+// Captions that are driven by world-state polling or input commands (dig,
+// chamber, spider, foodMark, rally, spiderPriority, queenDamage,
+// queenStarvation) are NOT events — they keep using checkAndTrigger directly.
+
+// Recurring alerts re-fire their caption on EVERY occurrence of the event
+// (e.g. every spider rampage, not just the first). These never consult the
+// one-shot `triggered` map.
+const RECURRING_EVENT_CAPTIONS = new Map<SimEvent['type'], CaptionKey>([
+  ['spider_rampage_start', 'spiderRampage'],
+]);
+
+// One-shot onboarding events fire their caption once per session, then stay
+// silent. They share the same `triggered` dedup as checkAndTrigger, so an
+// event and any non-event trigger of the same CaptionKey suppress each other.
+const ONE_SHOT_EVENT_CAPTIONS = new Map<SimEvent['type'], CaptionKey>([
+  ['invasion_start', 'aiInvading'],
+]);
+
+/**
+ * Map a WorldState event type to the caption that should display for it, or
+ * null if the event has no caption (or a one-shot caption already fired).
+ *
+ * Recurring events (e.g. 'spider_rampage_start') return their caption on every
+ * call; one-shot events (e.g. 'invasion_start') return their text once per
+ * session then null. Unknown event types return null.
+ */
+export function captionForEvent(eventType: SimEvent['type']): string | null {
+  const recurringKey = RECURRING_EVENT_CAPTIONS.get(eventType);
+  if (recurringKey !== undefined) {
+    return CAPTION_TEXTS[recurringKey];
+  }
+  const oneShotKey = ONE_SHOT_EVENT_CAPTIONS.get(eventType);
+  if (oneShotKey !== undefined) {
+    return checkAndTrigger(oneShotKey);
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

PR 1 of the post-Phase-3 bug flurry (`plan/flurry/PLAN.md`). Fixes **#190** — the spider-rampage onboarding popup.

Two bugs:
1. **Fired only once.** The caption was gated by the one-shot `checkAndTrigger`, so it appeared on the *first* rampage and never again.
2. **Wrong copy.** It said the spider was *"in the tunnels"* — but the spider is surface-only now (#146/#176/#177).

## Change (render-only)

- **New pure event→caption policy** `captionForEvent(eventType)` in `src/render/onboarding-captions.ts`, keyed by the WorldState event `type` (`SimEvent['type']`), **not** a `CaptionKey`. The recurring-vs-one-shot decision lives in this policy, not at the call site:
  - **Recurring alerts** (`spider_rampage_start`) return their caption on **every** occurrence — never touch the one-shot `triggered` map.
  - **One-shot onboarding events** (`invasion_start`) dedup once per session via the shared `triggered` map, so an event and a non-event trigger of the same `CaptionKey` still suppress each other (the `ai_state_transition` belt-and-suspenders path stays consistent).
- `GameScene.consumeEventsForRender` dispatches `spider_rampage_start` and `invasion_start` through `captionForEvent(ev.type)`.
- Reworded `spiderRampage`: `"The spider has gone hungry and is hunting on the surface."` (no "tunnels").
- Genuine one-shot onboarding tips (`dig`/`chamber`/`foodMark`/`rally`/`spider`/`spiderPriority`/`queenDamage`/`queenStarvation`) keep `checkAndTrigger` one-shot semantics — **unaffected**.

This is a deliberate event→caption *policy* (per codex R3 on the plan), not an `alwaysTriggerCaption(key)` text accessor — dispatch is keyed by event, and the tests prove **per-event** recurrence, not text lookup.

**No `simVersion` bump** — render-only, no change to the deterministic sim sequence (Standing constraint #4 / ADR-0015).

## Tests

`src/render/onboarding-captions.test.ts`:
- `spider_rampage_start` returns its caption on **every** call (per-event dispatch — the #190 regression guard).
- Copy contains no "tunnel".
- Recurring dispatch does **not** mutate the one-shot `triggered` map.
- `invasion_start` returns once then `null`; shares one-shot state with `checkAndTrigger('aiInvading')` both directions.
- Unknown / caption-less events → `null`.
- Genuine one-shot onboarding tips still fire exactly once (no regression).

## Verification

- `npm run verify` green locally — format, lint, tsc, type-aware lint, sim/asset guards, full Vitest suite (**2318 tests**).
- Internal `ship-review` loop: passed (2 rounds, 0 remaining findings).

## Plan-vs-code discrepancies

None material. The plan's line references (`onboarding-captions.ts:~28`, `game-scene.ts:~630-636`) matched the current code. One refinement over the plan's sketched signature `captionForEvent(eventType: string)`: the type is narrowed to `SimEvent['type']` (the telemetry event union) for compile-time safety — surfaced and applied during internal review.

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)