### PR TITLE
feat(sim): static surface terrain + reachable-spawn + connectivity (V28) — flurry PR 4

### DIFF
--- a/src/input/surface-input.test.ts
+++ b/src/input/surface-input.test.ts
@@ -16,6 +16,7 @@ import {
   handleSurfaceLeftClick,
   handleSurfaceRightClick,
   isEmptySurfaceTile,
+  isValidEntranceTarget,
   isForeignColonyEntrance,
   handleSetRallyPoint,
   resetSurfaceInputState,
@@ -31,7 +32,12 @@ import type { ViewState } from '../render/camera.js';
 import { VIEWPORT_WIDTH_TILES, VIEWPORT_HEIGHT_TILES } from '../render/camera.js';
 import { HUD, TILE_SIZE_PX } from '../render/sprites.js';
 import { SPIDER_SPRITE_WIDTH, SPIDER_SPRITE_HEIGHT } from '../render/ant-sprite-layer.js';
-import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
+import {
+  PLAYER_COLONY_ID,
+  ENEMY_COLONY_ID,
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
+} from '../sim/constants.js';
 import type { SimCommand } from '../sim/commands.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
 
@@ -131,6 +137,12 @@ function makeWorld(
     colonies: overrides.colonies ?? {},
     pheromoneGrids: {},
     surface: { data: new Uint8Array(sw * sh), width: sw, height: sh },
+    // PR 4 — fully-walkable frozen terrain (all Cosmetic) so the new
+    // isValidEntranceTarget component/clearance gate treats every empty tile as a
+    // valid preview target, matching pre-PR-4 input behaviour. Tests that need a
+    // rejected target set HardBlock cells explicitly.
+    bakedSurfaceEffect: new Uint8Array(SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT),
+    surfaceComponentMask: null,
     undergroundGrids: {},
     foodPiles: overrides.foodPiles ?? [],
     pendingChambers: {},
@@ -628,6 +640,32 @@ describe('handleSurfaceRightClick', () => {
     handleSurfaceRightClick(world, vs, x, y, state);
     expect(state.pendingEntranceTileX).toBe(40);
     expect(state.pendingEntranceTileY).toBe(50);
+  });
+
+  // PR 4 — the preview must match the stricter DesignateEntrance gate, which
+  // rejects tiles outside the connected component or with a blocked clearance
+  // halo (terrain can no longer be carved at designation time). Previewing those
+  // would advertise a target confirmation silently drops.
+  it('shows NO preview when the target tile is not in the walkable component (HardBlock)', () => {
+    const world = makeWorld({ surfaceWidth: 128, surfaceHeight: 128 });
+    world.bakedSurfaceEffect[50 * SURFACE_GRID_WIDTH + 40] = 2; // HardBlock at (40,50)
+    expect(isValidEntranceTarget(world, 40, 50)).toBe(false);
+    const vs = makeViewState('surface', 64, 64);
+    const state = makeState();
+    const { x, y } = tileToScreen(40, 50, 64, 64);
+    handleSurfaceRightClick(world, vs, x, y, state);
+    expect(state.pendingEntranceTileX).toBeNull();
+  });
+
+  it('shows NO preview when a clearance-halo tile is blocked (candidate itself walkable)', () => {
+    const world = makeWorld({ surfaceWidth: 128, surfaceHeight: 128 });
+    world.bakedSurfaceEffect[50 * SURFACE_GRID_WIDTH + 41] = 2; // HardBlock adjacent to (40,50)
+    expect(isValidEntranceTarget(world, 40, 50)).toBe(false); // halo not all in-component
+    const vs = makeViewState('surface', 64, 64);
+    const state = makeState();
+    const { x, y } = tileToScreen(40, 50, 64, 64);
+    handleSurfaceRightClick(world, vs, x, y, state);
+    expect(state.pendingEntranceTileX).toBeNull();
   });
 
   it('is a no-op when activeView is underground', () => {

--- a/src/input/surface-input.ts
+++ b/src/input/surface-input.ts
@@ -32,7 +32,8 @@ import type {
   MarkSpiderPriorityCommand,
 } from '../sim/commands.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
-import { PLAYER_COLONY_ID } from '../sim/constants.js';
+import { PLAYER_COLONY_ID, SURFACE_ROOT_CLEARANCE_RADIUS } from '../sim/constants.js';
+import { isSurfaceTileInComponent } from '../sim/surface-features.js';
 import { FP_SHIFT } from '../sim/fixed.js';
 import { TILE_SIZE_PX } from '../render/sprites.js';
 import { SPIDER_SPRITE_WIDTH, SPIDER_SPRITE_HEIGHT } from '../render/ant-sprite-layer.js';
@@ -99,6 +100,28 @@ export function isEmptySurfaceTile(world: WorldState, tileX: number, tileY: numb
     }
   }
 
+  return true;
+}
+
+/**
+ * PR 4 — true iff `DesignateEntrance` would ACCEPT this tile, so the preview
+ * never advertises a target the (now stricter) sim gate will silently drop.
+ * Mirrors `tick.ts`'s gate: the tile is an empty surface tile AND it plus its
+ * whole `SURFACE_ROOT_CLEARANCE_RADIUS` neighbourhood are in the single connected
+ * walkable component of the frozen terrain (terrain can no longer be carved at
+ * designation time). Bounds-clamped halo tiles are skipped, matching the gate.
+ */
+export function isValidEntranceTarget(world: WorldState, tileX: number, tileY: number): boolean {
+  if (!isEmptySurfaceTile(world, tileX, tileY)) return false;
+  if (!isSurfaceTileInComponent(world, tileX, tileY)) return false;
+  for (let dy = -SURFACE_ROOT_CLEARANCE_RADIUS; dy <= SURFACE_ROOT_CLEARANCE_RADIUS; dy++) {
+    for (let dx = -SURFACE_ROOT_CLEARANCE_RADIUS; dx <= SURFACE_ROOT_CLEARANCE_RADIUS; dx++) {
+      const cx = tileX + dx;
+      const cy = tileY + dy;
+      if (cx < 0 || cy < 0 || cx >= world.surface.width || cy >= world.surface.height) continue;
+      if (!isSurfaceTileInComponent(world, cx, cy)) return false;
+    }
+  }
   return true;
 }
 
@@ -383,12 +406,13 @@ export function handleSurfaceRightClick(
     }
   }
 
-  // Entrance preview — only on valid entrance target tiles. The sim rejects
-  // DesignateEntrance on food piles and tiles already occupied by any colony's
-  // entrance; previewing those would advertise a target the sim will silently
-  // drop and mislead the player. Invalid click: do nothing (no preview, no
-  // state change). isEmptySurfaceTile already does the bounds check.
-  if (!isEmptySurfaceTile(world, tileX, tileY)) return;
+  // Entrance preview — only on tiles DesignateEntrance will actually accept. The
+  // sim rejects food piles, occupied entrances, and (PR 4) any tile whose
+  // candidate+clearance neighbourhood is not in the single connected walkable
+  // component of the frozen terrain. Previewing those would advertise a target
+  // the sim silently drops, so confirmation would do nothing. Invalid click: no
+  // preview, no state change.
+  if (!isValidEntranceTarget(world, tileX, tileY)) return;
   state.pendingEntranceTileX = tileX;
   state.pendingEntranceTileY = tileY;
 }

--- a/src/input/surface-input.ts
+++ b/src/input/surface-input.ts
@@ -32,7 +32,12 @@ import type {
   MarkSpiderPriorityCommand,
 } from '../sim/commands.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
-import { PLAYER_COLONY_ID, SURFACE_ROOT_CLEARANCE_RADIUS } from '../sim/constants.js';
+import {
+  PLAYER_COLONY_ID,
+  SURFACE_ROOT_CLEARANCE_RADIUS,
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
+} from '../sim/constants.js';
 import { isSurfaceTileInComponent } from '../sim/surface-features.js';
 import { FP_SHIFT } from '../sim/fixed.js';
 import { TILE_SIZE_PX } from '../render/sprites.js';
@@ -118,7 +123,10 @@ export function isValidEntranceTarget(world: WorldState, tileX: number, tileY: n
     for (let dx = -SURFACE_ROOT_CLEARANCE_RADIUS; dx <= SURFACE_ROOT_CLEARANCE_RADIUS; dx++) {
       const cx = tileX + dx;
       const cy = tileY + dy;
-      if (cx < 0 || cy < 0 || cx >= world.surface.width || cy >= world.surface.height) continue;
+      // Bound with the grid CONSTANTS (not world.surface.*) so the preview gate
+      // clamps identically to the sim gate + isSurfaceTileInComponent (which use
+      // the constants). Identical in production; consistent for hand-built worlds.
+      if (cx < 0 || cy < 0 || cx >= SURFACE_GRID_WIDTH || cy >= SURFACE_GRID_HEIGHT) continue;
       if (!isSurfaceTileInComponent(world, cx, cy)) return false;
     }
   }

--- a/src/platform/investigation/harness.test.ts
+++ b/src/platform/investigation/harness.test.ts
@@ -280,6 +280,7 @@ describe('PR 4 — static-terrain feature-field oracle (full SurfaceFeatureSlice
 
     // 3. Entrance designation — issue commands across many columns; terrain is
     //    frozen so the hash must not move whether or not each is accepted.
+    const entrancesBefore = world.colonies[colonyId]!.entrances.length;
     for (let col = 28; col < 100; col += 4) {
       const cmd: SimCommand = {
         type: 'DesignateEntrance',
@@ -290,6 +291,10 @@ describe('PR 4 — static-terrain feature-field oracle (full SurfaceFeatureSlice
       };
       tick(world, [cmd]);
     }
+    // Prove the ACCEPTED path is exercised, not just the rejection path: at least
+    // one designation must have actually added an entrance (else this step would
+    // only cover hash-invariance under rejection — Fable P3).
+    expect(world.colonies[colonyId]!.entrances.length).toBeGreaterThan(entrancesBefore);
     assertSame('entrance-designate');
 
     // 4. Entrance opening — toggle isOpen on every entrance (no terrain effect).

--- a/src/platform/investigation/harness.test.ts
+++ b/src/platform/investigation/harness.test.ts
@@ -35,13 +35,22 @@ import {
   WORKER_BASE_SPEED,
   WORKER_LIFESPAN_TICKS,
 } from '../../sim/constants.js';
-import { serializeWorldState, deserializeWorldState } from '../save.js';
+import { serializeWorldState, deserializeWorldState, MIN_ACCEPTED_SIM_VERSION } from '../save.js';
+import { LATEST_SIM_VERSION } from '../../sim/types.js';
+import {
+  isSurfaceTileInComponent,
+  validateSurfaceConnectivity,
+  surfaceMovementAt,
+  SurfaceMovementEffect,
+} from '../../sim/surface-features.js';
+import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT } from '../../sim/constants.js';
 import type { ColonyId } from '../../sim/colony/colony-store.js';
 import type { SimCommand } from '../../sim/commands.js';
 import {
   DISCOVERY_SEEDS,
   CALIBRATION_SEEDS,
   ACCEPTANCE_SEEDS,
+  DIFFICULTIES,
   seedSetsAreDisjoint,
 } from './seeds.js';
 import { emptyLog, playerConstructionLog } from './input-logs.js';
@@ -233,68 +242,118 @@ describe('#128 natural reproduction via the construction input log', () => {
 // 6. Static-terrain feature-field oracle (plan §3, R3-P1-6)
 // ---------------------------------------------------------------------------
 
-describe('static-terrain feature-field oracle', () => {
-  it('the 128×128 feature-effect field MUTATES when a food pile is removed (today bug)', () => {
-    const world = createScenario(99, 'Normal');
-    const before = featureFieldHash(world);
-
-    // Removing a food pile lifts its suppression halo, potentially REVEALING a
-    // procedural HardBlock under/near it. If the chosen seed's piles never
-    // overlap a suppressed feature, scan a few seeds until one demonstrates the
-    // mutation (the class is known to exist — 348/3000 in the Codex probe).
-    let demonstrated = mutationOnPileRemoval(world, before);
-    if (!demonstrated) {
-      for (const seed of [11, 42, 7, 123, 256, 777]) {
-        const w = createScenario(seed, 'Normal');
-        if (mutationOnPileRemoval(w, featureFieldHash(w))) {
-          demonstrated = true;
-          break;
-        }
-      }
+/** First walkable, in-component surface tile not already occupied by a food pile
+ *  (PR 4 helper for spawn placement). */
+function firstFreeInComponentTile(world: ReturnType<typeof createScenario>): {
+  x: number;
+  y: number;
+} {
+  const occupied = new Set(world.foodPiles.map((p) => `${p.tileX},${p.tileY}`));
+  for (let y = 0; y < SURFACE_GRID_HEIGHT; y++) {
+    for (let x = 0; x < SURFACE_GRID_WIDTH; x++) {
+      if (isSurfaceTileInComponent(world, x, y) && !occupied.has(`${x},${y}`)) return { x, y };
     }
-    expect(demonstrated).toBe(true);
-  });
+  }
+  throw new Error('no free in-component tile — connectivity is broken');
+}
 
-  it('the feature-effect field is invariant across save/load round-trip', () => {
+describe('PR 4 — static-terrain feature-field oracle (full SurfaceFeatureSlice)', () => {
+  it('feature field is EXACTLY invariant across pile spawn/deplete, entrance designate/open, save/load', () => {
     const world = createScenario(42, 'Normal');
-    for (let t = 0; t < 50; t++) tick(world, []);
-    const restored = deserializeWorldState(serializeWorldState(world));
-    expect(featureFieldHash(restored)).toBe(featureFieldHash(world));
-    expect(featureFieldDiffCount(world, restored)).toBe(0);
-  });
+    const base = featureFieldHash(world);
+    const colonyId = PLAYER_COLONY_ID as ColonyId;
+    const assertSame = (label: string): void => {
+      expect(featureFieldHash(world), `feature field changed after ${label}`).toBe(base);
+    };
 
-  it('designating an entrance can change the feature-effect field (suppression halo)', () => {
-    // Designation adds an entrance whose Chebyshev-radius halo suppresses
-    // features. Whether a given column flips depends on the procedural field;
-    // scan a few columns to demonstrate the dynamic-suppression class exists.
-    let changed = false;
-    for (const seed of [42, 11, 99, 7]) {
-      const world = createScenario(seed, 'Normal');
-      const before = featureFieldHash(world);
-      const colonyId = PLAYER_COLONY_ID as ColonyId;
-      for (let col = 30; col < 90 && !changed; col += 1) {
-        const w = createScenario(seed, 'Normal');
-        const cmd: SimCommand = {
-          type: 'DesignateEntrance',
-          colonyId,
-          surfaceTileX: col,
-          surfaceTileY: PLAYER_START_Y,
-          issuedAtTick: 0,
-        };
-        tick(w, [cmd]);
-        if (featureFieldHash(w) !== before) changed = true;
-      }
-      if (changed) break;
+    // 1. Pile depletion — remove a pile (what depletion does).
+    const removed = world.foodPiles.length > 0 ? world.foodPiles.splice(0, 1)[0]! : null;
+    assertSame('pile-deplete');
+
+    // 2. Pile spawn — re-add a pile (valid pickup values from the removed one) on
+    //    a free in-component tile; must not flip terrain.
+    if (removed !== null) {
+      const spot = firstFreeInComponentTile(world);
+      world.foodPiles.push({ ...removed, tileX: spot.x, tileY: spot.y });
     }
-    expect(changed).toBe(true);
+    assertSame('pile-spawn');
+
+    // 3. Entrance designation — issue commands across many columns; terrain is
+    //    frozen so the hash must not move whether or not each is accepted.
+    for (let col = 28; col < 100; col += 4) {
+      const cmd: SimCommand = {
+        type: 'DesignateEntrance',
+        colonyId,
+        surfaceTileX: col,
+        surfaceTileY: PLAYER_START_Y,
+        issuedAtTick: 0,
+      };
+      tick(world, [cmd]);
+    }
+    assertSame('entrance-designate');
+
+    // 4. Entrance opening — toggle isOpen on every entrance (no terrain effect).
+    for (const key of Object.keys(world.colonies)) {
+      for (const e of world.colonies[Number(key)]!.entrances) e.isOpen = !e.isOpen;
+    }
+    assertSame('entrance-open');
+
+    // 5. Run ticks (drives pile/AI churn) — still invariant.
+    for (let t = 0; t < 60; t++) tick(world, []);
+    assertSame('ticks');
+
+    // 6. Save / load round-trip — diff must be 0 over the FULL slice.
+    const restored = deserializeWorldState(serializeWorldState(world));
+    expect(featureFieldDiffCount(world, restored)).toBe(0);
+    expect(featureFieldHash(restored)).toBe(base);
+
+    console.log(
+      `PASS static-terrain oracle: featureFieldHash invariant (0 mutate) across pile spawn/deplete, entrance designate/open, ticks, save/load — hash=${base}`,
+    );
   }, 30_000);
 });
 
-/** Remove the first food pile and report whether the feature-effect field
- *  changed (proving the dynamic-suppression mutation). Mutates `world`. */
-function mutationOnPileRemoval(world: ReturnType<typeof createScenario>, before: number): boolean {
-  if (world.foodPiles.length === 0) return false;
-  // Splice out one pile (the same operation depletion performs) and re-hash.
-  world.foodPiles.splice(0, 1);
-  return featureFieldHash(world) !== before;
-}
+describe('PR 4 — connectivity + reachable-spawn', () => {
+  it('one walkable component holds every colony root, food pile, and entrance', () => {
+    const seeds = [11, 42, 99];
+    for (const seed of seeds) {
+      for (const diff of DIFFICULTIES) {
+        const world = createScenario(seed, diff);
+        // validateSurfaceConnectivity asserts every entrance + every pile is in
+        // the single connected component.
+        expect(validateSurfaceConnectivity(world)).toBe(true);
+        // Every food pile + entrance is walkable (non-HardBlock) AND in-component.
+        for (const pile of world.foodPiles) {
+          expect(isSurfaceTileInComponent(world, pile.tileX, pile.tileY)).toBe(true);
+          expect(surfaceMovementAt(world, pile.tileX, pile.tileY)).not.toBe(
+            SurfaceMovementEffect.HardBlock,
+          );
+        }
+        for (const key of Object.keys(world.colonies)) {
+          for (const e of world.colonies[Number(key)]!.entrances) {
+            expect(isSurfaceTileInComponent(world, e.surfaceTileX, e.surfaceTileY)).toBe(true);
+          }
+        }
+      }
+    }
+    console.log(
+      `PASS connectivity: single component contains all roots/piles/entrances over ${seeds.length} seeds × ${DIFFICULTIES.length} difficulties`,
+    );
+  }, 30_000);
+});
+
+describe('PR 4 — simVersion rejection boundary (posture 2)', () => {
+  it('a save at the new LATEST loads; a save below MIN_ACCEPTED is rejected', () => {
+    const ser = serializeWorldState(createScenario(42, 'Normal'));
+    expect(LATEST_SIM_VERSION).toBe(28);
+    // At LATEST → loads.
+    expect(() => deserializeWorldState({ ...ser, simVersion: LATEST_SIM_VERSION })).not.toThrow();
+    // Below MIN_ACCEPTED → rejected.
+    expect(() =>
+      deserializeWorldState({ ...ser, simVersion: MIN_ACCEPTED_SIM_VERSION - 1 }),
+    ).toThrow();
+    console.log(
+      `PASS simVersion boundary: LATEST=${LATEST_SIM_VERSION} loads, ${MIN_ACCEPTED_SIM_VERSION - 1} (< MIN_ACCEPTED=${MIN_ACCEPTED_SIM_VERSION}) rejected`,
+    );
+  });
+});

--- a/src/platform/investigation/harness.ts
+++ b/src/platform/investigation/harness.ts
@@ -23,7 +23,11 @@
 import { tick } from '../../sim/tick.js';
 import { createScenario } from '../../sim/scenario.js';
 import { canEnterUndergroundTile } from '../../sim/ant/ant-system.js';
-import { surfaceMovementAt, SurfaceMovementEffect } from '../../sim/surface-features.js';
+import {
+  surfaceMovementAt,
+  surfaceFeatureAt,
+  SurfaceMovementEffect,
+} from '../../sim/surface-features.js';
 import { Zone, ugGet } from '../../sim/terrain.js';
 import { AntTask, ForagingSubState, PheromoneType } from '../../sim/enums.js';
 import { FP_SHIFT } from '../../sim/fixed.js';
@@ -185,30 +189,61 @@ function freshWindow(): AntWindow {
 // ===========================================================================
 
 /**
- * FNV-1a hash of the COMPLETE 128×128 surface feature-effect field. Two worlds
- * with the same hash have identical movement effect (Cosmetic/SoftCost/
- * HardBlock) on every surface tile. Used to prove the field MUTATES across
- * pile spawn/depletion + entrance designation today (the bug the static-terrain
- * redesign removes) and to require exact equality across save/load.
+ * FNV-1a hash of the COMPLETE 128×128 surface feature field, over the FULL
+ * `SurfaceFeatureSlice` (kind + variantIndex + anchorX + anchorY + movement) —
+ * not just the movement effect (PR 4 / R1-2). Two worlds with the same hash
+ * render AND move identically on every surface tile, so a visual-only terrain
+ * change (e.g. a feature whose kind/variant flips without changing passability)
+ * cannot slip past the static-terrain invariance oracle. Used to prove the
+ * field is INVARIANT across pile spawn/depletion, entrance designation/opening,
+ * and save/load (PR 4 froze terrain; the old dynamic suppression is gone).
  */
 export function featureFieldHash(world: WorldState): number {
   let h = 0x811c9dc5;
+  const mix = (v: number): void => {
+    h ^= v & 0xff;
+    h = Math.imul(h, 0x01000193) >>> 0;
+  };
   for (let y = 0; y < SURFACE_GRID_HEIGHT; y++) {
     for (let x = 0; x < SURFACE_GRID_WIDTH; x++) {
-      const effect = surfaceMovementAt(world, x, y);
-      h ^= effect & 0xff;
-      h = Math.imul(h, 0x01000193) >>> 0;
+      const slice = surfaceFeatureAt(world, x, y);
+      if (slice === null) {
+        mix(0); // distinct "no feature" sentinel
+        continue;
+      }
+      // +1 so kind 0 (Boulder) doesn't collide with the null sentinel.
+      mix(slice.kind + 1);
+      mix(slice.variantIndex);
+      mix(slice.anchorX);
+      mix(slice.anchorX >> 8);
+      mix(slice.anchorY);
+      mix(slice.anchorY >> 8);
+      mix(slice.movement);
     }
   }
   return h >>> 0;
 }
 
-/** Count of surface tiles whose effect differs between two worlds. */
+/** Count of surface tiles whose FULL feature slice differs between two worlds. */
 export function featureFieldDiffCount(a: WorldState, b: WorldState): number {
   let diff = 0;
   for (let y = 0; y < SURFACE_GRID_HEIGHT; y++) {
     for (let x = 0; x < SURFACE_GRID_WIDTH; x++) {
-      if (surfaceMovementAt(a, x, y) !== surfaceMovementAt(b, x, y)) diff++;
+      const sa = surfaceFeatureAt(a, x, y);
+      const sb = surfaceFeatureAt(b, x, y);
+      if (sa === null || sb === null) {
+        if (sa !== sb) diff++;
+        continue;
+      }
+      if (
+        sa.kind !== sb.kind ||
+        sa.variantIndex !== sb.variantIndex ||
+        sa.anchorX !== sb.anchorX ||
+        sa.anchorY !== sb.anchorY ||
+        sa.movement !== sb.movement
+      ) {
+        diff++;
+      }
     }
   }
   return diff;

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -18,11 +18,17 @@ import {
   FutureSimVersionError,
   OldSimVersionError,
   SaveVersionMismatchError,
+  unpackBakedSurfaceEffect,
   type SaveFile,
 } from './save.js';
 import { createScenario } from '../sim/scenario.js';
 import { tick } from '../sim/tick.js';
-import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
+import {
+  PLAYER_COLONY_ID,
+  ENEMY_COLONY_ID,
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
+} from '../sim/constants.js';
 import type { SimCommand } from '../sim/commands.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
 import { ChamberType } from '../sim/enums.js';
@@ -2043,5 +2049,65 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(info!.playerWorkers).toBe(0);
       expect(info!.playerFoodStored).toBe(0);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR 4 (Fable review) — bakedSurfaceEffect field-specific serialization (R1-12)
+// + unpackBakedSurfaceEffect rejection paths + load-time connectivity rejection.
+// ---------------------------------------------------------------------------
+
+describe('bakedSurfaceEffect serialization', () => {
+  const TILE_COUNT = SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT;
+  // Build standard-base64 of a packed grid where tile 0 holds `code`, rest 0.
+  const packedGridB64 = (code: number): string => {
+    const packed = new Uint8Array((TILE_COUNT + 3) >> 2);
+    packed[0] = code & 0x3;
+    return Buffer.from(packed).toString('base64');
+  };
+  const allHardBlockB64 = (): string => {
+    // every 2-bit code = 2 (HardBlock) → byte 0b10101010 = 0xAA.
+    const packed = new Uint8Array((TILE_COUNT + 3) >> 2).fill(0xaa);
+    return Buffer.from(packed).toString('base64');
+  };
+
+  it('save→load round-trips a MUTATED baked grid (not re-derived from terrainSeed)', () => {
+    const world = createScenario(42, 'Normal');
+    // Flip a procedurally-Cosmetic tile to SoftCost: walkable (no connectivity
+    // break) but DIFFERENT from what terrainSeed would re-derive. A deserializer
+    // that rebuilt the grid from the seed would lose this.
+    let idx = -1;
+    for (let i = 0; i < world.bakedSurfaceEffect.length; i++) {
+      if (world.bakedSurfaceEffect[i] === 0) {
+        idx = i;
+        break;
+      }
+    }
+    expect(idx).toBeGreaterThanOrEqual(0);
+    world.bakedSurfaceEffect[idx] = 1; // SoftCost
+    const restored = deserializeWorldState(serializeWorldState(world));
+    expect(restored.bakedSurfaceEffect[idx]).toBe(1);
+    expect(restored.bakedSurfaceEffect.length).toBe(world.bakedSurfaceEffect.length);
+  });
+
+  it('unpackBakedSurfaceEffect rejects malformed input (all paths return null)', () => {
+    expect(unpackBakedSurfaceEffect('AAA!', TILE_COUNT)).toBeNull(); // bad base64 char
+    expect(unpackBakedSurfaceEffect('AB==CDEF', TILE_COUNT)).toBeNull(); // mid-string padding
+    expect(unpackBakedSurfaceEffect('AB=C', TILE_COUNT)).toBeNull(); // "x=y" padding form
+    expect(unpackBakedSurfaceEffect('AAAA', TILE_COUNT)).toBeNull(); // valid b64, wrong packed length
+    expect(unpackBakedSurfaceEffect(packedGridB64(3), TILE_COUNT)).toBeNull(); // enum code 3
+    // Non-zero unused trailing bits in the final byte (expectedLen not /4):
+    // byte 0b00110000 — tiles 0,1 = 0 but trailing bits 4-7 = 0b0011 ≠ 0.
+    expect(unpackBakedSurfaceEffect(Buffer.from([0x30]).toString('base64'), 2)).toBeNull();
+    // Sanity: a clean all-Cosmetic grid decodes.
+    expect(unpackBakedSurfaceEffect(packedGridB64(0), TILE_COUNT)).not.toBeNull();
+  });
+
+  it('deserialize rejects a baked grid that violates connectivity (all HardBlock)', () => {
+    const ser = serializeWorldState(createScenario(42, 'Normal'));
+    // simVersion stays at LATEST so the version gate passes and we reach the
+    // connectivity check; the all-HardBlock grid disconnects every pile/entrance.
+    const corrupt = { ...ser, bakedSurfaceEffect: allHardBlockB64() };
+    expect(() => deserializeWorldState(corrupt)).toThrow();
   });
 });

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -1441,9 +1441,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   // Issue #112 — finite food piles + recentlyDepletedFood persistence
   // ---------------------------------------------------------------------------
   describe('Issue #112 — depletion / spawn save format (v3)', () => {
-    it('SAVE_FORMAT_VERSION === 4 and SAVE_KEY ends with :v4 (PR 4 static terrain)', () => {
-      expect(SAVE_FORMAT_VERSION).toBe(4);
-      expect(SAVE_KEY).toBe('subterrans:save:v4');
+    it('SAVE_FORMAT_VERSION === 3 and SAVE_KEY ends with :v3', () => {
+      expect(SAVE_FORMAT_VERSION).toBe(3);
+      expect(SAVE_KEY).toBe('subterrans:save:v3');
     });
 
     it('rejects v2 envelopes with SaveVersionMismatchError', () => {

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -2091,10 +2091,22 @@ describe('bakedSurfaceEffect serialization', () => {
   });
 
   it('unpackBakedSurfaceEffect rejects malformed input (all paths return null)', () => {
-    expect(unpackBakedSurfaceEffect('AAA!', TILE_COUNT)).toBeNull(); // bad base64 char
-    expect(unpackBakedSurfaceEffect('AB==CDEF', TILE_COUNT)).toBeNull(); // mid-string padding
-    expect(unpackBakedSurfaceEffect('AB=C', TILE_COUNT)).toBeNull(); // "x=y" padding form
-    expect(unpackBakedSurfaceEffect('AAAA', TILE_COUNT)).toBeNull(); // valid b64, wrong packed length
+    // Wrong length: rejected by the DoS length pre-check, never reaches the decoder.
+    expect(unpackBakedSurfaceEffect('AAAA', TILE_COUNT)).toBeNull();
+    // Every other malformed input below must be the EXACT base64 length for a
+    // full grid (ceil(packedBytes/3)*4) so it passes that length gate and
+    // exercises the decoder branch its label names — a short string would be
+    // length-rejected and shadow the branch under test.
+    const valid = packedGridB64(0);
+    expect(valid.length).toBe((((((TILE_COUNT + 3) >> 2) + 2) / 3) | 0) * 4);
+    const corruptAt = (pos: number, repl: string): string =>
+      valid.slice(0, pos) + repl + valid.slice(pos + repl.length);
+    // Bad base64 char (c0 of a mid-string quartet → alphabet lookup fails):
+    expect(unpackBakedSurfaceEffect(corruptAt(100, '!'), TILE_COUNT)).toBeNull();
+    // '=' padding in a NON-final quartet (ch2 of the quartet at index 100):
+    expect(unpackBakedSurfaceEffect(corruptAt(102, '='), TILE_COUNT)).toBeNull();
+    // "x=y" padding form in the final quartet (ch2 '=', ch3 not '='):
+    expect(unpackBakedSurfaceEffect(corruptAt(valid.length - 4, 'AB=C'), TILE_COUNT)).toBeNull();
     expect(unpackBakedSurfaceEffect(packedGridB64(3), TILE_COUNT)).toBeNull(); // enum code 3
     // Non-zero unused trailing bits in the final byte (expectedLen not /4):
     // byte 0b00110000 — tiles 0,1 = 0 but trailing bits 4-7 = 0b0011 ≠ 0.

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -1441,9 +1441,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   // Issue #112 — finite food piles + recentlyDepletedFood persistence
   // ---------------------------------------------------------------------------
   describe('Issue #112 — depletion / spawn save format (v3)', () => {
-    it('SAVE_FORMAT_VERSION === 3 and SAVE_KEY ends with :v3', () => {
-      expect(SAVE_FORMAT_VERSION).toBe(3);
-      expect(SAVE_KEY).toBe('subterrans:save:v3');
+    it('SAVE_FORMAT_VERSION === 4 and SAVE_KEY ends with :v4 (PR 4 static terrain)', () => {
+      expect(SAVE_FORMAT_VERSION).toBe(4);
+      expect(SAVE_KEY).toBe('subterrans:save:v4');
     });
 
     it('rejects v2 envelopes with SaveVersionMismatchError', () => {

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -949,8 +949,8 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(() => deserializeWorldState(snapshot)).toThrow(FutureSimVersionError);
     });
     it('exact boundary: simVersion = MIN_ACCEPTED - 1 throws OldSimVersionError', () => {
-      // Any simVersion below MIN_ACCEPTED_SIM_VERSION (22) is rejected with
-      // OldSimVersionError so bootFromSave can handle it appropriately.
+      // Any simVersion below MIN_ACCEPTED_SIM_VERSION (28 as of PR 4) is rejected
+      // with OldSimVersionError so bootFromSave can handle it appropriately.
       const snapshot = makeSavedSnapshot((s) => {
         s.simVersion = 1;
       });

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -74,13 +74,15 @@ import { validateSurfaceConnectivity } from '../sim/surface-features.js';
 // require a format bump. `>>> 0` and the prior `| 0` coercion preserve the
 // same 32 bits, so a v3 save's `rngState` reloads to an identical PRNG output
 // sequence either way — there is no on-disk incompatibility to reject.
-//   v4 — PR 4 (static terrain): SerializedWorldState gains a REQUIRED
-//        `bakedSurfaceEffect` (packed/base64). Pre-v4 saves lack it. The
-//        simVersion floor (MIN_ACCEPTED = V28) already rejects them, but the
-//        on-disk shape break is made explicit here so save-shape correctness is
-//        not silently coupled to the simVersion floor (ship-review advisory).
-export const SAVE_FORMAT_VERSION = 4 as const;
-export const SAVE_KEY = 'subterrans:save:v4' as const;
+//
+// PR 4 (static terrain) deliberately does NOT bump SAVE_FORMAT_VERSION: the new
+// required `bakedSurfaceEffect` lives in the SNAPSHOT (SerializedWorldState), and
+// snapshot-content shape changes are gated by `simVersion`, not the envelope's
+// SAVE_FORMAT_VERSION (which versions the envelope structure). Raising
+// MIN_ACCEPTED_SIM_VERSION to V28 rejects every pre-static-terrain save — which
+// also lacks the field — before unpack is reached, matching the v2/v3 precedent.
+export const SAVE_FORMAT_VERSION = 3 as const;
+export const SAVE_KEY = 'subterrans:save:v3' as const;
 export const AUTOSAVE_INTERVAL_MS = 30_000 as const;
 
 export class SaveVersionMismatchError extends Error {
@@ -1530,15 +1532,17 @@ export function parseSaveFile(raw: string): SaveFile {
  * purge fires on the first save-touching operation.
  *
  * Issue #112 — added v2 to the purge list when SAVE_KEY moved to v3.
- * PR 4 — added v3 to the purge list when SAVE_KEY moved to v4 (static terrain).
  */
 function purgeLegacySaves(): void {
-  for (const key of ['subterrans:save:v1', 'subterrans:save:v2', 'subterrans:save:v3']) {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      /* quota / private mode — silent: best-effort cleanup, no UX signal */
-    }
+  try {
+    localStorage.removeItem('subterrans:save:v1');
+  } catch {
+    /* quota / private mode — silent: best-effort cleanup, no UX signal */
+  }
+  try {
+    localStorage.removeItem('subterrans:save:v2');
+  } catch {
+    /* quota / private mode — silent: best-effort cleanup, no UX signal */
   }
 }
 

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -12,7 +12,7 @@
 //   6. Version-gated: bumping SAVE_FORMAT_VERSION invalidates old saves (intentional for beta)
 
 import type { WorldState, EntityId, AIStateRecord, SpiderState } from '../sim/types.js';
-import { LATEST_SIM_VERSION, SIM_VERSION_V22_DIFFICULTY } from '../sim/types.js';
+import { LATEST_SIM_VERSION, SIM_VERSION_V28_STATIC_TERRAIN } from '../sim/types.js';
 import { AI_MAX_OPERATION_FIGHTERS, SPIDER_HUNT_INTERVAL_TICKS } from '../sim/constants.js';
 import type { AntComponents } from '../sim/ant/ant-store.js';
 import { createAntComponents } from '../sim/ant/ant-store.js';
@@ -46,6 +46,7 @@ import {
 } from '../sim/constants.js';
 import { FP_SHIFT } from '../sim/fixed.js';
 import { CHAMBER_DIMENSIONS } from '../sim/colony/chamber.js';
+import { validateSurfaceConnectivity } from '../sim/surface-features.js';
 
 // SAVE_FORMAT_VERSION is bumped on any breaking change to the on-disk shape
 // or to invariants that survivors must respect. Pre-bump saves are rejected
@@ -109,7 +110,11 @@ export class FutureSimVersionError extends Error {
   }
 }
 
-export const MIN_ACCEPTED_SIM_VERSION = SIM_VERSION_V22_DIFFICULTY;
+// PR 4 (posture 2): static terrain changed WorldState field semantics (new baked
+// grid + removed dynamic suppression), so pre-V28 saves cannot be continued
+// correctly — raise the floor to reject them cleanly rather than load a broken
+// (suppression-era) map.
+export const MIN_ACCEPTED_SIM_VERSION = SIM_VERSION_V28_STATIC_TERRAIN;
 
 export class OldSimVersionError extends Error {
   constructor(public got: number | null) {
@@ -506,6 +511,12 @@ export interface SerializedWorldState {
   colonies: Record<string, SerializedColony>;
   pheromoneGrids: Record<string, SerializedGrid>;
   surface: SerializedGrid;
+  /**
+   * PR 4 — frozen surface movement-effect grid, packed 2 bits/tile then base64.
+   * `SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT` entries (values 0/1/2). ~5.5 KB
+   * vs ~48 KB for a raw number[] — keeps the save-size delta well within quota.
+   */
+  bakedSurfaceEffect: string;
   undergroundGrids: Record<string, SerializedGrid>;
   foodPiles: FoodPile[];
   recentlyDepletedFood: DepletionRecord[];
@@ -633,6 +644,99 @@ function serializePheromoneGrid(g: PheromoneGrid): SerializedGrid {
   return { width: g.width, height: g.height, data: Array.from(g.data) };
 }
 
+// ---------------------------------------------------------------------------
+// PR 4 — baked surface terrain pack/unpack (2 bits/tile) + cross-env base64.
+// Pure, table-based base64 (no Buffer/btoa dependency) so it works identically
+// in Node and the browser. Values are 0/1/2 (Cosmetic/SoftCost/HardBlock); the
+// 2-bit code 3 is never produced and is rejected on load as a corrupt enum.
+// ---------------------------------------------------------------------------
+
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let out = '';
+  let i = 0;
+  for (; i + 3 <= bytes.length; i += 3) {
+    const n = (bytes[i]! << 16) | (bytes[i + 1]! << 8) | bytes[i + 2]!;
+    out +=
+      BASE64_ALPHABET[(n >> 18) & 63]! +
+      BASE64_ALPHABET[(n >> 12) & 63]! +
+      BASE64_ALPHABET[(n >> 6) & 63]! +
+      BASE64_ALPHABET[n & 63]!;
+  }
+  const rem = bytes.length - i;
+  if (rem === 1) {
+    const n = bytes[i]! << 16;
+    out += BASE64_ALPHABET[(n >> 18) & 63]! + BASE64_ALPHABET[(n >> 12) & 63]! + '==';
+  } else if (rem === 2) {
+    const n = (bytes[i]! << 16) | (bytes[i + 1]! << 8);
+    out +=
+      BASE64_ALPHABET[(n >> 18) & 63]! +
+      BASE64_ALPHABET[(n >> 12) & 63]! +
+      BASE64_ALPHABET[(n >> 6) & 63]! +
+      '=';
+  }
+  return out;
+}
+
+/** Decode base64 → bytes. Returns null on any malformed input (bad char,
+ *  length not a multiple of 4) so the caller can reject the save loudly. */
+function base64ToBytes(s: string): Uint8Array | null {
+  if (s.length % 4 !== 0) return null;
+  const lut = new Int16Array(128).fill(-1);
+  for (let k = 0; k < BASE64_ALPHABET.length; k++) lut[BASE64_ALPHABET.charCodeAt(k)] = k;
+  let pad = 0;
+  if (s.endsWith('==')) pad = 2;
+  else if (s.endsWith('=')) pad = 1;
+  const outLen = (s.length >> 2) * 3 - pad;
+  const out = new Uint8Array(outLen);
+  let o = 0;
+  for (let i = 0; i < s.length; i += 4) {
+    const c0 = lut[s.charCodeAt(i)] ?? -1;
+    const c1 = lut[s.charCodeAt(i + 1)] ?? -1;
+    const ch2 = s[i + 2];
+    const ch3 = s[i + 3];
+    const c2 = ch2 === '=' ? 0 : (lut[s.charCodeAt(i + 2)] ?? -1);
+    const c3 = ch3 === '=' ? 0 : (lut[s.charCodeAt(i + 3)] ?? -1);
+    if (c0 < 0 || c1 < 0 || c2 < 0 || c3 < 0) return null;
+    const n = (c0 << 18) | (c1 << 12) | (c2 << 6) | c3;
+    if (o < outLen) out[o++] = (n >> 16) & 0xff;
+    if (o < outLen) out[o++] = (n >> 8) & 0xff;
+    if (o < outLen) out[o++] = n & 0xff;
+  }
+  return out;
+}
+
+/** Pack a per-tile effect grid (values 0..3) into 2-bit codes, base64-encoded. */
+function packBakedSurfaceEffect(grid: Uint8Array): string {
+  const packed = new Uint8Array((grid.length + 3) >> 2);
+  for (let i = 0; i < grid.length; i++) {
+    const pi = i >> 2;
+    packed[pi] = packed[pi]! | ((grid[i]! & 0x3) << ((i & 3) << 1));
+  }
+  return bytesToBase64(packed);
+}
+
+/**
+ * Decode + validate a packed baked-surface grid. Returns the Uint8Array of
+ * `expectedLen` effect values, or null if the string is malformed, the wrong
+ * length, or contains an out-of-range (code 3) effect — every failure mode the
+ * load validator must reject.
+ */
+export function unpackBakedSurfaceEffect(s: string, expectedLen: number): Uint8Array | null {
+  if (typeof s !== 'string') return null;
+  const packed = base64ToBytes(s);
+  if (packed === null) return null;
+  if (packed.length !== (expectedLen + 3) >> 2) return null;
+  const grid = new Uint8Array(expectedLen);
+  for (let i = 0; i < expectedLen; i++) {
+    const v = (packed[i >> 2]! >> ((i & 3) << 1)) & 0x3;
+    if (v === 3) return null; // 0/1/2 only — code 3 is a corrupt enum value
+    grid[i] = v;
+  }
+  return grid;
+}
+
 export function serializeWorldState(world: WorldState): SerializedWorldState {
   // ADR-0006: colonies is a PLAIN OBJECT. Use Object.entries — NOT Array.from(world.colonies.entries())
   const coloniesOut: Record<string, SerializedColony> = {};
@@ -663,6 +767,7 @@ export function serializeWorldState(world: WorldState): SerializedWorldState {
     colonies: coloniesOut,
     pheromoneGrids: pheromoneOut,
     surface: serializeSurfaceGrid(world.surface),
+    bakedSurfaceEffect: packBakedSurfaceEffect(world.bakedSurfaceEffect),
     undergroundGrids: undergroundOut,
     foodPiles: world.foodPiles.map((p) => ({ ...p })),
     recentlyDepletedFood: world.recentlyDepletedFood.map((r) => ({ ...r })),
@@ -1267,7 +1372,21 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
   // can be forced null when spider is null (B11 fix: ghost-scatter prevention).
   const _deserializedSpider = deserializeSpider(s);
 
-  return {
+  // PR 4 — decode + validate the baked static-terrain grid. Reject wrong
+  // dimensions, malformed base64, or an out-of-range (code 3) movement-effect
+  // value before accepting the field (R3-8/R5-2). Connectivity is validated
+  // after the world is assembled (it needs colonies + foodPiles).
+  const bakedSurfaceEffect = unpackBakedSurfaceEffect(
+    (s as { bakedSurfaceEffect?: unknown }).bakedSurfaceEffect as string,
+    SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT,
+  );
+  if (bakedSurfaceEffect === null) {
+    throw new Error(
+      'Invalid bakedSurfaceEffect: wrong dimensions, malformed encoding, or out-of-range effect value',
+    );
+  }
+
+  const world: WorldState = {
     tick: rawTick,
     rngState: rawRng,
     nextEntityId: rawNext,
@@ -1286,6 +1405,8 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     colonies,
     pheromoneGrids,
     surface: deserializeSurfaceGrid(s.surface),
+    bakedSurfaceEffect,
+    surfaceComponentMask: null,
     undergroundGrids,
     foodPiles: s.foodPiles.map((p) => ({ ...p })),
     recentlyDepletedFood: validatedRecentlyDepleted.map((r) => ({ ...r })),
@@ -1324,6 +1445,18 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
         : 0,
     difficulty: s.difficulty === 'Easy' || s.difficulty === 'Hard' ? s.difficulty : 'Normal',
   };
+
+  // PR 4 — re-run the FULL connectivity check against the assembled world: every
+  // saved food pile and every saved entrance must sit in the single connected
+  // walkable component of the baked grid (not just the roots — R3-8/R5-2). A
+  // corrupt/old map fails loudly here rather than loading a broken world.
+  if (!validateSurfaceConnectivity(world)) {
+    throw new Error(
+      'Invalid bakedSurfaceEffect: connectivity violated (a food pile or entrance is not in the single walkable component)',
+    );
+  }
+
+  return world;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -74,8 +74,13 @@ import { validateSurfaceConnectivity } from '../sim/surface-features.js';
 // require a format bump. `>>> 0` and the prior `| 0` coercion preserve the
 // same 32 bits, so a v3 save's `rngState` reloads to an identical PRNG output
 // sequence either way — there is no on-disk incompatibility to reject.
-export const SAVE_FORMAT_VERSION = 3 as const;
-export const SAVE_KEY = 'subterrans:save:v3' as const;
+//   v4 — PR 4 (static terrain): SerializedWorldState gains a REQUIRED
+//        `bakedSurfaceEffect` (packed/base64). Pre-v4 saves lack it. The
+//        simVersion floor (MIN_ACCEPTED = V28) already rejects them, but the
+//        on-disk shape break is made explicit here so save-shape correctness is
+//        not silently coupled to the simVersion floor (ship-review advisory).
+export const SAVE_FORMAT_VERSION = 4 as const;
+export const SAVE_KEY = 'subterrans:save:v4' as const;
 export const AUTOSAVE_INTERVAL_MS = 30_000 as const;
 
 export class SaveVersionMismatchError extends Error {
@@ -692,10 +697,15 @@ function base64ToBytes(s: string): Uint8Array | null {
   const out = new Uint8Array(outLen);
   let o = 0;
   for (let i = 0; i < s.length; i += 4) {
+    const isFinalQuartet = i + 4 === s.length;
     const c0 = lut[s.charCodeAt(i)] ?? -1;
     const c1 = lut[s.charCodeAt(i + 1)] ?? -1;
     const ch2 = s[i + 2];
     const ch3 = s[i + 3];
+    // `=` padding is only legal in the final quartet, in standard positions
+    // (c3, or c2+c3). Anywhere else it's a corrupt encoding — reject (Codex P2).
+    if ((ch2 === '=' || ch3 === '=') && !isFinalQuartet) return null;
+    if (ch2 === '=' && ch3 !== '=') return null; // "x=y" is never valid
     const c2 = ch2 === '=' ? 0 : (lut[s.charCodeAt(i + 2)] ?? -1);
     const c3 = ch3 === '=' ? 0 : (lut[s.charCodeAt(i + 3)] ?? -1);
     if (c0 < 0 || c1 < 0 || c2 < 0 || c3 < 0) return null;
@@ -1520,17 +1530,15 @@ export function parseSaveFile(raw: string): SaveFile {
  * purge fires on the first save-touching operation.
  *
  * Issue #112 — added v2 to the purge list when SAVE_KEY moved to v3.
+ * PR 4 — added v3 to the purge list when SAVE_KEY moved to v4 (static terrain).
  */
 function purgeLegacySaves(): void {
-  try {
-    localStorage.removeItem('subterrans:save:v1');
-  } catch {
-    /* quota / private mode — silent: best-effort cleanup, no UX signal */
-  }
-  try {
-    localStorage.removeItem('subterrans:save:v2');
-  } catch {
-    /* quota / private mode — silent: best-effort cleanup, no UX signal */
+  for (const key of ['subterrans:save:v1', 'subterrans:save:v2', 'subterrans:save:v3']) {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      /* quota / private mode — silent: best-effort cleanup, no UX signal */
+    }
   }
 }
 

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -746,6 +746,13 @@ export function unpackBakedSurfaceEffect(s: string, expectedLen: number): Uint8A
     if (v === 3) return null; // 0/1/2 only — code 3 is a corrupt enum value
     grid[i] = v;
   }
+  // When expectedLen isn't a multiple of 4 the final packed byte has unused high
+  // bits; serialize always leaves them 0, so non-zero bits mean a tampered/
+  // malformed payload that decodes to a grid we'd never emit — reject it. (No-op
+  // for the production 16384-tile grid, but keeps this exported, length-general
+  // validator honest.)
+  const rem = expectedLen & 3;
+  if (rem !== 0 && packed[packed.length - 1]! >> (rem << 1) !== 0) return null;
   return grid;
 }
 

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -46,7 +46,10 @@ import {
 } from '../sim/constants.js';
 import { FP_SHIFT } from '../sim/fixed.js';
 import { CHAMBER_DIMENSIONS } from '../sim/colony/chamber.js';
-import { validateSurfaceConnectivity } from '../sim/surface-features.js';
+import {
+  validateSurfaceConnectivity,
+  ensureSurfaceComponentMask,
+} from '../sim/surface-features.js';
 
 // SAVE_FORMAT_VERSION is bumped on any breaking change to the on-disk shape
 // or to invariants that survivors must respect. Pre-bump saves are rejected
@@ -719,12 +722,18 @@ function base64ToBytes(s: string): Uint8Array | null {
   return out;
 }
 
-/** Pack a per-tile effect grid (values 0..3) into 2-bit codes, base64-encoded. */
+/** Pack a per-tile effect grid (valid values 0=Cosmetic/1=SoftCost/2=HardBlock)
+ *  into 2-bit codes, base64-encoded. Throws on any out-of-range value so an
+ *  already-corrupt in-memory grid fails at the WRITE rather than masking to a
+ *  wrong-but-loadable terrain (`& 0x3` would launder a 4 into Cosmetic; a 3 would
+ *  only fail at the next load via unpack's code-3 guard). */
 function packBakedSurfaceEffect(grid: Uint8Array): string {
   const packed = new Uint8Array((grid.length + 3) >> 2);
   for (let i = 0; i < grid.length; i++) {
+    const v = grid[i]!;
+    if (v > 2) throw new Error(`packBakedSurfaceEffect: out-of-range effect ${v} at tile ${i}`);
     const pi = i >> 2;
-    packed[pi] = packed[pi]! | ((grid[i]! & 0x3) << ((i & 3) << 1));
+    packed[pi] = packed[pi]! | (v << ((i & 3) << 1));
   }
   return bytesToBase64(packed);
 }
@@ -737,9 +746,17 @@ function packBakedSurfaceEffect(grid: Uint8Array): string {
  */
 export function unpackBakedSurfaceEffect(s: string, expectedLen: number): Uint8Array | null {
   if (typeof s !== 'string') return null;
+  // DoS guard (issue #99 posture): reject by LENGTH before decoding, so a
+  // tampered localStorage save with an arbitrarily long valid-base64 string
+  // can't force a large allocation + O(n) decode in base64ToBytes before the
+  // post-decode size check rejects it. The exact base64 length for a
+  // `expectedLen`-tile grid is ceil(packedBytes / 3) * 4.
+  const packedBytes = (expectedLen + 3) >> 2;
+  const expectedB64Len = (((packedBytes + 2) / 3) | 0) * 4;
+  if (s.length !== expectedB64Len) return null;
   const packed = base64ToBytes(s);
   if (packed === null) return null;
-  if (packed.length !== (expectedLen + 3) >> 2) return null;
+  if (packed.length !== packedBytes) return null;
   const grid = new Uint8Array(expectedLen);
   for (let i = 0; i < expectedLen; i++) {
     const v = (packed[i >> 2]! >> ((i & 3) << 1)) & 0x3;
@@ -1474,6 +1491,11 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
       'Invalid bakedSurfaceEffect: connectivity violated (a food pile or entrance is not in the single walkable component)',
     );
   }
+  // Eagerly materialise the derived component mask on load (idempotent —
+  // validateSurfaceConnectivity already populated it), so post-load
+  // isSurfaceTileInComponent queries (incl. the render/input preview gate) are
+  // pure reads of a pre-built mask, never a lazy world mutation.
+  ensureSurfaceComponentMask(world);
 
   return world;
 }

--- a/src/render/terrain-atlas.test.ts
+++ b/src/render/terrain-atlas.test.ts
@@ -15,6 +15,7 @@ import type { GfxLike } from './draw-surface.js';
 import { TILE_SIZE_PX } from './sprites.js';
 import { createWorldState } from '../sim/types.js';
 import { createColonyRecord } from '../sim/colony/colony-store.js';
+import { SURFACE_GRID_WIDTH } from '../sim/constants.js';
 
 // Issue #44 step 2: drawBarrenEarthTile now consults the sim-side surface-
 // feature selector, which mixes WorldState.terrainSeed into the hash.
@@ -212,12 +213,12 @@ describe('drawBarrenEarthTile + sim selector integration (issue #44 step 2)', ()
     expect(differingTiles).toBeGreaterThan(20);
   });
 
-  it('respects entrance suppression — a feature tile becomes substrate-only when an entrance is placed there', () => {
-    // Build a world; find a tile where the renderer paints a feature
-    // (call cost > substrate-only baseline). Install an entrance at that
-    // tile in a fresh world. The same tile should now render with no
-    // feature — the sim selector returns null and drawBarrenEarthTile
-    // proceeds to per-tile motif scattering only.
+  it('PR 4 — static terrain: an entrance no longer suppresses a feature; the carve override does', () => {
+    // Find a tile where the renderer paints a feature (call cost > substrate
+    // baseline). PR 4 froze terrain: installing an entrance there must NOT change
+    // the render (dynamic suppression deleted), but carving that tile passable in
+    // the baked grid MUST drop it to substrate-only (render consults the carve
+    // override — R4-3).
     const baseline = createWorldState(42);
     let featureTile: { x: number; y: number; baselineCalls: number } | null = null;
     for (let ty = 0; ty < 60 && featureTile === null; ty++) {
@@ -232,27 +233,25 @@ describe('drawBarrenEarthTile + sim selector integration (issue #44 step 2)', ()
     }
     expect(featureTile).not.toBeNull();
 
-    const suppressed = createWorldState(42);
-    // Install a colony with an entrance at the feature tile. surface-features
-    // suppresses any anchor whose footprint enters the entrance radius (3).
+    // Installing an entrance on the feature tile changes nothing (terrain frozen).
+    const withEntrance = createWorldState(42);
     const colony = createColonyRecord(1, 0);
     colony.entrances = [
-      {
-        entranceId: 0,
-        surfaceTileX: featureTile!.x,
-        surfaceTileY: featureTile!.y,
-        isOpen: true,
-      },
+      { entranceId: 0, surfaceTileX: featureTile!.x, surfaceTileY: featureTile!.y, isOpen: true },
     ];
     colony.rallyPoint = null;
     colony.digFlowFieldDirty = false;
-    suppressed.colonies[1] = colony;
+    withEntrance.colonies[1] = colony;
+    const gfxEntrance = new MockGfx();
+    drawBarrenEarthTile(gfxEntrance, withEntrance, 0, 0, featureTile!.x, featureTile!.y);
+    expect(gfxEntrance.callsOf('fillRect').length).toBe(featureTile!.baselineCalls);
 
-    const gfx = new MockGfx();
-    drawBarrenEarthTile(gfx, suppressed, 0, 0, featureTile!.x, featureTile!.y);
-    // Feature gone → fewer fillRects than the baseline. (Substrate base ~50,
-    // a feature slice adds 50–250 more depending on sprite density.)
-    expect(gfx.callsOf('fillRect').length).toBeLessThan(featureTile!.baselineCalls);
+    // Carving the tile passable in the baked grid removes the rendered feature.
+    const carved = createWorldState(42);
+    carved.bakedSurfaceEffect[featureTile!.y * SURFACE_GRID_WIDTH + featureTile!.x] = 0; // Cosmetic
+    const gfxCarved = new MockGfx();
+    drawBarrenEarthTile(gfxCarved, carved, 0, 0, featureTile!.x, featureTile!.y);
+    expect(gfxCarved.callsOf('fillRect').length).toBeLessThan(featureTile!.baselineCalls);
   });
 });
 

--- a/src/sim/constants.ts
+++ b/src/sim/constants.ts
@@ -268,6 +268,15 @@ export const UNDERGROUND_GRID_WIDTH = 128;
 export const UNDERGROUND_GRID_HEIGHT = 64;
 
 /**
+ * PR 4 (static terrain) — Chebyshev radius of the static walkable clearance
+ * carved around every canonical colony root at world-gen. Replaces the deleted
+ * dynamic entrance suppression halo (`SURFACE_FEATURE_ENTRANCE_RADIUS`, also 3)
+ * that guaranteed clear launch space for co-spawned ants — now baked once into
+ * the frozen terrain instead of recomputed from live entrance state.
+ */
+export const SURFACE_ROOT_CLEARANCE_RADIUS = 3;
+
+/**
  * Issue #30 — y-coordinate of the underground "ceiling strip." Row 0 of the
  * underground grid renders as the underside of the surface grass (see the
  * `ty === 0` branch in `src/render/draw-underground.ts`); it's a visual cue

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -388,6 +388,22 @@ describe('issue #27: simVersion plumbing', () => {
     expect(dst.ants.waitingDeposit[5]).toBe(0); // untouched slots stay zero
   });
 
+  it('copyWorldState round-trips bakedSurfaceEffect (PR 4 — R1-12 per-field copy)', async () => {
+    const { copyWorldState } = await import('./types.js');
+    const src = createWorldState(42);
+    const dst = createWorldState(99);
+    // Mutate distinct effect codes so a copy that re-derives from terrainSeed (or
+    // drops the field) is caught — both worlds have DIFFERENT terrainSeeds.
+    src.bakedSurfaceEffect[0] = 1; // SoftCost
+    src.bakedSurfaceEffect[1] = 2; // HardBlock
+    src.bakedSurfaceEffect[2] = 0; // Cosmetic
+    copyWorldState(src, dst);
+    expect(dst.bakedSurfaceEffect[0]).toBe(1);
+    expect(dst.bakedSurfaceEffect[1]).toBe(2);
+    expect(dst.bakedSurfaceEffect[2]).toBe(0);
+    expect(dst.bakedSurfaceEffect.length).toBe(src.bakedSurfaceEffect.length);
+  });
+
   it('two LATEST runs at the same seed produce byte-identical state (drain-fullest determinism)', () => {
     // Direct duplicate of base SCEN-06 Test 1 but with extra runtime to push
     // colonies into chamber-saturation territory where v3's drain-fullest

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -154,6 +154,9 @@ function serializeWorldState(w: WorldState): string {
         },
         {} as Record<string, unknown>,
       ),
+    // PR 4: baked static surface terrain — a divergence in the frozen grid must
+    // break byte-identity.
+    bakedSurfaceEffect: Array.from(w.bakedSurfaceEffect),
     // Phase 7: food piles and pending chambers
     foodPiles: w.foodPiles.map((p) => ({ ...p })),
     pendingChambers: Object.keys(w.pendingChambers)

--- a/src/sim/food-system.ts
+++ b/src/sim/food-system.ts
@@ -27,7 +27,7 @@
 import type { WorldState } from './types.js';
 import type { FoodPile, FoodPileId } from './food.js';
 import { allocateEntityId, INVALID_ENTITY_ID } from './types.js';
-import { surfaceMovementAt, SurfaceMovementEffect } from './surface-features.js';
+import { isSurfaceTileInComponent } from './surface-features.js';
 import { sgGet, SurfaceTileState } from './terrain.js';
 import { Rng } from './rng.js';
 import {
@@ -179,10 +179,10 @@ export function tickFoodPileSpawn(world: WorldState, rng: Rng): void {
     // stable regardless of which earlier rejection short-circuited a candidate.
     const terrainRoll = rng.nextU32();
 
-    // Surface-passable check — HardBlock features (boulders, twigs, leaves)
-    // are not eligible. SoftCost (bushes, grass clumps as movement layer) is
-    // fine; the tile-state grass weighting handles the "vegetation" axis.
-    if (surfaceMovementAt(world, tileX, tileY) === SurfaceMovementEffect.HardBlock) continue;
+    // PR 4 reachable-spawn invariant: a runtime pile may only land on a walkable
+    // tile in the single connected surface component of the frozen terrain.
+    // Subsumes the old HardBlock check (component membership excludes HardBlock).
+    if (!isSurfaceTileInComponent(world, tileX, tileY)) continue;
 
     // Distance from every colony's entrances + rallyPoint, inlined so we
     // don't allocate a noGoTiles staging array per spawn call.

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -26,6 +26,7 @@ import {
   bakeStaticTerrain,
   isSurfaceTileInComponent,
   validateSurfaceConnectivity,
+  ensureSurfaceComponentMask,
   type SurfaceRoot,
 } from './surface-features.js';
 import { Rng } from './rng.js';
@@ -431,6 +432,12 @@ export function createScenario(
       'createScenario: surface connectivity invariant violated after bakeStaticTerrain (an entrance or food pile is not in the single walkable component)',
     );
   }
+  // Eagerly materialise the derived component mask at world-gen (idempotent —
+  // validateSurfaceConnectivity already populated it). Terrain is immutable, so
+  // every later `isSurfaceTileInComponent` query — including the render/input
+  // entrance-preview gate — is a pure read of an already-built mask; no query
+  // path lazily mutates the world.
+  ensureSurfaceComponentMask(world);
 
   // --- Step 8: Pheromone grids — all 8 (2 colonies × 2 types × 2 zones) ---
   // All 8 must exist so tick-step lookups never hit a missing key.

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -414,6 +414,13 @@ export function createScenario(
     QUEEN_EGG_INTERVAL_DIFFICULTY_NUMERATOR[tierIndex(difficulty)];
   // Player colony keeps default eggIntervalNumerator=4 (identity).
 
+  // generateFoodPiles above memoised the component mask using the pre-colony
+  // fallback root (no entrances existed yet). Now that colonies + entrances are
+  // in place, drop that cached mask so the persisted/validated mask is rooted at
+  // the real canonical root (the first colony's entrance) rather than relying on
+  // the fallback happening to equal it (ship-review advisory).
+  world.surfaceComponentMask = null;
+
   // PR 4 — assert the connectivity invariant AT WORLD-GEN (not only on save
   // load): every colony entrance (initColony places one at each root start tile,
   // so the entrance IS the root) and every food pile must sit in the single

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -22,6 +22,12 @@ import {
 import { initAnt } from './ant/ant-store.js';
 import { createColonyRecord } from './colony/colony-store.js';
 import { createPheromoneGrid, pheromoneGridKey } from './pheromone/pheromone-store.js';
+import {
+  bakeStaticTerrain,
+  isSurfaceTileInComponent,
+  validateSurfaceConnectivity,
+  type SurfaceRoot,
+} from './surface-features.js';
 import { Rng } from './rng.js';
 import { FP_SHIFT } from './fixed.js';
 import { AntTask, PheromoneType } from './enums.js';
@@ -93,6 +99,12 @@ function generateFoodPiles(world: WorldState, rng: Rng): void {
   ) {
     const tileX = rng.nextRange(0, SURFACE_GRID_WIDTH - 1);
     const tileY = rng.nextRange(0, SURFACE_GRID_HEIGHT - 1);
+
+    // PR 4 reachable-spawn invariant: a pile may only land on a walkable tile in
+    // the single connected surface component (against the now-frozen terrain), so
+    // baking can never strand a pile behind a wall. Subsumes the old HardBlock
+    // check (component membership excludes HardBlock tiles).
+    if (!isSurfaceTileInComponent(world, tileX, tileY)) continue;
 
     // Reject if too close to any colony start (Manhattan distance)
     let tooCloseToColony = false;
@@ -377,7 +389,20 @@ export function createScenario(
     UNDERGROUND_GRID_HEIGHT,
   );
 
-  // --- Step 4: Food pile scatter ---
+  // --- Step 3b (PR 4): bake FROZEN static terrain BEFORE placing piles. ---
+  // Canonical roots = the colony start tiles (entrances are created at these in
+  // initColony below). Reserve a static clearance around each root and carve a
+  // deterministic corridor so the whole surface is ONE connected walkable
+  // component. No terrainSeed retry, no RNG draws — keeps the pile/spider RNG
+  // stream that follows unaffected by terrain baking.
+  const roots: SurfaceRoot[] = [
+    { tileX: PLAYER_START_X, tileY: PLAYER_START_Y },
+    { tileX: ENEMY_START_X, tileY: ENEMY_START_Y },
+  ];
+  world.bakedSurfaceEffect = bakeStaticTerrain(world, roots);
+  world.surfaceComponentMask = null; // recompute from the carved grid on next use
+
+  // --- Step 4: Food pile scatter (against the fixed, reserved+connected field) ---
   generateFoodPiles(world, rng);
 
   // --- Steps 5-6: Colony initialization (player + enemy) ---
@@ -388,6 +413,17 @@ export function createScenario(
   world.colonies[ENEMY_COLONY_ID]!.eggIntervalNumerator =
     QUEEN_EGG_INTERVAL_DIFFICULTY_NUMERATOR[tierIndex(difficulty)];
   // Player colony keeps default eggIntervalNumerator=4 (identity).
+
+  // PR 4 — assert the connectivity invariant AT WORLD-GEN (not only on save
+  // load): every colony entrance (initColony places one at each root start tile,
+  // so the entrance IS the root) and every food pile must sit in the single
+  // walkable component the bake constructed. A regression in the bake/corridor
+  // logic fails loudly here instead of shipping a stranded world.
+  if (!validateSurfaceConnectivity(world)) {
+    throw new Error(
+      'createScenario: surface connectivity invariant violated after bakeStaticTerrain (an entrance or food pile is not in the single walkable component)',
+    );
+  }
 
   // --- Step 8: Pheromone grids — all 8 (2 colonies × 2 types × 2 zones) ---
   // All 8 must exist so tick-step lookups never hit a missing key.

--- a/src/sim/surface-features.test.ts
+++ b/src/sim/surface-features.test.ts
@@ -10,10 +10,14 @@
 import { describe, it, expect } from 'vitest';
 import { createWorldState, type WorldState } from './types.js';
 import { createColonyRecord } from './colony/colony-store.js';
-import { SURFACE_GRID_WIDTH } from './constants.js';
+import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT } from './constants.js';
 import {
   surfaceFeatureAt,
   surfaceMovementAt,
+  surfaceFeatureProcedural,
+  bakeSurfaceEffectGrid,
+  bakeStaticTerrain,
+  computeSurfaceComponentMask,
   SurfaceFeatureKind,
   SurfaceMovementEffect,
   type SurfaceFeatureSlice,
@@ -348,5 +352,84 @@ describe('SURFACE_FEATURES registry contract', () => {
     if (seen.has(SurfaceFeatureKind.GrassClump)) {
       expect(seen.get(SurfaceFeatureKind.GrassClump)).toBe(SurfaceMovementEffect.SoftCost);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR 4 (Fable review) — load-bearing bake↔selector equivalence + component/
+// corridor regression coverage. These were verified out-of-band during PR 4;
+// committing them guards the carve-detection invariant against future drift.
+// ---------------------------------------------------------------------------
+
+describe('bakeSurfaceEffectGrid ≡ per-tile surfaceFeatureProcedural', () => {
+  it('is byte-identical to the per-tile selector across seeds × all 16,384 tiles', () => {
+    // surfaceFeatureAt's carve detection rests on baked[idx] ===
+    // surfaceFeatureProcedural(...).movement for every un-carved tile; the
+    // anchor-iterating bake must reproduce the per-tile selector exactly or
+    // carved-vs-procedural desync silently hides sprites over walkable terrain.
+    let mismatches = 0;
+    for (const seed of [1, 7, 42, 99, 256, 2024]) {
+      const w = createWorldState(seed);
+      const baked = bakeSurfaceEffectGrid(w);
+      for (let y = 0; y < SURFACE_GRID_HEIGHT; y++) {
+        for (let x = 0; x < SURFACE_GRID_WIDTH; x++) {
+          const proc = surfaceFeatureProcedural(w, x, y);
+          const expected = proc === null ? SurfaceMovementEffect.Cosmetic : proc.movement;
+          if (baked[y * SURFACE_GRID_WIDTH + x] !== expected) mismatches++;
+        }
+      }
+    }
+    expect(mismatches).toBe(0);
+  });
+});
+
+describe('computeSurfaceComponentMask', () => {
+  it('marks only the region reachable from the root, excluding a walled-off pocket', () => {
+    // Hand-built grid: a full-height HardBlock wall at x=64 splits left|right.
+    const grid = new Uint8Array(SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT);
+    for (let y = 0; y < SURFACE_GRID_HEIGHT; y++) {
+      grid[y * SURFACE_GRID_WIDTH + 64] = SurfaceMovementEffect.HardBlock;
+    }
+    const mask = computeSurfaceComponentMask(grid, 10, 10); // root on the left
+    expect(mask[10 * SURFACE_GRID_WIDTH + 10]).toBe(1); // root in component
+    expect(mask[10 * SURFACE_GRID_WIDTH + 30]).toBe(1); // same (left) side
+    expect(mask[10 * SURFACE_GRID_WIDTH + 64]).toBe(0); // the wall itself
+    expect(mask[10 * SURFACE_GRID_WIDTH + 100]).toBe(0); // walled-off right pocket
+  });
+});
+
+describe('bakeStaticTerrain corridor clears HardBlocks + connects roots (carveCorridor)', () => {
+  it('carves through a procedural HardBlock on the corridor row, joining the two roots', () => {
+    // carveCorridor clears the PROCEDURAL HardBlock features (via
+    // surfaceFeatureProcedural) along the Manhattan path between two roots — so
+    // this exercises the real carve on procedural terrain (not an injected wall,
+    // which the carve does not recognise). Find a row with a procedural HardBlock
+    // in the interior, run a corridor across it, and assert it is cleared and the
+    // roots end mutually reachable.
+    const world = createWorldState(42);
+    const proc = world.bakedSurfaceEffect; // createWorldState bakes the procedural field
+    let ry = -1;
+    let hx = -1;
+    outer: for (let y = 0; y < SURFACE_GRID_HEIGHT; y++) {
+      for (let x = 25; x <= 95; x++) {
+        if (proc[y * SURFACE_GRID_WIDTH + x] === SurfaceMovementEffect.HardBlock) {
+          ry = y;
+          hx = x;
+          break outer;
+        }
+      }
+    }
+    expect(ry).toBeGreaterThanOrEqual(0); // a procedural HardBlock to clear exists
+    expect(proc[ry * SURFACE_GRID_WIDTH + hx]).toBe(SurfaceMovementEffect.HardBlock);
+
+    const leftRoot = { tileX: 20, tileY: ry };
+    const rightRoot = { tileX: 100, tileY: ry };
+    const baked = bakeStaticTerrain(world, [leftRoot, rightRoot]);
+    // The HardBlock on the corridor row is cleared by the carve.
+    expect(baked[ry * SURFACE_GRID_WIDTH + hx]).not.toBe(SurfaceMovementEffect.HardBlock);
+    // Both roots are in one walkable component after the corridor carve.
+    const post = computeSurfaceComponentMask(baked, leftRoot.tileX, leftRoot.tileY);
+    expect(post[leftRoot.tileY * SURFACE_GRID_WIDTH + leftRoot.tileX]).toBe(1);
+    expect(post[rightRoot.tileY * SURFACE_GRID_WIDTH + rightRoot.tileX]).toBe(1);
   });
 });

--- a/src/sim/surface-features.test.ts
+++ b/src/sim/surface-features.test.ts
@@ -10,12 +10,12 @@
 import { describe, it, expect } from 'vitest';
 import { createWorldState, type WorldState } from './types.js';
 import { createColonyRecord } from './colony/colony-store.js';
+import { SURFACE_GRID_WIDTH } from './constants.js';
 import {
   surfaceFeatureAt,
   surfaceMovementAt,
   SurfaceFeatureKind,
   SurfaceMovementEffect,
-  SURFACE_FEATURE_ENTRANCE_RADIUS,
   type SurfaceFeatureSlice,
 } from './surface-features.js';
 
@@ -181,205 +181,73 @@ describe('surfaceFeatureAt — anchor overlap suppression', () => {
   });
 });
 
-describe('surfaceFeatureAt — gameplay suppression', () => {
-  it('an entrance suppresses any feature whose footprint enters its radius', () => {
-    // Find a tile where a feature naturally lands without any colony
-    // installed; then install an entrance there and confirm the feature
-    // is gone. If the selector skipped suppression we'd still see the
-    // feature, which is the bug Codex flagged (queen boxed in by seed luck).
+describe('surfaceFeatureAt — STATIC terrain (PR 4): no dynamic suppression', () => {
+  it('installing an entrance on a feature tile does NOT remove the feature', () => {
+    // PR 4 deleted the dynamic entrance suppression halo — terrain is frozen at
+    // bake. Installing an entrance on a feature tile must leave it unchanged.
     const seed = 42;
     const baseline = createWorldState(seed);
     const found = findFirstFeatureTile(baseline, 60, 60);
     expect(found).not.toBeNull();
 
-    const suppressed = createWorldState(seed);
-    installColonyWithEntrance(suppressed, /* colonyId */ 1, found!.x, found!.y);
-    expect(surfaceFeatureAt(suppressed, found!.x, found!.y)).toBeNull();
+    const withEntrance = createWorldState(seed);
+    installColonyWithEntrance(withEntrance, /* colonyId */ 1, found!.x, found!.y);
+    expect(surfaceFeatureAt(withEntrance, found!.x, found!.y)).toEqual(found!.slice);
   });
 
-  it('suppression radius extends SURFACE_FEATURE_ENTRANCE_RADIUS in Chebyshev distance', () => {
-    // An entrance at (50, 50) suppresses any 1-tile probe inside the
-    // [50-3 .. 50+3, 50-3 .. 50+3] square. Anchors with multi-tile
-    // footprints can be suppressed even further out (their footprint
-    // overlaps the radius rectangle), but the per-tile probe at the edge
-    // of the rectangle must consistently return suppressed.
-    const seed = 99;
-    const world = createWorldState(seed);
-    installColonyWithEntrance(world, 1, 50, 50);
-    const r = SURFACE_FEATURE_ENTRANCE_RADIUS;
-    // Every tile inside the suppression rectangle should be free of any
-    // anchor whose own anchor position sits inside the rectangle. The
-    // strongest invariant we can assert without coupling to the registry
-    // hash: the four corner tiles of the radius square (ex±r, ey±r) and
-    // the centre return null OR a slice anchored OUTSIDE the rectangle.
-    const tiles: Array<[number, number]> = [
-      [50, 50],
-      [50 - r, 50 - r],
-      [50 + r, 50 - r],
-      [50 - r, 50 + r],
-      [50 + r, 50 + r],
-    ];
-    for (const [tx, ty] of tiles) {
-      const slice = surfaceFeatureAt(world, tx, ty);
-      if (slice === null) continue;
-      // Anchor must be outside the suppression rectangle (otherwise the
-      // gameplay check should have rejected it).
-      const insideX = slice.anchorX >= 50 - r && slice.anchorX <= 50 + r;
-      const insideY = slice.anchorY >= 50 - r && slice.anchorY <= 50 + r;
-      expect(insideX && insideY).toBe(false);
-    }
-  });
-
-  it('a food pile suppresses any feature covering its tile', () => {
+  it('adding a food pile on a feature tile does NOT remove the feature', () => {
     const seed = 11;
     const baseline = createWorldState(seed);
     const found = findFirstFeatureTile(baseline, 60, 60);
     expect(found).not.toBeNull();
 
-    const suppressed = createWorldState(seed);
-    suppressed.foodPiles.push({
+    const withPile = createWorldState(seed);
+    withPile.foodPiles.push({
       foodPileId: 0,
       tileX: found!.x,
       tileY: found!.y,
       pickupsRemaining: 50,
       pickupsInitial: 50,
     });
-    expect(surfaceFeatureAt(suppressed, found!.x, found!.y)).toBeNull();
+    expect(surfaceFeatureAt(withPile, found!.x, found!.y)).toEqual(found!.slice);
   });
 
-  it('multiple colonies all contribute to suppression', () => {
-    // Install two colonies with entrances at distant tiles. A feature that
-    // would land within either suppression radius should be suppressed.
-    const seed = 55;
-    const baseline = createWorldState(seed);
-    // Find two distant feature tiles so neither colony's radius reaches
-    // the other entrance position.
-    const first = findFirstFeatureTile(baseline, 30, 30);
-    expect(first).not.toBeNull();
-    let second: { x: number; y: number; slice: SurfaceFeatureSlice } | null = null;
-    for (let y = 60; y < 90 && second === null; y++) {
-      for (let x = 60; x < 90; x++) {
-        const slice = surfaceFeatureAt(baseline, x, y);
-        if (slice !== null) {
-          second = { x, y, slice };
-          break;
-        }
-      }
-    }
-    expect(second).not.toBeNull();
-
-    const suppressed = createWorldState(seed);
-    installColonyWithEntrance(suppressed, 1, first!.x, first!.y);
-    installColonyWithEntrance(suppressed, 2, second!.x, second!.y);
-    expect(surfaceFeatureAt(suppressed, first!.x, first!.y)).toBeNull();
-    expect(surfaceFeatureAt(suppressed, second!.x, second!.y)).toBeNull();
-  });
-
-  it('v8+ — gameplay-suppressed shadow no longer hides outside-zone anchors (Codex P2 round-3 fix)', () => {
-    // Pre-fix bug: a higher-priority anchor sitting inside an entrance
-    // suppression zone never rendered, but `isAnchorSuppressedByOverlap`
-    // would still treat it as a real suppressor of LOWER-priority
-    // anchors whose footprints overlap its shadow OUTSIDE the zone.
-    // The result was unintended empty halos around the suppression
-    // ring. Post-fix, the recursion also rejects gameplay-suppressed
-    // candidate suppressors, so lower-priority anchors that pre-fix
-    // were unjustly hidden now surface.
-    //
-    // Property-test pattern: scan many seeds, find a tile T near (but
-    // outside) an entrance suppression zone where:
-    //   - baseline (no entrance) returns a feature at T,
-    //   - the baseline anchor at T sits INSIDE the zone of a
-    //     hypothetical entrance E,
-    // Then install entrance E and verify v8 returns SOMETHING at T
-    // (it might be a different lower-priority anchor than baseline,
-    // but it must NOT be null — that's the v8 invariant). Pre-v8
-    // would return null in the same scenario.
-    //
-    // The test counts how many tiles SHIFT from null (pre-fix) to
-    // non-null (post-fix) across a seed sweep. Even a single proven
-    // example demonstrates the fix; the count gives statistical
-    // confidence the fix matters in practice rather than only in
-    // theory.
-    const r = SURFACE_FEATURE_ENTRANCE_RADIUS;
-    let demonstrationCount = 0;
-    seedLoop: for (let seed = 1; seed < 80; seed++) {
-      const baseline = createWorldState(seed);
-      // Place an entrance at a known location with room around it.
-      const ex = 30,
-        ey = 30;
-      // Examine tiles just OUTSIDE the entrance suppression rectangle
-      // — on the perimeter where the shadow bug would manifest.
-      for (let dy = -r - 6; dy <= r + 6; dy++) {
-        for (let dx = -r - 6; dx <= r + 6; dx++) {
-          const tx = ex + dx;
-          const ty = ey + dy;
-          // Skip tiles inside the suppression rectangle — those are
-          // legitimately suppressed and not part of this bug.
-          if (Math.abs(dx) <= r && Math.abs(dy) <= r) continue;
-          const baselineSlice = surfaceFeatureAt(baseline, tx, ty);
-          if (baselineSlice === null) continue;
-          // Need the baseline anchor to be INSIDE the would-be
-          // suppression rectangle — that's the geometric setup for
-          // the shadow bug.
-          const ax = baselineSlice.anchorX;
-          const ay = baselineSlice.anchorY;
-          const anchorInsideZone = ax >= ex - r && ax <= ex + r && ay >= ey - r && ay <= ey + r;
-          if (!anchorInsideZone) continue;
-          // Setup: install the entrance, re-query.
-          const withEntrance = createWorldState(seed);
-          installColonyWithEntrance(withEntrance, 1, ex, ey);
-          const v8Slice = surfaceFeatureAt(withEntrance, tx, ty);
-          // v8 invariant: the tile MAY have a different feature now
-          // (the baseline shadower is gone), but it should not
-          // collapse to null when a lower-priority anchor exists in
-          // the shadow region. The strongest v8 claim we can make
-          // without re-running the registry-walk: the v8 path returns
-          // SOMETHING for this tile, OR the v8 path correctly returns
-          // null because no lower-priority shadower exists.
-          //
-          // To make the assertion meaningful we narrow further: only
-          // record a demonstration when v8 returns a feature whose
-          // anchor is NOT inside the zone (proves the lower-priority
-          // anchor surfaced) AND whose feature kind differs from
-          // baseline (proves a different anchor took over).
-          if (v8Slice === null) continue;
-          const v8AnchorOutsideZone =
-            v8Slice.anchorX < ex - r ||
-            v8Slice.anchorX > ex + r ||
-            v8Slice.anchorY < ey - r ||
-            v8Slice.anchorY > ey + r;
-          // baselineSlice anchor is INSIDE the zone (anchorInsideZone
-          // gate above); requiring v8 anchor to be OUTSIDE the zone
-          // is sufficient to prove a different anchor surfaced — they
-          // can't match coordinates when one is inside and the other
-          // outside.
-          if (!v8AnchorOutsideZone) continue;
-          demonstrationCount++;
-          if (demonstrationCount >= 3) break seedLoop;
-        }
-      }
-    }
-    // The fix MUST surface at least one previously-hidden anchor
-    // across the 80-seed sweep. Three independent demonstrations
-    // prove the fix is working in practice, not just in a single
-    // contrived setup.
-    expect(demonstrationCount).toBeGreaterThanOrEqual(1);
+  it('the baked carve override suppresses the rendered feature on a carved tile (R4-3)', () => {
+    // A tile carved passable in bakedSurfaceEffect (root reservation / corridor)
+    // must return null from surfaceFeatureAt so render paints no boulder over it,
+    // and surfaceMovementAt must read Cosmetic.
+    const seed = 42;
+    const world = createWorldState(seed);
+    const found = findFirstFeatureTile(world, 60, 60);
+    expect(found).not.toBeNull();
+    world.bakedSurfaceEffect[found!.y * SURFACE_GRID_WIDTH + found!.x] =
+      SurfaceMovementEffect.Cosmetic;
+    expect(surfaceFeatureAt(world, found!.x, found!.y)).toBeNull();
+    expect(surfaceMovementAt(world, found!.x, found!.y)).toBe(SurfaceMovementEffect.Cosmetic);
   });
 });
 
 describe('surfaceMovementAt', () => {
-  it('returns Cosmetic when no feature covers the tile', () => {
-    // Pick a tile that's definitely empty: a tile inside the radius of an
-    // entrance with no other features around. surfaceFeatureAt returns
-    // null → surfaceMovementAt returns Cosmetic.
+  it('returns Cosmetic for a tile with no feature', () => {
     const world = createWorldState(42);
-    installColonyWithEntrance(world, 1, 50, 50);
-    expect(surfaceMovementAt(world, 50, 50)).toBe(SurfaceMovementEffect.Cosmetic);
+    let emptyX = -1;
+    let emptyY = -1;
+    outer: for (let y = 0; y < 80; y++) {
+      for (let x = 0; x < 80; x++) {
+        if (surfaceFeatureAt(world, x, y) === null) {
+          emptyX = x;
+          emptyY = y;
+          break outer;
+        }
+      }
+    }
+    expect(emptyX).toBeGreaterThanOrEqual(0);
+    expect(surfaceMovementAt(world, emptyX, emptyY)).toBe(SurfaceMovementEffect.Cosmetic);
   });
 
   it('returns the slice movement when a feature covers the tile', () => {
     // Walk until we find a covered tile, then assert the helper agrees
-    // with the slice's movement field.
+    // with the slice's movement field (baked grid == procedural for a bare world).
     const world = createWorldState(42);
     const found = findFirstFeatureTile(world, 60, 60);
     expect(found).not.toBeNull();

--- a/src/sim/surface-features.ts
+++ b/src/sim/surface-features.ts
@@ -200,6 +200,19 @@ for (let i = 0; i < SURFACE_FEATURES.length; i++) {
   if (e.probability < 0 || e.probability > 255) {
     throw new Error(`SURFACE_FEATURES[${i}]: probability must be 0..255`);
   }
+  // PR 4 carve-detection precondition: `surfaceFeatureAt` infers "this feature
+  // was carved passable" from `baked[idx] !== proc.movement` (carving sets the
+  // baked effect to Cosmetic). That proxy is only sound while NO registry
+  // feature has Cosmetic movement — otherwise a carved tile's baked Cosmetic
+  // would equal the feature's own Cosmetic movement, the feature would NOT be
+  // suppressed, and the renderer would paint a sprite over a carved-passable
+  // tile (violating R4-3). Enforce the precondition here so a future Cosmetic
+  // feature fails loudly at boot instead of silently breaking the carve.
+  if (e.movement === SurfaceMovementEffect.Cosmetic) {
+    throw new Error(
+      `SURFACE_FEATURES[${i}]: movement must not be Cosmetic — it breaks PR 4 carve detection in surfaceFeatureAt`,
+    );
+  }
 }
 
 // Cross-entry maximum span — bounds the anchor-candidate scan window. A tile
@@ -241,81 +254,13 @@ export function getSurfaceFeatureRegistryEntry(kind: SurfaceFeatureKind): {
 }
 
 // ---------------------------------------------------------------------------
-// Gameplay suppression — keep features off critical tiles
-// ---------------------------------------------------------------------------
-
-/**
- * Chebyshev-distance radius around every entrance within which feature
- * anchors are suppressed. Picked at 3 to give the queen and starting
- * workers roughly half a screen of clear ground in any direction. Smaller
- * (1..2) leaves grass claustrophobic right at the doorway; larger (5+)
- * starts to dominate the visible surface.
- *
- * Applied to ALL features in this selector — both HardBlock and SoftCost.
- * HardBlock suppression is mandatory (seed luck could otherwise box in the
- * queen on tick 0); SoftCost suppression is a polish call (grass right on
- * the doorstep would feel weird visually too).
- */
-export const SURFACE_FEATURE_ENTRANCE_RADIUS = 3 as const;
-
-/**
- * True if the candidate anchor's footprint overlaps any entrance suppression
- * radius or any food pile tile.
- *
- * Walks every colony's entrances and the food-pile array. Cost is bounded
- * by colony-count × entrance-count + food-pile-count, which the scenario
- * keeps small (typical: ≤4 colonies × ≤4 entrances + ~10 food piles).
- */
-function isAnchorGameplaySuppressed(
-  world: WorldState,
-  anchorX: number,
-  anchorY: number,
-  footprintW: number,
-  footprintH: number,
-): boolean {
-  const fx0 = anchorX;
-  const fy0 = anchorY;
-  const fx1 = anchorX + footprintW - 1;
-  const fy1 = anchorY + footprintH - 1;
-
-  // Entrances — Chebyshev-radius rectangle overlap. Footprint overlaps
-  // (ex - r .. ex + r, ey - r .. ey + r) iff both axes overlap.
-  const r = SURFACE_FEATURE_ENTRANCE_RADIUS;
-  for (const cidStr in world.colonies) {
-    if (!Object.hasOwn(world.colonies, cidStr)) continue;
-    const colony = world.colonies[cidStr as unknown as number]!;
-    // The Phase 3 PRD §2a contract requires the caller to initialize
-    // `entrances` after createColonyRecord, but several pre-#44 tests
-    // create a colony without that init because their code path never
-    // reads it. Be defensive — undefined → "no entrances to suppress
-    // around" rather than a TypeError that breaks unrelated tests.
-    const entrances = colony.entrances;
-    if (entrances === undefined) continue;
-    for (let i = 0; i < entrances.length; i++) {
-      const e = entrances[i]!;
-      const ex = e.surfaceTileX;
-      const ey = e.surfaceTileY;
-      if (fx1 >= ex - r && fx0 <= ex + r && fy1 >= ey - r && fy0 <= ey + r) {
-        return true;
-      }
-    }
-  }
-
-  // Food piles — Chebyshev-radius rectangle overlap (same r as entrances).
-  // Pre-#44 step 4 this was an exact-tile check; once movement honors
-  // HardBlock features, foragers need a clear approach corridor or they
-  // can't deposit pheromone trails to the pile and the colony starves.
-  const piles = world.foodPiles;
-  for (let i = 0; i < piles.length; i++) {
-    const p = piles[i]!;
-    if (fx1 >= p.tileX - r && fx0 <= p.tileX + r && fy1 >= p.tileY - r && fy0 <= p.tileY + r) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
+// PR 4 — dynamic gameplay suppression DELETED. Terrain is now frozen at
+// world-gen (see bakeStaticTerrain below); the old entrance/food-pile
+// suppression halo that flipped terrain as piles depleted / entrances were
+// designated is replaced by the reachable-spawn + connectivity invariants
+// (placement only on already-walkable, in-component tiles) plus a static
+// per-root clearance carve. `SURFACE_FEATURE_ENTRANCE_RADIUS` and
+// `isAnchorGameplaySuppressed` are gone.
 // ---------------------------------------------------------------------------
 // Spatial hash — same MurmurHash3-style mixer as render-side terrain-noise.ts
 // but with terrainSeed folded in. Lives here in sim because src/render/
@@ -380,7 +325,6 @@ function isAnchorSuppressedByOverlap(
         // reduces ownEntryIndex (this branch) or reduces (ay, ax) lex
         // order (the same-type branch).
         if (isAnchorSuppressedByOverlap(world, px, py, ei, terrainSeed)) continue;
-        if (isAnchorGameplaySuppressed(world, px, py, W, H)) continue;
         return true;
       }
     }
@@ -422,7 +366,6 @@ function isAnchorSuppressedByOverlap(
       // zone never renders, so it must not suppress sibling anchors
       // outside the zone.
       if (isAnchorSuppressedByOverlap(world, px, py, ownEntryIndex, terrainSeed)) continue;
-      if (isAnchorGameplaySuppressed(world, px, py, ownW, ownH)) continue;
       return true;
     }
   }
@@ -454,7 +397,7 @@ function isAnchorSuppressedByOverlap(
  * Pure: never mutates `world`. Cost is bounded by MAX_W × MAX_H × kinds ×
  * gameplay-suppression cost (small constants for typical scenarios).
  */
-export function surfaceFeatureAt(
+export function surfaceFeatureProcedural(
   world: WorldState,
   tileX: number,
   tileY: number,
@@ -475,17 +418,6 @@ export function surfaceFeatureAt(
         const h = tileHash(ax, ay, entry.salt, terrainSeed);
         if ((h & 0x1ff) >= entry.probability) continue;
         if (isAnchorSuppressedByOverlap(world, ax, ay, ei, terrainSeed)) {
-          break;
-        }
-        if (
-          isAnchorGameplaySuppressed(
-            world,
-            ax,
-            ay,
-            entry.footprintTilesWide,
-            entry.footprintTilesTall,
-          )
-        ) {
           break;
         }
         if (bestEntryIndex < 0 || ay < bestAy || (ay === bestAy && ax < bestAx)) {
@@ -513,16 +445,62 @@ export function surfaceFeatureAt(
 }
 
 /**
- * Convenience helper for surface movement code (step 4/5). Returns the
- * movement effect of any feature covering this tile, or `Cosmetic` if no
- * feature is present (i.e. ant walks freely with no cost).
+ * STATIC surface feature selector (PR 4). Returns the feature slice covering
+ * (tileX, tileY) for BOTH movement and render, as a pure function of
+ * `terrainSeed` and the **frozen baked grid** — with the old dynamic
+ * entrance/food-pile suppression DELETED, so depleting a pile or designating
+ * an entrance can never flip terrain.
+ *
+ * The procedural feature is filtered by the baked movement-effect grid (the
+ * carve override): a tile reserved/carved passable at world-gen has its whole
+ * feature footprint set to `Cosmetic` in the baked grid, so the procedural
+ * feature there is suppressed (returns null) — the render must not paint a
+ * boulder/leaf over a carved-passable tile (R4-3). When no baked grid is
+ * present yet (mid-bake, or a bare hand-built world), falls back to the raw
+ * procedural feature so the selector still works.
+ */
+export function surfaceFeatureAt(
+  world: WorldState,
+  tileX: number,
+  tileY: number,
+): SurfaceFeatureSlice | null {
+  const proc = surfaceFeatureProcedural(world, tileX, tileY);
+  if (proc === null) return null;
+  const baked = world.bakedSurfaceEffect;
+  if (
+    baked !== undefined &&
+    tileX >= 0 &&
+    tileY >= 0 &&
+    tileX < SURFACE_GRID_WIDTH &&
+    tileY < SURFACE_GRID_HEIGHT
+  ) {
+    // Feature present iff the baked effect at this tile still matches the
+    // procedural movement. A carved-out feature has its footprint set to
+    // Cosmetic, so baked !== proc.movement ⇒ removed.
+    if (baked[tileY * SURFACE_GRID_WIDTH + tileX] !== proc.movement) return null;
+  }
+  return proc;
+}
+
+/**
+ * Movement effect of the (frozen) terrain at this tile. Reads the baked
+ * movement-effect grid directly — O(1), static across pile/entrance events —
+ * falling back to the raw procedural movement only when no baked grid exists
+ * (bare hand-built worlds). `Cosmetic` for out-of-bounds / no feature.
  */
 export function surfaceMovementAt(
   world: WorldState,
   tileX: number,
   tileY: number,
 ): SurfaceMovementEffect {
-  const slice = surfaceFeatureAt(world, tileX, tileY);
+  const baked = world.bakedSurfaceEffect;
+  if (baked !== undefined) {
+    if (tileX < 0 || tileY < 0 || tileX >= SURFACE_GRID_WIDTH || tileY >= SURFACE_GRID_HEIGHT) {
+      return SurfaceMovementEffect.Cosmetic;
+    }
+    return baked[tileY * SURFACE_GRID_WIDTH + tileX] as SurfaceMovementEffect;
+  }
+  const slice = surfaceFeatureProcedural(world, tileX, tileY);
   return slice === null ? SurfaceMovementEffect.Cosmetic : slice.movement;
 }
 
@@ -550,7 +528,13 @@ export function surfaceMovementAt(
 // helpers, never persisted).
 // ---------------------------------------------------------------------------
 
-import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT } from './constants.js';
+import {
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
+  SURFACE_ROOT_CLEARANCE_RADIUS,
+  PLAYER_START_X,
+  PLAYER_START_Y,
+} from './constants.js';
 
 const SURFACE_MOVE_CACHE_SENTINEL = 255 as const;
 
@@ -596,4 +580,247 @@ export function surfaceMovementAtCached(
     cache[idx] = v;
   }
   return v as SurfaceMovementEffect;
+}
+
+// ===========================================================================
+// PR 4 — static terrain baking, root reservation, corridor carve, connectivity
+//
+// All pure integer ops (FNDN-04 / determinism): the baked grid + component
+// mask are deterministic functions of (terrainSeed, canonical roots). No
+// PRNG, no float, no clock. A tile is "walkable" iff its effect != HardBlock
+// (SoftCost slows but is passable). Connectivity is 4-connected over walkable.
+// ===========================================================================
+
+const SURFACE_TILE_COUNT = SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT;
+
+/** A canonical colony root (initial start tile) the bake reserves + connects. */
+export interface SurfaceRoot {
+  tileX: number;
+  tileY: number;
+}
+
+/**
+ * Bake the raw procedural movement-effect grid (no carves) — the frozen
+ * snapshot of `surfaceFeatureProcedural(...).movement` for every tile. Used
+ * for bare worlds (no colonies) and as the starting point for the reserved +
+ * connected bake below.
+ */
+export function bakeSurfaceEffectGrid(world: WorldState): Uint8Array {
+  const grid = new Uint8Array(SURFACE_TILE_COUNT);
+  for (let y = 0; y < SURFACE_GRID_HEIGHT; y++) {
+    for (let x = 0; x < SURFACE_GRID_WIDTH; x++) {
+      const proc = surfaceFeatureProcedural(world, x, y);
+      grid[y * SURFACE_GRID_WIDTH + x] =
+        proc === null ? SurfaceMovementEffect.Cosmetic : proc.movement;
+    }
+  }
+  return grid;
+}
+
+/**
+ * Carve (to Cosmetic) the ENTIRE footprint of the procedural feature covering
+ * (tileX, tileY) — at feature granularity so the render never paints a sprite
+ * over a carved-passable tile (R4-3). Only the tiles where this feature is the
+ * procedural winner are cleared (overlapping higher-priority neighbours keep
+ * their effect). No-op if the tile already has no feature. When
+ * `hardBlockOnly`, a SoftCost feature is left intact (used by corridor carving,
+ * which only needs to clear impassable HardBlock).
+ */
+function carveFeatureFootprint(
+  world: WorldState,
+  grid: Uint8Array,
+  tileX: number,
+  tileY: number,
+  hardBlockOnly: boolean,
+): void {
+  const winner = surfaceFeatureProcedural(world, tileX, tileY);
+  if (winner === null) return;
+  if (hardBlockOnly && winner.movement !== SurfaceMovementEffect.HardBlock) return;
+  const ax = winner.anchorX;
+  const ay = winner.anchorY;
+  for (let py = ay; py < ay + winner.footprintTilesTall; py++) {
+    if (py < 0 || py >= SURFACE_GRID_HEIGHT) continue;
+    for (let px = ax; px < ax + winner.footprintTilesWide; px++) {
+      if (px < 0 || px >= SURFACE_GRID_WIDTH) continue;
+      const at = surfaceFeatureProcedural(world, px, py);
+      if (at !== null && at.anchorX === ax && at.anchorY === ay && at.kind === winner.kind) {
+        grid[py * SURFACE_GRID_WIDTH + px] = SurfaceMovementEffect.Cosmetic;
+      }
+    }
+  }
+}
+
+/** Carve a deterministic Manhattan path (horizontal then vertical) between two
+ *  roots, clearing every HardBlock feature it crosses so the two endpoints end
+ *  up in one walkable component. */
+function carveCorridor(world: WorldState, grid: Uint8Array, a: SurfaceRoot, b: SurfaceRoot): void {
+  const stepX = a.tileX <= b.tileX ? 1 : -1;
+  for (let x = a.tileX; x !== b.tileX + stepX; x += stepX) {
+    carveFeatureFootprint(world, grid, x, a.tileY, true);
+  }
+  const stepY = a.tileY <= b.tileY ? 1 : -1;
+  for (let y = a.tileY; y !== b.tileY + stepY; y += stepY) {
+    carveFeatureFootprint(world, grid, b.tileX, y, true);
+  }
+}
+
+/**
+ * Bake the FROZEN static terrain for a scenario: raw procedural field, then
+ * (1) reserve a static clearance neighbourhood around every canonical root
+ * (clear ALL features so co-spawned ants have launch space), and (2) carve a
+ * deterministic corridor chaining every root to the first, guaranteeing ONE
+ * connected walkable component (constructed, not merely asserted — R4-2).
+ * Deterministic; no `terrainSeed` retry (R1-3).
+ */
+export function bakeStaticTerrain(
+  world: WorldState,
+  roots: ReadonlyArray<SurfaceRoot>,
+): Uint8Array {
+  const grid = bakeSurfaceEffectGrid(world);
+  const r = SURFACE_ROOT_CLEARANCE_RADIUS;
+  for (const root of roots) {
+    for (let dy = -r; dy <= r; dy++) {
+      for (let dx = -r; dx <= r; dx++) {
+        const tx = root.tileX + dx;
+        const ty = root.tileY + dy;
+        if (tx < 0 || ty < 0 || tx >= SURFACE_GRID_WIDTH || ty >= SURFACE_GRID_HEIGHT) continue;
+        carveFeatureFootprint(world, grid, tx, ty, false);
+      }
+    }
+  }
+  for (let i = 1; i < roots.length; i++) {
+    carveCorridor(world, grid, roots[i]!, roots[0]!);
+  }
+  return grid;
+}
+
+/**
+ * BFS the single connected walkable component (effect != HardBlock, 4-connected)
+ * reachable from (rootX, rootY). Returns a 0/1 membership mask. Pure +
+ * allocation-bounded (one Uint8Array mask + one Int32Array queue).
+ */
+export function computeSurfaceComponentMask(
+  grid: Uint8Array,
+  rootX: number,
+  rootY: number,
+): Uint8Array {
+  // Fail loudly on a malformed grid: out-of-range reads return undefined, and
+  // `undefined !== HardBlock` is true, so a short grid would silently flood the
+  // whole map into one walkable component (a wrong-but-plausible mask).
+  if (grid.length !== SURFACE_TILE_COUNT) {
+    throw new Error(
+      `computeSurfaceComponentMask: grid length ${grid.length} !== ${SURFACE_TILE_COUNT}`,
+    );
+  }
+  const mask = new Uint8Array(SURFACE_TILE_COUNT);
+  if (rootX < 0 || rootY < 0 || rootX >= SURFACE_GRID_WIDTH || rootY >= SURFACE_GRID_HEIGHT) {
+    return mask;
+  }
+  const rootIdx = rootY * SURFACE_GRID_WIDTH + rootX;
+  if (grid[rootIdx] === SurfaceMovementEffect.HardBlock) return mask;
+  const queue = new Int32Array(SURFACE_TILE_COUNT);
+  let head = 0;
+  let tail = 0;
+  mask[rootIdx] = 1;
+  queue[tail++] = rootIdx;
+  while (head < tail) {
+    const idx = queue[head++]!;
+    const x = idx % SURFACE_GRID_WIDTH;
+    // 4-connected neighbours, derived from idx without division: a North
+    // neighbour exists iff idx >= WIDTH; South iff idx < tileCount - WIDTH.
+    if (idx >= SURFACE_GRID_WIDTH)
+      tail = visitNeighbour(grid, mask, queue, idx - SURFACE_GRID_WIDTH, tail);
+    if (idx < SURFACE_TILE_COUNT - SURFACE_GRID_WIDTH)
+      tail = visitNeighbour(grid, mask, queue, idx + SURFACE_GRID_WIDTH, tail);
+    if (x < SURFACE_GRID_WIDTH - 1) tail = visitNeighbour(grid, mask, queue, idx + 1, tail);
+    if (x > 0) tail = visitNeighbour(grid, mask, queue, idx - 1, tail);
+  }
+  return mask;
+}
+
+function visitNeighbour(
+  grid: Uint8Array,
+  mask: Uint8Array,
+  queue: Int32Array,
+  nIdx: number,
+  tail: number,
+): number {
+  if (mask[nIdx] === 0 && grid[nIdx] !== SurfaceMovementEffect.HardBlock) {
+    mask[nIdx] = 1;
+    queue[tail++] = nIdx;
+  }
+  return tail;
+}
+
+/** Canonical BFS root for the connected component — the first colony's first
+ *  entrance (lowest colonyId), else the player start tile for bare worlds. */
+function canonicalSurfaceRoot(world: WorldState): SurfaceRoot {
+  let bestId = Number.POSITIVE_INFINITY;
+  let root: SurfaceRoot | null = null;
+  for (const key in world.colonies) {
+    if (!Object.hasOwn(world.colonies, key)) continue;
+    const colony = world.colonies[key as unknown as number]!;
+    const ents = colony.entrances;
+    if (ents === undefined || ents.length === 0) continue;
+    if (colony.colonyId < bestId) {
+      bestId = colony.colonyId;
+      root = { tileX: ents[0]!.surfaceTileX, tileY: ents[0]!.surfaceTileY };
+    }
+  }
+  return root ?? { tileX: PLAYER_START_X, tileY: PLAYER_START_Y };
+}
+
+/**
+ * Memoised single-component membership mask for the frozen surface terrain.
+ * Terrain is immutable after bake, so the mask is computed once from the baked
+ * grid + canonical root and cached on `world.surfaceComponentMask`.
+ */
+export function ensureSurfaceComponentMask(world: WorldState): Uint8Array {
+  let mask = world.surfaceComponentMask;
+  if (mask === null || mask === undefined) {
+    const root = canonicalSurfaceRoot(world);
+    mask = computeSurfaceComponentMask(world.bakedSurfaceEffect, root.tileX, root.tileY);
+    world.surfaceComponentMask = mask;
+  }
+  return mask;
+}
+
+/** True iff (tileX, tileY) is walkable AND in the single connected surface
+ *  component — the reachable-spawn gate for piles + entrances. */
+export function isSurfaceTileInComponent(world: WorldState, tileX: number, tileY: number): boolean {
+  if (tileX < 0 || tileY < 0 || tileX >= SURFACE_GRID_WIDTH || tileY >= SURFACE_GRID_HEIGHT) {
+    return false;
+  }
+  return ensureSurfaceComponentMask(world)[tileY * SURFACE_GRID_WIDTH + tileX] === 1;
+}
+
+/**
+ * Connectivity invariant (R1-5): exactly one walkable surface component must
+ * contain every colony **entrance** and every **food pile**. (Each colony's root
+ * start tile gets an entrance at world-gen — `initColony` — so the entrance IS
+ * the root; a colony with `entrances === undefined` contributes nothing and is
+ * skipped.) Returns true iff the invariant holds. Called at world-gen
+ * (`createScenario`) and on save load (`deserializeWorldState`).
+ */
+export function validateSurfaceConnectivity(world: WorldState): boolean {
+  const mask = ensureSurfaceComponentMask(world);
+  const inMask = (x: number, y: number): boolean =>
+    x >= 0 &&
+    y >= 0 &&
+    x < SURFACE_GRID_WIDTH &&
+    y < SURFACE_GRID_HEIGHT &&
+    mask[y * SURFACE_GRID_WIDTH + x] === 1;
+  for (const key in world.colonies) {
+    if (!Object.hasOwn(world.colonies, key)) continue;
+    const colony = world.colonies[key as unknown as number]!;
+    const ents = colony.entrances;
+    if (ents === undefined) continue;
+    for (const e of ents) {
+      if (!inMask(e.surfaceTileX, e.surfaceTileY)) return false;
+    }
+  }
+  for (const pile of world.foodPiles) {
+    if (!inMask(pile.tileX, pile.tileY)) return false;
+  }
+  return true;
 }

--- a/src/sim/surface-features.ts
+++ b/src/sim/surface-features.ts
@@ -600,28 +600,15 @@ export interface SurfaceRoot {
 }
 
 /**
- * Memo of the raw procedural movement-effect grid keyed by `terrainSeed`. The
- * procedural field is a PURE function of `terrainSeed` (via
- * `surfaceFeatureProcedural`), so the same seed always yields the same grid.
- * `createWorldState` + `createScenario` bake on every call (the latter twice via
- * `bakeStaticTerrain`), and tests construct many same-seed worlds — without this
- * memo each bake re-scans 16,384 tiles × recursive overlap-suppression, and the
- * heavy many-iteration tests blow their 5 s timeout (the PR-4 CI regression).
- * Deterministic (no RNG, no clock); callers always receive a COPY so they can
- * carve/fill freely. Bounded so a long seed sweep can't grow it without limit.
- */
-const proceduralBakeCache = new Map<number, Uint8Array>();
-const PROCEDURAL_BAKE_CACHE_CAP = 256;
-
-/**
  * Bake the raw procedural movement-effect grid (no carves) — the frozen
- * snapshot of `surfaceFeatureProcedural(...).movement` for every tile. Used
- * for bare worlds (no colonies) and as the starting point for the reserved +
- * connected bake below. Returns a fresh copy (safe for the caller to mutate).
+ * snapshot of `surfaceFeatureProcedural(...).movement` for every tile. Used by
+ * `createWorldState` (bare worlds) and as the starting point for the reserved +
+ * connected bake. `createScenario` does this ONCE (in `createWorldState`);
+ * `bakeStaticTerrain` then carves a copy rather than re-baking, so a scenario
+ * pays a single full procedural pass (no module-level cache — AGENTS.md forbids
+ * mutable state outside the world snapshot).
  */
 export function bakeSurfaceEffectGrid(world: WorldState): Uint8Array {
-  const cached = proceduralBakeCache.get(world.terrainSeed);
-  if (cached !== undefined) return cached.slice();
   const grid = new Uint8Array(SURFACE_TILE_COUNT);
   for (let y = 0; y < SURFACE_GRID_HEIGHT; y++) {
     for (let x = 0; x < SURFACE_GRID_WIDTH; x++) {
@@ -630,9 +617,7 @@ export function bakeSurfaceEffectGrid(world: WorldState): Uint8Array {
         proc === null ? SurfaceMovementEffect.Cosmetic : proc.movement;
     }
   }
-  if (proceduralBakeCache.size >= PROCEDURAL_BAKE_CACHE_CAP) proceduralBakeCache.clear();
-  proceduralBakeCache.set(world.terrainSeed, grid);
-  return grid.slice();
+  return grid;
 }
 
 /**
@@ -697,7 +682,9 @@ export function bakeStaticTerrain(
   world: WorldState,
   roots: ReadonlyArray<SurfaceRoot>,
 ): Uint8Array {
-  const grid = bakeSurfaceEffectGrid(world);
+  // Reuse the procedural bake `createWorldState` already computed (carve a copy)
+  // rather than re-baking from scratch — one full procedural pass per scenario.
+  const grid = world.bakedSurfaceEffect.slice();
   const r = SURFACE_ROOT_CLEARANCE_RADIUS;
   for (const root of roots) {
     for (let dy = -r; dy <= r; dy++) {

--- a/src/sim/surface-features.ts
+++ b/src/sim/surface-features.ts
@@ -600,12 +600,28 @@ export interface SurfaceRoot {
 }
 
 /**
+ * Memo of the raw procedural movement-effect grid keyed by `terrainSeed`. The
+ * procedural field is a PURE function of `terrainSeed` (via
+ * `surfaceFeatureProcedural`), so the same seed always yields the same grid.
+ * `createWorldState` + `createScenario` bake on every call (the latter twice via
+ * `bakeStaticTerrain`), and tests construct many same-seed worlds — without this
+ * memo each bake re-scans 16,384 tiles × recursive overlap-suppression, and the
+ * heavy many-iteration tests blow their 5 s timeout (the PR-4 CI regression).
+ * Deterministic (no RNG, no clock); callers always receive a COPY so they can
+ * carve/fill freely. Bounded so a long seed sweep can't grow it without limit.
+ */
+const proceduralBakeCache = new Map<number, Uint8Array>();
+const PROCEDURAL_BAKE_CACHE_CAP = 256;
+
+/**
  * Bake the raw procedural movement-effect grid (no carves) — the frozen
  * snapshot of `surfaceFeatureProcedural(...).movement` for every tile. Used
  * for bare worlds (no colonies) and as the starting point for the reserved +
- * connected bake below.
+ * connected bake below. Returns a fresh copy (safe for the caller to mutate).
  */
 export function bakeSurfaceEffectGrid(world: WorldState): Uint8Array {
+  const cached = proceduralBakeCache.get(world.terrainSeed);
+  if (cached !== undefined) return cached.slice();
   const grid = new Uint8Array(SURFACE_TILE_COUNT);
   for (let y = 0; y < SURFACE_GRID_HEIGHT; y++) {
     for (let x = 0; x < SURFACE_GRID_WIDTH; x++) {
@@ -614,7 +630,9 @@ export function bakeSurfaceEffectGrid(world: WorldState): Uint8Array {
         proc === null ? SurfaceMovementEffect.Cosmetic : proc.movement;
     }
   }
-  return grid;
+  if (proceduralBakeCache.size >= PROCEDURAL_BAKE_CACHE_CAP) proceduralBakeCache.clear();
+  proceduralBakeCache.set(world.terrainSeed, grid);
+  return grid.slice();
 }
 
 /**
@@ -668,9 +686,12 @@ function carveCorridor(world: WorldState, grid: Uint8Array, a: SurfaceRoot, b: S
  * Bake the FROZEN static terrain for a scenario: raw procedural field, then
  * (1) reserve a static clearance neighbourhood around every canonical root
  * (clear ALL features so co-spawned ants have launch space), and (2) carve a
- * deterministic corridor chaining every root to the first, guaranteeing ONE
- * connected walkable component (constructed, not merely asserted — R4-2).
- * Deterministic; no `terrainSeed` retry (R1-3).
+ * deterministic corridor chaining every root to the first, so all canonical
+ * roots — and, via the reachable-spawn gate, every food pile + entrance — share
+ * ONE connected walkable component (constructed, not merely asserted — R4-2).
+ * (Isolated *empty* walkable pockets elsewhere are harmless and not gameplay
+ * tiles; the reachable-spawn gate never places anything in them.) Deterministic;
+ * no `terrainSeed` retry (R1-3).
  */
 export function bakeStaticTerrain(
   world: WorldState,
@@ -795,8 +816,9 @@ export function isSurfaceTileInComponent(world: WorldState, tileX: number, tileY
 }
 
 /**
- * Connectivity invariant (R1-5): exactly one walkable surface component must
- * contain every colony **entrance** and every **food pile**. (Each colony's root
+ * Connectivity invariant (R1-5): the single canonical walkable component (rooted
+ * at `canonicalSurfaceRoot`) must contain every colony **entrance** and every
+ * **food pile** — i.e. they are all mutually reachable. (Each colony's root
  * start tile gets an entrance at world-gen — `initColony` — so the entrance IS
  * the root; a colony with `entrances === undefined` contributes nothing and is
  * skipped.) Returns true iff the invariant holds. Called at world-gen

--- a/src/sim/surface-features.ts
+++ b/src/sim/surface-features.ts
@@ -601,20 +601,70 @@ export interface SurfaceRoot {
 
 /**
  * Bake the raw procedural movement-effect grid (no carves) — the frozen
- * snapshot of `surfaceFeatureProcedural(...).movement` for every tile. Used by
+ * per-tile snapshot of `surfaceFeatureProcedural(...).movement`. Used by
  * `createWorldState` (bare worlds) and as the starting point for the reserved +
- * connected bake. `createScenario` does this ONCE (in `createWorldState`);
- * `bakeStaticTerrain` then carves a copy rather than re-baking, so a scenario
- * pays a single full procedural pass (no module-level cache — AGENTS.md forbids
- * mutable state outside the world snapshot).
+ * connected bake; `bakeStaticTerrain` carves a copy rather than re-baking, so a
+ * scenario pays one bake. No module-level cache (AGENTS.md forbids mutable state
+ * outside the world snapshot).
+ *
+ * Iterates ANCHORS, not tiles: the per-tile selector calls the recursive
+ * overlap-suppression check up to 16,384× per grid; walking real anchors in
+ * lex (ay,ax) order and letting the first one claim each footprint tile yields
+ * the IDENTICAL lex-smallest-winner result (so it stays consistent with the
+ * per-tile `surfaceFeatureProcedural` the visual selector still uses) while
+ * calling the suppression check only ~once per real anchor (hundreds, not 16k)
+ * — the difference between a ~8 ms and a sub-ms bake (PR-4 CI regression fix).
  */
 export function bakeSurfaceEffectGrid(world: WorldState): Uint8Array {
-  const grid = new Uint8Array(SURFACE_TILE_COUNT);
-  for (let y = 0; y < SURFACE_GRID_HEIGHT; y++) {
-    for (let x = 0; x < SURFACE_GRID_WIDTH; x++) {
-      const proc = surfaceFeatureProcedural(world, x, y);
-      grid[y * SURFACE_GRID_WIDTH + x] =
-        proc === null ? SurfaceMovementEffect.Cosmetic : proc.movement;
+  const grid = new Uint8Array(SURFACE_TILE_COUNT); // 0 = Cosmetic (no feature)
+  const claimed = new Uint8Array(SURFACE_TILE_COUNT);
+  const terrainSeed = world.terrainSeed;
+  // Per-anchor scratch: for tile-offset (dy,dx) within an anchor, which passing
+  // feature is the FIRST that covers it (the per-tile selector's "first covering
+  // feature, then break"). Reset per anchor (only when it has a passing feature).
+  const offsetHandled = new Uint8Array(MAX_FEATURE_TILES_WIDE * MAX_FEATURE_TILES_TALL);
+  // Anchors in lex (ay, ax) order so the FIRST surviving anchor covering a tile
+  // wins — matching `surfaceFeatureProcedural`'s lex-smallest tie-break. Anchors
+  // start at -(MAX-1): a feature anchored above/left of the grid still covers
+  // in-grid tiles, and the per-tile selector considers those negative anchors.
+  for (let ay = -(MAX_FEATURE_TILES_TALL - 1); ay < SURFACE_GRID_HEIGHT; ay++) {
+    for (let ax = -(MAX_FEATURE_TILES_WIDE - 1); ax < SURFACE_GRID_WIDTH; ax++) {
+      let anchorReset = false;
+      for (let ei = 0; ei < SURFACE_FEATURES.length; ei++) {
+        const entry = SURFACE_FEATURES[ei]!;
+        const h = tileHash(ax, ay, entry.salt, terrainSeed);
+        if ((h & 0x1ff) >= entry.probability) continue; // not a passing anchor for ei
+        if (!anchorReset) {
+          offsetHandled.fill(0);
+          anchorReset = true;
+        }
+        // Suppression is per (ax,ay,ei). When the FIRST passing feature covering
+        // a tile is suppressed, that tile gets nothing from this anchor (the
+        // per-tile selector's break) — mark the offset handled but don't claim,
+        // so neither a later feature here nor this anchor claims it (a later
+        // anchor still can).
+        const suppressed = isAnchorSuppressedByOverlap(world, ax, ay, ei, terrainSeed);
+        for (let dy = 0; dy < entry.footprintTilesTall; dy++) {
+          const ty = ay + dy;
+          if (ty < 0) continue; // off the top edge — a larger dy may be in-grid
+          if (ty >= SURFACE_GRID_HEIGHT) break;
+          for (let dx = 0; dx < entry.footprintTilesWide; dx++) {
+            const tx = ax + dx;
+            if (tx < 0) continue; // off the left edge — a larger dx may be in-grid
+            if (tx >= SURFACE_GRID_WIDTH) break;
+            const off = dy * MAX_FEATURE_TILES_WIDE + dx;
+            if (offsetHandled[off] === 1) continue; // an earlier passing feature covers it
+            offsetHandled[off] = 1; // ei is the first covering feature for this offset
+            if (!suppressed) {
+              const idx = ty * SURFACE_GRID_WIDTH + tx;
+              if (claimed[idx] === 0) {
+                claimed[idx] = 1;
+                grid[idx] = entry.movement;
+              }
+            }
+          }
+        }
+      }
     }
   }
   return grid;

--- a/src/sim/surface-features.ts
+++ b/src/sim/surface-features.ts
@@ -297,9 +297,13 @@ function tileHash(tileX: number, tileY: number, salt: number, terrainSeed: numbe
 // ---------------------------------------------------------------------------
 
 /**
- * @param world         used to consult `isAnchorGameplaySuppressed` at v8+
- *                      so suppressors that themselves sit in an entrance/
- *                      food-pile zone don't shadow other anchors.
+ * @param world         only threaded through to the recursive
+ *                      `isAnchorSuppressedByOverlap` calls below; no field of it
+ *                      is read here. (It formerly gated the deleted
+ *                      `isAnchorGameplaySuppressed` check — PR 4 removed dynamic
+ *                      entrance/food-pile suppression, so terrain no longer
+ *                      depends on world state, but the param is kept to avoid
+ *                      churning every caller's signature.)
  */
 function isAnchorSuppressedByOverlap(
   world: WorldState,

--- a/src/sim/surface-features.ts
+++ b/src/sim/surface-features.ts
@@ -857,11 +857,17 @@ export function isSurfaceTileInComponent(world: WorldState, tileX: number, tileY
 }
 
 /**
- * Connectivity invariant (R1-5): the single canonical walkable component (rooted
- * at `canonicalSurfaceRoot`) must contain every colony **entrance** and every
- * **food pile** — i.e. they are all mutually reachable. (Each colony's root
- * start tile gets an entrance at world-gen — `initColony` — so the entrance IS
- * the root; a colony with `entrances === undefined` contributes nothing and is
+ * Connectivity invariant (R1-5, spec R3-8): the single canonical walkable
+ * component (rooted at `canonicalSurfaceRoot`) must contain every colony
+ * **entrance** AND that entrance's full clearance halo, plus every **food pile**
+ * — i.e. they are all mutually reachable and an entrance's launch space is open.
+ * The entrance-clearance check mirrors the runtime `DesignateEntrance` gate
+ * (`tick.ts`): an entrance is only legitimately produced (world-gen carve or the
+ * in-component+clear designation gate) with its whole radius-`SURFACE_ROOT_
+ * CLEARANCE_RADIUS` Chebyshev halo in-component, so a save whose halo is blocked
+ * is corrupt/tampered and must be rejected at load. (Each colony's root start
+ * tile gets an entrance at world-gen — `initColony` — so the entrance IS the
+ * root; a colony with `entrances === undefined` contributes nothing and is
  * skipped.) Returns true iff the invariant holds. Called at world-gen
  * (`createScenario`) and on save load (`deserializeWorldState`).
  */
@@ -873,6 +879,13 @@ export function validateSurfaceConnectivity(world: WorldState): boolean {
     x < SURFACE_GRID_WIDTH &&
     y < SURFACE_GRID_HEIGHT &&
     mask[y * SURFACE_GRID_WIDTH + x] === 1;
+  // The canonical root itself must be in-component. Normally trivially true (the
+  // mask is rooted there), but it catches the degenerate/tampered case where the
+  // root tile is HardBlock — then computeSurfaceComponentMask returns an all-zero
+  // mask and, with zero entrances + zero piles to check, the loops below would
+  // otherwise vacuously return true on a garbage component.
+  const root = canonicalSurfaceRoot(world);
+  if (!inMask(root.tileX, root.tileY)) return false;
   for (const key in world.colonies) {
     if (!Object.hasOwn(world.colonies, key)) continue;
     const colony = world.colonies[key as unknown as number]!;
@@ -880,6 +893,18 @@ export function validateSurfaceConnectivity(world: WorldState): boolean {
     if (ents === undefined) continue;
     for (const e of ents) {
       if (!inMask(e.surfaceTileX, e.surfaceTileY)) return false;
+      // Clearance halo: every in-bounds tile in the entrance's Chebyshev
+      // SURFACE_ROOT_CLEARANCE_RADIUS neighbourhood must also be in-component
+      // (matches the DesignateEntrance gate; off-grid halo tiles are skipped,
+      // as that gate does).
+      for (let dy = -SURFACE_ROOT_CLEARANCE_RADIUS; dy <= SURFACE_ROOT_CLEARANCE_RADIUS; dy++) {
+        for (let dx = -SURFACE_ROOT_CLEARANCE_RADIUS; dx <= SURFACE_ROOT_CLEARANCE_RADIUS; dx++) {
+          const cx = e.surfaceTileX + dx;
+          const cy = e.surfaceTileY + dy;
+          if (cx < 0 || cy < 0 || cx >= SURFACE_GRID_WIDTH || cy >= SURFACE_GRID_HEIGHT) continue;
+          if (!inMask(cx, cy)) return false;
+        }
+      }
     }
   }
   for (const pile of world.foodPiles) {

--- a/src/sim/tick.test.ts
+++ b/src/sim/tick.test.ts
@@ -1265,6 +1265,11 @@ describe('Phase 7: MarkDigTile command processing', () => {
       UNDERGROUND_GRID_WIDTH,
       UNDERGROUND_GRID_HEIGHT,
     );
+    // PR 4 — clear the frozen surface to fully walkable so the DesignateEntrance
+    // connectivity/clearance gate accepts any candidate tile; these tests cover
+    // the entrance logic, not terrain. (Reset the derived component mask too.)
+    world.bakedSurfaceEffect.fill(0);
+    world.surfaceComponentMask = null;
     return { world, colonyId: 1 as ColonyId };
   }
 
@@ -1879,6 +1884,11 @@ describe('Phase 7: Step ordering tests', () => {
       UNDERGROUND_GRID_WIDTH,
       UNDERGROUND_GRID_HEIGHT,
     );
+    // PR 4 — clear the frozen surface to fully walkable so the DesignateEntrance
+    // connectivity/clearance gate accepts any candidate tile (these tests cover
+    // entrance/step-ordering logic, not terrain).
+    world.bakedSurfaceEffect.fill(0);
+    world.surfaceComponentMask = null;
     return { world, colonyId: 1 as ColonyId };
   }
 
@@ -2135,6 +2145,10 @@ describe('Phase 7: Integration tests', () => {
   // SC 5: createScenario + DesignateEntrance + manually open shaft → entrance.isOpen=true
   it('SC 5: DesignateEntrance then manually open shaft tiles → entrance opens', () => {
     const world = createScenario(42);
+    // PR 4 — clear the frozen surface so the DesignateEntrance gate accepts the
+    // (50,0) candidate (this test exercises entrance opening, not terrain).
+    world.bakedSurfaceEffect.fill(0);
+    world.surfaceComponentMask = null;
     const colonyId = PLAYER_COLONY_ID as ColonyId;
     const colony = world.colonies[colonyId]!;
 
@@ -2270,6 +2284,10 @@ describe('Regression: reviewer P1 fixes', () => {
       UNDERGROUND_GRID_WIDTH,
       UNDERGROUND_GRID_HEIGHT,
     );
+    // PR 4 — clear the frozen surface to fully walkable so DesignateEntrance's
+    // connectivity/clearance gate accepts any candidate tile.
+    world.bakedSurfaceEffect.fill(0);
+    world.surfaceComponentMask = null;
     return { world, colonyId: 1 as ColonyId };
   }
 

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -36,7 +36,7 @@ import {
   PLAYER_COLONY_ID,
   SURFACE_ROOT_CLEARANCE_RADIUS,
 } from './constants.js';
-import { isSurfaceTileInComponent } from './surface-features.js';
+import { isSurfaceTileInComponent, ensureSurfaceComponentMask } from './surface-features.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
 import { allocateWorkers, computeDigDemand } from './behavior/allocation-system.js';
 import {
@@ -245,6 +245,13 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
   const digFlowFields = caches.dig;
   const entranceFlowFields = caches.entrance;
   const chamberFlowFields = caches.chamber;
+
+  // PR 4 — materialize the derived surface component mask once at tick ENTRY
+  // (idempotent; createScenario/deserialize already do). Terrain is immutable, so
+  // this guarantees mid-tick `isSurfaceTileInComponent` queries (e.g.
+  // tickFoodPileSpawn) are pure reads and never lazily mutate the world during a
+  // step — even for a hand-built world that reached tick() without eager build.
+  ensureSurfaceComponentMask(world);
 
   // Reconstruct Rng from saved state at tick start (PRD §4 contract).
   const rng = new Rng(world.rngState);

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -36,11 +36,7 @@ import {
   PLAYER_COLONY_ID,
   SURFACE_ROOT_CLEARANCE_RADIUS,
 } from './constants.js';
-import {
-  isSurfaceTileInComponent,
-  surfaceMovementAt,
-  SurfaceMovementEffect,
-} from './surface-features.js';
+import { isSurfaceTileInComponent } from './surface-features.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
 import { allocateWorkers, computeDigDemand } from './behavior/allocation-system.js';
 import {
@@ -645,14 +641,21 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         // grid (the static replacement for the old auto-carved entrance halo).
         // Checked before any allocation/mutation.
         {
-          if (!isSurfaceTileInComponent(world, cmd.surfaceTileX, cmd.surfaceTileY)) break;
-          // The halo uses a bare HardBlock test (not a component test) on purpose:
-          // under the single-connected-component invariant, any non-HardBlock tile
-          // within radius of the in-component candidate is itself reachable from it,
-          // hence in-component. (If that invariant is ever relaxed, switch the halo
-          // check to isSurfaceTileInComponent too.)
-          let clearanceBlocked = false;
-          for (let dy = -SURFACE_ROOT_CLEARANCE_RADIUS; dy <= SURFACE_ROOT_CLEARANCE_RADIUS; dy++) {
+          // Candidate AND its whole clearance neighbourhood must be in the SAME
+          // connected walkable component. Checking component membership per halo
+          // tile (not a bare HardBlock test) keeps this correct even if the map
+          // had an isolated walkable pocket — it does NOT rely on a global
+          // "exactly one component" assumption the bake doesn't guarantee.
+          let clearanceBlocked = !isSurfaceTileInComponent(
+            world,
+            cmd.surfaceTileX,
+            cmd.surfaceTileY,
+          );
+          for (
+            let dy = -SURFACE_ROOT_CLEARANCE_RADIUS;
+            dy <= SURFACE_ROOT_CLEARANCE_RADIUS && !clearanceBlocked;
+            dy++
+          ) {
             for (
               let dx = -SURFACE_ROOT_CLEARANCE_RADIUS;
               dx <= SURFACE_ROOT_CLEARANCE_RADIUS;
@@ -662,7 +665,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
               const cy = cmd.surfaceTileY + dy;
               if (cx < 0 || cy < 0 || cx >= SURFACE_GRID_WIDTH || cy >= SURFACE_GRID_HEIGHT)
                 continue;
-              if (surfaceMovementAt(world, cx, cy) === SurfaceMovementEffect.HardBlock) {
+              if (!isSurfaceTileInComponent(world, cx, cy)) {
                 clearanceBlocked = true;
                 break;
               }

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -34,7 +34,13 @@ import {
   SURFACE_GRID_HEIGHT,
   SPIDER_SCATTER_RADIUS_TILES,
   PLAYER_COLONY_ID,
+  SURFACE_ROOT_CLEARANCE_RADIUS,
 } from './constants.js';
+import {
+  isSurfaceTileInComponent,
+  surfaceMovementAt,
+  SurfaceMovementEffect,
+} from './surface-features.js';
 import { FP_SHIFT, FP_ONE } from './fixed.js';
 import { allocateWorkers, computeDigDemand } from './behavior/allocation-system.js';
 import {
@@ -633,6 +639,38 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         // (NaN doesn't round-trip cleanly through JSON.stringify).
         if (!isTileCoord(cmd.surfaceTileX, SURFACE_GRID_WIDTH)) break;
         if (!isTileCoord(cmd.surfaceTileY, SURFACE_GRID_HEIGHT)) break;
+        // PR 4 — terrain is frozen: DesignateEntrance can no longer carve. Reject
+        // unless the candidate tile is in the single connected walkable component
+        // AND its full clearance neighbourhood is already passable on the baked
+        // grid (the static replacement for the old auto-carved entrance halo).
+        // Checked before any allocation/mutation.
+        {
+          if (!isSurfaceTileInComponent(world, cmd.surfaceTileX, cmd.surfaceTileY)) break;
+          // The halo uses a bare HardBlock test (not a component test) on purpose:
+          // under the single-connected-component invariant, any non-HardBlock tile
+          // within radius of the in-component candidate is itself reachable from it,
+          // hence in-component. (If that invariant is ever relaxed, switch the halo
+          // check to isSurfaceTileInComponent too.)
+          let clearanceBlocked = false;
+          for (let dy = -SURFACE_ROOT_CLEARANCE_RADIUS; dy <= SURFACE_ROOT_CLEARANCE_RADIUS; dy++) {
+            for (
+              let dx = -SURFACE_ROOT_CLEARANCE_RADIUS;
+              dx <= SURFACE_ROOT_CLEARANCE_RADIUS;
+              dx++
+            ) {
+              const cx = cmd.surfaceTileX + dx;
+              const cy = cmd.surfaceTileY + dy;
+              if (cx < 0 || cy < 0 || cx >= SURFACE_GRID_WIDTH || cy >= SURFACE_GRID_HEIGHT)
+                continue;
+              if (surfaceMovementAt(world, cx, cy) === SurfaceMovementEffect.HardBlock) {
+                clearanceBlocked = true;
+                break;
+              }
+            }
+            if (clearanceBlocked) break;
+          }
+          if (clearanceBlocked) break;
+        }
         // T-07-12: cap check (mitigate tamper — prevent unbounded entrance creation)
         if (colony4.entrances.length >= MAX_ENTRANCES_PER_COLONY) break;
         // Column uniqueness — same surfaceTileX collapses in underground view (PRD §3g)

--- a/src/sim/types.test.ts
+++ b/src/sim/types.test.ts
@@ -29,10 +29,12 @@ describe('WorldState', () => {
       expect(world.rngState).toBe(4294967295);
     });
 
-    it('has exactly twenty-three fields (4 Phase 5 + 3 Phase 6 + 4 Phase 7 + 1 issue #27 + 1 issue #44 + 1 issue #112 + 3 S0b telemetry + 1 S1 pendingQueenDeathContexts + 1 S2 aiState + 3 S3 spider + 1 S5 difficulty)', () => {
+    it('has exactly twenty-five fields (… + 2 PR 4 static terrain: bakedSurfaceEffect + surfaceComponentMask)', () => {
       const world = createWorldState(0);
       const keys = Object.keys(world);
-      expect(keys).toHaveLength(23);
+      expect(keys).toHaveLength(25);
+      expect(keys).toContain('bakedSurfaceEffect'); // PR 4
+      expect(keys).toContain('surfaceComponentMask'); // PR 4
       expect(keys).toContain('tick');
       expect(keys).toContain('rngState');
       expect(keys).toContain('nextEntityId');

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -17,6 +17,9 @@ import { createSurfaceGrid, createUndergroundGrid } from './terrain.js';
 import type { DepletionRecord, FoodPile } from './food.js';
 import type { PendingChamber } from './colony/chamber.js';
 import { MAX_ENTITIES, SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT } from './constants.js';
+// PR 4 — runtime import for the procedural terrain bake. surface-features.ts
+// back-imports WorldState as a TYPE only, so there is no runtime import cycle.
+import { bakeSurfaceEffectGrid } from './surface-features.js';
 
 export type EntityId = number; // incrementing counter from 0, no recycling per PRD §1/§3
 
@@ -362,7 +365,12 @@ export const SIM_VERSION_V26_SPIDER_EDGE_MARGIN = 26 as const;
  * demotion (gated on simVersion >= V27) for byte-identical replay.
  */
 export const SIM_VERSION_V27_FORAGE_BACKPRESSURE = 27 as const;
-export const LATEST_SIM_VERSION = SIM_VERSION_V27_FORAGE_BACKPRESSURE;
+// PR 4 — static surface terrain: the baked movement-effect grid is a new stored
+// WorldState field and the dynamic feature-suppression behaviour is removed, so
+// the field semantics change. Posture 2 (bump + raise MIN_ACCEPTED, no
+// cross-version gate); pre-V28 saves reject at load.
+export const SIM_VERSION_V28_STATIC_TERRAIN = 28 as const;
+export const LATEST_SIM_VERSION = SIM_VERSION_V28_STATIC_TERRAIN;
 
 /**
  * S2 — AI colony state machine states.
@@ -551,6 +559,28 @@ export interface WorldState {
 
   // Phase 7 additions (PRD §2e):
   surface: SurfaceGrid; // shared surface terrain (SURF-01)
+
+  /**
+   * PR 4 (static terrain) — frozen per-tile surface movement-effect grid
+   * (`SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT` bytes; values 0=Cosmetic,
+   * 1=SoftCost, 2=HardBlock). Baked once at world-gen from the procedural
+   * feature field + deterministic root-clearance/corridor carves; the SOURCE OF
+   * TRUTH for `surfaceMovementAt`. Immutable after bake — pile/entrance events
+   * never rewrite it (that was the #127/#128 static-terrain bug). Serialized
+   * packed+base64 (save.ts). Bare `createWorldState` worlds get the raw
+   * procedural bake (no carves).
+   */
+  bakedSurfaceEffect: Uint8Array;
+
+  /**
+   * PR 4 — DERIVED (not serialized): memoised 0/1 membership mask of the single
+   * connected walkable surface component, lazily computed from
+   * `bakedSurfaceEffect` via `ensureSurfaceComponentMask`. Null until first use;
+   * terrain is immutable so it never needs invalidation. `copyWorldState`
+   * recomputes lazily (set to null) rather than threading it.
+   */
+  surfaceComponentMask: Uint8Array | null;
+
   undergroundGrids: Record<ColonyId, UndergroundGrid>; // per-colony underground (UNDR-08)
   foodPiles: FoodPile[]; // surface food sources (SURF-02 + issue #112 depletion/respawn)
 
@@ -617,7 +647,7 @@ export interface WorldState {
  */
 export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIES): WorldState {
   const seedU32 = seed >>> 0;
-  return {
+  const world: WorldState = {
     tick: 0,
     rngState: seedU32,
     nextEntityId: 0, // PRD §3 line 130: starts at 0, no recycling
@@ -634,6 +664,10 @@ export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIE
     pheromoneGrids: {},
     // Phase 7 defaults:
     surface: createSurfaceGrid(SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT),
+    // PR 4 — placeholder; overwritten with the procedural bake below (needs the
+    // constructed world for terrainSeed + the procedural selector).
+    bakedSurfaceEffect: new Uint8Array(SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT),
+    surfaceComponentMask: null,
     undergroundGrids: {},
     foodPiles: [],
     recentlyDepletedFood: [], // issue #112 — empty until first depletion
@@ -651,6 +685,11 @@ export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIE
     spiderPriorityColonyId: null,
     scatterReticleTile: null,
   };
+  // PR 4 — bake the raw procedural movement-effect field now that the world
+  // (terrainSeed) exists. Bare worlds (no colonies) get no carves; createScenario
+  // re-bakes with root reservation + corridor connectivity once colonies exist.
+  world.bakedSurfaceEffect = bakeSurfaceEffectGrid(world);
+  return world;
 }
 
 /**
@@ -988,6 +1027,15 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   // --- Phase 7: surface grid ---
   // Uint8Array.set — zero allocation; dimensions are fixed at world creation
   dst.surface.data.set(src.surface.data);
+
+  // --- PR 4: baked static terrain (Uint8Array.set, fixed dims) + derived mask.
+  // The component mask is derived + immutable; share the src reference (read-only)
+  // so the double-buffered dst sees the same memoised mask without recompute.
+  if (dst.bakedSurfaceEffect.length !== src.bakedSurfaceEffect.length) {
+    dst.bakedSurfaceEffect = new Uint8Array(src.bakedSurfaceEffect.length);
+  }
+  dst.bakedSurfaceEffect.set(src.bakedSurfaceEffect);
+  dst.surfaceComponentMask = src.surfaceComponentMask;
 
   // --- Phase 7: undergroundGrids — same delete-stale + upsert pattern as pheromoneGrids ---
   for (const key in dst.undergroundGrids) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,14 +16,6 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     environment: 'node',
     setupFiles: ['src/platform/test-setup.ts'],
-    // PR 4 (static terrain): world construction now bakes the 128×128 surface
-    // movement-effect grid (~8 ms each), so construction-heavy sweeps that build
-    // hundreds of worlds (e.g. the 200-seed spider-lair check, 500-iteration
-    // pause-cadence check) sit closer to vitest's 5 s default — and tip over it
-    // under CI-runner CPU contention. Raise the default ceiling so legitimately
-    // heavy setup isn't killed mid-run; assertions and iteration counts are
-    // unchanged. Genuinely-hung tests still fail (just later).
-    testTimeout: 15_000,
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,14 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     environment: 'node',
     setupFiles: ['src/platform/test-setup.ts'],
+    // PR 4 (static terrain): world construction now bakes the 128×128 surface
+    // movement-effect grid (~8 ms each), so construction-heavy sweeps that build
+    // hundreds of worlds (e.g. the 200-seed spider-lair check, 500-iteration
+    // pause-cadence check) sit closer to vitest's 5 s default — and tip over it
+    // under CI-runner CPU contention. Raise the default ceiling so legitimately
+    // heavy setup isn't killed mid-run; assertions and iteration counts are
+    // unchanged. Genuinely-hung tests still fail (just later).
+    testTimeout: 15_000,
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
**PR 4 of the #127/#128 fix series** (`plan/flurry/PR2-FIX-SPECS.md` → "PR 4"; lands first — PR 5/6 depend on a stable, reachable terrain model). Freezes surface terrain so it never mutates as food piles spawn/deplete or entrances are designated — the static-terrain bug class Phase 0 measured (**477/900** piles revealed a `HardBlock` on removal). **Scope is strictly static terrain — no #127/#128 movement fixes** (PR 5 / PR 6). **simVersion V28; do not merge until Rob OKs.**

## What changed
- **`surface-features.ts`** — deleted dynamic entrance/food-pile suppression from the shared selector (movement **and** render). Split procedural vs frozen: `surfaceMovementAt` reads a baked **128×128 movement-effect grid** (Cosmetic/SoftCost/HardBlock) O(1); `surfaceFeatureAt` consults the **carve override** so render never paints a sprite over a carved-passable tile (R4-3). Added `bakeStaticTerrain` (deterministic root-clearance reservation + corridor carve → **one connected component**, **no `terrainSeed` retry**), `computeSurfaceComponentMask`, `validateSurfaceConnectivity`. Boot-asserts no registry feature is `Cosmetic` (carve-detection precondition).
- **`types.ts`** — `SIM_VERSION_V28_STATIC_TERRAIN` (LATEST=28); stored `bakedSurfaceEffect` + derived `surfaceComponentMask`; procedural bake in `createWorldState`; threaded `copyWorldState`.
- **`save.ts`** — baked grid serialized **packed 2-bit + base64** (~5.3 KB vs ~48 KB raw). Deserialize validates **dims / enum range / full connectivity** (every saved pile + entrance), rejecting corrupt or pre-V28 maps. **`MIN_ACCEPTED` raised to V28** (posture 2 — old saves reject cleanly).
- **`scenario.ts`** — bake **before** placing piles; reachable-spawn pile gate; world-gen connectivity assertion.
- **`tick.ts`** — `DesignateEntrance` rejects unless candidate + clearance are already passable on the frozen grid **and** in the connected component (can no longer carve).
- **`food-system.ts`** — runtime pile spawn gated on the connected component.

## Acceptance (committed tests, printed PASS)
- **Static-terrain oracle** (full `SurfaceFeatureSlice` = kind+variant+anchor): `featureFieldDiffCount == 0` across pile spawn/deplete, entrance designate/open, ticks, save/load — **0 mutate** (baseline 477/900).
- **Connectivity + reachable-spawn**: one component holds every root/pile/entrance; all spawns land in it.
- **simVersion rejection boundary**: V28 loads; a save < `MIN_ACCEPTED`(28) rejects (posture 2; no cross-version behaviour tests).
- Neutrality + determinism guards green; determinism serializer threads the baked grid.

## Measurements
- **Save-size delta +0.49–0.50%** (≤ +5%); **tick-time ~0.23–0.24 ms/tick** (≤ 0.5).
- **Final acceptance sweep** (10 acceptance seeds × 3 difficulties = 30 runs): **0 connectivity failures, 0 hash mutations**.

## Verification
`npm run verify` green — **79 files / 2336 tests**; internal `ship-review` `passed:true` (×2). **Does NOT close #127/#128** (PR 5/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)