### PR TITLE
feat(controls): Stage 1 input-model rework — tool palette + gesture arbiter (#18)

### DIFF
--- a/src/input/camera-input.test.ts
+++ b/src/input/camera-input.test.ts
@@ -2,26 +2,31 @@
 //
 // Stage 1 controls rework (issue #18): Space-pan is gone (panInputState carries
 // only `isPanning`); the new interactive HUD zones (TOOLS / HINTS / SPEED) are
-// masked by isPointerOverHUD. registerDragPan now handles middle-button only and
-// is verified by the browser smoke test (Phaser scene events).
+// masked by isPointerOverHUD. registerDragPan handles middle-button only.
 //
 // Tests cover:
 //   - isPointerOverHUD: each masked zone (incl. TOOLS / HINTS / SPEED) + misses
 //   - isPointerOverHUD: underground-only colony toggle masking
 //   - processCameraInput: keyboard pan (arrow + WASD), clamp after pan
 //   - processCameraInput: suppressed while panInputState.isPanning
+//   - registerDragPan: an in-flight middle-drag stops when isBlocked flips true
+//     (Codex P2 — a modal opening mid-drag must suspend the pan, not just block
+//     new drags)
 //   - reset helpers
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   isPointerOverHUD,
   processCameraInput,
+  registerDragPan,
   panInputState,
   resetPanInputState,
   resetDragState,
   type DragState,
   type PanInputs,
 } from './camera-input.js';
+import type * as Phaser from 'phaser';
+import { TILE_SIZE_PX } from '../render/sprites.js';
 
 beforeEach(() => {
   resetPanInputState();
@@ -189,6 +194,84 @@ describe('processCameraInput', () => {
     processCameraInput(vs, makePanInputs({ leftDown: true }));
     expect(vs.surfaceCamera.x).toBeGreaterThanOrEqual(VIEWPORT_WIDTH_TILES / 2);
     expect(vs.surfaceCamera.x).toBeLessThanOrEqual(SURFACE_GRID_WIDTH - VIEWPORT_WIDTH_TILES / 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerDragPan — in-flight suspend when isBlocked flips true
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal fake Phaser.Scene that captures the input handlers registerDragPan
+ * registers (keyed by event name) so a test can dispatch synthetic pointer
+ * events at them. Only the surface registerDragPan touches (scene.input.on) is
+ * modelled.
+ */
+function makeFakeScene(): {
+  scene: Phaser.Scene;
+  emit: (event: string, pointer: unknown) => void;
+} {
+  const handlers = new Map<string, (pointer: unknown) => void>();
+  const scene = {
+    input: {
+      on: (event: string, fn: (pointer: unknown) => void) => {
+        handlers.set(event, fn);
+      },
+    },
+  } as unknown as Phaser.Scene;
+  const emit = (event: string, pointer: unknown): void => {
+    handlers.get(event)?.(pointer);
+  };
+  return { scene, emit };
+}
+
+/** Fake middle-button pointer at (x, y). */
+function middlePointer(x: number, y: number): Phaser.Input.Pointer {
+  return { x, y, middleButtonDown: () => true } as unknown as Phaser.Input.Pointer;
+}
+
+describe('registerDragPan (middle-button)', () => {
+  it('pans the active camera on a middle-button drag', () => {
+    const vs = makeViewState('surface', 100, 100);
+    const { scene, emit } = makeFakeScene();
+    registerDragPan(scene, vs);
+    // Non-HUD points (mid play-area, clear of every HUD rect).
+    emit('pointerdown', middlePointer(400, 300));
+    expect(panInputState.isPanning).toBe(true);
+    emit('pointermove', middlePointer(400 + TILE_SIZE_PX, 300));
+    // Pointer moved +1 tile in x → camera pans -1 tile in x (drag-the-world).
+    expect(vs.surfaceCamera.x).toBeCloseTo(100 - 1);
+    emit('pointerup', middlePointer(400 + TILE_SIZE_PX, 300));
+    expect(panInputState.isPanning).toBe(false);
+  });
+
+  // Codex P2: a modal (Esc menu / SavePrompt / GameOver) opening DURING an active
+  // middle-drag must suspend the pan — not merely block new drags. isBlocked
+  // flips true mid-gesture; the very next pointermove must release the drag and
+  // stop moving the camera (pointermove calls releaseDrag() when isBlocked()).
+  it('stops an in-flight middle-drag when isBlocked flips true mid-gesture', () => {
+    const vs = makeViewState('surface', 100, 100);
+    const { scene, emit } = makeFakeScene();
+    const blocked = { value: false };
+    registerDragPan(scene, vs, () => blocked.value);
+
+    // Drag starts and pans while unblocked.
+    emit('pointerdown', middlePointer(400, 300));
+    emit('pointermove', middlePointer(400 + TILE_SIZE_PX, 300));
+    expect(vs.surfaceCamera.x).toBeCloseTo(100 - 1);
+    expect(panInputState.isPanning).toBe(true);
+
+    // Modal opens: isBlocked → true. The next pointermove must release the drag,
+    // clearing isPanning and leaving the camera where it was (no further delta).
+    blocked.value = true;
+    emit('pointermove', middlePointer(400 + 5 * TILE_SIZE_PX, 300));
+    expect(panInputState.isPanning).toBe(false);
+    expect(vs.surfaceCamera.x).toBeCloseTo(100 - 1); // unchanged since the block
+
+    // A further move while still blocked is a no-op (drag is no longer active).
+    emit('pointermove', middlePointer(400 + 9 * TILE_SIZE_PX, 300));
+    expect(vs.surfaceCamera.x).toBeCloseTo(100 - 1);
+    expect(panInputState.isPanning).toBe(false);
   });
 });
 

--- a/src/input/camera-input.test.ts
+++ b/src/input/camera-input.test.ts
@@ -1,19 +1,22 @@
 // camera-input.test.ts — Vitest unit tests for src/input/camera-input.ts
 //
-// Tests cover:
-//   - isPointerOverHUD: boundary conditions for each HUD zone
-//   - processCameraInput: keyboard pan (arrow + WASD), clamp after pan
-//   - processCameraInput: dual-axis surface vs underground world dimensions
-//   - processCameraInput: edge-pan is NOT fired (Phase 8.5 regression guards)
+// Stage 1 controls rework (issue #18): Space-pan is gone (panInputState carries
+// only `isPanning`); the new interactive HUD zones (TOOLS / HINTS / SPEED) are
+// masked by isPointerOverHUD. registerDragPan now handles middle-button only and
+// is verified by the browser smoke test (Phaser scene events).
 //
-// registerDragPan involves Phaser scene events — verified by browser smoke test only.
+// Tests cover:
+//   - isPointerOverHUD: each masked zone (incl. TOOLS / HINTS / SPEED) + misses
+//   - isPointerOverHUD: underground-only colony toggle masking
+//   - processCameraInput: keyboard pan (arrow + WASD), clamp after pan
+//   - processCameraInput: suppressed while panInputState.isPanning
+//   - reset helpers
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   isPointerOverHUD,
   processCameraInput,
   panInputState,
-  resetPanInputStateForTests,
   resetPanInputState,
   resetDragState,
   type DragState,
@@ -21,7 +24,7 @@ import {
 } from './camera-input.js';
 
 beforeEach(() => {
-  resetPanInputStateForTests();
+  resetPanInputState();
 });
 import type { ViewState } from '../render/camera.js';
 import {
@@ -30,19 +33,12 @@ import {
   CAMERA_SCROLL_SPEED,
 } from '../render/camera.js';
 import { HUD } from '../render/sprites.js';
-import {
-  UNDERGROUND_GRID_HEIGHT,
-  UNDERGROUND_GRID_WIDTH,
-  SURFACE_GRID_WIDTH,
-  SURFACE_GRID_HEIGHT,
-  PLAYER_COLONY_ID,
-} from '../sim/constants.js';
+import { SURFACE_GRID_WIDTH, PLAYER_COLONY_ID } from '../sim/constants.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Build a minimal ViewState for tests. */
 function makeViewState(
   view: 'surface' | 'underground' = 'surface',
   camX = 64,
@@ -50,6 +46,7 @@ function makeViewState(
 ): ViewState {
   return {
     activeView: view,
+    activeTool: view === 'surface' ? 'command' : 'dig',
     surfaceCamera: {
       x: camX,
       y: camY,
@@ -68,7 +65,6 @@ function makeViewState(
   };
 }
 
-/** Build a minimal mock PanInputs with all keys up. */
 function makePanInputs(
   overrides: Partial<{
     leftDown: boolean;
@@ -92,32 +88,28 @@ function makePanInputs(
     wasdS: false,
     ...overrides,
   };
-
   function key(isDown: boolean) {
     return { isDown } as unknown as import('phaser').Input.Keyboard.Key;
   }
-
   const cursors = {
     left: key(opts.leftDown),
     right: key(opts.rightDown),
     up: key(opts.upDown),
     down: key(opts.downDown),
   } as unknown as import('phaser').Types.Input.Keyboard.CursorKeys;
-
   const wasd = {
     W: key(opts.wasdW),
     A: key(opts.wasdA),
     S: key(opts.wasdS),
     D: key(opts.wasdD),
   };
-
   const dragState = { isDragging: false, lastX: 0, lastY: 0, active: false };
+  return { cursors, wasd, dragState };
+}
 
-  return {
-    cursors,
-    wasd,
-    dragState,
-  };
+/** Center point of a HUD rect. */
+function center(rect: { x: number; y: number; w: number; h: number }): [number, number] {
+  return [rect.x + rect.w / 2, rect.y + rect.h / 2];
 }
 
 // ---------------------------------------------------------------------------
@@ -125,506 +117,97 @@ function makePanInputs(
 // ---------------------------------------------------------------------------
 
 describe('isPointerOverHUD', () => {
-  describe('STATS zone (x:8, y:8, w:200, h:24)', () => {
-    it('returns true for point inside STATS', () => {
-      expect(isPointerOverHUD(10, 10)).toBe(true);
-    });
-    it('returns true for top-left corner of STATS', () => {
-      expect(isPointerOverHUD(HUD.STATS.x, HUD.STATS.y)).toBe(true);
-    });
-    it('returns false for point one pixel above STATS', () => {
-      expect(isPointerOverHUD(10, HUD.STATS.y - 1)).toBe(false);
-    });
-    it('returns false for point one pixel left of STATS', () => {
-      expect(isPointerOverHUD(HUD.STATS.x - 1, 10)).toBe(false);
-    });
-    it('returns false for point at right edge (exclusive)', () => {
-      // Right edge: x + w = 8 + 200 = 208 → 208 is outside
-      expect(isPointerOverHUD(HUD.STATS.x + HUD.STATS.w, HUD.STATS.y)).toBe(false);
-    });
-    it('returns false for point at bottom edge (exclusive)', () => {
-      // Bottom edge: y + h = 8 + 24 = 32 → 32 is outside
-      expect(isPointerOverHUD(HUD.STATS.x, HUD.STATS.y + HUD.STATS.h)).toBe(false);
-    });
-    it('returns true for point at (right-1, bottom-1) inside STATS', () => {
-      expect(isPointerOverHUD(HUD.STATS.x + HUD.STATS.w - 1, HUD.STATS.y + HUD.STATS.h - 1)).toBe(
-        true,
-      );
-    });
-  });
-
-  describe('TRIANGLE zone', () => {
-    it('returns true for point inside TRIANGLE', () => {
-      expect(isPointerOverHUD(HUD.TRIANGLE.x + 5, HUD.TRIANGLE.y + 5)).toBe(true);
-    });
-    it('returns false for point outside TRIANGLE', () => {
-      expect(isPointerOverHUD(HUD.TRIANGLE.x - 1, HUD.TRIANGLE.y + 5)).toBe(false);
-    });
-  });
-
-  describe('MINIMAP zone', () => {
-    it('returns true for point inside MINIMAP', () => {
-      expect(isPointerOverHUD(HUD.MINIMAP.x + 1, HUD.MINIMAP.y + 1)).toBe(true);
-    });
-    it('returns false for point below MINIMAP', () => {
-      expect(isPointerOverHUD(HUD.MINIMAP.x + 1, HUD.MINIMAP.y + HUD.MINIMAP.h)).toBe(false);
-    });
-  });
-
-  describe('VIEW_TOGGLE zone', () => {
-    it('returns true for point inside VIEW_TOGGLE', () => {
-      expect(isPointerOverHUD(HUD.VIEW_TOGGLE.x + 5, HUD.VIEW_TOGGLE.y + 5)).toBe(true);
-    });
-  });
-
-  describe('UNDERGROUND_COLONY_TOGGLE zone (issue #14)', () => {
-    // Helper: a minimal viewState fixture for the conditional-mask path.
-    function vs(activeView: 'surface' | 'underground'): import('../render/camera.js').ViewState {
-      return {
-        activeView,
-        surfaceCamera: { x: 0, y: 0, viewportWidth: 1, viewportHeight: 1 },
-        undergroundCamera: { x: 0, y: 0, viewportWidth: 1, viewportHeight: 1 },
-        undergroundVisited: true,
-        activeUndergroundColonyId: 1,
-        showPheromoneOverlay: true,
-      };
+  it('masks STATS / TRIANGLE / MINIMAP / VIEW_TOGGLE', () => {
+    const vs = makeViewState('surface');
+    for (const rect of [HUD.STATS, HUD.TRIANGLE, HUD.MINIMAP, HUD.VIEW_TOGGLE]) {
+      const [x, y] = center(rect);
+      expect(isPointerOverHUD(x, y, vs)).toBe(true);
     }
-
-    it('masks the colony-toggle zone ONLY when activeView === underground', () => {
-      const inside = [
-        HUD.UNDERGROUND_COLONY_TOGGLE.x + 5,
-        HUD.UNDERGROUND_COLONY_TOGGLE.y + 5,
-      ] as const;
-      // Underground view → the toggle is rendered → click zone is masked.
-      expect(isPointerOverHUD(inside[0], inside[1], vs('underground'))).toBe(true);
-      // Surface view → the toggle is invisible → masking it would create a
-      // dead zone above the minimap. Click zone must NOT be masked.
-      expect(isPointerOverHUD(inside[0], inside[1], vs('surface'))).toBe(false);
-      // Legacy / no-viewState path stays unmasked too (safe default).
-      expect(isPointerOverHUD(inside[0], inside[1])).toBe(false);
-    });
-
-    it('returns false for a point above the colony-toggle button', () => {
-      expect(
-        isPointerOverHUD(
-          HUD.UNDERGROUND_COLONY_TOGGLE.x + 5,
-          HUD.UNDERGROUND_COLONY_TOGGLE.y - 1,
-          vs('underground'),
-        ),
-      ).toBe(false);
-    });
   });
 
-  describe('Phase 9 reservation zones (intentionally unmasked in Phase 8)', () => {
-    it('does NOT mask SAVE_ICON — Phase 8 renders nothing there, so masking creates an invisible dead zone', () => {
-      expect(isPointerOverHUD(HUD.SAVE_ICON.x + 5, HUD.SAVE_ICON.y + 5)).toBe(false);
-    });
-    it('does NOT mask SPEED — Phase 8 renders nothing there, so masking creates an invisible dead zone', () => {
-      expect(isPointerOverHUD(HUD.SPEED.x + 5, HUD.SPEED.y + 5)).toBe(false);
-    });
+  it('masks the Stage 1 interactive zones: TOOLS, HINTS, and SPEED', () => {
+    const vs = makeViewState('surface');
+    for (const rect of [HUD.TOOLS, HUD.HINTS, HUD.SPEED]) {
+      const [x, y] = center(rect);
+      expect(isPointerOverHUD(x, y, vs)).toBe(true);
+    }
   });
 
-  describe('mid-canvas point (no zone)', () => {
-    it('returns false for point in center of canvas with no HUD zone', () => {
-      expect(isPointerOverHUD(400, 300)).toBe(false);
-    });
+  it('returns false for a clearly-empty world point', () => {
+    const vs = makeViewState('surface');
+    // A point in the mid-canvas play area clear of every rect.
+    expect(isPointerOverHUD(400, 300, vs)).toBe(false);
   });
 
-  describe('ant-activity popup — full-canvas mask while panel is open', () => {
-    // While the ant-activity popup is visible (or already pending dismissal),
-    // isPointerOverHUD must treat the ENTIRE canvas as HUD. Reason: UIScene's
-    // pointerdown handler and world-input pointerdown handlers fire on the
-    // same Phaser event, cross-scene dispatch order is not guaranteed, and
-    // the first outside click must never also become a world action. Masking
-    // both `visible` and `pendingHide` closes both listener orderings.
-    // See ant-activity-panel-state.ts.
-    //
-    // Imports are scoped to this block to keep the existing test cases using
-    // only the original import set.
-    it('does NOT mask the panel rect when panel is hidden', async () => {
-      const { antActivityPanelState, hideAntActivityPanel } =
-        await import('../render/ant-activity-panel-state.js');
-      const { ANT_ACTIVITY_PANEL } = await import('../render/ant-activity.js');
-      hideAntActivityPanel();
-      expect(antActivityPanelState.visible).toBe(false);
-      // Panel rect is safely outside every other HUD zone, so this is a
-      // clean conditional-mask test.
-      expect(isPointerOverHUD(ANT_ACTIVITY_PANEL.x + 5, ANT_ACTIVITY_PANEL.y + 5)).toBe(false);
-    });
+  it('uses a half-open inclusion rule [x, x+w) × [y, y+h)', () => {
+    const vs = makeViewState('surface');
+    // Top-left corner is inside.
+    expect(isPointerOverHUD(HUD.TOOLS.x, HUD.TOOLS.y, vs)).toBe(true);
+    // The exclusive right/bottom edge is outside.
+    expect(isPointerOverHUD(HUD.TOOLS.x + HUD.TOOLS.w, HUD.TOOLS.y, vs)).toBe(false);
+    expect(isPointerOverHUD(HUD.TOOLS.x, HUD.TOOLS.y + HUD.TOOLS.h, vs)).toBe(false);
+  });
 
-    it('masks the panel rect when panel is visible', async () => {
-      const { showAntActivityPanel, hideAntActivityPanel } =
-        await import('../render/ant-activity-panel-state.js');
-      const { ANT_ACTIVITY_PANEL } = await import('../render/ant-activity.js');
-      showAntActivityPanel();
-      try {
-        expect(isPointerOverHUD(ANT_ACTIVITY_PANEL.x + 5, ANT_ACTIVITY_PANEL.y + 5)).toBe(true);
-      } finally {
-        hideAntActivityPanel();
-      }
-    });
-
-    it('masks every screen position while panel is visible (world-input-first race guard)', async () => {
-      // Regression test for the world-input-first dispatch ordering. If a
-      // world-input pointerdown handler runs BEFORE UIScene gets a chance to
-      // call requestHideAntActivityPanel(), `pendingHide` is still false.
-      // The click must still be consumed — otherwise it leaks through as a
-      // food mark / rally placement / entrance designation / dig mark, and
-      // UIScene would then also dismiss the popup, so one physical click
-      // produces both a world action AND a dismissal. Masking on `visible`
-      // alone forces the world handler to drop the click regardless of
-      // listener order.
-      const { showAntActivityPanel, hideAntActivityPanel, antActivityPanelState } =
-        await import('../render/ant-activity-panel-state.js');
-      showAntActivityPanel();
-      try {
-        expect(antActivityPanelState.visible).toBe(true);
-        expect(antActivityPanelState.pendingHide).toBe(false);
-        // Deep middle of the world map — must be masked.
-        expect(isPointerOverHUD(400, 300)).toBe(true);
-        // A point near a map edge — also masked.
-        expect(isPointerOverHUD(50, 300)).toBe(true);
-        // A point over an empty region of the top HUD strip — masked.
-        expect(isPointerOverHUD(600, 4)).toBe(true);
-      } finally {
-        hideAntActivityPanel();
-      }
-    });
-
-    it('masks every screen position while pendingHide is set (UIScene-first race guard)', async () => {
-      // Regression test for the UIScene-first dispatch ordering. UIScene sees
-      // the outside click, calls requestHideAntActivityPanel() (pendingHide=
-      // true), and returns. A subsequent world-input handler running later
-      // in the SAME Phaser dispatch consults isPointerOverHUD with the raw
-      // screen coords; those coords may be anywhere on the map.
-      const {
-        showAntActivityPanel,
-        requestHideAntActivityPanel,
-        hideAntActivityPanel,
-        antActivityPanelState,
-      } = await import('../render/ant-activity-panel-state.js');
-      const { ANT_ACTIVITY_PANEL } = await import('../render/ant-activity.js');
-      showAntActivityPanel();
-      requestHideAntActivityPanel();
-      try {
-        expect(antActivityPanelState.visible).toBe(true);
-        expect(antActivityPanelState.pendingHide).toBe(true);
-        // Panel rect itself — masked.
-        expect(isPointerOverHUD(ANT_ACTIVITY_PANEL.x + 5, ANT_ACTIVITY_PANEL.y + 5)).toBe(true);
-        // Deep middle of the world map — must ALSO be masked.
-        expect(isPointerOverHUD(400, 300)).toBe(true);
-        // A point near a map edge — also masked.
-        expect(isPointerOverHUD(50, 300)).toBe(true);
-      } finally {
-        hideAntActivityPanel();
-      }
-    });
-
-    it('still flags Stats / View / Minimap / Triangle zones while panel is visible (HUD hit-rects preserved)', async () => {
-      // Sanity: UIScene checks its own HUD hit-rects directly (it does not
-      // consult isPointerOverHUD for its own dispatch), but isPointerOverHUD
-      // is also used by drag-pan to decide whether a pointerdown is a pan
-      // trigger. These zones must keep reporting true while the panel is up.
-      const { showAntActivityPanel, hideAntActivityPanel } =
-        await import('../render/ant-activity-panel-state.js');
-      showAntActivityPanel();
-      try {
-        expect(isPointerOverHUD(HUD.STATS.x + 5, HUD.STATS.y + 5)).toBe(true);
-        expect(isPointerOverHUD(HUD.VIEW_TOGGLE.x + 5, HUD.VIEW_TOGGLE.y + 5)).toBe(true);
-        expect(isPointerOverHUD(HUD.MINIMAP.x + 5, HUD.MINIMAP.y + 5)).toBe(true);
-        expect(isPointerOverHUD(HUD.TRIANGLE.x + 5, HUD.TRIANGLE.y + 5)).toBe(true);
-      } finally {
-        hideAntActivityPanel();
-      }
-    });
-
-    it('restores normal masking after the panel is hidden', async () => {
-      const { showAntActivityPanel, hideAntActivityPanel, antActivityPanelState } =
-        await import('../render/ant-activity-panel-state.js');
-      showAntActivityPanel();
-      hideAntActivityPanel();
-      expect(antActivityPanelState.visible).toBe(false);
-      expect(antActivityPanelState.pendingHide).toBe(false);
-      // Mid-canvas — no longer masked.
-      expect(isPointerOverHUD(400, 300)).toBe(false);
-      // HUD zones — still masked as usual.
-      expect(isPointerOverHUD(HUD.STATS.x + 5, HUD.STATS.y + 5)).toBe(true);
-    });
+  it('masks UNDERGROUND_COLONY_TOGGLE only on the underground view', () => {
+    const [x, y] = center(HUD.UNDERGROUND_COLONY_TOGGLE);
+    expect(isPointerOverHUD(x, y, makeViewState('surface'))).toBe(false);
+    expect(isPointerOverHUD(x, y, makeViewState('underground'))).toBe(true);
   });
 });
 
 // ---------------------------------------------------------------------------
-// processCameraInput — keyboard pan
+// processCameraInput
 // ---------------------------------------------------------------------------
 
-describe('processCameraInput — keyboard pan', () => {
-  it('moves camera left by CAMERA_SCROLL_SPEED when left arrow is down', () => {
-    const vs = makeViewState('surface', 64, 64);
+describe('processCameraInput', () => {
+  it('pans left/right/up/down by CAMERA_SCROLL_SPEED per held key (arrow keys)', () => {
+    const vs = makeViewState('surface', 100, 100);
     processCameraInput(vs, makePanInputs({ leftDown: true }));
-    expect(vs.surfaceCamera.x).toBeCloseTo(64 - CAMERA_SCROLL_SPEED);
-    expect(vs.surfaceCamera.y).toBeCloseTo(64);
+    expect(vs.surfaceCamera.x).toBeCloseTo(100 - CAMERA_SCROLL_SPEED);
+
+    const vs2 = makeViewState('surface', 100, 100);
+    processCameraInput(vs2, makePanInputs({ downDown: true }));
+    expect(vs2.surfaceCamera.y).toBeCloseTo(100 + CAMERA_SCROLL_SPEED);
   });
 
-  it('moves camera right by CAMERA_SCROLL_SPEED when right arrow is down', () => {
-    const vs = makeViewState('surface', 64, 64);
-    processCameraInput(vs, makePanInputs({ rightDown: true }));
-    expect(vs.surfaceCamera.x).toBeCloseTo(64 + CAMERA_SCROLL_SPEED);
-  });
-
-  it('moves camera up by CAMERA_SCROLL_SPEED when up arrow is down', () => {
-    const vs = makeViewState('surface', 64, 64);
-    processCameraInput(vs, makePanInputs({ upDown: true }));
-    expect(vs.surfaceCamera.y).toBeCloseTo(64 - CAMERA_SCROLL_SPEED);
-  });
-
-  it('moves camera down by CAMERA_SCROLL_SPEED when down arrow is down', () => {
-    const vs = makeViewState('surface', 64, 64);
-    processCameraInput(vs, makePanInputs({ downDown: true }));
-    expect(vs.surfaceCamera.y).toBeCloseTo(64 + CAMERA_SCROLL_SPEED);
-  });
-
-  it('WASD A also pans left', () => {
-    const vs = makeViewState('surface', 64, 64);
-    processCameraInput(vs, makePanInputs({ wasdA: true }));
-    expect(vs.surfaceCamera.x).toBeCloseTo(64 - CAMERA_SCROLL_SPEED);
-  });
-
-  it('left arrow AND wasd.A simultaneously decrements camera.x by ONE CAMERA_SCROLL_SPEED (|| semantics)', () => {
-    // Both down → single decrement (OR, not sum)
-    const vs = makeViewState('surface', 64, 64);
-    processCameraInput(vs, makePanInputs({ leftDown: true, wasdA: true }));
-    expect(vs.surfaceCamera.x).toBeCloseTo(64 - CAMERA_SCROLL_SPEED);
-  });
-
-  it('WASD D pans right', () => {
-    const vs = makeViewState('surface', 64, 64);
+  it('WASD pans identically to the arrow keys', () => {
+    const vs = makeViewState('surface', 100, 100);
     processCameraInput(vs, makePanInputs({ wasdD: true }));
-    expect(vs.surfaceCamera.x).toBeCloseTo(64 + CAMERA_SCROLL_SPEED);
+    expect(vs.surfaceCamera.x).toBeCloseTo(100 + CAMERA_SCROLL_SPEED);
   });
 
-  it('WASD W pans up', () => {
-    const vs = makeViewState('surface', 64, 64);
-    processCameraInput(vs, makePanInputs({ wasdW: true }));
-    expect(vs.surfaceCamera.y).toBeCloseTo(64 - CAMERA_SCROLL_SPEED);
-  });
-
-  it('WASD S pans down', () => {
-    const vs = makeViewState('surface', 64, 64);
-    processCameraInput(vs, makePanInputs({ wasdS: true }));
-    expect(vs.surfaceCamera.y).toBeCloseTo(64 + CAMERA_SCROLL_SPEED);
-  });
-
-  it('no keys down → camera unchanged (after clamp keeps it in place)', () => {
-    const vs = makeViewState('surface', 64, 64);
-    processCameraInput(vs, makePanInputs());
-    expect(vs.surfaceCamera.x).toBeCloseTo(64);
-    expect(vs.surfaceCamera.y).toBeCloseTo(64);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// processCameraInput — edge-pan is retired (Phase 8.5)
-// ---------------------------------------------------------------------------
-//
-// Regression guard: processCameraInput no longer consumes pointer position or
-// canvas dimensions. Calling it with only keyboard inputs must not move the
-// camera based on cursor proximity to any edge. These tests exercise the
-// specific historical edge-band positions to make sure nothing reintroduces
-// edge-pan silently.
-
-describe('processCameraInput — edge-pan is retired (Phase 8.5 regression guard)', () => {
-  it('does NOT pan even when the pointer would historically have been in the left edge band', () => {
-    // We can't pass a pointer anymore — the only way to see the regression is
-    // to confirm that with all keys up the camera stays put.
-    const vs = makeViewState('surface', 64, 64);
-    processCameraInput(vs, makePanInputs());
-    expect(vs.surfaceCamera.x).toBeCloseTo(64);
-    expect(vs.surfaceCamera.y).toBeCloseTo(64);
-  });
-
-  it('PanInputs no longer has pointer / canvasW / canvasH fields', () => {
-    const inputs = makePanInputs();
-    expect('pointer' in inputs).toBe(false);
-    expect('canvasW' in inputs).toBe(false);
-    expect('canvasH' in inputs).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// processCameraInput — clamp after pan
-// ---------------------------------------------------------------------------
-
-describe('processCameraInput — clamp after pan', () => {
-  it('clamps camera to minimum x after left pan near the west edge', () => {
-    // viewportWidth=50 → min cam.x = 25
-    // Start at cam.x=25.3, left key down → 24.8 → clamp → 25.0
-    const vs = makeViewState('surface', 25.3, 64);
+  it('is suppressed while panInputState.isPanning is true (drag claims the camera)', () => {
+    const vs = makeViewState('surface', 100, 100);
+    panInputState.isPanning = true;
     processCameraInput(vs, makePanInputs({ leftDown: true }));
-    expect(vs.surfaceCamera.x).toBeCloseTo(25.0);
+    expect(vs.surfaceCamera.x).toBe(100); // unchanged
   });
 
-  it('clamps camera to maximum x after right pan near the east edge', () => {
-    // worldW=SURFACE_GRID_WIDTH=128, viewportWidth=50 → max cam.x = 128 - 25 = 103
-    // Start at cam.x=103, right key → 103.5 → clamp → 103
-    const vs = makeViewState('surface', 103, 64);
-    processCameraInput(vs, makePanInputs({ rightDown: true }));
-    expect(vs.surfaceCamera.x).toBeCloseTo(103);
-  });
-
-  it('keyboard pan on underground view uses underground world dimensions', () => {
-    // UNDERGROUND_GRID_HEIGHT=64, viewportHeight=37 → max cam.y = 64 - 18.5 = 45.5
-    // Start at cam.y=45, down key → 45.5 → at boundary; another down → clamped to 45.5
-    const vs = makeViewState('underground', 64, 45);
-    processCameraInput(vs, makePanInputs({ downDown: true }));
-    // 45 + 0.5 = 45.5, exactly at max → no further clamping
-    expect(vs.undergroundCamera.y).toBeCloseTo(45.5);
-
-    // Second call with cam at 45.5 → tries 46.0 → clamped back to 45.5
-    processCameraInput(vs, makePanInputs({ downDown: true }));
-    expect(vs.undergroundCamera.y).toBeCloseTo(45.5);
-  });
-
-  it('underground view uses UNDERGROUND_GRID_WIDTH for x clamping', () => {
-    // max cam.x = UNDERGROUND_GRID_WIDTH - viewportWidth/2 = 128 - 25 = 103
-    const vs = makeViewState('underground', 103, 32);
-    processCameraInput(vs, makePanInputs({ rightDown: true }));
-    expect(vs.undergroundCamera.x).toBeCloseTo(103);
-  });
-
-  it('surface view uses SURFACE_GRID_HEIGHT for y clamping', () => {
-    // max cam.y = SURFACE_GRID_HEIGHT - viewportHeight/2 = 128 - 18.5 = 109.5
-    const vs = makeViewState('surface', 64, 109.5);
-    processCameraInput(vs, makePanInputs({ downDown: true }));
-    expect(vs.surfaceCamera.y).toBeCloseTo(109.5);
+  it('clamps the camera into world bounds after a pan', () => {
+    // Push left hard against the world edge; clamp pins x at half-viewport.
+    const vs = makeViewState('surface', 0, 100);
+    processCameraInput(vs, makePanInputs({ leftDown: true }));
+    expect(vs.surfaceCamera.x).toBeGreaterThanOrEqual(VIEWPORT_WIDTH_TILES / 2);
+    expect(vs.surfaceCamera.x).toBeLessThanOrEqual(SURFACE_GRID_WIDTH - VIEWPORT_WIDTH_TILES / 2);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Issue #85 — keyboard pan suppressed during drag-pan.
+// reset helpers
 // ---------------------------------------------------------------------------
 
-describe('processCameraInput — kbd pan suppressed while drag-pan active (#85)', () => {
-  beforeEach(() => {
-    panInputState.isPanning = false;
-  });
-
-  it('does not advance camera when isPanning=true and Right is held', () => {
-    const vs = makeViewState('surface', 64, 64);
-    panInputState.isPanning = true;
-    try {
-      processCameraInput(vs, makePanInputs({ rightDown: true }));
-      // No keyboard delta applied — drag-pan owns the camera.
-      expect(vs.surfaceCamera.x).toBe(64);
-      expect(vs.surfaceCamera.y).toBe(64);
-    } finally {
-      panInputState.isPanning = false;
-    }
-  });
-
-  it('does not advance camera when isPanning=true and Down is held', () => {
-    const vs = makeViewState('surface', 64, 64);
-    panInputState.isPanning = true;
-    try {
-      processCameraInput(vs, makePanInputs({ downDown: true }));
-      expect(vs.surfaceCamera.x).toBe(64);
-      expect(vs.surfaceCamera.y).toBe(64);
-    } finally {
-      panInputState.isPanning = false;
-    }
-  });
-
-  it('clamp still runs even when keyboard input is suppressed', () => {
-    // Pre-position camera outside grid; isPanning=true should still clamp it
-    // (the early-return runs clampCamera before bailing).
-    const vs = makeViewState('surface', -10, 64);
-    panInputState.isPanning = true;
-    try {
-      processCameraInput(vs, makePanInputs({ rightDown: true }));
-      // Clamped to viewport-edge minimum (viewportWidth/2 = 22).
-      expect(vs.surfaceCamera.x).toBeGreaterThanOrEqual(0);
-    } finally {
-      panInputState.isPanning = false;
-    }
-  });
-
-  it('with isPanning=false (default), kbd pan resumes normally', () => {
-    const vs = makeViewState('surface', 64, 64);
-    expect(panInputState.isPanning).toBe(false);
-    processCameraInput(vs, makePanInputs({ rightDown: true }));
-    expect(vs.surfaceCamera.x).toBeGreaterThan(64);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// processCameraInput — surface vs underground world dimensions sanity
-// ---------------------------------------------------------------------------
-
-describe('processCameraInput — world dimension constants', () => {
-  it('SURFACE_GRID_WIDTH and SURFACE_GRID_HEIGHT are 128×128', () => {
-    expect(SURFACE_GRID_WIDTH).toBe(128);
-    expect(SURFACE_GRID_HEIGHT).toBe(128);
-  });
-
-  it('UNDERGROUND_GRID_WIDTH is 128, UNDERGROUND_GRID_HEIGHT is 64', () => {
-    expect(UNDERGROUND_GRID_WIDTH).toBe(128);
-    expect(UNDERGROUND_GRID_HEIGHT).toBe(64);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// panInputState — Phase 8.5 Space+left-drag contract
-// ---------------------------------------------------------------------------
-
-describe('panInputState', () => {
-  it('defaults to both flags false', () => {
-    expect(panInputState.spaceHeld).toBe(false);
-    expect(panInputState.isPanning).toBe(false);
-  });
-
-  it('resetPanInputStateForTests clears both flags', () => {
-    panInputState.spaceHeld = true;
-    panInputState.isPanning = true;
-    resetPanInputStateForTests();
-    expect(panInputState.spaceHeld).toBe(false);
-    expect(panInputState.isPanning).toBe(false);
-  });
-
-  it('resetPanInputState (production alias) clears both flags', () => {
-    // Same behavior as the test helper; callable at session-restart boundaries.
-    panInputState.spaceHeld = true;
+describe('reset helpers', () => {
+  it('resetPanInputState clears isPanning', () => {
     panInputState.isPanning = true;
     resetPanInputState();
-    expect(panInputState.spaceHeld).toBe(false);
     expect(panInputState.isPanning).toBe(false);
   });
 
-  it('resetPanInputState === resetPanInputStateForTests (alias identity)', () => {
-    expect(resetPanInputState).toBe(resetPanInputStateForTests);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// resetDragState — Phase 9 session reset
-// ---------------------------------------------------------------------------
-
-describe('resetDragState', () => {
-  it('clears active/isDragging and zeroes lastX/lastY', () => {
-    const dragState: DragState = { isDragging: true, lastX: 42, lastY: 99, active: true };
-    resetDragState(dragState);
-    expect(dragState).toEqual({ isDragging: false, lastX: 0, lastY: 0, active: false });
-  });
-
-  it('preserves the DragState object identity (mutates in place)', () => {
-    // Critical: registerDragPan's pointermove handler captured this reference.
-    const dragState: DragState = { isDragging: true, lastX: 10, lastY: 20, active: true };
-    const ref = dragState;
-    resetDragState(dragState);
-    expect(dragState).toBe(ref);
-  });
-
-  it('is idempotent on an already-cleared state', () => {
-    const dragState: DragState = { isDragging: false, lastX: 0, lastY: 0, active: false };
-    resetDragState(dragState);
-    expect(dragState).toEqual({ isDragging: false, lastX: 0, lastY: 0, active: false });
+  it('resetDragState clears the drag fields in place', () => {
+    const ds: DragState = { isDragging: true, lastX: 42, lastY: 99, active: true };
+    const ref = ds;
+    resetDragState(ds);
+    expect(ds).toBe(ref);
+    expect(ds).toEqual({ isDragging: false, lastX: 0, lastY: 0, active: false });
   });
 });

--- a/src/input/camera-input.ts
+++ b/src/input/camera-input.ts
@@ -1,29 +1,25 @@
-// camera-input.ts — Phase 8 (Phase 8.5-stabilized) camera pan input orchestrator.
+// camera-input.ts — camera pan input (Stage 1 controls rework, issue #18).
 //
-// Supported camera pan triggers after the Phase 8.5 stabilization pass:
-//   1. Space + left-drag — primary map-style pan gesture. Works on any mouse
-//      or trackpad that can left-click. While Space is held, world-input
-//      handlers (dig marking, food mark, entrance designation, chamber menu)
-//      are suppressed so the same gesture never races between pan and world
-//      action.
-//   2. Middle-button drag — secondary pan gesture for users with a three-
-//      button mouse. Retained because it is strictly more convenient than
-//      reaching for Space when it is available.
-//   3. Keyboard pan — arrow keys + WASD (secondary path; per-frame poll).
+// Pan triggers after the controls rework:
+//   1. Left-drag — driven by the gesture arbiter (gesture-arbiter.ts), NOT here.
+//      Command / Dig-surface / Chamber drags pan; underground-Dig drags paint.
+//      The arbiter sets/clears `panInputState.isPanning` while a left-drag pan
+//      is active so keyboard pan is suppressed for the duration.
+//   2. Middle-button drag — secondary pan gesture for three-button mice, owned
+//      by registerDragPan below. Independent of the arbiter (the arbiter cancels
+//      any pending left gesture when a middle button goes down).
+//   3. Keyboard pan — arrow keys + WASD (per-frame poll in processCameraInput).
 //
-// Edge-pan (cursor-near-edge scroll) was removed in Phase 8.5 (2026-04-19). It
-// did not match the intended map-style surface navigation, it fought with HUD
-// widgets on the edges, and it caused drift when the cursor rested near a
-// canvas edge. The PRD (§7a) has been amended; `EDGE_PAN_THRESHOLD_PX` is kept
-// as a historical constant in `camera.ts` but is no longer consumed here.
+// Space no longer pans (the Space modifier was retired in the rework — Space is
+// now the pause toggle, bound in game-scene.ts). All `spaceHeld` handling is
+// gone; `panInputState` carries only `isPanning`.
 //
-// `panInputState` is a module-level singleton exposed so surface-input and
-// underground-input can suppress their own pointerdown handling while a pan
-// gesture is in flight. This keeps the left-drag excavation gesture intact
-// while still giving the player a practical trackpad-friendly primary pan.
+// `panInputState` remains a module-level singleton so the arbiter and the
+// keyboard-pan poll can coordinate (keyboard pan no-ops while a drag pan claims
+// the camera).
 //
-// No Phaser *runtime* dependency at the module level — Phaser types are
-// imported with `import type` only so this file can be tested without Phaser.
+// No Phaser *runtime* dependency at module level — Phaser types are `import
+// type` only so this file is testable without Phaser.
 
 import type * as Phaser from 'phaser';
 import { HUD, TILE_SIZE_PX } from '../render/sprites.js';
@@ -46,18 +42,15 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
- * Shared pan-gesture state, read by world-input handlers so they know when to
- * suppress a left-click (the same physical gesture is pan, not world action).
+ * Shared pan-gesture state.
  *
- * Mutated by registerDragPan's Phaser event handlers. Exposed as a live object
- * so consumers can read the latest values without subscribing.
+ * - `isPanning` is true while a drag pan (middle-button via registerDragPan, or
+ *   left-drag via the gesture arbiter) is in flight. processCameraInput skips
+ *   keyboard pan while it is true so the two pan systems don't stack deltas.
  *
- * - `spaceHeld` flips on Space keydown / keyup. While true, a left-drag pans.
- * - `isPanning`  is true from pan-start pointerdown until pointerup. This
- *   covers both Space+left and middle-button gestures.
+ * The Space modifier was removed in the controls rework, so `spaceHeld` is gone.
  */
 export const panInputState = {
-  spaceHeld: false,
   isPanning: false,
 };
 
@@ -65,16 +58,12 @@ export const panInputState = {
  * Reset the module-level panInputState singleton back to defaults.
  *
  * Used at session-restart boundaries (bootFresh / bootFromSave / restartGame)
- * so a Space key held or pan gesture in flight at the moment the user clicks
- * Restart or Continue does not leak into the new session. Without this, the
- * new GameScene instance would see `spaceHeld=true` and suppress left-click
- * world input until the next Space up-event.
+ * and by the GameOver guard so a pan gesture in flight at the moment of restart
+ * does not leak into the new session.
  *
- * Also used by unit tests as `resetPanInputStateForTests` (aliased below) so
- * tests that exercise world-input handlers don't inherit state across cases.
+ * Also used by unit tests as `resetPanInputStateForTests` (aliased below).
  */
 export function resetPanInputState(): void {
-  panInputState.spaceHeld = false;
   panInputState.isPanning = false;
 }
 
@@ -83,9 +72,8 @@ export const resetPanInputStateForTests = resetPanInputState;
 
 /**
  * Reset a DragState object in-place. registerDragPan owns the canonical
- * instance and passes it to processCameraInput via PanInputs; at session
- * restart we need to clear any in-flight gesture without replacing the
- * object (the input handlers closed over the original reference).
+ * instance; at session restart we clear any in-flight middle-button gesture
+ * without replacing the object (the input handlers closed over the original).
  */
 export function resetDragState(dragState: DragState): void {
   dragState.isDragging = false;
@@ -102,44 +90,24 @@ export function resetDragState(dragState: DragState): void {
  * isPointerOverHUD — return true if the screen-pixel point (px, py) falls
  * inside any *visible* HUD zone rectangle.
  *
- * Used by drag-pan and world-input handlers to suppress pointer events that
- * land on HUD widgets.
+ * Used by drag-pan and the gesture arbiter to suppress pointer events that land
+ * on HUD widgets.
  *
- * PRD §6 reserves HUD.SPEED and HUD.SAVE_ICON as Phase 9 layout slots —
- * Phase 8 renders nothing there, so masking those zones in Phase 8 creates
- * invisible input-dead zones that feel broken to the player. They are
- * intentionally omitted from the zone list here and should be re-added in
- * Phase 9 when the speed controls and autosave indicator render.
+ * Stage 1 controls rework (issue #18): HUD.TOOLS (tool palette), HUD.HINTS (hint
+ * strip), and HUD.SPEED (speed widget) are now DRAWN and interactive, so all
+ * three are masked here. HUD.SPEED was deliberately left unmasked pre-rework
+ * (reserved/undrawn); now that the speed widget renders there, masking it stops
+ * speed-button clicks leaking into the world arbiter (Codex R5-1). HUD.SAVE_ICON
+ * stays unmasked (still undrawn).
  *
  * Inclusion rule: x in [rect.x, rect.x + rect.w) and y in [rect.y, rect.y + rect.h).
  */
 export function isPointerOverHUD(px: number, py: number, viewState?: ViewState): boolean {
-  // Ant-activity popup full-canvas mask — while the panel is visible OR
-  // already dismissing (pendingHide), treat every screen pixel as HUD.
-  //
-  // Why the full canvas, not just the panel rect: UIScene's pointerdown
-  // handler and the world-input pointerdown handlers (surface-input /
-  // underground-input / drag-pan) are separate Phaser listeners on the
-  // same pointer event. Phaser does not guarantee cross-scene dispatch
-  // order. There are two orderings we must protect against:
-  //
-  //   1. UIScene-first. UIScene sees the outside click, calls
-  //      requestHideAntActivityPanel() → pendingHide=true, returns.
-  //      Then a world-input handler runs; `visible` is still true.
-  //
-  //   2. World-input-first. A world handler runs BEFORE UIScene has had a
-  //      chance to request the hide, so pendingHide is still false. If
-  //      we only masked during pendingHide, this click would leak through
-  //      as a food mark / rally placement / entrance designation / dig
-  //      mark, and the popup would ALSO get dismissed on the UIScene pass.
-  //
-  // Masking on `visible || pendingHide` closes both orderings: the world
-  // handler drops the click unconditionally while the panel is up, and
-  // UIScene's own HUD interactions (Stats toggle, view toggle, minimap,
-  // triangle) don't consult isPointerOverHUD — UIScene checks its own
-  // hit-rects directly — so those continue to work. The next
-  // UIScene.update frame commits the deferred hide and clears both flags,
-  // restoring normal masking.
+  // Ant-activity popup full-canvas mask — while the panel is visible OR already
+  // dismissing (pendingHide), treat every screen pixel as HUD. (See the long
+  // rationale retained below: Phaser does not guarantee cross-scene dispatch
+  // order, so masking the whole canvas closes both UIScene-first and
+  // world-input-first orderings of the dismissal click.)
   if (antActivityPanelState.visible || antActivityPanelState.pendingHide) {
     return true;
   }
@@ -147,17 +115,16 @@ export function isPointerOverHUD(px: number, py: number, viewState?: ViewState):
   const zones: Array<{ x: number; y: number; w: number; h: number }> = [
     HUD.STATS,
     HUD.TRIANGLE,
+    HUD.SPEED,
+    HUD.TOOLS,
+    HUD.HINTS,
     HUD.MINIMAP,
     HUD.VIEW_TOGGLE,
   ];
-  // Issue #14 — colony toggle is rendered ONLY on the underground view
-  // (ui-scene.ts gates `setVisible` on activeView === 'underground'). Mask
-  // the click zone only when it's actually visible — otherwise a 100×22
-  // pixel patch above the minimap on the surface view becomes a silent
-  // dead zone that swallows rally / food-mark / entrance-designation
-  // clicks. Callers that don't have a ViewState handy (legacy or test
-  // contexts) pass undefined and the toggle stays unmasked, which is
-  // strictly safer than the always-masked alternative.
+  // Issue #14 — colony toggle is rendered ONLY on the underground view. Mask the
+  // click zone only when it's actually visible — otherwise a patch above the
+  // minimap on the surface view becomes a silent dead zone. Callers without a
+  // ViewState (legacy/test) pass undefined and the toggle stays unmasked.
   if (viewState !== undefined && viewState.activeView === 'underground') {
     zones.push(HUD.UNDERGROUND_COLONY_TOGGLE);
   }
@@ -176,12 +143,9 @@ export function isPointerOverHUD(px: number, py: number, viewState?: ViewState):
 /**
  * PanInputs — shape of everything processCameraInput needs per frame.
  *
- * Passed from GameScene.update() each frame.
- *
- * Phase 8.5: edge-pan was removed, so `pointer`, `canvasW`, and `canvasH` are
- * no longer needed here. Keyboard pan is evaluated synchronously in
- * processCameraInput; drag-pan mutations happen inside registerDragPan's
- * event handlers.
+ * Passed from GameScene.update() each frame. Keyboard pan is evaluated
+ * synchronously in processCameraInput; drag-pan mutations happen inside
+ * registerDragPan's / the arbiter's event handlers.
  */
 export interface PanInputs {
   /** Phaser cursor-key state (arrow keys). */
@@ -194,9 +158,9 @@ export interface PanInputs {
     D: Phaser.Input.Keyboard.Key;
   };
   /**
-   * Drag state reference returned from registerDragPan.
-   * processCameraInput does NOT read this — drag-pan mutations happen
-   * directly in the pointermove handler. Included here for debugging.
+   * Drag state reference returned from registerDragPan. processCameraInput does
+   * NOT read this — drag-pan mutations happen directly in the pointermove
+   * handler. Included for debugging.
    */
   dragState: { isDragging: boolean; lastX: number; lastY: number; active: boolean };
 }
@@ -224,28 +188,16 @@ function activeCamera(viewState: ViewState): CameraState {
 /**
  * processCameraInput — apply keyboard pan triggers then clamp.
  *
- * Called once per frame from GameScene.update(). Drag-pan mutations happen
- * inside the event handlers registered by registerDragPan; this function
- * applies the keyboard triggers and issues the single end-of-frame clamp.
- *
- * Pan order:
- *   1. Keyboard (arrow keys + WASD) — each axis independent.
- *   2. clampCamera() — single call at end of frame.
- *
- * The Phaser camera scroll is synced in GameScene.update() after this call
- * returns.
- *
- * Phase 8.5: edge-pan was removed — see module header.
+ * Called once per frame from GameScene.update(). Drag-pan mutations happen in
+ * the event handlers; this applies the keyboard triggers and the single
+ * end-of-frame clamp.
  */
 export function processCameraInput(viewState: ViewState, inputs: PanInputs): void {
   const cam = activeCamera(viewState);
   const [worldW, worldH] = worldDimensions(viewState);
 
-  // Issue #85 — suppress keyboard pan while a drag-pan gesture is active.
-  // Pre-fix both pan systems applied on the same frame, so holding a
-  // direction key during a space-drag-pan stacked deltas (drag delta +
-  // CAMERA_SCROLL_SPEED). Drag is a 'claim the camera' gesture; keyboard
-  // resumes as soon as the drag ends.
+  // Issue #85 — suppress keyboard pan while a drag pan claims the camera. Drag
+  // is a 'claim the camera' gesture; keyboard resumes as soon as the drag ends.
   if (panInputState.isPanning) {
     clampCamera(cam, worldW, worldH);
     return;
@@ -270,50 +222,39 @@ export function processCameraInput(viewState: ViewState, inputs: PanInputs): voi
 }
 
 // ---------------------------------------------------------------------------
-// registerDragPan
+// registerDragPan — middle-button pan only
 // ---------------------------------------------------------------------------
 
 /**
- * DragState — shared mutable object tracking drag-pan progress.
+ * DragState — shared mutable object tracking middle-button drag-pan progress.
  */
 export interface DragState {
-  /** True when a left-button drag has moved at least one pixel. */
+  /** True when a middle-button drag has moved at least one pixel. */
   isDragging: boolean;
   /** Last pointer X seen during drag (pixels). */
   lastX: number;
   /** Last pointer Y seen during drag (pixels). */
   lastY: number;
-  /** True from pointerdown (left, non-HUD) until pointerup. */
+  /** True from pointerdown (middle, non-HUD) until pointerup. */
   active: boolean;
 }
 
 /**
- * registerDragPan — wire drag-pan event handlers on a Phaser.Scene.
+ * registerDragPan — wire MIDDLE-button drag-pan handlers on a Phaser.Scene.
  *
- * Supported pan gestures (Phase 8.5):
- *   1. **Space + left-drag** (primary, trackpad-friendly). While the Space
- *      key is held, pressing the left mouse button on a non-HUD region
- *      starts a pan; moving the pointer drags the camera; releasing the
- *      button ends the gesture. Works on any pointing device that has a
- *      left button (i.e. every mouse and trackpad).
- *   2. **Middle-button drag** (secondary, three-button mouse). Does not
- *      require Space. Retained because it is faster than reaching for Space
- *      when a middle button is available.
+ * The Space+left and plain-left pan paths were removed in the controls rework
+ * (left is now exclusively the gesture arbiter's). This retains only the
+ * middle-button pan for three-button mice. While it is active it sets
+ * `panInputState.isPanning` so keyboard pan is suppressed; the gesture arbiter
+ * also cancels any pending left gesture on a middle-button down so the two
+ * never run concurrently.
  *
- * Contract with world-input handlers:
- *   - While `panInputState.spaceHeld === true` or `panInputState.isPanning
- *     === true`, surface-input and underground-input must no-op on
- *     left-click / drag. This is how we keep left-drag excavation
- *     (underground dig marking) intact while still giving the player a
- *     practical primary pan gesture — the two gestures are disambiguated
- *     by the Space modifier, not by the mouse button.
+ * HUD-zone pointerdown / pointermove are ignored so a drag starting inside a HUD
+ * widget never pans, and a mid-drag HUD crossing doesn't jump the camera.
  *
- * Returns the shared dragState object for back-compat with PanInputs
- * (processCameraInput ignores it). `panInputState` is the source of truth
- * for cross-module pan-mode checks.
- *
- * HUD-zone pointerdown and HUD-zone pointermove are ignored so a drag
- * starting inside a HUD widget never pans the camera.
+ * Returns the shared dragState object (kept for PanInputs back-compat;
+ * processCameraInput ignores it). `isBlocked` lets GameScene suspend pan during
+ * GameOver.
  */
 export function registerDragPan(
   scene: Phaser.Scene,
@@ -327,36 +268,9 @@ export function registerDragPan(
     active: false,
   };
 
-  // --- Space modifier tracking -----------------------------------------
-  // We use the keyboard.addKey helper so Phaser manages the KeyCode lookup
-  // (avoids a direct `Phaser.Input.Keyboard.KeyCodes.SPACE` reference, which
-  // would require a runtime Phaser import). addCapture prevents Space from
-  // scrolling the host page while the canvas has focus.
-  const keyboard = scene.input.keyboard;
-  if (keyboard) {
-    keyboard.addCapture('SPACE');
-    const spaceKey = keyboard.addKey('SPACE');
-    spaceKey.on('down', () => {
-      panInputState.spaceHeld = true;
-    });
-    spaceKey.on('up', () => {
-      panInputState.spaceHeld = false;
-      // If we were panning via Space+left-drag but the user released Space
-      // before releasing the mouse, end the pan gracefully. pointerup below
-      // will also clear, so this is just defensive.
-      if (dragState.active && !panInputState.isPanning) return;
-    });
-  }
-
-  const isPanTriggerDown = (pointer: Phaser.Input.Pointer): boolean => {
-    if (pointer.middleButtonDown()) return true;
-    if (panInputState.spaceHeld && pointer.leftButtonDown()) return true;
-    return false;
-  };
-
   scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
     if (isBlocked?.()) return;
-    if (!isPanTriggerDown(pointer)) return;
+    if (!pointer.middleButtonDown()) return;
     if (isPointerOverHUD(pointer.x, pointer.y, viewState)) return;
     dragState.active = true;
     dragState.lastX = pointer.x;
@@ -365,20 +279,22 @@ export function registerDragPan(
     panInputState.isPanning = true;
   });
 
+  const releaseDrag = (): void => {
+    dragState.active = false;
+    dragState.isDragging = false;
+    panInputState.isPanning = false;
+  };
+
   scene.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
     if (isBlocked?.()) {
       releaseDrag();
       return;
     }
     if (!dragState.active) return;
-    // Continue pan only while the originating trigger is still held.
-    if (!isPanTriggerDown(pointer)) return;
-    // Issue #73 — when the pointer is over a HUD widget mid-drag, suppress
-    // the camera delta but STILL update lastX/lastY. Pre-fix the last-pos
-    // accumulator was frozen during the HUD crossing, so the next non-HUD
-    // pointermove computed a delta across the entire HUD strip — visible
-    // camera jump. Tracking the position through the HUD keeps the next
-    // valid move incremental.
+    // Continue only while the middle button is still held.
+    if (!pointer.middleButtonDown()) return;
+    // Issue #73 — over a HUD widget mid-drag, suppress the camera delta but
+    // still track lastX/lastY so the next non-HUD move is incremental.
     if (isPointerOverHUD(pointer.x, pointer.y, viewState)) {
       dragState.lastX = pointer.x;
       dragState.lastY = pointer.y;
@@ -400,19 +316,8 @@ export function registerDragPan(
     dragState.isDragging = true;
   });
 
-  // Issue #85 codex P2 follow-up — register on BOTH `pointerup` and
-  // `pointerupoutside`. Phaser fires the latter when the pointer is
-  // released outside the canvas (drag started in-canvas, ended over
-  // the page chrome / dev-tools / window edge). Pre-fix only `pointerup`
-  // cleared `panInputState.isPanning`, so a drag ending outside the
-  // canvas left the flag stuck true — combined with #85's keyboard-pan
-  // suppression, that meant arrow keys would silently no-op forever
-  // until another in-canvas pointerup.
-  const releaseDrag = (): void => {
-    dragState.active = false;
-    dragState.isDragging = false;
-    panInputState.isPanning = false;
-  };
+  // Register on BOTH pointerup and pointerupoutside so a drag ending off-canvas
+  // still clears isPanning (issue #85 follow-up).
   scene.input.on('pointerup', releaseDrag);
   scene.input.on('pointerupoutside', releaseDrag);
 

--- a/src/input/command-queue.test.ts
+++ b/src/input/command-queue.test.ts
@@ -1,0 +1,50 @@
+// command-queue.test.ts — Vitest unit tests for the input-side enqueueCommand
+// paused-cap helper (Stage 1 controls rework, issue #18, Codex R1-6/R2-8).
+
+import { describe, it, expect } from 'vitest';
+import { enqueueCommand } from './command-queue.js';
+import { MAX_COMMANDS_PER_TICK, type SimCommand } from '../sim/commands.js';
+import type { WorldState } from '../sim/types.js';
+
+function makeWorld(queue: SimCommand[] = []): WorldState {
+  return { tick: 0, commandQueue: queue } as unknown as WorldState;
+}
+const noop = (tick = 0): SimCommand => ({ type: 'NoOp', issuedAtTick: tick });
+
+describe('enqueueCommand', () => {
+  it('always pushes when NOT paused (steady-state queue drains each tick)', () => {
+    const world = makeWorld(Array.from({ length: MAX_COMMANDS_PER_TICK + 50 }, (_, i) => noop(i)));
+    const ok = enqueueCommand(world, noop(999), false);
+    expect(ok).toBe(true);
+    expect(world.commandQueue).toHaveLength(MAX_COMMANDS_PER_TICK + 51);
+  });
+
+  it('pushes while paused when under the non-Sync cap', () => {
+    const world = makeWorld(Array.from({ length: MAX_COMMANDS_PER_TICK - 1 }, (_, i) => noop(i)));
+    const ok = enqueueCommand(world, noop(), true);
+    expect(ok).toBe(true);
+    expect(world.commandQueue).toHaveLength(MAX_COMMANDS_PER_TICK);
+  });
+
+  it('DROPS (returns false, no push) while paused at the non-Sync cap', () => {
+    const world = makeWorld(Array.from({ length: MAX_COMMANDS_PER_TICK }, (_, i) => noop(i)));
+    const ok = enqueueCommand(world, noop(), true);
+    expect(ok).toBe(false);
+    expect(world.commandQueue).toHaveLength(MAX_COMMANDS_PER_TICK);
+  });
+
+  it('does NOT count SyncAIState toward the cap (mirrors tick.ts accounting)', () => {
+    // A queue full of SyncAIState should NOT block a real player command while paused.
+    const syncCmd = { type: 'SyncAIState' } as unknown as SimCommand;
+    const world = makeWorld(Array.from({ length: MAX_COMMANDS_PER_TICK + 5 }, () => syncCmd));
+    const ok = enqueueCommand(world, noop(), true);
+    expect(ok).toBe(true);
+  });
+
+  it('a SyncAIState command itself is never capped while paused', () => {
+    const world = makeWorld(Array.from({ length: MAX_COMMANDS_PER_TICK }, (_, i) => noop(i)));
+    const syncCmd = { type: 'SyncAIState' } as unknown as SimCommand;
+    const ok = enqueueCommand(world, syncCmd, true);
+    expect(ok).toBe(true);
+  });
+});

--- a/src/input/command-queue.test.ts
+++ b/src/input/command-queue.test.ts
@@ -1,5 +1,7 @@
 // command-queue.test.ts — Vitest unit tests for the input-side enqueueCommand
-// paused-cap helper (Stage 1 controls rework, issue #18, Codex R1-6/R2-8).
+// non-Sync cap helper (Stage 1 controls rework, issue #18, Codex R1-6/R2-8).
+// The cap is enforced UNCONDITIONALLY (paused OR running) so a fast paint stroke
+// can't silently lose tiles past tick.ts's MAX_COMMANDS_PER_TICK drop.
 
 import { describe, it, expect } from 'vitest';
 import { enqueueCommand } from './command-queue.js';
@@ -12,11 +14,21 @@ function makeWorld(queue: SimCommand[] = []): WorldState {
 const noop = (tick = 0): SimCommand => ({ type: 'NoOp', issuedAtTick: tick });
 
 describe('enqueueCommand', () => {
-  it('always pushes when NOT paused (steady-state queue drains each tick)', () => {
-    const world = makeWorld(Array.from({ length: MAX_COMMANDS_PER_TICK + 50 }, (_, i) => noop(i)));
+  it('pushes when NOT paused and UNDER the non-Sync cap', () => {
+    const world = makeWorld(Array.from({ length: MAX_COMMANDS_PER_TICK - 1 }, (_, i) => noop(i)));
     const ok = enqueueCommand(world, noop(999), false);
     expect(ok).toBe(true);
-    expect(world.commandQueue).toHaveLength(MAX_COMMANDS_PER_TICK + 51);
+    expect(world.commandQueue).toHaveLength(MAX_COMMANDS_PER_TICK);
+  });
+
+  it('REFUSES (returns false, no push) when NOT paused AT the non-Sync cap', () => {
+    // The fast-stroke fix: the cap is enforced UNCONDITIONALLY. tick.ts would
+    // drop anything past 64 regardless of pause state, so refusing here lets the
+    // caller defer the command instead of silently losing it.
+    const world = makeWorld(Array.from({ length: MAX_COMMANDS_PER_TICK }, (_, i) => noop(i)));
+    const ok = enqueueCommand(world, noop(999), false);
+    expect(ok).toBe(false);
+    expect(world.commandQueue).toHaveLength(MAX_COMMANDS_PER_TICK);
   });
 
   it('pushes while paused when under the non-Sync cap', () => {
@@ -26,7 +38,7 @@ describe('enqueueCommand', () => {
     expect(world.commandQueue).toHaveLength(MAX_COMMANDS_PER_TICK);
   });
 
-  it('DROPS (returns false, no push) while paused at the non-Sync cap', () => {
+  it('REFUSES (returns false, no push) while paused at the non-Sync cap', () => {
     const world = makeWorld(Array.from({ length: MAX_COMMANDS_PER_TICK }, (_, i) => noop(i)));
     const ok = enqueueCommand(world, noop(), true);
     expect(ok).toBe(false);

--- a/src/input/command-queue.ts
+++ b/src/input/command-queue.ts
@@ -1,0 +1,67 @@
+// command-queue.ts — Stage 1 controls rework (issue #18): single input-side
+// command enqueue helper with a paused-overflow guard.
+//
+// Why this exists (Codex R1-6, R2-8):
+//   tick() drains the queue FIFO and applies at most MAX_COMMANDS_PER_TICK
+//   NON-Sync commands per tick, silently dropping the excess (see
+//   src/sim/tick.ts — `if (nonSyncCmdCount >= MAX_COMMANDS_PER_TICK) break`).
+//   While the loop is PAUSED the queue never drains, so an unbounded burst of
+//   player orders (e.g. a long dig-paint stroke, or repeated chamber/behavior
+//   commands) silently piles up past the cap; on resume only the first 64 take
+//   effect and the rest vanish with no feedback.
+//
+//   The fix is purely input-side and emits the SAME SimCommands as today: every
+//   player command producer — the gesture arbiter, the chamber context menu
+//   (ui-scene.ts), and the Forage/Fight slider (ui-scene.ts) — routes through
+//   ONE enqueueCommand() that, WHEN PAUSED, refuses to push a non-Sync command
+//   once the queue already holds MAX_COMMANDS_PER_TICK non-Sync commands, and
+//   reports the overflow so the hint strip can surface "paused queue full —
+//   resume to continue". No sim change, no new command, determinism unaffected
+//   (a dropped-at-the-cap command would have been dropped by tick.ts anyway).
+//
+// When NOT paused the queue drains every tick, so the steady-state depth is
+// tiny and the cap is effectively never hit by hand-issued input — enqueue then
+// pushes unconditionally, matching today's `world.commandQueue.push(cmd)`.
+
+import { MAX_COMMANDS_PER_TICK, type SimCommand } from '../sim/commands.js';
+import type { WorldState } from '../sim/types.js';
+
+/**
+ * Count the non-Sync commands already queued. Mirrors tick.ts's accounting:
+ * `SyncAIState` is applied in an uncapped pre-pass and excluded from the cap,
+ * so it must not count against the paused budget here either (otherwise a
+ * pending AI sync would shave one slot off the player's allowance).
+ */
+function countNonSyncQueued(queue: readonly SimCommand[]): number {
+  let n = 0;
+  for (const cmd of queue) {
+    if (cmd.type !== 'SyncAIState') n++;
+  }
+  return n;
+}
+
+/**
+ * enqueueCommand — push a player command onto world.commandQueue, enforcing the
+ * paused non-Sync cap.
+ *
+ * - Not paused: always pushes (returns true). The queue drains each tick so the
+ *   cap is unreachable through hand input; matches the prior direct push.
+ * - Paused: pushes only if the queue currently holds fewer than
+ *   MAX_COMMANDS_PER_TICK non-Sync commands. If at/over the cap, drops the
+ *   command (it would have been dropped by tick.ts on resume regardless) and
+ *   returns false so the caller can surface the "paused queue full" hint.
+ *
+ * Never mutates anything but the queue array; never touches sim state beyond
+ * the command queue (the legitimate input→sim seam per ARCHITECTURE.md).
+ *
+ * @returns true if the command was enqueued; false if it was dropped at the cap.
+ */
+export function enqueueCommand(world: WorldState, cmd: SimCommand, isPaused: boolean): boolean {
+  if (isPaused && cmd.type !== 'SyncAIState') {
+    if (countNonSyncQueued(world.commandQueue) >= MAX_COMMANDS_PER_TICK) {
+      return false;
+    }
+  }
+  world.commandQueue.push(cmd);
+  return true;
+}

--- a/src/input/command-queue.ts
+++ b/src/input/command-queue.ts
@@ -1,27 +1,39 @@
 // command-queue.ts — Stage 1 controls rework (issue #18): single input-side
-// command enqueue helper with a paused-overflow guard.
+// command enqueue helper that enforces the non-Sync command cap.
 //
-// Why this exists (Codex R1-6, R2-8):
+// Why this exists (Codex R1-6, R2-8; cap made unconditional for the fast-stroke
+// drop fix):
 //   tick() drains the queue FIFO and applies at most MAX_COMMANDS_PER_TICK
 //   NON-Sync commands per tick, silently dropping the excess (see
 //   src/sim/tick.ts — `if (nonSyncCmdCount >= MAX_COMMANDS_PER_TICK) break`).
-//   While the loop is PAUSED the queue never drains, so an unbounded burst of
-//   player orders (e.g. a long dig-paint stroke, or repeated chamber/behavior
-//   commands) silently piles up past the cap; on resume only the first 64 take
-//   effect and the rest vanish with no feedback.
+//   That cap (64) lives in the sim and cannot change. Any producer that pushes
+//   MORE than 64 non-Sync commands toward a single tick therefore loses the
+//   overflow inside tick.ts with no feedback — whether the loop is paused (the
+//   queue never drains) OR running (a single fast dig-paint stroke can emit far
+//   more than 64 MarkDigTile in one pointer-move). The original guard only
+//   capped WHILE PAUSED and pushed unconditionally when running, so a fast
+//   unpaused stroke silently dropped its tail.
 //
 //   The fix is purely input-side and emits the SAME SimCommands as today: every
 //   player command producer — the gesture arbiter, the chamber context menu
 //   (ui-scene.ts), and the Forage/Fight slider (ui-scene.ts) — routes through
-//   ONE enqueueCommand() that, WHEN PAUSED, refuses to push a non-Sync command
-//   once the queue already holds MAX_COMMANDS_PER_TICK non-Sync commands, and
-//   reports the overflow so the hint strip can surface "paused queue full —
-//   resume to continue". No sim change, no new command, determinism unaffected
-//   (a dropped-at-the-cap command would have been dropped by tick.ts anyway).
+//   ONE enqueueCommand() that refuses to push a non-Sync command once the queue
+//   already holds MAX_COMMANDS_PER_TICK non-Sync commands (paused OR not), and
+//   reports the refusal so the caller can defer the command. No sim change, no
+//   new command, determinism unaffected (a command refused at the cap would have
+//   been dropped by tick.ts anyway).
 //
-// When NOT paused the queue drains every tick, so the steady-state depth is
-// tiny and the cap is effectively never hit by hand-issued input — enqueue then
-// pushes unconditionally, matching today's `world.commandQueue.push(cmd)`.
+// Paused vs running differ only in how the caller TREATS a refusal, not in
+// whether the cap applies:
+//   - Running: the queue drains every tick, so a refusal is transient back-
+//     pressure — the paint producer holds its stroke cursor at the last enqueued
+//     tile and re-emits the remainder on the next frame's flush as the queue
+//     drains (≤64/tick). No hint; it catches up next tick.
+//   - Paused: the queue genuinely cannot drain, so a refusal means the player
+//     must resume before more commands take effect — the caller surfaces the
+//     "paused queue full — resume to continue" hint.
+// The isPaused param is retained so callers can pass it uniformly, but it no
+// longer gates the cap (it never needed to — the cap is the same either way).
 
 import { MAX_COMMANDS_PER_TICK, type SimCommand } from '../sim/commands.js';
 import type { WorldState } from '../sim/types.js';
@@ -42,22 +54,32 @@ function countNonSyncQueued(queue: readonly SimCommand[]): number {
 
 /**
  * enqueueCommand — push a player command onto world.commandQueue, enforcing the
- * paused non-Sync cap.
+ * non-Sync cap UNCONDITIONALLY (paused or not).
  *
- * - Not paused: always pushes (returns true). The queue drains each tick so the
- *   cap is unreachable through hand input; matches the prior direct push.
- * - Paused: pushes only if the queue currently holds fewer than
- *   MAX_COMMANDS_PER_TICK non-Sync commands. If at/over the cap, drops the
- *   command (it would have been dropped by tick.ts on resume regardless) and
- *   returns false so the caller can surface the "paused queue full" hint.
+ * - A non-Sync command pushes only if the queue currently holds fewer than
+ *   MAX_COMMANDS_PER_TICK non-Sync commands. If at/over the cap, it is refused
+ *   (returns false, nothing pushed): the command would have been dropped by
+ *   tick.ts anyway, so refusing here lets the caller defer it instead of
+ *   silently losing it. Running callers re-emit it next tick as the queue
+ *   drains; paused callers surface the "paused queue full" hint.
+ * - A SyncAIState command always pushes (returns true): tick.ts applies it in an
+ *   uncapped pre-pass, so it never competes for the non-Sync budget.
+ *
+ * `isPaused` is retained for a uniform caller signature but no longer affects the
+ * cap (the cap is identical paused or running); callers use it only to decide
+ * how to treat a refusal (hint vs silent re-emit).
  *
  * Never mutates anything but the queue array; never touches sim state beyond
  * the command queue (the legitimate input→sim seam per ARCHITECTURE.md).
  *
- * @returns true if the command was enqueued; false if it was dropped at the cap.
+ * @returns true if the command was enqueued; false if it was refused at the cap.
  */
 export function enqueueCommand(world: WorldState, cmd: SimCommand, isPaused: boolean): boolean {
-  if (isPaused && cmd.type !== 'SyncAIState') {
+  // isPaused is intentionally unused for the cap decision (kept for the caller
+  // signature; see the doc above). Reference it so the unused-param lint stays
+  // quiet without weakening the public shape.
+  void isPaused;
+  if (cmd.type !== 'SyncAIState') {
     if (countNonSyncQueued(world.commandQueue) >= MAX_COMMANDS_PER_TICK) {
       return false;
     }

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -390,219 +390,178 @@ describe('paused-queue-full surfacing', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Fast-stroke deferral + per-frame flushPaint (Fix 1)
+// Fast-stroke cap deferral: cursor-hold + re-emit on the NEXT move (Fix 1).
+//
+// The minimal mechanism (no per-frame flush, no post-release drain): a paint move
+// that out-runs the MAX_COMMANDS_PER_TICK cap holds the stroke cursor at the last
+// enqueued tile. The held tiles re-emit when the NEXT pointermove drives
+// continuePaintStroke from that same cursor — by then the sim has drained the
+// queue, so the next move has fresh cap budget. A continuous drag therefore loses
+// nothing. Release ENDS the stroke (no draining). cancelGesture clears.
 // ---------------------------------------------------------------------------
 
-describe('flushPaint drains the deferred tail', () => {
-  it('a paint move that out-runs the cap holds the cursor; a later flush re-emits', () => {
-    const h = makeHarness('underground', 'dig');
+describe('fast-stroke cap deferral (cursor-hold + re-emit on next move)', () => {
+  it('a move that out-runs the cap holds the cursor; the NEXT move continues from there', () => {
+    const h = makeHarness('underground', 'dig', 100, 20);
     h.paused.value = false;
-    // Fill the queue to the cap so EVERY mark this stroke emits is refused.
-    for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
-    const start = tileCenter(5, 8, h.vs);
-    const end = tileCenter(8, 8, h.vs);
+    // Leave exactly 3 free slots: the begin-tile (1,10) takes one, then the
+    // classify→paint move emits 2 more tiles (2,10)+(3,10) before the cap refuses
+    // (4,10) — so the cursor is HELD at the real tile (3,10), not the sentinel.
+    for (let i = 0; i < 61; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
+    const start = tileCenter(1, 10, h.vs);
+    const mid = tileCenter(8, 10, h.vs);
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // classify → paint; all marks refused
-    // Nothing got through (queue still exactly the 64 NoOps); silent (unpaused).
-    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(0);
-    expect(h.pausedFullCount()).toBe(0);
-    expect(h.arbiter.isPainting()).toBe(true); // stroke still live, cursor held
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, mid.x, mid.y)); // classify → paint; caps mid-segment
+    const firstMarks = h.world.commandQueue
+      .filter((c) => c.type === 'MarkDigTile')
+      .map((c) => [(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
+    expect(firstMarks).toEqual([
+      [1, 10],
+      [2, 10],
+      [3, 10],
+    ]); // begin + 2 steps, then the cap held the cursor at (3,10)
+    expect(h.pausedFullCount()).toBe(0); // unpaused → silent
+    expect(h.arbiter.isPainting()).toBe(true); // stroke live, cursor held at (3,10)
 
-    // Simulate tick() draining the queue, then the per-frame flush.
+    // Simulate tick() draining the queue, then the player keeps dragging (the
+    // NEXT pointermove — this is what re-emits the held tail, NOT a per-frame flush).
     h.world.commandQueue.length = 0;
-    h.arbiter.flushPaint(h.world, false);
+    const end = tileCenter(10, 10, h.vs);
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y));
     const marks = h.world.commandQueue
       .filter((c) => c.type === 'MarkDigTile')
       .map((c) => [(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
-    // The deferred tiles (5,8)..(8,8) now emit toward the stored target.
-    expect(marks.length).toBeGreaterThan(0);
-    expect(marks).toContainEqual([8, 8]); // reached the target tile
+    // Continues from the held cursor (3,10): no gap, no duplicate, reaches target.
+    expect(marks).toContainEqual([4, 10]); // the tile the cap refused last move
+    expect(marks).toContainEqual([10, 10]); // reached the latest target tile
+    expect(marks).not.toContainEqual([3, 10]); // already enqueued — not re-emitted
   });
 
-  it('flushPaint is a no-op when no paint stroke is active', () => {
-    const h = makeHarness('underground', 'dig');
-    h.arbiter.flushPaint(h.world, false);
-    expect(h.world.commandQueue).toHaveLength(0);
-  });
-
-  it('flushPaint itself surfaces the hint on a paused cap refusal during drain', () => {
-    const h = makeHarness('underground', 'dig');
-    h.paused.value = true;
-    const start = tileCenter(5, 8, h.vs);
-    const end = tileCenter(8, 8, h.vs);
+  it('a continuous drag across many moves digs EVERY tile (queue drains between moves)', () => {
+    // Wide grid; drag in single-tile steps, draining the queue between each move
+    // (one tick per frame). Every stepped tile must be dug exactly once.
+    const h = makeHarness('underground', 'dig', 100, 20);
+    h.paused.value = false;
+    const startTile = 1;
+    const endTile = 90;
+    const start = tileCenter(startTile, 10, h.vs);
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // paint a few tiles while paused
-    // Jam the queue, then move the target further so the cursor can't reach it.
-    while (h.world.commandQueue.length < 64)
-      h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: 0 });
-    const far = tileCenter(12, 8, h.vs);
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, far.x, far.y)); // records target, refused at cap (fires hint)
-    // Capture the count AFTER the move so the next assertion isolates flushPaint.
-    const afterMove = h.pausedFullCount();
-    h.arbiter.flushPaint(h.world, true); // still capped, target unreached → flushPaint fires the hint
-    expect(h.pausedFullCount()).toBeGreaterThan(afterMove);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Fix 1: the deferred-paint drain OUTLIVES the gesture. On pointerup of a paint
-// stroke whose cursor has not reached the target, the arbiter enters a "draining"
-// state — the stored stroke + target persist and the per-frame flushPaint keeps
-// draining toward the target across ticks (and across pause→resume) until every
-// tile is dug, THEN clears. cancelGesture ABANDONS (clear immediately). A new
-// pointerdown supersedes a still-draining stroke.
-// ---------------------------------------------------------------------------
-
-describe('deferred-paint drain outlives the gesture (Fix 1)', () => {
-  /** Drain the queue and flush until the stroke finishes (or a tick budget runs out). */
-  function drainToCompletion(h: Harness, paused: boolean, marks: number[][]): void {
-    for (let i = 0; i < 20 && h.arbiter.isPainting(); i++) {
-      // Collect this frame's marks, then simulate tick() draining the queue.
+    const marks: number[][] = [];
+    for (let x = startTile + 1; x <= endTile; x++) {
+      const p = tileCenter(x, 10, h.vs);
+      h.arbiter.onPointerMove(ev(LEFT_BUTTON, p.x, p.y));
       for (const c of h.world.commandQueue) {
         if (c.type === 'MarkDigTile') {
           marks.push([(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
         }
       }
-      h.world.commandQueue.length = 0;
-      h.arbiter.flushPaint(h.world, paused);
+      h.world.commandQueue.length = 0; // tick() drains between moves
     }
-    // Capture the final partial frame (the flush that finished the stroke).
-    for (const c of h.world.commandQueue) {
-      if (c.type === 'MarkDigTile') {
-        marks.push([(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
-      }
-    }
-  }
-
-  it('a >64-tile stroke released before the queue drains digs EVERY tile (no loss)', () => {
-    // Wide grid so a single straight stroke spans far more than the 64/tick cap.
-    const h = makeHarness('underground', 'dig', 100, 20);
-    h.paused.value = false;
-    const start = tileCenter(1, 10, h.vs);
-    const end = tileCenter(90, 10, h.vs); // 90 new tiles → well past the cap
-    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // classify → paint; caps at 64, holds
-    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(64);
-
-    // Release with the queue STILL FULL (the tick hasn't drained it yet) — the
-    // cursor is parked mid-stroke, so the pointerup flush can't finish and the
-    // stroke must hand off to the per-frame drain.
-    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y));
-    expect(h.arbiter.hasPendingGesture()).toBe(false); // gesture over for new input
-    expect(h.arbiter.isPainting()).toBe(true); // but still draining the tail
-
-    const marks: number[][] = [];
-    drainToCompletion(h, false, marks);
-
-    // Every tile x=1..90 dug exactly once — the tail was NOT lost on release.
+    h.arbiter.onPointerUp(
+      ev(LEFT_BUTTON, tileCenter(endTile, 10, h.vs).x, tileCenter(endTile, 10, h.vs).y),
+    );
     const xs = marks.map((m) => m[0]).sort((a, b) => a! - b!);
-    expect(xs).toEqual(Array.from({ length: 90 }, (_, i) => i + 1));
-    // Drain finished → stroke cleared.
-    expect(h.arbiter.isPainting()).toBe(false);
+    expect(xs).toEqual(Array.from({ length: 90 }, (_, i) => i + 1)); // 1..90 each once
+    expect(h.arbiter.isPainting()).toBe(false); // release ended the stroke
   });
 
-  it('a PAUSED >64-tile stroke released then resumed digs all tiles', () => {
+  it('begin: a down-tile refused at the cap leaves the cursor at the sentinel; the stroke still paints once the queue drains', () => {
     const h = makeHarness('underground', 'dig', 100, 20);
-    h.paused.value = true; // bare user-pause: edits queue, sim frozen
-    const start = tileCenter(1, 10, h.vs);
-    const end = tileCenter(90, 10, h.vs);
-    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // 64 queued, rest held (paused)
-    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(64);
-
-    // Release while still paused — the target must survive so resume can finish it.
-    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y));
-    expect(h.arbiter.isPainting()).toBe(true); // draining, target preserved
-
-    // While paused the sim never ticks → the queue never drains, so it stays at
-    // the cap and a flush makes NO progress. The stroke must remain held (the
-    // deferred tail must not be discarded just because frames pass while paused).
-    h.arbiter.flushPaint(h.world, true);
-    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(64); // unchanged
-    expect(h.arbiter.isPainting()).toBe(true);
-
-    // Resume: now ticks drain the queue each frame and the deferred tail emits
-    // until every tile is dug.
     h.paused.value = false;
-    const marks: number[][] = [];
-    drainToCompletion(h, false, marks);
-    const xs = marks.map((m) => m[0]).sort((a, b) => a! - b!);
-    expect(xs).toEqual(Array.from({ length: 90 }, (_, i) => i + 1));
-    expect(h.arbiter.isPainting()).toBe(false);
+    // Jam the queue so the eager begin-tile mark (fired on the classify→paint
+    // move) is refused at the cap. beginPaintStroke leaves the cursor at the
+    // sentinel (-1,-1) so the stroke is not corrupted by a phantom start tile.
+    for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
+    const start = tileCenter(5, 10, h.vs);
+    const firstMove = tileCenter(5, 13, h.vs); // crosses threshold; begin-tile (5,10) refused
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, firstMove.x, firstMove.y));
+    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(0); // all refused
+    expect(h.arbiter.isPainting()).toBe(true); // stroke armed, cursor at sentinel
+
+    // Drain; the next move from the sentinel emits its target via the single-tile
+    // path and the stroke resumes painting normally (it was not left broken by the
+    // refused begin). The begin-tile that the cap dropped is the documented
+    // accepted residual of a coalesced refusal — what matters is the stroke heals.
+    h.world.commandQueue.length = 0;
+    const next = tileCenter(5, 13, h.vs);
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, next.x, next.y));
+    expect(
+      h.world.commandQueue
+        .filter((c) => c.type === 'MarkDigTile')
+        .map((c) => [(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]),
+    ).toContainEqual([5, 13]); // stroke resumed and painted the move target
+
+    // And a later move continues 4-connected from there with no gap.
+    h.world.commandQueue.length = 0;
+    const further = tileCenter(5, 15, h.vs);
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, further.x, further.y));
+    const tail = h.world.commandQueue
+      .filter((c) => c.type === 'MarkDigTile')
+      .map((c) => [(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
+    expect(tail).toEqual([
+      [5, 14],
+      [5, 15],
+    ]);
   });
 
-  it('a small stroke whose cursor already reached the target clears immediately on up (no draining)', () => {
-    const h = makeHarness('underground', 'dig');
-    h.paused.value = false;
-    const start = tileCenter(5, 8, h.vs);
-    const end = tileCenter(8, 8, h.vs); // few tiles, well under the cap
+  it('paused: a cap refusal on a paint move surfaces the hint', () => {
+    const h = makeHarness('underground', 'dig', 100, 20);
+    h.paused.value = true; // bare user-pause: queue never drains
+    for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
+    const start = tileCenter(1, 10, h.vs);
+    const end = tileCenter(8, 10, h.vs);
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y));
-    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y));
-    // Cursor reached the target during the stroke → no leftover drain.
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // refused at cap while paused → hint
+    expect(h.pausedFullCount()).toBeGreaterThan(0);
+  });
+
+  it('release ENDS the stroke immediately — no post-release draining', () => {
+    // Even when a move out-ran the cap and the tail is held, release clears the
+    // stroke. (The minimal design relies on intervening moves, not a drain.)
+    const h = makeHarness('underground', 'dig', 100, 20);
+    h.paused.value = false;
+    for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
+    const start = tileCenter(1, 10, h.vs);
+    const end = tileCenter(90, 10, h.vs); // single coalesced >64-tile move
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // caps, holds the tail
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y)); // IMMEDIATE release, no intervening move
+    // Stroke is fully ended; nothing lingers active to drain on later frames.
     expect(h.arbiter.isPainting()).toBe(false);
     expect(h.arbiter.hasPendingGesture()).toBe(false);
+    // Accepted residual: the held tail past the cap is NOT recovered (there is no
+    // later move and deliberately no flush). Draining the queue + further input
+    // must not resurrect the old stroke.
+    h.world.commandQueue.length = 0;
+    const tap = tileCenter(3, 5, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, tap.x, tap.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, tap.x, tap.y)); // a fresh, independent tap
+    const marks = h.world.commandQueue
+      .filter((c) => c.type === 'MarkDigTile')
+      .map((c) => [(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
+    expect(marks).toEqual([[3, 5]]); // only the new tap; the old stroke did not resume
   });
 
-  it('cancelGesture mid-stroke ABANDONS the paint — no further tiles drain', () => {
+  it('cancelGesture mid-stroke clears the paint — a later move does not resume it', () => {
     const h = makeHarness('underground', 'dig', 100, 20);
     h.paused.value = false;
     const start = tileCenter(1, 10, h.vs);
-    const end = tileCenter(90, 10, h.vs);
+    const mid = tileCenter(5, 10, h.vs);
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // caps at 64, holds, would defer the rest
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, mid.x, mid.y)); // paint a few tiles
+    expect(h.arbiter.isPainting()).toBe(true);
 
     // A modal opens / view switches mid-stroke → cancelGesture abandons.
     h.arbiter.cancelGesture();
     expect(h.arbiter.isPainting()).toBe(false);
     expect(h.arbiter.hasPendingGesture()).toBe(false);
 
-    // Drain the queue and flush repeatedly — NOTHING more should emit.
+    // A stray pointermove with no live snapshot must emit nothing.
     h.world.commandQueue.length = 0;
-    for (let i = 0; i < 5; i++) h.arbiter.flushPaint(h.world, false);
+    const stray = tileCenter(9, 10, h.vs);
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, stray.x, stray.y));
     expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(0);
-  });
-
-  it('cancelGesture ABANDONS a stroke that is already in the draining state', () => {
-    const h = makeHarness('underground', 'dig', 100, 20);
-    h.paused.value = false;
-    const start = tileCenter(1, 10, h.vs);
-    const end = tileCenter(90, 10, h.vs);
-    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y));
-    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y)); // → draining
-    expect(h.arbiter.isPainting()).toBe(true);
-
-    h.arbiter.cancelGesture(); // e.g. blur / colony switch during the drain
-    expect(h.arbiter.isPainting()).toBe(false);
-    h.world.commandQueue.length = 0;
-    for (let i = 0; i < 5; i++) h.arbiter.flushPaint(h.world, false);
-    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(0);
-  });
-
-  it('a new pointerdown SUPERSEDES a still-draining stroke (fresh gesture, old target dropped)', () => {
-    const h = makeHarness('underground', 'dig', 100, 20);
-    h.paused.value = false;
-    const start = tileCenter(1, 10, h.vs);
-    const end = tileCenter(90, 10, h.vs);
-    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y));
-    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y)); // → draining toward (90,10)
-    expect(h.arbiter.isPainting()).toBe(true);
-
-    // A brand-new press elsewhere: the draining stroke is cleared, a fresh tap is
-    // armed. A quick down+up taps the new tile only — the old (90,10) target is
-    // gone, so a later flush does not resume it.
-    h.world.commandQueue.length = 0;
-    const tap = tileCenter(3, 5, h.vs);
-    h.arbiter.onPointerDown(ev(LEFT_BUTTON, tap.x, tap.y));
-    expect(h.arbiter.hasPendingGesture()).toBe(true);
-    h.arbiter.onPointerUp(ev(LEFT_BUTTON, tap.x, tap.y)); // tap → one mark on (3,5)
-    h.arbiter.flushPaint(h.world, false); // old drain must NOT resume
-    const marks = h.world.commandQueue
-      .filter((c) => c.type === 'MarkDigTile')
-      .map((c) => [(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
-    expect(marks).toEqual([[3, 5]]);
   });
 });
 

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -97,6 +97,10 @@ interface Harness {
   hudHit: (x: number, y: number) => boolean;
   setHudHit: (fn: (x: number, y: number) => boolean) => void;
   pausedFullCount: () => number;
+  /** The `paused` argument from the most recent onPausedQueueFull call (Fix 3). */
+  lastQueueFullPaused: () => boolean | undefined;
+  /** Every `paused` argument passed to onPausedQueueFull, in order (Fix 3). */
+  queueFullPausedCalls: () => boolean[];
 }
 
 function makeHarness(
@@ -113,6 +117,7 @@ function makeHarness(
   const contextMenuActive = { value: false };
   let hudHit: (x: number, y: number) => boolean = () => false;
   let pausedFull = 0;
+  const queueFullPaused: boolean[] = [];
   const deps: GestureArbiterDeps = {
     getWorld: () => world,
     getPrevWorld: () => null,
@@ -122,8 +127,9 @@ function makeHarness(
     canEditWorld: () => canEditWorld.value,
     canPan: () => canPan.value,
     isContextMenuActive: () => contextMenuActive.value,
-    onPausedQueueFull: () => {
+    onPausedQueueFull: (p) => {
       pausedFull++;
+      queueFullPaused.push(p);
     },
   };
   const arbiter = new GestureArbiter(deps);
@@ -140,6 +146,8 @@ function makeHarness(
       hudHit = fn;
     },
     pausedFullCount: () => pausedFull,
+    lastQueueFullPaused: () => queueFullPaused[queueFullPaused.length - 1],
+    queueFullPausedCalls: () => queueFullPaused,
   };
 }
 
@@ -217,6 +225,87 @@ describe('drag then no tap', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Flick-pan: the first panMove applies the displacement from the pointer-DOWN
+// coords (Fix 1). A quick drag delivered as ONE coalesced move past the
+// threshold then pointer-up must actually move the camera by (current − down),
+// not 0px. Multi-move drags must then continue incrementally with no first-
+// increment loss and no double-count.
+//
+// The test world is 20×20 but the arbiter clamps against the REAL grid
+// (SURFACE 128×128). Center the camera at (50,30) so a small flick stays inside
+// the clamp window [25,103]×[18.5,109.5] and the assertion is exact.
+// ---------------------------------------------------------------------------
+
+describe('flick-pan first-move displacement (Fix 1)', () => {
+  it('a single coalesced move past the threshold then up pans by (current − down)', () => {
+    const h = makeHarness('surface', 'command');
+    h.vs.surfaceCamera.x = 50;
+    h.vs.surfaceCamera.y = 30;
+    const downX = 200;
+    const downY = 200;
+    const flickPx = 48; // 3 tiles; well past the 6px threshold
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, downX, downY));
+    // ONE move that both crosses the threshold AND is the whole flick, then up.
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, downX + flickPx, downY));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, downX + flickPx, downY));
+    // cam.x -= (current − down)/TILE_SIZE_PX. The OLD bug seeded panLast to the
+    // current move, making this delta 0 (camera unchanged) — this asserts the fix.
+    expect(h.vs.surfaceCamera.x).toBeCloseTo(50 - flickPx / TILE_SIZE_PX, 10);
+    expect(h.vs.surfaceCamera.y).toBeCloseTo(30, 10); // no vertical flick
+    expect(panInputState.isPanning).toBe(false); // released on up
+  });
+
+  it('the first increment is not lost on a vertical flick either', () => {
+    const h = makeHarness('underground', 'command');
+    h.vs.undergroundCamera.x = 50;
+    h.vs.undergroundCamera.y = 30;
+    const downX = 200;
+    const downY = 200;
+    const flickPx = 32; // 2 tiles down
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, downX, downY));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, downX, downY + flickPx));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, downX, downY + flickPx));
+    expect(h.vs.undergroundCamera.x).toBeCloseTo(50, 10);
+    expect(h.vs.undergroundCamera.y).toBeCloseTo(30 - flickPx / TILE_SIZE_PX, 10);
+  });
+
+  it('a multi-move drag pans by the cumulative delta — no first-increment loss, no double-count', () => {
+    const h = makeHarness('surface', 'command');
+    h.vs.surfaceCamera.x = 50;
+    h.vs.surfaceCamera.y = 30;
+    const downX = 200;
+    const downY = 200;
+    // Three successive moves; total horizontal displacement from DOWN = 96px.
+    // The first move both classifies (crosses threshold) and applies (m1 − down).
+    const xs = [downX + 16, downX + 48, downX + 96];
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, downX, downY));
+    for (const x of xs) h.arbiter.onPointerMove(ev(LEFT_BUTTON, x, downY));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, xs[xs.length - 1]!, downY));
+    // Cumulative pan = (last − down)/TILE_SIZE_PX = 96/16 = 6 tiles. If the first
+    // increment were lost the total would be (96−16)/16; if double-counted it
+    // would exceed 6. Exact equality pins both failure modes.
+    expect(h.vs.surfaceCamera.x).toBeCloseTo(50 - 96 / TILE_SIZE_PX, 10);
+    expect(h.vs.surfaceCamera.y).toBeCloseTo(30, 10);
+  });
+
+  it('intermediate moves each apply their own increment (cumulative == final − down)', () => {
+    // Same as above but assert the camera AFTER each move equals the running
+    // (x − down) displacement, proving no per-move double-application.
+    const h = makeHarness('surface', 'command');
+    h.vs.surfaceCamera.x = 50;
+    h.vs.surfaceCamera.y = 30;
+    const downX = 200;
+    const downY = 200;
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, downX, downY));
+    const checkpoints = [downX + 8, downX + 24, downX + 40, downX + 64];
+    for (const x of checkpoints) {
+      h.arbiter.onPointerMove(ev(LEFT_BUTTON, x, downY));
+      expect(h.vs.surfaceCamera.x).toBeCloseTo(50 - (x - downX) / TILE_SIZE_PX, 10);
+    }
+  });
+});
+
 describe('the drag matrix', () => {
   it('Dig + underground drag = paint (no camera move)', () => {
     const h = makeHarness('underground', 'dig');
@@ -263,6 +352,46 @@ describe('cancelGesture', () => {
     h.arbiter.onPointerDown(ev(MIDDLE_BUTTON, start.x, start.y));
     expect(panInputState.isPanning).toBe(true); // left to registerDragPan
     expect(h.arbiter.hasPendingGesture()).toBe(false);
+  });
+
+  it('a RIGHT-button down DURING an active left-drag pan releases isPanning (Fix 2)', () => {
+    // The left gesture is itself the active PAN (it set isPanning = true). A
+    // right-click has no registerDragPan release handler, so the arbiter MUST
+    // release the flag here or keyboard pan stays suppressed (the #85 lock) until
+    // another full pan / session reset. clearLeftGesture's ownership-gated release
+    // (dragMode==='pan') handles it.
+    const h = makeHarness('surface', 'command');
+    const start = tileCenter(10, 10, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y)); // left-drag PAN claim
+    expect(panInputState.isPanning).toBe(true);
+    h.arbiter.onPointerDown(ev(RIGHT_BUTTON, start.x, start.y)); // right-click during the pan
+    expect(panInputState.isPanning).toBe(false); // released → keyboard pan re-enabled
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+  });
+
+  it('a MIDDLE-button down while NOT left-panning leaves a registerDragPan-set isPanning intact (Fix 2 guard)', () => {
+    // Mirror of registerDragPan's claim: the left gesture is NOT panning (no move
+    // past threshold → dragMode null), so the arbiter does not own isPanning. A
+    // middle-down (registerDragPan already set isPanning = true) must NOT clear it.
+    const h = makeHarness('surface', 'command');
+    const start = tileCenter(10, 10, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y)); // pending tap, dragMode null
+    panInputState.isPanning = true; // registerDragPan's middle-down claim (runs first)
+    h.arbiter.onPointerDown(ev(MIDDLE_BUTTON, start.x, start.y));
+    expect(panInputState.isPanning).toBe(true); // preserved for the middle-drag
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+  });
+
+  it('a RIGHT-button down while NOT left-panning leaves a foreign isPanning intact (Fix 2 guard)', () => {
+    // Symmetric guard for right-click: if the left gesture never panned, the
+    // arbiter does not own isPanning and must not clear a flag another owner set.
+    const h = makeHarness('underground', 'command');
+    const start = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y)); // pending tap, dragMode null
+    panInputState.isPanning = true; // some other owner's claim
+    h.arbiter.onPointerDown(ev(RIGHT_BUTTON, start.x, start.y));
+    expect(panInputState.isPanning).toBe(true); // not the arbiter's to clear
   });
 
   it('pointerupoutside abandons the gesture with no tap', () => {
@@ -373,6 +502,7 @@ describe('paused-queue-full surfacing', () => {
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y)); // Dig tap dropped at the cap
     expect(h.pausedFullCount()).toBeGreaterThan(0);
+    expect(h.lastQueueFullPaused()).toBe(true); // paused drop → "resume" message (Fix 3)
   });
 
   it('a dropped one-shot tap surfaces the hint even WHILE UNPAUSED (Codex P2)', () => {
@@ -388,6 +518,7 @@ describe('paused-queue-full surfacing', () => {
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y)); // Dig tap refused at the cap (unpaused)
     expect(h.pausedFullCount()).toBeGreaterThan(0); // one-shot drop → hint fires
+    expect(h.lastQueueFullPaused()).toBe(false); // unpaused drop → "try again" message (Fix 3)
     // The command really was refused (nothing enqueued past the cap).
     expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(0);
   });
@@ -402,7 +533,52 @@ describe('paused-queue-full surfacing', () => {
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y)); // SetRallyPoint refused at the cap (unpaused)
     expect(h.pausedFullCount()).toBeGreaterThan(0);
+    expect(h.lastQueueFullPaused()).toBe(false); // unpaused drop → "try again" (Fix 3)
     expect(h.world.commandQueue.filter((c) => c.type === 'SetRallyPoint')).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 3 — accurate queue-full message: the arbiter threads the LIVE pause state
+// to onPausedQueueFull so the hint reads "resume to continue" when paused and a
+// running-state message when not. (The paused→true / unpaused→false threading is
+// also pinned on the existing one-shot tests above; these isolate the contract.)
+// ---------------------------------------------------------------------------
+
+describe('queue-full message pause-state threading (Fix 3)', () => {
+  it('an UNPAUSED one-shot drop requests the running-state message (paused=false)', () => {
+    const h = makeHarness('underground', 'dig');
+    h.paused.value = false;
+    for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y));
+    expect(h.queueFullPausedCalls()).toEqual([false]);
+  });
+
+  it('a PAUSED one-shot drop requests the paused message (paused=true)', () => {
+    const h = makeHarness('underground', 'dig');
+    h.paused.value = true;
+    for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y));
+    expect(h.queueFullPausedCalls()).toEqual([true]);
+  });
+
+  it('a PAUSED paint cap hit requests the paused message (paint hints only while paused)', () => {
+    // The paint path (notifyCapHit) fires only while paused and always reports
+    // paused=true. An UNPAUSED paint cap hit stays silent (no call) — verified
+    // separately in the fast-stroke deferral block.
+    const h = makeHarness('underground', 'dig', 100, 20);
+    h.paused.value = true;
+    for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
+    const start = tileCenter(1, 10, h.vs);
+    const end = tileCenter(8, 10, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // refused at cap while paused
+    expect(h.queueFullPausedCalls().length).toBeGreaterThan(0);
+    expect(h.queueFullPausedCalls().every((p) => p === true)).toBe(true);
   });
 });
 

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -58,17 +58,17 @@ function makeViewState(
   };
 }
 
-function makeWorld(): WorldState {
+function makeWorld(gridW = 20, gridH = 20): WorldState {
   return {
     tick: 0,
     commandQueue: [] as SimCommand[],
     colonies: {
       [PLAYER_COLONY_ID]: { colonyId: PLAYER_COLONY_ID, entrances: [], rallyPoint: null },
     },
-    surface: { data: new Uint8Array(20 * 20), width: 20, height: 20 },
-    bakedSurfaceEffect: new Uint8Array(20 * 20),
+    surface: { data: new Uint8Array(gridW * gridH), width: gridW, height: gridH },
+    bakedSurfaceEffect: new Uint8Array(gridW * gridH),
     surfaceComponentMask: null,
-    undergroundGrids: { [PLAYER_COLONY_ID]: createUndergroundGrid(20, 20) },
+    undergroundGrids: { [PLAYER_COLONY_ID]: createUndergroundGrid(gridW, gridH) },
     foodPiles: [],
     spider: null,
     spiderPriorityColonyId: null,
@@ -102,8 +102,10 @@ interface Harness {
 function makeHarness(
   view: 'surface' | 'underground',
   tool: 'command' | 'dig' | 'chamber',
+  gridW = 20,
+  gridH = 20,
 ): Harness {
-  const world = makeWorld();
+  const world = makeWorld(gridW, gridH);
   const vs = makeViewState(view, tool);
   const paused = { value: false };
   const canEditWorld = { value: true };
@@ -439,6 +441,168 @@ describe('flushPaint drains the deferred tail', () => {
     const afterMove = h.pausedFullCount();
     h.arbiter.flushPaint(h.world, true); // still capped, target unreached → flushPaint fires the hint
     expect(h.pausedFullCount()).toBeGreaterThan(afterMove);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 1: the deferred-paint drain OUTLIVES the gesture. On pointerup of a paint
+// stroke whose cursor has not reached the target, the arbiter enters a "draining"
+// state — the stored stroke + target persist and the per-frame flushPaint keeps
+// draining toward the target across ticks (and across pause→resume) until every
+// tile is dug, THEN clears. cancelGesture ABANDONS (clear immediately). A new
+// pointerdown supersedes a still-draining stroke.
+// ---------------------------------------------------------------------------
+
+describe('deferred-paint drain outlives the gesture (Fix 1)', () => {
+  /** Drain the queue and flush until the stroke finishes (or a tick budget runs out). */
+  function drainToCompletion(h: Harness, paused: boolean, marks: number[][]): void {
+    for (let i = 0; i < 20 && h.arbiter.isPainting(); i++) {
+      // Collect this frame's marks, then simulate tick() draining the queue.
+      for (const c of h.world.commandQueue) {
+        if (c.type === 'MarkDigTile') {
+          marks.push([(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
+        }
+      }
+      h.world.commandQueue.length = 0;
+      h.arbiter.flushPaint(h.world, paused);
+    }
+    // Capture the final partial frame (the flush that finished the stroke).
+    for (const c of h.world.commandQueue) {
+      if (c.type === 'MarkDigTile') {
+        marks.push([(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
+      }
+    }
+  }
+
+  it('a >64-tile stroke released before the queue drains digs EVERY tile (no loss)', () => {
+    // Wide grid so a single straight stroke spans far more than the 64/tick cap.
+    const h = makeHarness('underground', 'dig', 100, 20);
+    h.paused.value = false;
+    const start = tileCenter(1, 10, h.vs);
+    const end = tileCenter(90, 10, h.vs); // 90 new tiles → well past the cap
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // classify → paint; caps at 64, holds
+    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(64);
+
+    // Release with the queue STILL FULL (the tick hasn't drained it yet) — the
+    // cursor is parked mid-stroke, so the pointerup flush can't finish and the
+    // stroke must hand off to the per-frame drain.
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y));
+    expect(h.arbiter.hasPendingGesture()).toBe(false); // gesture over for new input
+    expect(h.arbiter.isPainting()).toBe(true); // but still draining the tail
+
+    const marks: number[][] = [];
+    drainToCompletion(h, false, marks);
+
+    // Every tile x=1..90 dug exactly once — the tail was NOT lost on release.
+    const xs = marks.map((m) => m[0]).sort((a, b) => a! - b!);
+    expect(xs).toEqual(Array.from({ length: 90 }, (_, i) => i + 1));
+    // Drain finished → stroke cleared.
+    expect(h.arbiter.isPainting()).toBe(false);
+  });
+
+  it('a PAUSED >64-tile stroke released then resumed digs all tiles', () => {
+    const h = makeHarness('underground', 'dig', 100, 20);
+    h.paused.value = true; // bare user-pause: edits queue, sim frozen
+    const start = tileCenter(1, 10, h.vs);
+    const end = tileCenter(90, 10, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // 64 queued, rest held (paused)
+    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(64);
+
+    // Release while still paused — the target must survive so resume can finish it.
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y));
+    expect(h.arbiter.isPainting()).toBe(true); // draining, target preserved
+
+    // While paused the sim never ticks → the queue never drains, so it stays at
+    // the cap and a flush makes NO progress. The stroke must remain held (the
+    // deferred tail must not be discarded just because frames pass while paused).
+    h.arbiter.flushPaint(h.world, true);
+    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(64); // unchanged
+    expect(h.arbiter.isPainting()).toBe(true);
+
+    // Resume: now ticks drain the queue each frame and the deferred tail emits
+    // until every tile is dug.
+    h.paused.value = false;
+    const marks: number[][] = [];
+    drainToCompletion(h, false, marks);
+    const xs = marks.map((m) => m[0]).sort((a, b) => a! - b!);
+    expect(xs).toEqual(Array.from({ length: 90 }, (_, i) => i + 1));
+    expect(h.arbiter.isPainting()).toBe(false);
+  });
+
+  it('a small stroke whose cursor already reached the target clears immediately on up (no draining)', () => {
+    const h = makeHarness('underground', 'dig');
+    h.paused.value = false;
+    const start = tileCenter(5, 8, h.vs);
+    const end = tileCenter(8, 8, h.vs); // few tiles, well under the cap
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y));
+    // Cursor reached the target during the stroke → no leftover drain.
+    expect(h.arbiter.isPainting()).toBe(false);
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+  });
+
+  it('cancelGesture mid-stroke ABANDONS the paint — no further tiles drain', () => {
+    const h = makeHarness('underground', 'dig', 100, 20);
+    h.paused.value = false;
+    const start = tileCenter(1, 10, h.vs);
+    const end = tileCenter(90, 10, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // caps at 64, holds, would defer the rest
+
+    // A modal opens / view switches mid-stroke → cancelGesture abandons.
+    h.arbiter.cancelGesture();
+    expect(h.arbiter.isPainting()).toBe(false);
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+
+    // Drain the queue and flush repeatedly — NOTHING more should emit.
+    h.world.commandQueue.length = 0;
+    for (let i = 0; i < 5; i++) h.arbiter.flushPaint(h.world, false);
+    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(0);
+  });
+
+  it('cancelGesture ABANDONS a stroke that is already in the draining state', () => {
+    const h = makeHarness('underground', 'dig', 100, 20);
+    h.paused.value = false;
+    const start = tileCenter(1, 10, h.vs);
+    const end = tileCenter(90, 10, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y)); // → draining
+    expect(h.arbiter.isPainting()).toBe(true);
+
+    h.arbiter.cancelGesture(); // e.g. blur / colony switch during the drain
+    expect(h.arbiter.isPainting()).toBe(false);
+    h.world.commandQueue.length = 0;
+    for (let i = 0; i < 5; i++) h.arbiter.flushPaint(h.world, false);
+    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(0);
+  });
+
+  it('a new pointerdown SUPERSEDES a still-draining stroke (fresh gesture, old target dropped)', () => {
+    const h = makeHarness('underground', 'dig', 100, 20);
+    h.paused.value = false;
+    const start = tileCenter(1, 10, h.vs);
+    const end = tileCenter(90, 10, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y)); // → draining toward (90,10)
+    expect(h.arbiter.isPainting()).toBe(true);
+
+    // A brand-new press elsewhere: the draining stroke is cleared, a fresh tap is
+    // armed. A quick down+up taps the new tile only — the old (90,10) target is
+    // gone, so a later flush does not resume it.
+    h.world.commandQueue.length = 0;
+    const tap = tileCenter(3, 5, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, tap.x, tap.y));
+    expect(h.arbiter.hasPendingGesture()).toBe(true);
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, tap.x, tap.y)); // tap → one mark on (3,5)
+    h.arbiter.flushPaint(h.world, false); // old drain must NOT resume
+    const marks = h.world.commandQueue
+      .filter((c) => c.type === 'MarkDigTile')
+      .map((c) => [(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
+    expect(marks).toEqual([[3, 5]]);
   });
 });
 

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -1,0 +1,446 @@
+// gesture-arbiter.test.ts — Vitest unit tests for the single left-button gesture
+// arbiter core (Stage 1 controls rework, issue #18). Exercises the pure
+// GestureArbiter directly with mock deps (no Phaser).
+//
+// Covers: tap-on-up; drag-then-no-tap; the view×tool drag matrix (pan vs paint);
+// cancelGesture on every trigger; snapshot acts on the DOWN tile; the enemy-view
+// read-only guard; reconcileContext cancelling on a mid-press tool/view/colony
+// change; the right-click chamber path.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  GestureArbiter,
+  LEFT_BUTTON,
+  MIDDLE_BUTTON,
+  RIGHT_BUTTON,
+  type GestureArbiterDeps,
+  type ArbiterPointerEvent,
+} from './gesture-arbiter.js';
+import { panInputState, resetPanInputState } from './camera-input.js';
+import { contextMenuState, hideContextMenu } from '../render/context-menu-state.js';
+import { UndergroundTileState, ugSet, createUndergroundGrid } from '../sim/terrain.js';
+import type { WorldState } from '../sim/types.js';
+import type { ViewState } from '../render/camera.js';
+import { VIEWPORT_WIDTH_TILES, VIEWPORT_HEIGHT_TILES } from '../render/camera.js';
+import { TILE_SIZE_PX } from '../render/sprites.js';
+import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
+import { DRAG_THRESHOLD_PX } from './gesture.js';
+import type { SimCommand } from '../sim/commands.js';
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeViewState(
+  view: 'surface' | 'underground',
+  tool: 'command' | 'dig' | 'chamber',
+  camX = 10,
+  camY = 10,
+): ViewState {
+  return {
+    activeView: view,
+    activeTool: tool,
+    surfaceCamera: {
+      x: camX,
+      y: camY,
+      viewportWidth: VIEWPORT_WIDTH_TILES,
+      viewportHeight: VIEWPORT_HEIGHT_TILES,
+    },
+    undergroundCamera: {
+      x: camX,
+      y: camY,
+      viewportWidth: VIEWPORT_WIDTH_TILES,
+      viewportHeight: VIEWPORT_HEIGHT_TILES,
+    },
+    undergroundVisited: true,
+    activeUndergroundColonyId: PLAYER_COLONY_ID,
+    showPheromoneOverlay: true,
+  };
+}
+
+function makeWorld(): WorldState {
+  return {
+    tick: 0,
+    commandQueue: [] as SimCommand[],
+    colonies: {
+      [PLAYER_COLONY_ID]: { colonyId: PLAYER_COLONY_ID, entrances: [], rallyPoint: null },
+    },
+    surface: { data: new Uint8Array(20 * 20), width: 20, height: 20 },
+    bakedSurfaceEffect: new Uint8Array(20 * 20),
+    surfaceComponentMask: null,
+    undergroundGrids: { [PLAYER_COLONY_ID]: createUndergroundGrid(20, 20) },
+    foodPiles: [],
+    spider: null,
+    spiderPriorityColonyId: null,
+  } as unknown as WorldState;
+}
+
+/** Screen px at the CENTER of a tile, mirroring the renderer's integer snap. */
+function tileCenter(tileX: number, tileY: number, vs: ViewState) {
+  const cam = vs.activeView === 'surface' ? vs.surfaceCamera : vs.undergroundCamera;
+  const left = Math.floor(cam.x - cam.viewportWidth / 2);
+  const top = Math.floor(cam.y - cam.viewportHeight / 2);
+  return { x: (tileX - left) * TILE_SIZE_PX + 1, y: (tileY - top) * TILE_SIZE_PX + 1 };
+}
+
+interface Harness {
+  arbiter: GestureArbiter;
+  world: WorldState;
+  vs: ViewState;
+  paused: { value: boolean };
+  /** Toggle the world-edit gate (tap / paint / chamber); defaults to allowed. */
+  canEditWorld: { value: boolean };
+  /** Toggle the pan gate (left-drag camera move); defaults to allowed. */
+  canPan: { value: boolean };
+  /** Toggle the chamber-context-menu-active gate; defaults to inactive. */
+  contextMenuActive: { value: boolean };
+  hudHit: (x: number, y: number) => boolean;
+  setHudHit: (fn: (x: number, y: number) => boolean) => void;
+  pausedFullCount: () => number;
+}
+
+function makeHarness(
+  view: 'surface' | 'underground',
+  tool: 'command' | 'dig' | 'chamber',
+): Harness {
+  const world = makeWorld();
+  const vs = makeViewState(view, tool);
+  const paused = { value: false };
+  const canEditWorld = { value: true };
+  const canPan = { value: true };
+  const contextMenuActive = { value: false };
+  let hudHit: (x: number, y: number) => boolean = () => false;
+  let pausedFull = 0;
+  const deps: GestureArbiterDeps = {
+    getWorld: () => world,
+    getPrevWorld: () => null,
+    viewState: vs,
+    isPointerOverHUD: (x, y) => hudHit(x, y),
+    isPaused: () => paused.value,
+    canEditWorld: () => canEditWorld.value,
+    canPan: () => canPan.value,
+    isContextMenuActive: () => contextMenuActive.value,
+    onPausedQueueFull: () => {
+      pausedFull++;
+    },
+  };
+  const arbiter = new GestureArbiter(deps);
+  return {
+    arbiter,
+    world,
+    vs,
+    paused,
+    canEditWorld,
+    canPan,
+    contextMenuActive,
+    hudHit: (x, y) => hudHit(x, y),
+    setHudHit: (fn) => {
+      hudHit = fn;
+    },
+    pausedFullCount: () => pausedFull,
+  };
+}
+
+function ev(button: number, x: number, y: number, pointerId = 1): ArbiterPointerEvent {
+  return { pointerId, button, x, y };
+}
+
+beforeEach(() => {
+  resetPanInputState();
+  hideContextMenu();
+});
+
+// ---------------------------------------------------------------------------
+// Tap vs drag
+// ---------------------------------------------------------------------------
+
+describe('tap on up (no threshold crossing)', () => {
+  it('underground Dig: down+up on a Solid tile → one MarkDigTile on the DOWN tile', () => {
+    const h = makeHarness('underground', 'dig');
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y));
+    const marks = h.world.commandQueue.filter((c) => c.type === 'MarkDigTile');
+    expect(marks).toHaveLength(1);
+    expect([(marks[0] as { tileX: number }).tileX, (marks[0] as { tileY: number }).tileY]).toEqual([
+      5, 8,
+    ]);
+  });
+
+  it('surface Command: tap on empty ground → SetRallyPoint', () => {
+    const h = makeHarness('surface', 'command');
+    const p = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y));
+    expect(h.world.commandQueue.some((c) => c.type === 'SetRallyPoint')).toBe(true);
+  });
+
+  it('the tap acts on the DOWN tile even if the pointer drifts within threshold by up', () => {
+    const h = makeHarness('underground', 'dig');
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    // Up a few px away but under the threshold — still a tap on (5,8).
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x + DRAG_THRESHOLD_PX, p.y));
+    const marks = h.world.commandQueue.filter((c) => c.type === 'MarkDigTile');
+    expect(marks).toHaveLength(1);
+    expect((marks[0] as { tileX: number }).tileX).toBe(5);
+  });
+});
+
+describe('drag then no tap', () => {
+  it('a pan drag (Command surface) moves the camera and fires NO tap on up', () => {
+    const h = makeHarness('surface', 'command');
+    const start = tileCenter(10, 10, h.vs);
+    const camXBefore = h.vs.surfaceCamera.x;
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y)); // crosses threshold → pan
+    expect(panInputState.isPanning).toBe(true);
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, start.x + 40, start.y));
+    expect(h.vs.surfaceCamera.x).not.toBe(camXBefore); // camera panned
+    expect(h.world.commandQueue).toHaveLength(0); // no tap command
+    expect(panInputState.isPanning).toBe(false); // cleared on up
+  });
+
+  it('a paint drag (Dig underground) marks multiple tiles and fires no tap', () => {
+    const h = makeHarness('underground', 'dig');
+    const start = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    const end = tileCenter(8, 8, h.vs);
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // crosses threshold → paint
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, end.x, end.y));
+    const marks = h.world.commandQueue.filter((c) => c.type === 'MarkDigTile');
+    expect(marks.length).toBeGreaterThan(1);
+    // No pan claim was made for a paint drag.
+    expect(panInputState.isPanning).toBe(false);
+  });
+});
+
+describe('the drag matrix', () => {
+  it('Dig + underground drag = paint (no camera move)', () => {
+    const h = makeHarness('underground', 'dig');
+    const start = tileCenter(5, 8, h.vs);
+    const camBefore = h.vs.undergroundCamera.x;
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y));
+    expect(h.vs.undergroundCamera.x).toBe(camBefore); // paint, not pan
+    expect(h.world.commandQueue.some((c) => c.type === 'MarkDigTile')).toBe(true);
+  });
+
+  it.each([
+    ['surface', 'command'],
+    ['surface', 'dig'],
+    ['underground', 'command'],
+    ['underground', 'chamber'],
+  ] as const)('%s + %s drag = pan', (view, tool) => {
+    const h = makeHarness(view, tool);
+    const cam = view === 'surface' ? h.vs.surfaceCamera : h.vs.undergroundCamera;
+    const start = tileCenter(10, 10, h.vs);
+    const before = cam.x;
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y));
+    expect(cam.x).not.toBe(before); // panned
+    expect(panInputState.isPanning).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancelGesture triggers
+// ---------------------------------------------------------------------------
+
+describe('cancelGesture', () => {
+  it('a middle-button down cancels a pending left gesture but leaves isPanning to registerDragPan', () => {
+    // Issue #85: registerDragPan's pointerdown fires FIRST on a middle-button
+    // down and sets isPanning = true to claim the camera for the middle-drag.
+    // The arbiter must cancel its own pending left gesture WITHOUT clearing that
+    // flag, or keyboard pan would stack with the middle-drag (the #85 regression).
+    const h = makeHarness('surface', 'command');
+    const start = tileCenter(10, 10, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y)); // pan claim
+    expect(panInputState.isPanning).toBe(true);
+    h.arbiter.onPointerDown(ev(MIDDLE_BUTTON, start.x, start.y));
+    expect(panInputState.isPanning).toBe(true); // left to registerDragPan
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+  });
+
+  it('pointerupoutside abandons the gesture with no tap', () => {
+    const h = makeHarness('underground', 'dig');
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUpOutside();
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+    expect(h.world.commandQueue).toHaveLength(0);
+  });
+
+  it('reconcileContext cancels a pending paint when the tool changes mid-press', () => {
+    const h = makeHarness('underground', 'dig');
+    const start = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y)); // paint armed
+    // Player presses a tool hotkey mid-stroke.
+    h.vs.activeTool = 'command';
+    h.arbiter.reconcileContext();
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+    expect(h.arbiter.isPainting()).toBe(false);
+  });
+
+  it('reconcileContext cancels when the underground colony switches mid-press', () => {
+    const h = makeHarness('underground', 'dig');
+    const start = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.vs.activeUndergroundColonyId = ENEMY_COLONY_ID;
+    h.arbiter.reconcileContext();
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+  });
+
+  it('explicit cancelGesture clears a pending tap (no command on a later up)', () => {
+    const h = makeHarness('surface', 'command');
+    const p = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.cancelGesture();
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y));
+    expect(h.world.commandQueue).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enemy-view read-only guard
+// ---------------------------------------------------------------------------
+
+describe('enemy-view read-only guard', () => {
+  it('a Dig tap on the enemy underground grid emits no command', () => {
+    const h = makeHarness('underground', 'dig');
+    h.vs.activeUndergroundColonyId = ENEMY_COLONY_ID;
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y));
+    expect(h.world.commandQueue).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HUD guard + right-click
+// ---------------------------------------------------------------------------
+
+describe('HUD + right-click', () => {
+  it('a left down over HUD never starts a gesture', () => {
+    const h = makeHarness('underground', 'dig');
+    h.setHudHit(() => true);
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y));
+    expect(h.world.commandQueue).toHaveLength(0);
+  });
+
+  it('right-click underground on Solid → requests chamber menu', () => {
+    const h = makeHarness('underground', 'command');
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(RIGHT_BUTTON, p.x, p.y));
+    expect(contextMenuState.pendingShow).toBe(true);
+    expect([contextMenuState.anchorTileX, contextMenuState.anchorTileY]).toEqual([5, 8]);
+  });
+
+  it('right-click on the SURFACE is a no-op (no menu)', () => {
+    const h = makeHarness('surface', 'command');
+    const p = tileCenter(5, 1, h.vs);
+    h.arbiter.onPointerDown(ev(RIGHT_BUTTON, p.x, p.y));
+    expect(contextMenuState.pendingShow).toBe(false);
+  });
+
+  it('right-click chamber menu excludes a Marked tile', () => {
+    const h = makeHarness('underground', 'chamber');
+    ugSet(h.world.undergroundGrids[PLAYER_COLONY_ID]!, 5, 8, UndergroundTileState.Marked);
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(RIGHT_BUTTON, p.x, p.y));
+    expect(contextMenuState.pendingShow).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Paused-cap surfacing
+// ---------------------------------------------------------------------------
+
+describe('paused-queue-full surfacing', () => {
+  it('onPausedQueueFull fires when a paint tap is dropped at the cap', () => {
+    const h = makeHarness('underground', 'dig');
+    h.paused.value = true;
+    for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y)); // Dig tap dropped at the cap
+    expect(h.pausedFullCount()).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// World-edit gate vs pan gate (bare user-pause): edits queue, pan still works
+// ---------------------------------------------------------------------------
+
+describe('canEditWorld / canPan split', () => {
+  // The real wiring during a bare user-pause: pan allowed, edits allowed (they
+  // queue via the paused cap). A modal (Esc menu pause / SavePrompt / GameOver)
+  // sets BOTH canEditWorld AND canPan false — GameScene wires both to
+  // !isModalOpen(), so they move together; a bare user-pause is not a modal, so
+  // both stay true. (These arbiter-layer tests inject canPan/canEditWorld
+  // directly, so they pin the arbiter's response to each combination regardless
+  // of how GameScene derives the two flags.)
+
+  it('paused (edits allowed): a Dig tap still queues a MarkDigTile', () => {
+    const h = makeHarness('underground', 'dig');
+    h.paused.value = true; // canEditWorld stays true (bare user-pause)
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y));
+    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(1);
+  });
+
+  it('canEditWorld false (e.g. menu pause): a tap fires NO command', () => {
+    const h = makeHarness('underground', 'dig');
+    h.canEditWorld.value = false;
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y));
+    expect(h.world.commandQueue).toHaveLength(0);
+  });
+
+  it('canEditWorld false but canPan true: left-drag pan still moves the camera', () => {
+    // The finding-2 case: bare-user-pause look-around must not be dead. Even with
+    // world edits blocked, a left-drag still pans.
+    const h = makeHarness('surface', 'command');
+    h.canEditWorld.value = false;
+    h.canPan.value = true;
+    const start = tileCenter(10, 10, h.vs);
+    const camXBefore = h.vs.surfaceCamera.x;
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y)); // crosses threshold → pan
+    expect(panInputState.isPanning).toBe(true);
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, start.x + 40, start.y));
+    expect(h.vs.surfaceCamera.x).not.toBe(camXBefore);
+    expect(h.world.commandQueue).toHaveLength(0);
+  });
+
+  it('canPan false (GameOver): a left-drag does NOT move the camera', () => {
+    const h = makeHarness('surface', 'command');
+    h.canPan.value = false;
+    h.canEditWorld.value = false; // GameOver blocks both
+    const start = tileCenter(10, 10, h.vs);
+    const camXBefore = h.vs.surfaceCamera.x;
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, start.x + 40, start.y));
+    expect(panInputState.isPanning).toBe(false);
+    expect(h.vs.surfaceCamera.x).toBe(camXBefore);
+  });
+
+  it('canEditWorld false: an underground-Dig paint drag paints nothing', () => {
+    const h = makeHarness('underground', 'dig');
+    h.canEditWorld.value = false;
+    const start = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y)); // would classify as paint
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, start.x + 40, start.y));
+    expect(h.world.commandQueue).toHaveLength(0);
+    expect(h.arbiter.isPainting()).toBe(false);
+  });
+});

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -364,7 +364,8 @@ describe('HUD + right-click', () => {
 // ---------------------------------------------------------------------------
 
 describe('paused-queue-full surfacing', () => {
-  it('onPausedQueueFull fires when a paint tap is dropped at the cap WHILE PAUSED', () => {
+  it('onPausedQueueFull fires when a one-shot tap is dropped at the cap WHILE PAUSED', () => {
+    // A down+up with no move is a single Dig TAP (a one-shot), not a paint drag.
     const h = makeHarness('underground', 'dig');
     h.paused.value = true;
     for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
@@ -374,18 +375,34 @@ describe('paused-queue-full surfacing', () => {
     expect(h.pausedFullCount()).toBeGreaterThan(0);
   });
 
-  it('an UNPAUSED cap hit is SILENT — no hint (transient throttling)', () => {
-    // Same overflow, but running: the queue drains each tick and the deferred
-    // tiles re-emit on the next flush, so the hint must NOT fire.
+  it('a dropped one-shot tap surfaces the hint even WHILE UNPAUSED (Codex P2)', () => {
+    // A one-shot (a single Dig tap here) does NOT re-emit, so a cap drop is a real
+    // loss — surface the hint regardless of pause state. (Contrast PAINT, whose
+    // unpaused cap hit IS silent because it re-drives from its held cursor on the
+    // next move — covered in the fast-stroke deferral block below.) The queue is
+    // momentarily full, e.g. right after a big dig-paint burst.
     const h = makeHarness('underground', 'dig');
     h.paused.value = false;
     for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
     const p = tileCenter(5, 8, h.vs);
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y)); // Dig tap refused at the cap (unpaused)
-    expect(h.pausedFullCount()).toBe(0);
+    expect(h.pausedFullCount()).toBeGreaterThan(0); // one-shot drop → hint fires
     // The command really was refused (nothing enqueued past the cap).
     expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(0);
+  });
+
+  it('a dropped surface Command tap (rally) surfaces the hint WHILE UNPAUSED (Codex P2)', () => {
+    // The surface Command tap is another one-shot. Unpaused, a drop at the cap is
+    // still a real loss and must flash the hint.
+    const h = makeHarness('surface', 'command');
+    h.paused.value = false;
+    for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
+    const p = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y)); // SetRallyPoint refused at the cap (unpaused)
+    expect(h.pausedFullCount()).toBeGreaterThan(0);
+    expect(h.world.commandQueue.filter((c) => c.type === 'SetRallyPoint')).toHaveLength(0);
   });
 });
 

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -362,7 +362,7 @@ describe('HUD + right-click', () => {
 // ---------------------------------------------------------------------------
 
 describe('paused-queue-full surfacing', () => {
-  it('onPausedQueueFull fires when a paint tap is dropped at the cap', () => {
+  it('onPausedQueueFull fires when a paint tap is dropped at the cap WHILE PAUSED', () => {
     const h = makeHarness('underground', 'dig');
     h.paused.value = true;
     for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
@@ -370,6 +370,75 @@ describe('paused-queue-full surfacing', () => {
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y)); // Dig tap dropped at the cap
     expect(h.pausedFullCount()).toBeGreaterThan(0);
+  });
+
+  it('an UNPAUSED cap hit is SILENT — no hint (transient throttling)', () => {
+    // Same overflow, but running: the queue drains each tick and the deferred
+    // tiles re-emit on the next flush, so the hint must NOT fire.
+    const h = makeHarness('underground', 'dig');
+    h.paused.value = false;
+    for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x, p.y)); // Dig tap refused at the cap (unpaused)
+    expect(h.pausedFullCount()).toBe(0);
+    // The command really was refused (nothing enqueued past the cap).
+    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fast-stroke deferral + per-frame flushPaint (Fix 1)
+// ---------------------------------------------------------------------------
+
+describe('flushPaint drains the deferred tail', () => {
+  it('a paint move that out-runs the cap holds the cursor; a later flush re-emits', () => {
+    const h = makeHarness('underground', 'dig');
+    h.paused.value = false;
+    // Fill the queue to the cap so EVERY mark this stroke emits is refused.
+    for (let i = 0; i < 64; i++) h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: i });
+    const start = tileCenter(5, 8, h.vs);
+    const end = tileCenter(8, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // classify → paint; all marks refused
+    // Nothing got through (queue still exactly the 64 NoOps); silent (unpaused).
+    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(0);
+    expect(h.pausedFullCount()).toBe(0);
+    expect(h.arbiter.isPainting()).toBe(true); // stroke still live, cursor held
+
+    // Simulate tick() draining the queue, then the per-frame flush.
+    h.world.commandQueue.length = 0;
+    h.arbiter.flushPaint(h.world, false);
+    const marks = h.world.commandQueue
+      .filter((c) => c.type === 'MarkDigTile')
+      .map((c) => [(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
+    // The deferred tiles (5,8)..(8,8) now emit toward the stored target.
+    expect(marks.length).toBeGreaterThan(0);
+    expect(marks).toContainEqual([8, 8]); // reached the target tile
+  });
+
+  it('flushPaint is a no-op when no paint stroke is active', () => {
+    const h = makeHarness('underground', 'dig');
+    h.arbiter.flushPaint(h.world, false);
+    expect(h.world.commandQueue).toHaveLength(0);
+  });
+
+  it('flushPaint itself surfaces the hint on a paused cap refusal during drain', () => {
+    const h = makeHarness('underground', 'dig');
+    h.paused.value = true;
+    const start = tileCenter(5, 8, h.vs);
+    const end = tileCenter(8, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, end.x, end.y)); // paint a few tiles while paused
+    // Jam the queue, then move the target further so the cursor can't reach it.
+    while (h.world.commandQueue.length < 64)
+      h.world.commandQueue.push({ type: 'NoOp', issuedAtTick: 0 });
+    const far = tileCenter(12, 8, h.vs);
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, far.x, far.y)); // records target, refused at cap (fires hint)
+    // Capture the count AFTER the move so the next assertion isolates flushPaint.
+    const afterMove = h.pausedFullCount();
+    h.arbiter.flushPaint(h.world, true); // still capped, target unreached → flushPaint fires the hint
+    expect(h.pausedFullCount()).toBeGreaterThan(afterMove);
   });
 });
 

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -29,19 +29,22 @@
 // (middle/right) button down instead uses clearLeftGesture so a middle-button
 // drag-pan's isPanning claim survives. The GameScene update loop calls
 // reconcileContext() each frame to catch tool/view/colony transitions that
-// happened via keyboard between pointer events, AND flushPaint() each frame to
-// drain any dig tiles a fast stroke deferred past the MAX_COMMANDS_PER_TICK cap.
+// happened via keyboard between pointer events.
 //
 // Fast-stroke cap deferral (Fix 1): continuePaintStroke emits one MarkDigTile per
 // 4-connected step. A single fast pointer-move can emit far more than the sim's
-// 64-command/tick cap; enqueueCommand now refuses the overflow (paused OR
-// running) and continuePaintStroke holds its cursor at the last enqueued tile
-// instead of skipping ahead. The arbiter remembers the latest paint TARGET tile
-// and re-drives the stroke toward it every frame (flushPaint) plus once on
-// pointerup, so the deferred tail emits as the queue drains — no silently lost
-// tiles. The "paused queue full" hint fires only when a refusal happens WHILE
-// PAUSED (notifyCapHit); an unpaused refusal is silent throttling that catches up
-// next tick.
+// 64-command/tick cap; enqueueCommand refuses the overflow (paused OR running)
+// and continuePaintStroke holds its cursor at the last enqueued tile instead of
+// skipping ahead. The held tiles re-emit from that cursor on the NEXT
+// pointermove — during a continuous drag the queue drains between moves, so each
+// subsequent move re-drives the stroke from the held cursor and no tiles are
+// lost. There is no per-frame flush and no post-release draining: the pointer's
+// own moves are the only thing that advances the stroke. ACCEPTED narrow
+// residual: a single coalesced >64-tile pointer-move followed by an IMMEDIATE
+// release with NO intervening move can lose the tail past the cap (there is no
+// later move to re-emit it from the held cursor). The "paused queue full" hint
+// fires only when a refusal happens WHILE PAUSED (notifyCapHit); an unpaused
+// refusal is silent throttling that catches up on the next move.
 //
 // Right-click is handled here too (tool-independent): underground Solid/Open →
 // chamber menu via tryOpenChamberMenu; surface RMB → no-op. Middle button is
@@ -180,31 +183,9 @@ export class GestureArbiter {
   private snapshot: GestureSnapshot | null = null;
   /** Once the threshold is crossed, the resolved drag mode ('paint' | 'pan'); null while still a tap. */
   private dragMode: 'paint' | 'pan' | null = null;
-  /**
-   * Fix 1 — "draining" state: the left gesture has ENDED for new pointer input
-   * (pointerup of a paint stroke), but the paint stroke + target deliberately
-   * OUTLIVE the gesture so the per-frame flushPaint keeps draining the deferred
-   * tail toward the stored target across subsequent ticks (and across
-   * pause→resume) until the cursor reaches it, THEN clears. snapshot is null
-   * while draining (so onPointerMove ignores stray moves and a new pointerdown
-   * starts fresh), but dragMode stays 'paint' and paintStroke stays active so
-   * flushPaint keeps running. Set ONLY on a paint pointerup whose cursor has not
-   * yet reached the target; cleared when the cursor reaches the target, on
-   * cancelGesture (abandon), or when a new gesture supersedes it.
-   */
-  private draining = false;
   /** Last pointer position seen during a pan drag (for incremental camera delta). */
   private panLastX = 0;
   private panLastY = 0;
-  /**
-   * Latest paint TARGET tile — the tile under the pointer on the most recent
-   * paintMove. The per-frame flushPaint() re-drives continuePaintStroke toward
-   * this so a fast stroke that out-ran the MAX_COMMANDS_PER_TICK cap drains its
-   * deferred tail (≤64/tick) even if the pointer then stops. Meaningful only
-   * while a paint stroke is active; -1 = none recorded yet.
-   */
-  private paintTargetX = -1;
-  private paintTargetY = -1;
 
   /**
    * Context fingerprint captured at down + after each frame, so a keyboard-driven
@@ -264,9 +245,6 @@ export class GestureArbiter {
   private clearLeftGesture(): void {
     this.snapshot = null;
     this.dragMode = null;
-    this.draining = false;
-    this.paintTargetX = -1;
-    this.paintTargetY = -1;
     resetPaintStrokeState(this.paintStroke);
   }
 
@@ -288,53 +266,6 @@ export class GestureArbiter {
     this.ctxTool = vs.activeTool;
     this.ctxView = vs.activeView;
     this.ctxColony = vs.activeUndergroundColonyId;
-  }
-
-  /**
-   * flushPaint — called once per frame by GameScene.update() (alongside
-   * reconcileContext). While a paint stroke is active, re-drive
-   * continuePaintStroke toward the latest recorded paint TARGET tile so any
-   * tiles deferred by the MAX_COMMANDS_PER_TICK cap drain out (≤64/tick) even if
-   * the pointer has stopped moving. The whole call is a no-op once the cursor has
-   * reached the target (continuePaintStroke's same-tile debounce returns early),
-   * and a no-op when no paint stroke is active or no target has been recorded.
-   *
-   * Pass-through of the live world + paused flag mirrors paintMove. capHit is
-   * surfaced through the same paused-gated hint path.
-   */
-  flushPaint(world: WorldState, isPaused: boolean): void {
-    if (this.dragMode !== 'paint' || !this.paintStroke.active) return;
-    if (this.paintTargetX === -1 && this.paintTargetY === -1) return;
-    // Already at the target → the deferred tail is fully drained. continuePaint-
-    // Stroke would debounce to a no-op; skip the work, and if this stroke is in
-    // the post-pointerup "draining" state (Fix 1) its job is done — clear it so a
-    // finished drain doesn't linger active across frames.
-    if (
-      this.paintStroke.lastMarkedTileX === this.paintTargetX &&
-      this.paintStroke.lastMarkedTileY === this.paintTargetY
-    ) {
-      if (this.draining) this.clearLeftGesture();
-      return;
-    }
-    const capHit = continuePaintStroke(
-      this.paintStroke,
-      world,
-      this.deps.viewState,
-      this.paintTargetX,
-      this.paintTargetY,
-      isPaused,
-    );
-    this.notifyCapHit(capHit);
-    // Fix 1: if this flush drained the last of the tail (cursor reached the
-    // target) and we are draining a released stroke, clear now — the deferred
-    // tail has fully emitted, so the stroke must not persist into the next frame.
-    if (
-      this.draining &&
-      this.paintStroke.lastMarkedTileX === this.paintTargetX &&
-      this.paintStroke.lastMarkedTileY === this.paintTargetY
-    ) {
-      this.clearLeftGesture();
-    }
   }
 
   onPointerDown(ev: ArbiterPointerEvent): void {
@@ -361,13 +292,6 @@ export class GestureArbiter {
     // press on canEditWorld here would kill left-drag pan while user-paused.
     if (!this.deps.canPan() && !this.deps.canEditWorld()) return;
     if (this.deps.isPointerOverHUD(ev.x, ev.y)) return;
-
-    // Fix 1 — a new left press cleanly SUPERSEDES any still-draining paint
-    // stroke (a prior stroke released with a tail the per-frame flush hadn't
-    // finished). Clear it before arming the new snapshot so the stale stroke +
-    // target can't bleed into this gesture's flushPaint. clearLeftGesture leaves
-    // panInputState.isPanning untouched (a paint never owned it).
-    if (this.draining) this.clearLeftGesture();
 
     const world = this.deps.getWorld();
     if (!world) return;
@@ -433,10 +357,6 @@ export class GestureArbiter {
             snap.tileY,
             this.deps.isPaused(),
           );
-          // Seed the flush target at the down-tile; paintMove below overwrites it
-          // with the live tile, and subsequent moves keep it current.
-          this.paintTargetX = snap.tileX;
-          this.paintTargetY = snap.tileY;
           this.notifyCapHit(dropped);
         }
       } else {
@@ -477,35 +397,15 @@ export class GestureArbiter {
     // Drag occurred → no tap; end the gesture for new input.
     if (this.dragMode !== null) {
       if (this.dragMode === 'paint') {
-        // Fix 1 — the deferred-paint drain must OUTLIVE the gesture. The
-        // per-frame flushPaint kept the cursor caught up DURING the stroke, but
-        // on release the tail emitted by the final move (or the entire stroke,
-        // if the queue was full the whole time — the PAUSED case) may not have
-        // enqueued yet. If we cleared the stroke now (as cancelGesture does), any
-        // un-emitted tail would be lost: paint a >64-tile stroke while paused →
-        // 64 queued, rest held → release → tail vanishes on resume.
-        //
-        // Instead: do one final flush toward the stored target, then if the
-        // cursor still has not reached it, ENTER the draining state — drop only
-        // the snapshot (the gesture is over for new pointer input) but KEEP the
-        // paint stroke + target so the per-frame flushPaint keeps draining toward
-        // the target across subsequent ticks (and across pause→resume) until the
-        // cursor reaches it, at which point flushPaint clears. A new pointerdown
-        // supersedes any still-draining stroke (see onPointerDown).
-        const world = this.deps.getWorld();
-        if (world) this.flushPaint(world, this.deps.isPaused());
-        const reached =
-          this.paintStroke.lastMarkedTileX === this.paintTargetX &&
-          this.paintStroke.lastMarkedTileY === this.paintTargetY;
-        if (this.paintStroke.active && !reached) {
-          // Tail still outstanding → hand off to the per-frame drain.
-          this.snapshot = null;
-          this.draining = true;
-          return;
-        }
-        // Fully drained (or nothing to drain) → clear as before. No pan was
-        // owned by a paint stroke, so clearLeftGesture (not cancelGesture) is the
-        // right teardown — it leaves panInputState.isPanning untouched.
+        // Release ENDS the stroke — no post-release draining. Each pointermove
+        // during the drag already re-emitted any cap-deferred tiles from the held
+        // cursor (the queue drains between moves), so a continuous drag has
+        // nothing left outstanding at release. The one accepted residual is a
+        // single coalesced >64-tile move followed by an IMMEDIATE release with no
+        // intervening move: its tail past the cap is lost because there is no
+        // later move to re-drive from the held cursor. No pan was owned by a paint
+        // stroke, so clearLeftGesture (not cancelGesture) is the right teardown —
+        // it leaves panInputState.isPanning untouched.
         this.clearLeftGesture();
         return;
       }
@@ -583,10 +483,12 @@ export class GestureArbiter {
     if (!world) return;
     const cam = activeCamera(this.deps.viewState);
     const { tileX, tileY } = screenToTile(ev.x, ev.y, cam);
-    // Remember the live target so flushPaint can drain the deferred tail toward
-    // it on later frames even if the pointer stops here.
-    this.paintTargetX = tileX;
-    this.paintTargetY = tileY;
+    // A cap-deferred tail from the previous move stays held at the stroke cursor;
+    // this move re-drives continuePaintStroke from that cursor (the queue has
+    // drained between moves), so the held tiles re-emit and the stroke advances.
+    // Accepted residual: a single coalesced >64-tile move + immediate release
+    // (no later move) loses the tail past the cap — see continuePaintStroke and
+    // the file header.
     const capHit = continuePaintStroke(
       this.paintStroke,
       world,

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -155,8 +155,15 @@ export interface GestureArbiterDeps {
    * behind a request issued in the same pointerdown dispatch (cf. hotkey-policy).
    */
   isContextMenuActive: () => boolean;
-  /** Called when a command is dropped at the paused cap, to surface the hint. */
-  onPausedQueueFull?: () => void;
+  /**
+   * Called when a command is dropped at the queue cap, to surface the queue-full
+   * hint. `paused` carries the live pause state at the moment of the drop so the
+   * hint can be accurate: a PAUSED drop means the queue can't drain ("resume to
+   * continue"), while a RUNNING drop is transient throttling ("try again"). Paint
+   * only calls this while paused (an unpaused paint cap hit is silent — it re-emits
+   * on the next move); one-shot taps call it on ANY drop (no re-emit) (Codex P2).
+   */
+  onPausedQueueFull?: (paused: boolean) => void;
 }
 
 /** Return the active camera for the current view. */
@@ -226,6 +233,14 @@ export class GestureArbiter {
    * stacked keyboard+drag pan (registerDragPan only re-sets isPanning on its
    * pointerdown, never on move). When dragMode!=='pan' the arbiter does not own
    * isPanning, so it leaves the flag to whoever does.
+   *
+   * Fix 2 — cancelGesture (NOT clearLeftGesture) is what the RIGHT-button branch
+   * uses, so a right-click DURING an active left-drag pan (dragMode==='pan')
+   * releases the pan claim: right-click has no registerDragPan release handler, so
+   * without this the flag would stay set and keyboard pan would remain suppressed
+   * (the #85 lock) until another full pan or a session reset. The ownership guard
+   * keeps it safe when the left gesture was NOT panning (dragMode null → a foreign
+   * isPanning, e.g. set by some other owner, is left intact).
    */
   cancelGesture(): void {
     const ownsPan = this.dragMode === 'pan';
@@ -234,13 +249,22 @@ export class GestureArbiter {
   }
 
   /**
-   * clearLeftGesture — drop only the arbiter's OWN left-gesture state (snapshot,
-   * drag mode, paint stroke) without touching panInputState.isPanning. Used by
-   * the secondary-button branch: a middle-button down (registerDragPan's pan)
-   * runs FIRST and sets isPanning = true to claim the camera; cancelGesture's
-   * unconditional clear would then defeat the issue-#85 keyboard-pan suppression
-   * for the whole middle-drag. The arbiter never owns isPanning on a secondary
-   * button, so it must leave that flag to registerDragPan here.
+   * clearLeftGesture — drop ONLY the arbiter's own left-gesture state (snapshot,
+   * drag mode, paint stroke) WITHOUT touching panInputState.isPanning.
+   *
+   * Used by the MIDDLE-button secondary branch, where the flag must survive even
+   * when the left gesture was itself an active pan: on a middle-button down
+   * registerDragPan's pointerdown runs (and sets/keeps isPanning = true to claim
+   * the camera for the MIDDLE drag), so clearing it here — even though the left
+   * gesture "owned" a pan a moment ago — would clobber registerDragPan's fresh
+   * claim and re-open the issue-#85 stacked keyboard+middle-drag pan. The middle
+   * drag is now the owner; its own pointerup/upoutside clears the flag.
+   *
+   * This is why the right-click path uses cancelGesture (ownership-gated release)
+   * while the middle path uses clearLeftGesture (release nothing): right-click has
+   * NO successor pan claim, middle-down DOES. The paint-bail / paint-up sites also
+   * use clearLeftGesture, but there dragMode==='paint' so there is no pan claim to
+   * release anyway.
    */
   private clearLeftGesture(): void {
     this.snapshot = null;
@@ -269,15 +293,28 @@ export class GestureArbiter {
   }
 
   onPointerDown(ev: ArbiterPointerEvent): void {
-    // Secondary buttons: cancel any pending left gesture first (Codex R2-5), then
-    // dispatch the right-click chamber path. Middle is reserved for registerDragPan.
-    // Use clearLeftGesture (not cancelGesture) so we don't clear
-    // panInputState.isPanning: on a middle-button down registerDragPan has already
-    // run and set isPanning = true to claim the camera, and clobbering it here
-    // would re-open the issue-#85 stacked keyboard+middle-drag pan.
+    // Secondary buttons: abandon any pending left gesture first (Codex R2-5), then
+    // dispatch the right-click chamber path. The two buttons differ ONLY in how
+    // they treat panInputState.isPanning (Fix 2):
+    //   - MIDDLE: registerDragPan's pointerdown runs on the same event and sets
+    //     isPanning = true to claim the camera for the MIDDLE drag. Use
+    //     clearLeftGesture, which leaves the flag ALONE — even if the left gesture
+    //     was itself an active pan a moment ago — so we don't clobber
+    //     registerDragPan's fresh claim and re-open the issue-#85 stacked
+    //     keyboard+middle-drag pan. The middle drag's own pointerup clears it.
+    //   - RIGHT: there is NO successor pan claim and right-click has no
+    //     registerDragPan release handler. Use cancelGesture, whose ownership-
+    //     gated release drops isPanning IFF the LEFT gesture owned the pan
+    //     (dragMode==='pan') — otherwise keyboard pan would stay suppressed (the
+    //     #85 lock) until another full pan / session reset. A right-click while
+    //     the left gesture was NOT panning leaves a foreign isPanning intact.
     if (ev.button === MIDDLE_BUTTON || ev.button === RIGHT_BUTTON) {
-      this.clearLeftGesture();
-      if (ev.button === RIGHT_BUTTON) this.handleRightClick(ev);
+      if (ev.button === RIGHT_BUTTON) {
+        this.cancelGesture();
+        this.handleRightClick(ev);
+      } else {
+        this.clearLeftGesture();
+      }
       return;
     }
     if (ev.button !== LEFT_BUTTON) return;
@@ -362,16 +399,24 @@ export class GestureArbiter {
       } else {
         // Pan is a pure camera move, so it obeys canPan (allowed while
         // user-paused, like keyboard / middle-button pan). Bail BEFORE claiming
-        // the camera; clearLeftGesture leaves isPanning untouched (we never set
-        // it on this path, and a concurrent middle-drag may own it).
+        // the camera; clearLeftGesture leaves isPanning untouched (we have not set
+        // it yet on this path — the claim below is the only setter — and a
+        // concurrent middle-drag may own it).
         if (!this.deps.canPan()) {
           this.clearLeftGesture();
           return;
         }
         // Claim the camera so keyboard pan is suppressed for the duration.
         panInputState.isPanning = true;
-        this.panLastX = ev.x;
-        this.panLastY = ev.y;
+        // Seed the pan reference at the pointer-DOWN coords, NOT this move's
+        // coords. The first panMove below then applies the full (current − down)
+        // displacement, so a fast flick delivered as ONE coalesced move past the
+        // threshold actually moves the camera (seeding from ev here would make
+        // the first delta zero — the flick would classify as a drag but pan 0px).
+        // panMove updates panLastX/Y to the current point afterwards, so
+        // subsequent incremental moves are not double-counted.
+        this.panLastX = snap.downX;
+        this.panLastY = snap.downY;
       }
     }
 
@@ -403,9 +448,9 @@ export class GestureArbiter {
         // nothing left outstanding at release. The one accepted residual is a
         // single coalesced >64-tile move followed by an IMMEDIATE release with no
         // intervening move: its tail past the cap is lost because there is no
-        // later move to re-drive from the held cursor. No pan was owned by a paint
-        // stroke, so clearLeftGesture (not cancelGesture) is the right teardown —
-        // it leaves panInputState.isPanning untouched.
+        // later move to re-drive from the held cursor. A paint stroke never owns
+        // the pan (no isPanning claim), so clearLeftGesture (which never touches
+        // isPanning) is the right teardown here.
         this.clearLeftGesture();
         return;
       }
@@ -449,10 +494,11 @@ export class GestureArbiter {
    * nothing for the player to act on (a hint would be a spurious flash on every
    * fast stroke). While paused the queue genuinely can't drain, so the refusal is
    * actionable — resume to continue. (One-shot taps use notifyOneShotDrop, which
-   * fires on ANY drop — see below.)
+   * fires on ANY drop — see below.) This path only fires while paused, so it
+   * always passes paused=true to the hint.
    */
   private notifyCapHit(capHit: boolean): void {
-    if (capHit && this.deps.isPaused()) this.deps.onPausedQueueFull?.();
+    if (capHit && this.deps.isPaused()) this.deps.onPausedQueueFull?.(true);
   }
 
   /**
@@ -461,11 +507,13 @@ export class GestureArbiter {
    * tail on the next move), a one-shot — a surface/underground command tap, a
    * single Dig tap — does NOT re-emit: a drop at the cap is a real, silent loss.
    * So whenever enqueueCommand refuses a one-shot we flash the hint regardless of
-   * pause state. (When unpaused this is rare: the queue is momentarily full, e.g.
-   * right after a big dig-paint burst.)
+   * pause state, passing the LIVE pause state so the message is accurate: a paused
+   * drop says "resume to continue", an unpaused (transient-burst) drop says "try
+   * again". (When unpaused this is rare: the queue is momentarily full, e.g. right
+   * after a big dig-paint burst.)
    */
   private notifyOneShotDrop(dropped: boolean): void {
-    if (dropped) this.deps.onPausedQueueFull?.();
+    if (dropped) this.deps.onPausedQueueFull?.(this.deps.isPaused());
   }
 
   private dispatchTap(snap: GestureSnapshot, world: WorldState): void {

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -180,6 +180,19 @@ export class GestureArbiter {
   private snapshot: GestureSnapshot | null = null;
   /** Once the threshold is crossed, the resolved drag mode ('paint' | 'pan'); null while still a tap. */
   private dragMode: 'paint' | 'pan' | null = null;
+  /**
+   * Fix 1 — "draining" state: the left gesture has ENDED for new pointer input
+   * (pointerup of a paint stroke), but the paint stroke + target deliberately
+   * OUTLIVE the gesture so the per-frame flushPaint keeps draining the deferred
+   * tail toward the stored target across subsequent ticks (and across
+   * pause→resume) until the cursor reaches it, THEN clears. snapshot is null
+   * while draining (so onPointerMove ignores stray moves and a new pointerdown
+   * starts fresh), but dragMode stays 'paint' and paintStroke stays active so
+   * flushPaint keeps running. Set ONLY on a paint pointerup whose cursor has not
+   * yet reached the target; cleared when the cursor reaches the target, on
+   * cancelGesture (abandon), or when a new gesture supersedes it.
+   */
+  private draining = false;
   /** Last pointer position seen during a pan drag (for incremental camera delta). */
   private panLastX = 0;
   private panLastY = 0;
@@ -251,6 +264,7 @@ export class GestureArbiter {
   private clearLeftGesture(): void {
     this.snapshot = null;
     this.dragMode = null;
+    this.draining = false;
     this.paintTargetX = -1;
     this.paintTargetY = -1;
     resetPaintStrokeState(this.paintStroke);
@@ -291,12 +305,15 @@ export class GestureArbiter {
   flushPaint(world: WorldState, isPaused: boolean): void {
     if (this.dragMode !== 'paint' || !this.paintStroke.active) return;
     if (this.paintTargetX === -1 && this.paintTargetY === -1) return;
-    // Already at the target → continuePaintStroke debounces to a no-op; calling
-    // it is harmless but we can skip the work.
+    // Already at the target → the deferred tail is fully drained. continuePaint-
+    // Stroke would debounce to a no-op; skip the work, and if this stroke is in
+    // the post-pointerup "draining" state (Fix 1) its job is done — clear it so a
+    // finished drain doesn't linger active across frames.
     if (
       this.paintStroke.lastMarkedTileX === this.paintTargetX &&
       this.paintStroke.lastMarkedTileY === this.paintTargetY
     ) {
+      if (this.draining) this.clearLeftGesture();
       return;
     }
     const capHit = continuePaintStroke(
@@ -308,6 +325,16 @@ export class GestureArbiter {
       isPaused,
     );
     this.notifyCapHit(capHit);
+    // Fix 1: if this flush drained the last of the tail (cursor reached the
+    // target) and we are draining a released stroke, clear now — the deferred
+    // tail has fully emitted, so the stroke must not persist into the next frame.
+    if (
+      this.draining &&
+      this.paintStroke.lastMarkedTileX === this.paintTargetX &&
+      this.paintStroke.lastMarkedTileY === this.paintTargetY
+    ) {
+      this.clearLeftGesture();
+    }
   }
 
   onPointerDown(ev: ArbiterPointerEvent): void {
@@ -334,6 +361,13 @@ export class GestureArbiter {
     // press on canEditWorld here would kill left-drag pan while user-paused.
     if (!this.deps.canPan() && !this.deps.canEditWorld()) return;
     if (this.deps.isPointerOverHUD(ev.x, ev.y)) return;
+
+    // Fix 1 — a new left press cleanly SUPERSEDES any still-draining paint
+    // stroke (a prior stroke released with a tail the per-frame flush hadn't
+    // finished). Clear it before arming the new snapshot so the stale stroke +
+    // target can't bleed into this gesture's flushPaint. clearLeftGesture leaves
+    // panInputState.isPanning untouched (a paint never owned it).
+    if (this.draining) this.clearLeftGesture();
 
     const world = this.deps.getWorld();
     if (!world) return;
@@ -440,18 +474,42 @@ export class GestureArbiter {
       return;
     }
 
-    // Drag occurred → no tap; just end the gesture.
+    // Drag occurred → no tap; end the gesture for new input.
     if (this.dragMode !== null) {
-      // Stroke-end drain (Fix 1.3b): if this was a paint drag whose last move
-      // out-ran the cap, do one final flush toward the stored target so the
-      // tail emitted by the final move isn't stranded when the per-frame flush
-      // stops (the gesture is cancelled just below). Per-frame flushPaint kept
-      // the cursor caught up during the drag, so at most the last move's worth
-      // remains here; this clears what fits (≤ the cap as the queue drains).
       if (this.dragMode === 'paint') {
+        // Fix 1 — the deferred-paint drain must OUTLIVE the gesture. The
+        // per-frame flushPaint kept the cursor caught up DURING the stroke, but
+        // on release the tail emitted by the final move (or the entire stroke,
+        // if the queue was full the whole time — the PAUSED case) may not have
+        // enqueued yet. If we cleared the stroke now (as cancelGesture does), any
+        // un-emitted tail would be lost: paint a >64-tile stroke while paused →
+        // 64 queued, rest held → release → tail vanishes on resume.
+        //
+        // Instead: do one final flush toward the stored target, then if the
+        // cursor still has not reached it, ENTER the draining state — drop only
+        // the snapshot (the gesture is over for new pointer input) but KEEP the
+        // paint stroke + target so the per-frame flushPaint keeps draining toward
+        // the target across subsequent ticks (and across pause→resume) until the
+        // cursor reaches it, at which point flushPaint clears. A new pointerdown
+        // supersedes any still-draining stroke (see onPointerDown).
         const world = this.deps.getWorld();
         if (world) this.flushPaint(world, this.deps.isPaused());
+        const reached =
+          this.paintStroke.lastMarkedTileX === this.paintTargetX &&
+          this.paintStroke.lastMarkedTileY === this.paintTargetY;
+        if (this.paintStroke.active && !reached) {
+          // Tail still outstanding → hand off to the per-frame drain.
+          this.snapshot = null;
+          this.draining = true;
+          return;
+        }
+        // Fully drained (or nothing to drain) → clear as before. No pan was
+        // owned by a paint stroke, so clearLeftGesture (not cancelGesture) is the
+        // right teardown — it leaves panInputState.isPanning untouched.
+        this.clearLeftGesture();
+        return;
       }
+      // Pan drag: end the gesture and release the camera claim.
       this.cancelGesture();
       return;
     }

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -1,0 +1,546 @@
+// gesture-arbiter.ts — Stage 1 controls rework (issue #18): the single
+// left-button gesture arbiter (Codex R1-1).
+//
+// Before this, three independent GameScene listener sets (camera-input,
+// surface-input, underground-input) each claimed the left button. Phaser does
+// not guarantee handler order, and camera released first, so a completed pan
+// could be misread as a tap. This arbiter EXCLUSIVELY owns the left button:
+// pointerdown / move / up / upoutside. Surface & underground tap logic are pure
+// functions it calls; left-drag pan and underground-Dig paint are driven here.
+//
+// Lifecycle of one left press:
+//   down (non-HUD)  → snapshot { pointerId, downX/Y, tile, spiderHit, tool,
+//                                 view, undergroundColonyId } and arm a pending
+//                                 tap; if Dig+underground also begin a paint
+//                                 stroke (so the down-tile mark fires eagerly).
+//   move            → once past DRAG_THRESHOLD_PX, classify (PLAN §A2):
+//                       paint iff (Dig && underground), else pan.
+//                       paint → continuePaintStroke; pan → camera delta +
+//                       panInputState.isPanning = true.
+//   up (no drag)    → TAP: dispatch the pure tap fn for the SNAPSHOTTED tool/view,
+//                     acting on the SNAPSHOTTED down-tile.
+//   up (after drag) → end the gesture; no tap fires.
+//
+// cancelGesture() synchronously clears the pending tap, the paint stroke, and
+// the pan/drag state, and clears panInputState.isPanning ONLY when the arbiter
+// owns the pan (a left-drag pan). It runs on: tool/view/colony change,
+// context-menu request, modal / overlay open, gamePhase ≠ Playing, blur, and
+// pointerupoutside (PLAN §A3, Codex R1-3/R2-3/R2-5/R3-3). A secondary
+// (middle/right) button down instead uses clearLeftGesture so a middle-button
+// drag-pan's isPanning claim survives. The GameScene update loop calls
+// reconcileContext() each frame to catch tool/view/colony transitions that
+// happened via keyboard between pointer events.
+//
+// Right-click is handled here too (tool-independent): underground Solid/Open →
+// chamber menu via tryOpenChamberMenu; surface RMB → no-op. Middle button is
+// reserved for registerDragPan's pan; the arbiter just cancels the left gesture
+// when any secondary button goes down so middle-pan can't run concurrently with
+// a pending left gesture.
+//
+// All commands emitted are the SAME SimCommands as today; input enqueues through
+// enqueueCommand, never mutating WorldState. Determinism/replay unaffected.
+
+import type { WorldState } from '../sim/types.js';
+import type { ViewState, ToolId, CameraState } from '../render/camera.js';
+import { clampCamera, screenToTile } from '../render/camera.js';
+import { TILE_SIZE_PX } from '../render/sprites.js';
+import {
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
+  UNDERGROUND_GRID_WIDTH,
+  UNDERGROUND_GRID_HEIGHT,
+} from '../sim/constants.js';
+import { panInputState } from './camera-input.js';
+import { classifyDragMode, hasCrossedDragThreshold, DRAG_THRESHOLD_PX } from './gesture.js';
+import { handleSurfaceCommandTap, handleSurfaceDigTap, isSpiderHit } from './surface-input.js';
+import {
+  handleUndergroundCommandTap,
+  handleUndergroundDigTap,
+  beginPaintStroke,
+  continuePaintStroke,
+  createPaintStrokeState,
+  resetPaintStrokeState,
+  tryOpenChamberMenu,
+  type PaintStrokeState,
+} from './underground-input.js';
+
+/** Pointer button codes, matching Phaser's Pointer button accessors. */
+export const LEFT_BUTTON = 0;
+export const MIDDLE_BUTTON = 1;
+export const RIGHT_BUTTON = 2;
+
+/** A device-agnostic pointer event the arbiter core consumes (no Phaser type). */
+export interface ArbiterPointerEvent {
+  /** Phaser pointer.id — used to ignore moves/ups from a different pointer. */
+  pointerId: number;
+  /** 0 = left, 1 = middle, 2 = right. */
+  button: number;
+  /** Screen X in pixels. */
+  x: number;
+  /** Screen Y in pixels. */
+  y: number;
+}
+
+/** Snapshot taken at left pointer-down; the tap acts on these, not live state. */
+interface GestureSnapshot {
+  pointerId: number;
+  downX: number;
+  downY: number;
+  tileX: number;
+  tileY: number;
+  spiderHit: boolean;
+  tool: ToolId;
+  view: 'surface' | 'underground';
+  undergroundColonyId: ViewState['activeUndergroundColonyId'];
+}
+
+/**
+ * Everything the arbiter needs, as injectable functions/values so the core is
+ * unit-testable without Phaser.
+ */
+export interface GestureArbiterDeps {
+  /** Live world accessor (lazy — world is swapped on boot/restart). */
+  getWorld: () => WorldState | undefined;
+  /** Previous-tick world for spider hit-box widening; null when unavailable. */
+  getPrevWorld: () => WorldState | null;
+  /** Render-layer view state (active view/tool/colony + cameras). */
+  viewState: ViewState;
+  /** True if the screen point falls on a HUD zone (camera-input.isPointerOverHUD). */
+  isPointerOverHUD: (x: number, y: number) => boolean;
+  /** True if the render loop is paused (drives the enqueue paused cap). */
+  isPaused: () => boolean;
+  /**
+   * True if a world-EDITING gesture (tap / paint / chamber menu) may run. A bare
+   * user-pause must still allow these — they queue through enqueueCommand for
+   * application on resume (the whole point of the paused cap) — so this gates on
+   * "no modal open", NOT on gamePhase===Playing. A menu pause / GameOver /
+   * SavePrompt blocks it.
+   */
+  canEditWorld: () => boolean;
+  /**
+   * True if a left-drag PAN may run. Panning is a pure camera move with no world
+   * effect, so it is permitted during a bare user-pause exactly like keyboard /
+   * middle-button pan. A modal (Esc menu pause / SavePrompt / GameOver) blocks it
+   * — GameScene wires this to !isModalOpen(), the same gate as canEditWorld, so
+   * the two move together. Blocking the menu/SavePrompt case matters because the
+   * arbiter's pan runs from Phaser pointermove handlers independent of update(),
+   * and nothing resets the camera on Resume — an un-gated pan would leak the
+   * camera behind the menu and persist after it closes. Kept as a SEPARATE dep
+   * from canEditWorld so a future caller could re-split them (e.g. allow look-
+   * around but not edits) without conflating the two.
+   */
+  canPan: () => boolean;
+  /**
+   * True while the chamber context menu is up OR about to (dis)appear —
+   * contextMenuState.visible || pendingShow || pendingHide. A left press is then
+   * a menu interaction owned by UIScene's pointerdown (select / dismiss), so the
+   * arbiter must NOT also run world-tap logic on it (mirrors the retired
+   * underground-input `if (contextMenuState.visible) return;` guard). The pending
+   * flags cover the deferred-show/hide race window where `visible` lags a frame
+   * behind a request issued in the same pointerdown dispatch (cf. hotkey-policy).
+   */
+  isContextMenuActive: () => boolean;
+  /** Called when a command is dropped at the paused cap, to surface the hint. */
+  onPausedQueueFull?: () => void;
+}
+
+/** Return the active camera for the current view. */
+function activeCamera(viewState: ViewState): CameraState {
+  return viewState.activeView === 'surface' ? viewState.surfaceCamera : viewState.undergroundCamera;
+}
+
+/** Return [worldW, worldH] tile dimensions for the active view. */
+function worldDimensions(viewState: ViewState): [number, number] {
+  return viewState.activeView === 'surface'
+    ? [SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT]
+    : [UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT];
+}
+
+/**
+ * GestureArbiter — the pure core. GameScene constructs one and feeds it pointer
+ * events (via registerGestureArbiter) plus a per-frame reconcileContext() call.
+ */
+export class GestureArbiter {
+  private readonly deps: GestureArbiterDeps;
+  private readonly paintStroke: PaintStrokeState = createPaintStrokeState();
+
+  /** Snapshot of the active left press, or null when no left gesture is pending. */
+  private snapshot: GestureSnapshot | null = null;
+  /** Once the threshold is crossed, the resolved drag mode ('paint' | 'pan'); null while still a tap. */
+  private dragMode: 'paint' | 'pan' | null = null;
+  /** Last pointer position seen during a pan drag (for incremental camera delta). */
+  private panLastX = 0;
+  private panLastY = 0;
+
+  /**
+   * Context fingerprint captured at down + after each frame, so a keyboard-driven
+   * tool/view/colony change mid-press is detected and cancels the gesture.
+   */
+  private ctxTool: ToolId;
+  private ctxView: 'surface' | 'underground';
+  private ctxColony: ViewState['activeUndergroundColonyId'];
+
+  constructor(deps: GestureArbiterDeps) {
+    this.deps = deps;
+    this.ctxTool = deps.viewState.activeTool;
+    this.ctxView = deps.viewState.activeView;
+    this.ctxColony = deps.viewState.activeUndergroundColonyId;
+  }
+
+  /** Read the current entrance-hover paint-stroke cursor (debug/tests). */
+  isPainting(): boolean {
+    return this.dragMode === 'paint' && this.paintStroke.active;
+  }
+
+  /** True while a left gesture is pending (down seen, up not yet). */
+  hasPendingGesture(): boolean {
+    return this.snapshot !== null;
+  }
+
+  /**
+   * cancelGesture — synchronously abandon any in-flight left gesture: clear the
+   * pending tap (snapshot), the paint stroke, the pan/drag state, AND
+   * panInputState.isPanning IFF the arbiter currently owns the pan (a left-drag
+   * pan, dragMode==='pan'). Idempotent; safe to call when nothing is pending.
+   *
+   * The isPanning clear is guarded on ownership because that flag is a shared
+   * singleton: registerDragPan claims it for a MIDDLE-button drag-pan. Callers
+   * such as reconcileContext (tool/view/colony change) and selectTool fire on the
+   * frame a hotkey lands, which can be DURING a live middle-drag; an unconditional
+   * clear there would flip isPanning off mid-middle-drag and re-open the issue-#85
+   * stacked keyboard+drag pan (registerDragPan only re-sets isPanning on its
+   * pointerdown, never on move). When dragMode!=='pan' the arbiter does not own
+   * isPanning, so it leaves the flag to whoever does.
+   */
+  cancelGesture(): void {
+    const ownsPan = this.dragMode === 'pan';
+    this.clearLeftGesture();
+    if (ownsPan) panInputState.isPanning = false;
+  }
+
+  /**
+   * clearLeftGesture — drop only the arbiter's OWN left-gesture state (snapshot,
+   * drag mode, paint stroke) without touching panInputState.isPanning. Used by
+   * the secondary-button branch: a middle-button down (registerDragPan's pan)
+   * runs FIRST and sets isPanning = true to claim the camera; cancelGesture's
+   * unconditional clear would then defeat the issue-#85 keyboard-pan suppression
+   * for the whole middle-drag. The arbiter never owns isPanning on a secondary
+   * button, so it must leave that flag to registerDragPan here.
+   */
+  private clearLeftGesture(): void {
+    this.snapshot = null;
+    this.dragMode = null;
+    resetPaintStrokeState(this.paintStroke);
+  }
+
+  /**
+   * reconcileContext — called once per frame by GameScene. If the tool, view, or
+   * underground colony changed since the last check (e.g. via a keyboard hotkey
+   * between pointer events), cancel any in-flight gesture so a stroke/pan/tap
+   * can't act under the new context. Always refreshes the fingerprint.
+   */
+  reconcileContext(): void {
+    const vs = this.deps.viewState;
+    if (
+      vs.activeTool !== this.ctxTool ||
+      vs.activeView !== this.ctxView ||
+      vs.activeUndergroundColonyId !== this.ctxColony
+    ) {
+      this.cancelGesture();
+    }
+    this.ctxTool = vs.activeTool;
+    this.ctxView = vs.activeView;
+    this.ctxColony = vs.activeUndergroundColonyId;
+  }
+
+  onPointerDown(ev: ArbiterPointerEvent): void {
+    // Secondary buttons: cancel any pending left gesture first (Codex R2-5), then
+    // dispatch the right-click chamber path. Middle is reserved for registerDragPan.
+    // Use clearLeftGesture (not cancelGesture) so we don't clear
+    // panInputState.isPanning: on a middle-button down registerDragPan has already
+    // run and set isPanning = true to claim the camera, and clobbering it here
+    // would re-open the issue-#85 stacked keyboard+middle-drag pan.
+    if (ev.button === MIDDLE_BUTTON || ev.button === RIGHT_BUTTON) {
+      this.clearLeftGesture();
+      if (ev.button === RIGHT_BUTTON) this.handleRightClick(ev);
+      return;
+    }
+    if (ev.button !== LEFT_BUTTON) return;
+    // While the chamber context menu is up (or about to (dis)appear), a left
+    // press is a menu select/dismiss owned by UIScene's pointerdown — don't arm
+    // a snapshot, or the same click would also fire a world tap (re-open the
+    // menu / mark a dig). Mirrors the retired underground-input guard.
+    if (this.deps.isContextMenuActive()) return;
+    // Arm a snapshot if EITHER a pan or a world edit could result; the per-mode
+    // gate is re-checked when the gesture resolves (canPan in the move→pan
+    // branch, canEditWorld at paint-begin / tap dispatch). Gating the whole
+    // press on canEditWorld here would kill left-drag pan while user-paused.
+    if (!this.deps.canPan() && !this.deps.canEditWorld()) return;
+    if (this.deps.isPointerOverHUD(ev.x, ev.y)) return;
+
+    const world = this.deps.getWorld();
+    if (!world) return;
+    const vs = this.deps.viewState;
+    const cam = activeCamera(vs);
+    const { tileX, tileY } = screenToTile(ev.x, ev.y, cam);
+    const spiderHit =
+      vs.activeView === 'surface'
+        ? isSpiderHit(world, vs, ev.x, ev.y, this.deps.getPrevWorld())
+        : false;
+
+    this.snapshot = {
+      pointerId: ev.pointerId,
+      downX: ev.x,
+      downY: ev.y,
+      tileX,
+      tileY,
+      spiderHit,
+      tool: vs.activeTool,
+      view: vs.activeView,
+      undergroundColonyId: vs.activeUndergroundColonyId,
+    };
+    this.dragMode = null;
+    this.panLastX = ev.x;
+    this.panLastY = ev.y;
+
+    // Eagerly begin a paint stroke for underground-Dig so the down-tile mark
+    // fires immediately (matching the prior click-then-drag behavior). The
+    // stroke only PAINTS once the threshold is crossed; a release before then
+    // is a single-tile Dig tap (handled in onPointerUp), so we must not let the
+    // eager begin double-emit. We therefore arm the stroke lazily on the first
+    // move classified as paint instead — see onPointerMove.
+  }
+
+  onPointerMove(ev: ArbiterPointerEvent): void {
+    const snap = this.snapshot;
+    if (snap === null || ev.pointerId !== snap.pointerId) return;
+
+    // Classify on first crossing of the threshold.
+    if (this.dragMode === null) {
+      if (!hasCrossedDragThreshold(snap.downX, snap.downY, ev.x, ev.y, DRAG_THRESHOLD_PX)) {
+        return; // still a potential tap
+      }
+      this.dragMode = classifyDragMode(snap.tool, snap.view);
+      if (this.dragMode === 'paint') {
+        // Paint writes to the world, so it obeys canEditWorld (a menu pause /
+        // GameOver blocks it; a bare user-pause queues via the paused cap).
+        // Use clearLeftGesture (not cancelGesture): no pan was claimed here, so
+        // we must not touch panInputState.isPanning a concurrent owner may hold.
+        if (!this.deps.canEditWorld()) {
+          this.clearLeftGesture();
+          return;
+        }
+        const world = this.deps.getWorld();
+        if (world) {
+          // Begin the stroke at the SNAPSHOTTED down-tile so the first painted
+          // segment interpolates from there, then extend to the current tile.
+          const dropped = beginPaintStroke(
+            this.paintStroke,
+            world,
+            this.deps.viewState,
+            snap.tileX,
+            snap.tileY,
+            this.deps.isPaused(),
+          );
+          if (dropped) this.deps.onPausedQueueFull?.();
+        }
+      } else {
+        // Pan is a pure camera move, so it obeys canPan (allowed while
+        // user-paused, like keyboard / middle-button pan). Bail BEFORE claiming
+        // the camera; clearLeftGesture leaves isPanning untouched (we never set
+        // it on this path, and a concurrent middle-drag may own it).
+        if (!this.deps.canPan()) {
+          this.clearLeftGesture();
+          return;
+        }
+        // Claim the camera so keyboard pan is suppressed for the duration.
+        panInputState.isPanning = true;
+        this.panLastX = ev.x;
+        this.panLastY = ev.y;
+      }
+    }
+
+    if (this.dragMode === 'paint') {
+      this.paintMove(ev);
+    } else if (this.dragMode === 'pan') {
+      this.panMove(ev);
+    }
+  }
+
+  onPointerUp(ev: ArbiterPointerEvent): void {
+    const snap = this.snapshot;
+    if (snap === null || ev.pointerId !== snap.pointerId) {
+      // A left-up with no matching snapshot: the arbiter has no pending left
+      // gesture, so it does NOT own panInputState.isPanning here. Leave the flag
+      // alone — a concurrent MIDDLE-button drag-pan (registerDragPan) may own it,
+      // and clearing it would flip keyboard-pan suppression off mid-middle-drag
+      // (the issue-#85 stacking bug). registerDragPan's own pointerup/upoutside
+      // clears it when the middle drag ends.
+      return;
+    }
+
+    // Drag occurred → no tap; just end the gesture.
+    if (this.dragMode !== null) {
+      this.cancelGesture();
+      return;
+    }
+
+    // If the chamber context menu went up (or pending) between this gesture's
+    // down and up — e.g. a right-click opened it in the same dispatch that armed
+    // a stale left snapshot, or pendingShow/pendingHide was set — the release is
+    // part of the menu interaction; swallow the tap so it can't re-open the menu
+    // or mark a dig at the menu-anchor tile. (onPointerDown already blocks NEW
+    // presses while the menu is active; this covers the in-flight case.)
+    if (this.deps.isContextMenuActive()) {
+      this.cancelGesture();
+      return;
+    }
+
+    // No threshold crossing → TAP on the snapshotted down-tile, using the
+    // snapshotted tool/view (a later keyboard change can't retarget it — and
+    // reconcileContext would already have cancelled on such a change).
+    const world = this.deps.getWorld();
+    if (world && this.deps.canEditWorld()) {
+      this.dispatchTap(snap, world);
+    }
+    this.cancelGesture();
+  }
+
+  /** pointerupoutside / blur — abandon whatever was pending. */
+  onPointerUpOutside(): void {
+    this.cancelGesture();
+  }
+
+  // --- internals -----------------------------------------------------------
+
+  private dispatchTap(snap: GestureSnapshot, world: WorldState): void {
+    const vs = this.deps.viewState;
+    const paused = this.deps.isPaused();
+    let dropped = false;
+    if (snap.view === 'surface') {
+      if (snap.tool === 'command') {
+        dropped = handleSurfaceCommandTap(world, snap.tileX, snap.tileY, snap.spiderHit, paused);
+      } else if (snap.tool === 'dig') {
+        dropped = handleSurfaceDigTap(world, snap.tileX, snap.tileY, paused);
+      }
+      // surface Chamber is unreachable (no-op).
+    } else {
+      // underground
+      if (snap.tool === 'command') {
+        dropped = handleUndergroundCommandTap(world, vs, snap.tileX, snap.tileY, paused);
+      } else if (snap.tool === 'dig') {
+        dropped = handleUndergroundDigTap(world, vs, snap.tileX, snap.tileY, paused);
+      } else if (snap.tool === 'chamber') {
+        tryOpenChamberMenu(world, vs, snap.downX, snap.downY, snap.tileX, snap.tileY);
+      }
+    }
+    if (dropped) this.deps.onPausedQueueFull?.();
+  }
+
+  private paintMove(ev: ArbiterPointerEvent): void {
+    const world = this.deps.getWorld();
+    if (!world) return;
+    const cam = activeCamera(this.deps.viewState);
+    const { tileX, tileY } = screenToTile(ev.x, ev.y, cam);
+    const dropped = continuePaintStroke(
+      this.paintStroke,
+      world,
+      this.deps.viewState,
+      tileX,
+      tileY,
+      this.deps.isPaused(),
+    );
+    if (dropped) this.deps.onPausedQueueFull?.();
+  }
+
+  private panMove(ev: ArbiterPointerEvent): void {
+    const vs = this.deps.viewState;
+    // Suppress the camera delta over HUD but keep tracking position so the next
+    // valid move is incremental (mirrors registerDragPan's #73 fix).
+    if (this.deps.isPointerOverHUD(ev.x, ev.y)) {
+      this.panLastX = ev.x;
+      this.panLastY = ev.y;
+      return;
+    }
+    const dx = (ev.x - this.panLastX) / TILE_SIZE_PX;
+    const dy = (ev.y - this.panLastY) / TILE_SIZE_PX;
+    const cam = activeCamera(vs);
+    cam.x -= dx;
+    cam.y -= dy;
+    const [worldW, worldH] = worldDimensions(vs);
+    clampCamera(cam, worldW, worldH);
+    this.panLastX = ev.x;
+    this.panLastY = ev.y;
+  }
+
+  private handleRightClick(ev: ArbiterPointerEvent): void {
+    if (!this.deps.canEditWorld()) return;
+    const vs = this.deps.viewState;
+    if (vs.activeView !== 'underground') return; // surface RMB no-op
+    if (this.deps.isPointerOverHUD(ev.x, ev.y)) return;
+    const world = this.deps.getWorld();
+    if (!world) return;
+    const cam = activeCamera(vs);
+    const { tileX, tileY } = screenToTile(ev.x, ev.y, cam);
+    tryOpenChamberMenu(world, vs, ev.x, ev.y, tileX, tileY);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// registerGestureArbiter — Phaser glue
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire a GestureArbiter to a Phaser.Scene's pointer event bus and return it.
+ *
+ * The arbiter exclusively owns the left button; registerDragPan stays wired in
+ * parallel for the middle-button pan only (its left/Space paths are removed).
+ * Both register pointerdown — the arbiter cancels its left gesture on a
+ * middle-button down, and registerDragPan ignores left, so they don't fight.
+ *
+ * Phaser's Pointer carries `.id`, `.x`, `.y`, and `.button` (the button whose
+ * state change fired the event: 0=left, 1=middle, 2=right). We forward those as
+ * a plain ArbiterPointerEvent so the core stays Phaser-free and unit-testable.
+ *
+ * `import type` keeps Phaser out of the module runtime (this file is exercised
+ * by unit tests without a Phaser runtime via the GestureArbiter class directly).
+ */
+export function registerGestureArbiter(
+  scene: import('phaser').Scene,
+  deps: GestureArbiterDeps,
+): GestureArbiter {
+  const arbiter = new GestureArbiter(deps);
+
+  scene.input.on('pointerdown', (pointer: import('phaser').Input.Pointer) => {
+    arbiter.onPointerDown({
+      pointerId: pointer.id,
+      button: pointer.button,
+      x: pointer.x,
+      y: pointer.y,
+    });
+  });
+  scene.input.on('pointermove', (pointer: import('phaser').Input.Pointer) => {
+    // Only relevant while a button is down; the arbiter also guards on a pending
+    // snapshot, but short-circuiting here avoids per-move work on hover.
+    if (!pointer.isDown) return;
+    arbiter.onPointerMove({
+      pointerId: pointer.id,
+      button: pointer.button,
+      x: pointer.x,
+      y: pointer.y,
+    });
+  });
+  scene.input.on('pointerup', (pointer: import('phaser').Input.Pointer) => {
+    arbiter.onPointerUp({
+      pointerId: pointer.id,
+      button: pointer.button,
+      x: pointer.x,
+      y: pointer.y,
+    });
+  });
+  scene.input.on('pointerupoutside', () => {
+    arbiter.onPointerUpOutside();
+  });
+
+  return arbiter;
+}

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -29,7 +29,19 @@
 // (middle/right) button down instead uses clearLeftGesture so a middle-button
 // drag-pan's isPanning claim survives. The GameScene update loop calls
 // reconcileContext() each frame to catch tool/view/colony transitions that
-// happened via keyboard between pointer events.
+// happened via keyboard between pointer events, AND flushPaint() each frame to
+// drain any dig tiles a fast stroke deferred past the MAX_COMMANDS_PER_TICK cap.
+//
+// Fast-stroke cap deferral (Fix 1): continuePaintStroke emits one MarkDigTile per
+// 4-connected step. A single fast pointer-move can emit far more than the sim's
+// 64-command/tick cap; enqueueCommand now refuses the overflow (paused OR
+// running) and continuePaintStroke holds its cursor at the last enqueued tile
+// instead of skipping ahead. The arbiter remembers the latest paint TARGET tile
+// and re-drives the stroke toward it every frame (flushPaint) plus once on
+// pointerup, so the deferred tail emits as the queue drains — no silently lost
+// tiles. The "paused queue full" hint fires only when a refusal happens WHILE
+// PAUSED (notifyCapHit); an unpaused refusal is silent throttling that catches up
+// next tick.
 //
 // Right-click is handled here too (tool-independent): underground Solid/Open →
 // chamber menu via tryOpenChamberMenu; surface RMB → no-op. Middle button is
@@ -171,6 +183,15 @@ export class GestureArbiter {
   /** Last pointer position seen during a pan drag (for incremental camera delta). */
   private panLastX = 0;
   private panLastY = 0;
+  /**
+   * Latest paint TARGET tile — the tile under the pointer on the most recent
+   * paintMove. The per-frame flushPaint() re-drives continuePaintStroke toward
+   * this so a fast stroke that out-ran the MAX_COMMANDS_PER_TICK cap drains its
+   * deferred tail (≤64/tick) even if the pointer then stops. Meaningful only
+   * while a paint stroke is active; -1 = none recorded yet.
+   */
+  private paintTargetX = -1;
+  private paintTargetY = -1;
 
   /**
    * Context fingerprint captured at down + after each frame, so a keyboard-driven
@@ -230,6 +251,8 @@ export class GestureArbiter {
   private clearLeftGesture(): void {
     this.snapshot = null;
     this.dragMode = null;
+    this.paintTargetX = -1;
+    this.paintTargetY = -1;
     resetPaintStrokeState(this.paintStroke);
   }
 
@@ -251,6 +274,40 @@ export class GestureArbiter {
     this.ctxTool = vs.activeTool;
     this.ctxView = vs.activeView;
     this.ctxColony = vs.activeUndergroundColonyId;
+  }
+
+  /**
+   * flushPaint — called once per frame by GameScene.update() (alongside
+   * reconcileContext). While a paint stroke is active, re-drive
+   * continuePaintStroke toward the latest recorded paint TARGET tile so any
+   * tiles deferred by the MAX_COMMANDS_PER_TICK cap drain out (≤64/tick) even if
+   * the pointer has stopped moving. The whole call is a no-op once the cursor has
+   * reached the target (continuePaintStroke's same-tile debounce returns early),
+   * and a no-op when no paint stroke is active or no target has been recorded.
+   *
+   * Pass-through of the live world + paused flag mirrors paintMove. capHit is
+   * surfaced through the same paused-gated hint path.
+   */
+  flushPaint(world: WorldState, isPaused: boolean): void {
+    if (this.dragMode !== 'paint' || !this.paintStroke.active) return;
+    if (this.paintTargetX === -1 && this.paintTargetY === -1) return;
+    // Already at the target → continuePaintStroke debounces to a no-op; calling
+    // it is harmless but we can skip the work.
+    if (
+      this.paintStroke.lastMarkedTileX === this.paintTargetX &&
+      this.paintStroke.lastMarkedTileY === this.paintTargetY
+    ) {
+      return;
+    }
+    const capHit = continuePaintStroke(
+      this.paintStroke,
+      world,
+      this.deps.viewState,
+      this.paintTargetX,
+      this.paintTargetY,
+      isPaused,
+    );
+    this.notifyCapHit(capHit);
   }
 
   onPointerDown(ev: ArbiterPointerEvent): void {
@@ -342,7 +399,11 @@ export class GestureArbiter {
             snap.tileY,
             this.deps.isPaused(),
           );
-          if (dropped) this.deps.onPausedQueueFull?.();
+          // Seed the flush target at the down-tile; paintMove below overwrites it
+          // with the live tile, and subsequent moves keep it current.
+          this.paintTargetX = snap.tileX;
+          this.paintTargetY = snap.tileY;
+          this.notifyCapHit(dropped);
         }
       } else {
         // Pan is a pure camera move, so it obeys canPan (allowed while
@@ -381,6 +442,16 @@ export class GestureArbiter {
 
     // Drag occurred → no tap; just end the gesture.
     if (this.dragMode !== null) {
+      // Stroke-end drain (Fix 1.3b): if this was a paint drag whose last move
+      // out-ran the cap, do one final flush toward the stored target so the
+      // tail emitted by the final move isn't stranded when the per-frame flush
+      // stops (the gesture is cancelled just below). Per-frame flushPaint kept
+      // the cursor caught up during the drag, so at most the last move's worth
+      // remains here; this clears what fits (≤ the cap as the queue drains).
+      if (this.dragMode === 'paint') {
+        const world = this.deps.getWorld();
+        if (world) this.flushPaint(world, this.deps.isPaused());
+      }
       this.cancelGesture();
       return;
     }
@@ -413,6 +484,18 @@ export class GestureArbiter {
 
   // --- internals -----------------------------------------------------------
 
+  /**
+   * Surface the "paused queue full" hint for a cap refusal, but ONLY while
+   * paused. An UNPAUSED cap hit is silent transient throttling: the queue drains
+   * each tick and the deferred tiles re-emit on the next flush/move, so there is
+   * nothing for the player to act on (a hint would be a spurious flash on every
+   * fast stroke). While paused the queue genuinely can't drain, so the refusal is
+   * actionable — resume to continue.
+   */
+  private notifyCapHit(capHit: boolean): void {
+    if (capHit && this.deps.isPaused()) this.deps.onPausedQueueFull?.();
+  }
+
   private dispatchTap(snap: GestureSnapshot, world: WorldState): void {
     const vs = this.deps.viewState;
     const paused = this.deps.isPaused();
@@ -434,7 +517,7 @@ export class GestureArbiter {
         tryOpenChamberMenu(world, vs, snap.downX, snap.downY, snap.tileX, snap.tileY);
       }
     }
-    if (dropped) this.deps.onPausedQueueFull?.();
+    this.notifyCapHit(dropped);
   }
 
   private paintMove(ev: ArbiterPointerEvent): void {
@@ -442,7 +525,11 @@ export class GestureArbiter {
     if (!world) return;
     const cam = activeCamera(this.deps.viewState);
     const { tileX, tileY } = screenToTile(ev.x, ev.y, cam);
-    const dropped = continuePaintStroke(
+    // Remember the live target so flushPaint can drain the deferred tail toward
+    // it on later frames even if the pointer stops here.
+    this.paintTargetX = tileX;
+    this.paintTargetY = tileY;
+    const capHit = continuePaintStroke(
       this.paintStroke,
       world,
       this.deps.viewState,
@@ -450,7 +537,7 @@ export class GestureArbiter {
       tileY,
       this.deps.isPaused(),
     );
-    if (dropped) this.deps.onPausedQueueFull?.();
+    this.notifyCapHit(capHit);
   }
 
   private panMove(ev: ArbiterPointerEvent): void {

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -443,15 +443,29 @@ export class GestureArbiter {
   // --- internals -----------------------------------------------------------
 
   /**
-   * Surface the "paused queue full" hint for a cap refusal, but ONLY while
-   * paused. An UNPAUSED cap hit is silent transient throttling: the queue drains
+   * Surface the queue-full hint for a PAINT cap refusal, but ONLY while paused.
+   * An UNPAUSED paint cap hit is silent transient throttling: the queue drains
    * each tick and the deferred tiles re-emit on the next flush/move, so there is
    * nothing for the player to act on (a hint would be a spurious flash on every
    * fast stroke). While paused the queue genuinely can't drain, so the refusal is
-   * actionable — resume to continue.
+   * actionable — resume to continue. (One-shot taps use notifyOneShotDrop, which
+   * fires on ANY drop — see below.)
    */
   private notifyCapHit(capHit: boolean): void {
     if (capHit && this.deps.isPaused()) this.deps.onPausedQueueFull?.();
+  }
+
+  /**
+   * Surface the queue-full hint for a ONE-SHOT command drop, paused OR unpaused
+   * (Codex P2). Unlike paint (which holds its cursor and re-emits the deferred
+   * tail on the next move), a one-shot — a surface/underground command tap, a
+   * single Dig tap — does NOT re-emit: a drop at the cap is a real, silent loss.
+   * So whenever enqueueCommand refuses a one-shot we flash the hint regardless of
+   * pause state. (When unpaused this is rare: the queue is momentarily full, e.g.
+   * right after a big dig-paint burst.)
+   */
+  private notifyOneShotDrop(dropped: boolean): void {
+    if (dropped) this.deps.onPausedQueueFull?.();
   }
 
   private dispatchTap(snap: GestureSnapshot, world: WorldState): void {
@@ -475,7 +489,10 @@ export class GestureArbiter {
         tryOpenChamberMenu(world, vs, snap.downX, snap.downY, snap.tileX, snap.tileY);
       }
     }
-    this.notifyCapHit(dropped);
+    // A tap is a ONE-SHOT command (no re-emit): surface the hint on ANY drop,
+    // paused or not (Codex P2). Paint, by contrast, re-drives from its held
+    // cursor on the next move, so it uses the paused-only notifyCapHit.
+    this.notifyOneShotDrop(dropped);
   }
 
   private paintMove(ev: ArbiterPointerEvent): void {

--- a/src/input/gesture.test.ts
+++ b/src/input/gesture.test.ts
@@ -1,0 +1,44 @@
+// gesture.test.ts — Vitest unit tests for the pure gesture classifier (issue #18).
+
+import { describe, it, expect } from 'vitest';
+import { hasCrossedDragThreshold, classifyDragMode, DRAG_THRESHOLD_PX } from './gesture.js';
+
+describe('hasCrossedDragThreshold', () => {
+  it('false for zero movement and for movement at the threshold', () => {
+    expect(hasCrossedDragThreshold(0, 0, 0, 0)).toBe(false);
+    expect(hasCrossedDragThreshold(0, 0, DRAG_THRESHOLD_PX, 0)).toBe(false);
+    expect(hasCrossedDragThreshold(0, 0, 0, DRAG_THRESHOLD_PX)).toBe(false);
+  });
+
+  it('true once either axis exceeds the threshold', () => {
+    expect(hasCrossedDragThreshold(0, 0, DRAG_THRESHOLD_PX + 1, 0)).toBe(true);
+    expect(hasCrossedDragThreshold(0, 0, 0, DRAG_THRESHOLD_PX + 1)).toBe(true);
+  });
+
+  it('is symmetric for negative deltas (jitter in any direction)', () => {
+    expect(hasCrossedDragThreshold(100, 100, 100 - (DRAG_THRESHOLD_PX + 1), 100)).toBe(true);
+    expect(hasCrossedDragThreshold(100, 100, 100, 100 - (DRAG_THRESHOLD_PX + 1))).toBe(true);
+    // Sub-threshold jitter stays a tap.
+    expect(
+      hasCrossedDragThreshold(100, 100, 100 - DRAG_THRESHOLD_PX, 100 - DRAG_THRESHOLD_PX),
+    ).toBe(false);
+  });
+
+  it('honors a custom threshold', () => {
+    expect(hasCrossedDragThreshold(0, 0, 3, 0, 2)).toBe(true);
+    expect(hasCrossedDragThreshold(0, 0, 2, 0, 2)).toBe(false);
+  });
+});
+
+describe('classifyDragMode (the view×tool drag matrix)', () => {
+  it('paints ONLY for Dig + underground', () => {
+    expect(classifyDragMode('dig', 'underground')).toBe('paint');
+  });
+
+  it('pans for every other combination', () => {
+    expect(classifyDragMode('command', 'surface')).toBe('pan');
+    expect(classifyDragMode('command', 'underground')).toBe('pan');
+    expect(classifyDragMode('dig', 'surface')).toBe('pan');
+    expect(classifyDragMode('chamber', 'underground')).toBe('pan');
+  });
+});

--- a/src/input/gesture.ts
+++ b/src/input/gesture.ts
@@ -1,0 +1,65 @@
+// gesture.ts — Stage 1 controls rework (issue #18): pure left-button gesture
+// classification. No Phaser, no DOM — trivially unit-testable.
+//
+// The arbiter (gesture-arbiter.ts) owns the LEFT pointer button and uses these
+// pure helpers to decide, frame by frame, whether an in-flight press is:
+//   - still a potential TAP (pointer has not moved past the threshold), or
+//   - a DRAG (pointer crossed the threshold) — and if so, whether that drag is
+//     a PAINT (underground Dig) or a PAN (everything else).
+//
+// The threshold is a small pixel radius so trackpad jitter on a "click" is not
+// misread as a drag (Codex R2's tap-vs-drag concern). It is a tunable constant,
+// unit-tested at/just-below/just-above the boundary.
+
+import type { ToolId } from '../render/camera.js';
+
+/**
+ * Movement (in screen pixels, Chebyshev/max-axis distance from the down point)
+ * beyond which a left press is reclassified from a pending tap to a drag.
+ *
+ * 6px: large enough to swallow trackpad micro-movement during a physical click,
+ * small enough that an intentional drag is recognized almost immediately. Pinned
+ * here and unit-tested; fine-tuned in UAT.
+ */
+export const DRAG_THRESHOLD_PX = 6;
+
+/** The outcome of a drag, once the threshold has been crossed. */
+export type DragMode = 'paint' | 'pan';
+
+/**
+ * hasCrossedDragThreshold — true once the pointer has moved more than
+ * DRAG_THRESHOLD_PX from the down point on either axis.
+ *
+ * Uses max(|dx|,|dy|) (Chebyshev) rather than Euclidean distance: it is
+ * allocation- and sqrt-free, and the difference at a 6px radius is immaterial
+ * for this purpose. A press that never crosses this stays a tap.
+ */
+export function hasCrossedDragThreshold(
+  downX: number,
+  downY: number,
+  curX: number,
+  curY: number,
+  threshold: number = DRAG_THRESHOLD_PX,
+): boolean {
+  const dx = curX - downX;
+  const dy = curY - downY;
+  const adx = dx < 0 ? -dx : dx;
+  const ady = dy < 0 ? -dy : dy;
+  return (adx > threshold ? adx : ady) > threshold;
+}
+
+/**
+ * classifyDragMode — given the snapshotted tool + view at pointer-down, decide
+ * what a threshold-crossing drag does.
+ *
+ * The complete view×tool matrix (PLAN §A2, Codex R1-3/R2-4/R3-6) reduces to one
+ * rule: **left-drag = pan everywhere EXCEPT underground-Dig, which paints.**
+ *   - Dig + underground            → 'paint' (MarkDigTile stroke)
+ *   - Command (either view)        → 'pan'
+ *   - Dig + surface                → 'pan'
+ *   - Chamber (underground only)   → 'pan'
+ * Surface Chamber is unreachable (Chamber is underground-only), so it has no row.
+ */
+export function classifyDragMode(tool: ToolId, view: 'surface' | 'underground'): DragMode {
+  return tool === 'dig' && view === 'underground' ? 'paint' : 'pan';
+}

--- a/src/input/hotkey-policy.test.ts
+++ b/src/input/hotkey-policy.test.ts
@@ -1,0 +1,74 @@
+// hotkey-policy.test.ts — Vitest unit tests for canAcceptWorldHotkey
+// (Stage 1 controls rework, issue #18, Codex R1-11/R4-2/R4-4).
+
+import { describe, it, expect } from 'vitest';
+import { canAcceptWorldHotkey, type HotkeyPolicyDeps } from './hotkey-policy.js';
+
+function deps(overrides: Partial<HotkeyPolicyDeps> = {}): HotkeyPolicyDeps {
+  return {
+    gamePhase: 'playing',
+    modalOpen: false,
+    contextMenuVisible: false,
+    contextMenuPendingShow: false,
+    contextMenuPendingHide: false,
+    antActivityPanelVisible: false,
+    antActivityPanelPendingHide: false,
+    ...overrides,
+  };
+}
+
+describe('canAcceptWorldHotkey', () => {
+  it('accepts when Playing with no modal/menu/panel', () => {
+    expect(canAcceptWorldHotkey(deps())).toBe(true);
+  });
+
+  it('rejects when phase is not playing', () => {
+    expect(canAcceptWorldHotkey(deps({ gamePhase: 'paused' }))).toBe(false);
+    expect(canAcceptWorldHotkey(deps({ gamePhase: 'gameover' }))).toBe(false);
+    expect(canAcceptWorldHotkey(deps({ gamePhase: 'saveprompt' }))).toBe(false);
+  });
+
+  it('rejects when a modal is open', () => {
+    expect(canAcceptWorldHotkey(deps({ modalOpen: true }))).toBe(false);
+  });
+
+  it('rejects when the context menu is visible OR pending-show OR pending-hide (Codex R4-2)', () => {
+    expect(canAcceptWorldHotkey(deps({ contextMenuVisible: true }))).toBe(false);
+    expect(canAcceptWorldHotkey(deps({ contextMenuPendingShow: true }))).toBe(false);
+    expect(canAcceptWorldHotkey(deps({ contextMenuPendingHide: true }))).toBe(false);
+  });
+
+  it('rejects when the ant-activity panel is visible', () => {
+    expect(canAcceptWorldHotkey(deps({ antActivityPanelVisible: true }))).toBe(false);
+  });
+
+  // Stage 1 controls rework advisory fix: a click on a tool/speed button while
+  // the ant-activity panel is up sets pendingHide=true (deferred dismiss) but
+  // leaves visible=true for THIS dispatch. The same click then routes through
+  // this gate. It must be ACCEPTED so the action lands in one click — otherwise
+  // the first click is eaten and the user has to click twice.
+  it('accepts when the ant-activity panel is dismissing this frame (visible && pendingHide)', () => {
+    expect(
+      canAcceptWorldHotkey(
+        deps({ antActivityPanelVisible: true, antActivityPanelPendingHide: true }),
+      ),
+    ).toBe(true);
+  });
+
+  // pendingHide is only a let-through while the panel is actually up. If a stale
+  // pendingHide were set with visible=false, the gate is governed by the other
+  // flags (here: still accepted, panel is not blocking).
+  it('pendingHide alone (panel not visible) does not block', () => {
+    expect(canAcceptWorldHotkey(deps({ antActivityPanelPendingHide: true }))).toBe(true);
+  });
+
+  // The pendingHide let-through is specific to the ant panel and must NOT relax
+  // the other gates: a modal still blocks even mid-dismiss.
+  it('a modal still blocks even when the panel is dismissing', () => {
+    expect(
+      canAcceptWorldHotkey(
+        deps({ modalOpen: true, antActivityPanelVisible: true, antActivityPanelPendingHide: true }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/input/hotkey-policy.test.ts
+++ b/src/input/hotkey-policy.test.ts
@@ -32,10 +32,39 @@ describe('canAcceptWorldHotkey', () => {
     expect(canAcceptWorldHotkey(deps({ modalOpen: true }))).toBe(false);
   });
 
-  it('rejects when the context menu is visible OR pending-show OR pending-hide (Codex R4-2)', () => {
+  it('rejects when the context menu is visible OR pending-show (Codex R4-2)', () => {
     expect(canAcceptWorldHotkey(deps({ contextMenuVisible: true }))).toBe(false);
     expect(canAcceptWorldHotkey(deps({ contextMenuPendingShow: true }))).toBe(false);
-    expect(canAcceptWorldHotkey(deps({ contextMenuPendingHide: true }))).toBe(false);
+  });
+
+  // Codex P2: when the chamber menu is open and the player clicks a tool/speed
+  // HUD control OUTSIDE the menu, ui-scene requests a deferred hide
+  // (pendingHide=true, visible still true this dispatch) and the SAME click falls
+  // through to this gate. It must be ACCEPTED so the tool/speed action lands in
+  // one click — otherwise the first click only closes the menu (click-twice bug).
+  // (A click ON a menu item is intercepted upstream in ui-scene and never reaches
+  // this predicate, so relaxing pendingHide only affects the outside-click path.)
+  it('accepts when the context menu is dismissing this frame (visible && pendingHide)', () => {
+    expect(
+      canAcceptWorldHotkey(deps({ contextMenuVisible: true, contextMenuPendingHide: true })),
+    ).toBe(true);
+  });
+
+  // pendingShow keeps blocking even though pendingHide is the dismiss let-through:
+  // a pendingShow with no pendingHide is the deferred-show race and must stay shut
+  // (Codex R4-2) so a tool hotkey can't switch tools beneath a menu about to open.
+  it('still rejects when the context menu is pending-show (no pendingHide)', () => {
+    expect(canAcceptWorldHotkey(deps({ contextMenuPendingShow: true }))).toBe(false);
+  });
+
+  // The pendingHide let-through is scoped to the context-menu gate and must NOT
+  // relax the others: a modal still blocks even when the menu is dismissing.
+  it('a modal still blocks even when the context menu is dismissing (contextMenuPendingHide)', () => {
+    expect(
+      canAcceptWorldHotkey(
+        deps({ modalOpen: true, contextMenuVisible: true, contextMenuPendingHide: true }),
+      ),
+    ).toBe(false);
   });
 
   it('rejects when the ant-activity panel is visible', () => {

--- a/src/input/hotkey-policy.ts
+++ b/src/input/hotkey-policy.ts
@@ -1,0 +1,80 @@
+// hotkey-policy.ts — Stage 1 controls rework (issue #18): one predicate that
+// gates every world-affecting hotkey.
+//
+// Codex R1-11, R4-2, R4-4. Before this, the world hotkeys had divergent gates:
+//   - the 1/2/4 speed keys checked only `gamePhase === Playing`;
+//   - Tab polled JustDown every frame regardless of phase (game-scene.ts:1312-),
+//     so a Tab press behind the Esc pause menu still flipped the view;
+//   - X/P checked Playing only.
+// A single predicate, `canAcceptWorldHotkey()`, now gates 1/2/3 (tools), the
+// speed keys (= / - / numpad), Space (user pause), AND Tab (view toggle). X/P
+// are gated the same way at the call site; Esc is UIScene-owned (it is what
+// OPENS/closes the modals, so it must work while a modal is up); F9 is
+// intentionally global (debug export must work whenever a world exists).
+//
+// A hotkey is accepted iff ALL hold:
+//   - gamePhase === 'playing'                  (not Paused / GameOver / SavePrompt)
+//   - no modal overlay is open                 (pause menu / Save-Load dialog /
+//                                                survey / game-over / save-prompt)
+//   - the chamber context menu is NOT visible || pendingShow || pendingHide
+//     (the deferred-show race: requestShowContextMenu sets pendingShow=true with
+//     visible=false until the next frame, so a tool hotkey fired in that gap
+//     would switch tools beneath a menu about to appear — Codex R4-2)
+//   - the ant-activity inspector panel is NOT visible, UNLESS it is dismissing
+//     this frame (pendingHide). The panel uses a deferred hide: a click on a
+//     tool/speed button while the panel is up calls requestHideAntActivityPanel()
+//     — which sets pendingHide=true but leaves visible=true for the rest of THIS
+//     dispatch (so the dismissal click can't fall through to world input). The
+//     SAME click then routes to selectTool/onSpeedControl. If we blocked on bare
+//     `visible`, that first click would be eaten and the user would have to click
+//     twice. Treating `visible && pendingHide` as the panel-is-going-away state
+//     lets the action through in one click. (This is the dual of the context
+//     menu: there pendingHide blocks because the dismissal is a menu-item SELECT
+//     that must not also fire a tool change; here the click IS the tool action.)
+//
+// Pure: takes a plain snapshot of the relevant flags and returns a boolean. No
+// Phaser, no singleton reads inside — the caller passes today's values so the
+// predicate is trivially unit-testable across the whole matrix.
+
+/** Phase values relevant to hotkey gating (mirror of GameScene's GamePhase). */
+export type HotkeyGamePhase = 'playing' | 'paused' | 'gameover' | 'saveprompt';
+
+/** Everything canAcceptWorldHotkey needs, captured as plain values. */
+export interface HotkeyPolicyDeps {
+  /** Current GameScene phase. Only 'playing' accepts world hotkeys. */
+  gamePhase: HotkeyGamePhase;
+  /** True if any modal overlay (pause menu, Save-Load, survey, game-over, save-prompt) is open. */
+  modalOpen: boolean;
+  /** contextMenuState.visible. */
+  contextMenuVisible: boolean;
+  /** contextMenuState.pendingShow — the deferred-show race window (Codex R4-2). */
+  contextMenuPendingShow: boolean;
+  /** contextMenuState.pendingHide — symmetric deferred-hide window. */
+  contextMenuPendingHide: boolean;
+  /** antActivityPanelState.visible — the inspector panel eats clicks while up. */
+  antActivityPanelVisible: boolean;
+  /**
+   * antActivityPanelState.pendingHide — the deferred-hide window. When true the
+   * panel is being dismissed THIS dispatch (the same click that triggers a tool
+   * /speed action), so it must NOT block: see the module header.
+   */
+  antActivityPanelPendingHide: boolean;
+}
+
+/**
+ * canAcceptWorldHotkey — the single gate for 1/2/3, =/-, Space, and Tab.
+ * Returns true only when the world is interactive and no modal/menu/panel is
+ * (about to be) up.
+ */
+export function canAcceptWorldHotkey(deps: HotkeyPolicyDeps): boolean {
+  if (deps.gamePhase !== 'playing') return false;
+  if (deps.modalOpen) return false;
+  if (deps.contextMenuVisible || deps.contextMenuPendingShow || deps.contextMenuPendingHide) {
+    return false;
+  }
+  // Block while the panel is up, EXCEPT when it is dismissing this frame
+  // (pendingHide) — then the same click should both close the panel and perform
+  // the tool/speed action. See the module header for the context-menu contrast.
+  if (deps.antActivityPanelVisible && !deps.antActivityPanelPendingHide) return false;
+  return true;
+}

--- a/src/input/hotkey-policy.ts
+++ b/src/input/hotkey-policy.ts
@@ -16,10 +16,20 @@
 //   - gamePhase === 'playing'                  (not Paused / GameOver / SavePrompt)
 //   - no modal overlay is open                 (pause menu / Save-Load dialog /
 //                                                survey / game-over / save-prompt)
-//   - the chamber context menu is NOT visible || pendingShow || pendingHide
-//     (the deferred-show race: requestShowContextMenu sets pendingShow=true with
+//   - the chamber context menu is NOT (visible || pendingShow), UNLESS it is
+//     dismissing this frame (pendingHide). pendingShow stays blocking: the
+//     deferred-show race — requestShowContextMenu sets pendingShow=true with
 //     visible=false until the next frame, so a tool hotkey fired in that gap
-//     would switch tools beneath a menu about to appear — Codex R4-2)
+//     would switch tools beneath a menu about to appear (Codex R4-2). pendingHide
+//     is the DISMISS window and must NOT block: when the menu is open and the
+//     player clicks a tool/speed HUD control OUTSIDE the menu, ui-scene requests a
+//     deferred hide (requestHideContextMenu → pendingHide=true, visible still true
+//     this dispatch) and the SAME click falls through to the tool/speed handler.
+//     If we blocked on pendingHide, that first click would only close the menu and
+//     the player would have to click twice. Crucially, a click ON a menu ITEM is
+//     handled and returns early in ui-scene and never reaches this gate — so
+//     relaxing pendingHide only affects the outside-click fall-through, which is
+//     exactly the tool/speed action we want to land in one click (Codex P2).
 //   - the ant-activity inspector panel is NOT visible, UNLESS it is dismissing
 //     this frame (pendingHide). The panel uses a deferred hide: a click on a
 //     tool/speed button while the panel is up calls requestHideAntActivityPanel()
@@ -28,9 +38,10 @@
 //     SAME click then routes to selectTool/onSpeedControl. If we blocked on bare
 //     `visible`, that first click would be eaten and the user would have to click
 //     twice. Treating `visible && pendingHide` as the panel-is-going-away state
-//     lets the action through in one click. (This is the dual of the context
-//     menu: there pendingHide blocks because the dismissal is a menu-item SELECT
-//     that must not also fire a tool change; here the click IS the tool action.)
+//     lets the action through in one click. The context menu now behaves the same
+//     way (above): both treat pendingHide as "going away this frame, let the
+//     fall-through action through", since a menu-item SELECT is intercepted
+//     upstream and never reaches this predicate.
 //
 // Pure: takes a plain snapshot of the relevant flags and returns a boolean. No
 // Phaser, no singleton reads inside — the caller passes today's values so the
@@ -49,7 +60,12 @@ export interface HotkeyPolicyDeps {
   contextMenuVisible: boolean;
   /** contextMenuState.pendingShow — the deferred-show race window (Codex R4-2). */
   contextMenuPendingShow: boolean;
-  /** contextMenuState.pendingHide — symmetric deferred-hide window. */
+  /**
+   * contextMenuState.pendingHide — the deferred-hide (dismiss) window. When true
+   * the menu is going away THIS dispatch and the same outside-click should fall
+   * through to the tool/speed action, so it must NOT block (Codex P2): see the
+   * module header.
+   */
   contextMenuPendingHide: boolean;
   /** antActivityPanelState.visible — the inspector panel eats clicks while up. */
   antActivityPanelVisible: boolean;
@@ -69,7 +85,15 @@ export interface HotkeyPolicyDeps {
 export function canAcceptWorldHotkey(deps: HotkeyPolicyDeps): boolean {
   if (deps.gamePhase !== 'playing') return false;
   if (deps.modalOpen) return false;
-  if (deps.contextMenuVisible || deps.contextMenuPendingShow || deps.contextMenuPendingHide) {
+  // Block while the chamber context menu is up or about to appear, EXCEPT when
+  // it is dismissing this frame (pendingHide). pendingShow keeps blocking (the
+  // Codex R4-2 deferred-show race). pendingHide is the dismiss window: a menu-
+  // ITEM selection returns early in ui-scene and never reaches this gate, so
+  // relaxing pendingHide only affects the OUTSIDE-click fall-through (a click on
+  // a tool/speed HUD control while the menu is open) — and there the same click
+  // should both close the menu and perform the tool/speed action. See the module
+  // header for the (now-resolved) ant-panel contrast.
+  if ((deps.contextMenuVisible || deps.contextMenuPendingShow) && !deps.contextMenuPendingHide) {
     return false;
   }
   // Block while the panel is up, EXCEPT when it is dismissing this frame

--- a/src/input/surface-input.test.ts
+++ b/src/input/surface-input.test.ts
@@ -17,6 +17,7 @@ import {
   isForeignColonyEntrance,
   isValidEntranceTarget,
   isSpiderHit,
+  effectiveSpiderPriority,
   handleSurfaceCommandTap,
   handleSurfaceDigTap,
 } from './surface-input.js';
@@ -262,6 +263,81 @@ describe('handleSurfaceCommandTap priority', () => {
     const world = makeWorld({ colonies: { [PLAYER_COLONY_ID]: makeColony() } });
     handleSurfaceCommandTap(world, -1, 2, false, false);
     expect(world.commandQueue).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// effectiveSpiderPriority + paused spider-priority toggle (Codex P2)
+// ---------------------------------------------------------------------------
+
+describe('effectiveSpiderPriority', () => {
+  it('falls back to the live spiderPriorityColonyId when nothing is queued', () => {
+    const offWorld = makeWorld({ spiderPriorityColonyId: null });
+    expect(effectiveSpiderPriority(offWorld, PLAYER_COLONY_ID)).toBe(false);
+    const onWorld = makeWorld({ spiderPriorityColonyId: PLAYER_COLONY_ID });
+    expect(effectiveSpiderPriority(onWorld, PLAYER_COLONY_ID)).toBe(true);
+  });
+
+  it('reflects the LATEST queued MarkSpiderPriority for the player colony', () => {
+    const world = makeWorld({
+      spiderPriorityColonyId: null,
+      commandQueue: [
+        {
+          type: 'MarkSpiderPriority',
+          colonyId: PLAYER_COLONY_ID,
+          isPriority: true,
+          issuedAtTick: 0,
+        },
+        {
+          type: 'MarkSpiderPriority',
+          colonyId: PLAYER_COLONY_ID,
+          isPriority: false,
+          issuedAtTick: 1,
+        },
+      ],
+    });
+    // Last-queued wins (mirrors tick.ts FIFO apply order) → effectively OFF.
+    expect(effectiveSpiderPriority(world, PLAYER_COLONY_ID)).toBe(false);
+  });
+
+  it('ignores queued MarkSpiderPriority for OTHER colonies', () => {
+    const ENEMY = 2 as ColonyId;
+    const world = makeWorld({
+      spiderPriorityColonyId: null,
+      commandQueue: [
+        { type: 'MarkSpiderPriority', colonyId: ENEMY, isPriority: true, issuedAtTick: 0 },
+      ],
+    });
+    expect(effectiveSpiderPriority(world, PLAYER_COLONY_ID)).toBe(false);
+  });
+});
+
+describe('paused spider-priority tap-tap toggles correctly (Codex P2)', () => {
+  it('while PAUSED, two taps net priority-on-then-off (frozen sim, queue-aware)', () => {
+    // Bare-user-paused: the sim never advances, so spiderPriorityColonyId stays
+    // frozen at null across both taps. The toggle must resolve against the queue.
+    const world = makeWorld({ spider: makeSpider(10, 2), spiderPriorityColonyId: null });
+    handleSurfaceCommandTap(world, 10, 2, true /* spiderHit */, true /* paused */);
+    handleSurfaceCommandTap(world, 10, 2, true, true);
+    const cmds = world.commandQueue.filter((c) => c.type === 'MarkSpiderPriority') as Array<{
+      isPriority: boolean;
+    }>;
+    expect(cmds).toHaveLength(2);
+    expect(cmds[0]!.isPriority).toBe(true); // first tap turns priority ON
+    expect(cmds[1]!.isPriority).toBe(false); // second tap toggles it back OFF
+  });
+
+  it('unpaused behaviour unchanged: a single tap toggles against the live flag', () => {
+    // Priority already ON in the live world (queue empty, as it is after a tick
+    // drains) → one tap turns it OFF.
+    const world = makeWorld({
+      spider: makeSpider(10, 2),
+      spiderPriorityColonyId: PLAYER_COLONY_ID,
+    });
+    handleSurfaceCommandTap(world, 10, 2, true /* spiderHit */, false /* unpaused */);
+    const cmd = lastCmd(world) as { type: string; isPriority: boolean };
+    expect(cmd.type).toBe('MarkSpiderPriority');
+    expect(cmd.isPriority).toBe(false); // toggled OFF against the live ON flag
   });
 });
 

--- a/src/input/surface-input.test.ts
+++ b/src/input/surface-input.test.ts
@@ -18,6 +18,7 @@ import {
   isValidEntranceTarget,
   isSpiderHit,
   effectiveSpiderPriority,
+  effectiveRallyState,
   handleSurfaceCommandTap,
   handleSurfaceDigTap,
 } from './surface-input.js';
@@ -338,6 +339,92 @@ describe('paused spider-priority tap-tap toggles correctly (Codex P2)', () => {
     const cmd = lastCmd(world) as { type: string; isPriority: boolean };
     expect(cmd.type).toBe('MarkSpiderPriority');
     expect(cmd.isPriority).toBe(false); // toggled OFF against the live ON flag
+  });
+});
+
+// ---------------------------------------------------------------------------
+// effectiveRallyState + paused rally tap-tap (Codex P2)
+// ---------------------------------------------------------------------------
+
+describe('effectiveRallyState', () => {
+  it('falls back to the live rallyPoint when nothing is queued', () => {
+    const noneWorld = makeWorld({ colonies: { [PLAYER_COLONY_ID]: makeColony() } });
+    expect(effectiveRallyState(noneWorld, PLAYER_COLONY_ID)).toBeNull();
+    const setWorld = makeWorld({
+      colonies: { [PLAYER_COLONY_ID]: makeColony({ rallyPoint: { tileX: 8, tileY: 2 } }) },
+    });
+    expect(effectiveRallyState(setWorld, PLAYER_COLONY_ID)).toEqual({ tileX: 8, tileY: 2 });
+  });
+
+  it('reflects the LATEST queued Set/Clear for the player colony (last wins)', () => {
+    // A queued Set THEN Clear nets no rally; a queued Clear THEN Set nets the Set.
+    const clearLast = makeWorld({
+      colonies: { [PLAYER_COLONY_ID]: makeColony({ rallyPoint: { tileX: 1, tileY: 1 } }) },
+      commandQueue: [
+        { type: 'SetRallyPoint', colonyId: PLAYER_COLONY_ID, tileX: 8, tileY: 2, issuedAtTick: 0 },
+        { type: 'ClearRallyPoint', colonyId: PLAYER_COLONY_ID, issuedAtTick: 1 },
+      ],
+    });
+    expect(effectiveRallyState(clearLast, PLAYER_COLONY_ID)).toBeNull();
+    const setLast = makeWorld({
+      colonies: { [PLAYER_COLONY_ID]: makeColony({ rallyPoint: { tileX: 1, tileY: 1 } }) },
+      commandQueue: [
+        { type: 'ClearRallyPoint', colonyId: PLAYER_COLONY_ID, issuedAtTick: 0 },
+        { type: 'SetRallyPoint', colonyId: PLAYER_COLONY_ID, tileX: 9, tileY: 3, issuedAtTick: 1 },
+      ],
+    });
+    expect(effectiveRallyState(setLast, PLAYER_COLONY_ID)).toEqual({ tileX: 9, tileY: 3 });
+  });
+
+  it('ignores queued Set/Clear for OTHER colonies', () => {
+    const ENEMY = 2 as ColonyId;
+    const world = makeWorld({
+      colonies: { [PLAYER_COLONY_ID]: makeColony({ rallyPoint: { tileX: 4, tileY: 4 } }) },
+      commandQueue: [
+        { type: 'ClearRallyPoint', colonyId: ENEMY, issuedAtTick: 0 },
+        { type: 'SetRallyPoint', colonyId: ENEMY, tileX: 7, tileY: 7, issuedAtTick: 1 },
+      ],
+    });
+    // Enemy commands don't shadow the player's live rally.
+    expect(effectiveRallyState(world, PLAYER_COLONY_ID)).toEqual({ tileX: 4, tileY: 4 });
+  });
+});
+
+describe('paused rally tap-tap toggles correctly (Codex P2)', () => {
+  it('while PAUSED, tap-tap on an EMPTY tile nets Set then Clear (queue-aware)', () => {
+    // Bare-user-paused: the sim never advances, so playerColony.rallyPoint stays
+    // frozen at null across both taps. The clear-vs-set decision must resolve
+    // against the queue — otherwise the second tap would queue a SECOND Set.
+    const world = makeWorld({ colonies: { [PLAYER_COLONY_ID]: makeColony({ rallyPoint: null }) } });
+    handleSurfaceCommandTap(world, 20, 2, false /* spiderHit */, true /* paused */);
+    handleSurfaceCommandTap(world, 20, 2, false, true);
+    const cmds = world.commandQueue.filter(
+      (c) => c.type === 'SetRallyPoint' || c.type === 'ClearRallyPoint',
+    );
+    expect(cmds.map((c) => c.type)).toEqual(['SetRallyPoint', 'ClearRallyPoint']);
+  });
+
+  it('while PAUSED, tap-tap on the (effective) rally tile nets Clear then Set', () => {
+    // The tile already IS the live rally. First tap clears it; second tap sees the
+    // queued Clear (effective rally null) and re-sets it on the empty tile.
+    const world = makeWorld({
+      colonies: { [PLAYER_COLONY_ID]: makeColony({ rallyPoint: { tileX: 20, tileY: 2 } }) },
+    });
+    handleSurfaceCommandTap(world, 20, 2, false /* spiderHit */, true /* paused */);
+    handleSurfaceCommandTap(world, 20, 2, false, true);
+    const cmds = world.commandQueue.filter(
+      (c) => c.type === 'SetRallyPoint' || c.type === 'ClearRallyPoint',
+    );
+    expect(cmds.map((c) => c.type)).toEqual(['ClearRallyPoint', 'SetRallyPoint']);
+  });
+
+  it('unpaused behaviour unchanged: tapping the live rally tile clears it', () => {
+    // Queue empty (as after a tick drains) → effective rally equals the live one.
+    const world = makeWorld({
+      colonies: { [PLAYER_COLONY_ID]: makeColony({ rallyPoint: { tileX: 8, tileY: 2 } }) },
+    });
+    handleSurfaceCommandTap(world, 8, 2, false /* spiderHit */, false /* unpaused */);
+    expect((lastCmd(world) as { type: string }).type).toBe('ClearRallyPoint');
   });
 });
 

--- a/src/input/surface-input.test.ts
+++ b/src/input/surface-input.test.ts
@@ -1,56 +1,39 @@
-// surface-input.test.ts — Vitest unit tests for src/input/surface-input.ts
+// surface-input.test.ts — Vitest unit tests for the Stage 1 controls-rework
+// surface tap handlers (issue #18).
 //
-// Tests cover pure dispatch logic only.
-// Phaser scene integration (registerSurfaceInput) is verified by Plan 07 Playwright smoke test.
-//
-// Key invariants:
-//   - Food-pile mark pushes MarkFoodPileCommand with correct tile coords.
-//   - Entrance designation: right-click sets preview; left-click same tileX confirms.
-//   - Both handlers are no-ops when activeView !== 'surface'.
-//   - Both handlers are no-ops when pointer is over a HUD zone.
-//   - Tile out-of-bounds (tileX/Y < 0) → no command.
+// The arbiter owns the left button and calls these PURE handlers on a
+// tap-without-drag. Tests cover:
+//   - pure helpers: findFoodPileAt, isEmptySurfaceTile, isForeignColonyEntrance,
+//     isValidEntranceTarget, isSpiderHit
+//   - handleSurfaceCommandTap priority: spider → food → clear-rally →
+//     foreign-entrance → empty (Codex R1-4)
+//   - handleSurfaceDigTap: DesignateEntrance on a valid target; no-op otherwise
+//   - paused-cap: enqueueCommand drops past MAX_COMMANDS_PER_TICK while paused
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   findFoodPileAt,
-  handleSurfaceLeftClick,
-  handleSurfaceRightClick,
   isEmptySurfaceTile,
-  isValidEntranceTarget,
   isForeignColonyEntrance,
-  handleSetRallyPoint,
-  resetSurfaceInputState,
-  type SurfaceInputState,
+  isValidEntranceTarget,
+  isSpiderHit,
+  handleSurfaceCommandTap,
+  handleSurfaceDigTap,
 } from './surface-input.js';
-import { panInputState, resetPanInputStateForTests } from './camera-input.js';
-
-beforeEach(() => {
-  resetPanInputStateForTests();
-});
 import type { WorldState } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
 import { VIEWPORT_WIDTH_TILES, VIEWPORT_HEIGHT_TILES } from '../render/camera.js';
-import { HUD, TILE_SIZE_PX } from '../render/sprites.js';
-import { SPIDER_SPRITE_WIDTH, SPIDER_SPRITE_HEIGHT } from '../render/ant-sprite-layer.js';
-import {
-  PLAYER_COLONY_ID,
-  ENEMY_COLONY_ID,
-  SURFACE_GRID_WIDTH,
-  SURFACE_GRID_HEIGHT,
-} from '../sim/constants.js';
-import type { SimCommand } from '../sim/commands.js';
+import { TILE_SIZE_PX } from '../render/sprites.js';
+import { FP_ONE } from '../sim/fixed.js';
+import { SPIDER_SPRITE_WIDTH } from '../render/ant-sprite-layer.js';
+import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT, PLAYER_COLONY_ID } from '../sim/constants.js';
+import { MAX_COMMANDS_PER_TICK, type SimCommand } from '../sim/commands.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
-
-// Re-export TILE_SIZE_PX from sprites where it actually lives — camera.ts re-exports via void
-// but we need the numeric value. It is 16 per Plan 01.
-// We derive screen coords from tile coords: screenX = tile * 16 - (cam.x - vw/2) * 16
-// i.e. screenX = (tile - cam.x + vw/2) * TILE_SIZE_PX
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Build a minimal ViewState pointing to the given view, camera centered at cx,cy. */
 function makeViewState(
   view: 'surface' | 'underground' = 'surface',
   camX = 64,
@@ -58,6 +41,7 @@ function makeViewState(
 ): ViewState {
   return {
     activeView: view,
+    activeTool: view === 'surface' ? 'command' : 'dig',
     surfaceCamera: {
       x: camX,
       y: camY,
@@ -76,72 +60,37 @@ function makeViewState(
   };
 }
 
-/**
- * Convert tile coords to screen pixel coords given the surface camera at (camX, camY).
- * Mirrors the renderer's integer-tile snap (`Math.floor(cam.x - vw/2)`) so tests
- * target the pixel the player would actually see the tile at. Using the raw
- * fractional camera here caused a 1-tile drift whenever the half-viewport was
- * fractional (e.g. VIEWPORT_HEIGHT_TILES=37 → vh/2 = 18.5).
- */
-function tileToScreen(
-  tileX: number,
-  tileY: number,
-  camX: number,
-  camY: number,
-): { x: number; y: number } {
+/** tile → screen px, mirroring the renderer's integer-tile snap. */
+function tileToScreen(tileX: number, tileY: number, camX: number, camY: number) {
   const left = Math.floor(camX - VIEWPORT_WIDTH_TILES / 2);
   const top = Math.floor(camY - VIEWPORT_HEIGHT_TILES / 2);
-  const px = (tileX - left) * TILE_SIZE_PX;
-  const py = (tileY - top) * TILE_SIZE_PX;
-  return { x: px, y: py };
+  return { x: (tileX - left) * TILE_SIZE_PX, y: (tileY - top) * TILE_SIZE_PX };
 }
 
-/** Build a minimal WorldState stub with given foodPiles, colonies, and commandQueue. */
 function makeWorld(
   overrides: {
     tick?: number;
     foodPiles?: WorldState['foodPiles'];
     colonies?: WorldState['colonies'];
-    surfaceWidth?: number;
-    surfaceHeight?: number;
     spider?: WorldState['spider'];
     spiderPriorityColonyId?: WorldState['spiderPriorityColonyId'];
+    commandQueue?: SimCommand[];
   } = {},
 ): WorldState {
-  const sw = overrides.surfaceWidth ?? 128;
-  const sh = overrides.surfaceHeight ?? 4;
+  const sw = SURFACE_GRID_WIDTH;
+  const sh = SURFACE_GRID_HEIGHT;
   return {
     tick: overrides.tick ?? 0,
     rngState: 0,
     nextEntityId: 0,
-    commandQueue: [] as SimCommand[],
-    ants: {
-      posX: new Int32Array(0),
-      posY: new Int32Array(0),
-      colonyId: new Int32Array(0),
-      task: new Int32Array(0),
-      subTask: new Int32Array(0),
-      speed: new Int32Array(0),
-      foodCarrying: new Int32Array(0),
-      starvationTimer: new Int32Array(0),
-      age: new Int32Array(0),
-      alive: new Int32Array(0),
-      lifespan: new Int32Array(0),
-      zone: new Int32Array(0),
-      digTileX: new Int32Array(0),
-      digTileY: new Int32Array(0),
-      digTicksRemaining: new Int32Array(0),
-      targetPosX: new Int32Array(0),
-      targetPosY: new Int32Array(0),
-    },
+    commandQueue: overrides.commandQueue ?? ([] as SimCommand[]),
+    ants: {} as WorldState['ants'],
     colonies: overrides.colonies ?? {},
     pheromoneGrids: {},
     surface: { data: new Uint8Array(sw * sh), width: sw, height: sh },
-    // PR 4 — fully-walkable frozen terrain (all Cosmetic) so the new
-    // isValidEntranceTarget component/clearance gate treats every empty tile as a
-    // valid preview target, matching pre-PR-4 input behaviour. Tests that need a
-    // rejected target set HardBlock cells explicitly.
-    bakedSurfaceEffect: new Uint8Array(SURFACE_GRID_WIDTH * SURFACE_GRID_HEIGHT),
+    // Fully-walkable frozen terrain so every empty tile is a valid entrance
+    // target unless a test sets the component mask otherwise.
+    bakedSurfaceEffect: new Uint8Array(sw * sh),
     surfaceComponentMask: null,
     undergroundGrids: {},
     foodPiles: overrides.foodPiles ?? [],
@@ -151,1215 +100,214 @@ function makeWorld(
   } as unknown as WorldState;
 }
 
-/** Build a minimal colony record stub with an optional rally point and entrances. */
 function makeColony(
   overrides: {
     colonyId?: ColonyId;
     rallyPoint?: { tileX: number; tileY: number } | null;
     entrances?: Array<{ surfaceTileX: number; surfaceTileY: number }>;
   } = {},
-) {
+): WorldState['colonies'][number] {
+  // Only the fields the surface tap handlers read are populated; the cast keeps
+  // the stub minimal (the handlers never touch the rest of ColonyRecord).
   return {
     colonyId: overrides.colonyId ?? (PLAYER_COLONY_ID as ColonyId),
-    queenEntityId: 0,
-    queenStarvationTimer: 0,
-    foodStored: 0,
-    workerCount: 0,
-    eggCount: 0,
-    larvaeCount: 0,
-    nurseCount: 0,
-    eggs: [],
-    larvae: [],
-    workers: [],
-    chambers: [],
-    // Phase 10 / CTRL-01' (LOCKED): targetRatio is two-field {forage, fight};
-    // dig is auto-assigned via CTRL-06. Original 33/33/34 was the percentage
-    // convention; rebalanced here to 50/50 (preserves the original "balanced"
-    // semantic intent — dig:33 dropped, residual forage/fight evened).
-    // computedAllocation + taskCensus remain 4-field (WorkerAllocation per D-03).
-    targetRatio: { forage: 50, fight: 50 },
-    computedAllocation: { nurse: 0, forage: 0, dig: 0, fight: 0 },
-    taskCensus: { nurse: 0, forage: 0, dig: 0, fight: 0 },
-    defeated: false,
-    reconcileCountdown: 0,
     entrances: overrides.entrances ?? [],
     rallyPoint: overrides.rallyPoint ?? null,
-    digFlowFieldDirty: false,
-    killCount: 0,
-  };
+  } as unknown as WorldState['colonies'][number];
 }
 
-/** A SurfaceInputState equivalent (the exported interface in surface-input.ts). */
-function makeState(
-  pendingEntranceTileX: number | null = null,
-  pendingEntranceTileY: number | null = null,
-) {
-  return { pendingEntranceTileX, pendingEntranceTileY };
+function makeSpider(tileX: number, tileY: number): WorldState['spider'] {
+  return {
+    posX: tileX * FP_ONE,
+    posY: tileY * FP_ONE,
+  } as unknown as WorldState['spider'];
 }
 
 // ---------------------------------------------------------------------------
-// findFoodPileAt
+// Pure helpers
 // ---------------------------------------------------------------------------
 
 describe('findFoodPileAt', () => {
-  it('returns the pile at the exact tile coordinate', () => {
+  it('returns the pile at the tile, or null', () => {
     const world = makeWorld({
-      foodPiles: [
-        { foodPileId: 1, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
-        { foodPileId: 2, tileX: 30, tileY: 40, pickupsRemaining: 50, pickupsInitial: 50 },
-        { foodPileId: 3, tileX: 50, tileY: 60, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
+      foodPiles: [{ foodPileId: 1, tileX: 5, tileY: 2, pickupsRemaining: 9, pickupsInitial: 9 }],
     });
-    expect(findFoodPileAt(world, 30, 40)).toEqual({
-      foodPileId: 2,
-      tileX: 30,
-      tileY: 40,
-      pickupsRemaining: 50,
-      pickupsInitial: 50,
-    });
-  });
-
-  it('returns null when no pile is at the given tile', () => {
-    const world = makeWorld({
-      foodPiles: [
-        { foodPileId: 1, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    expect(findFoodPileAt(world, 11, 20)).toBeNull();
-  });
-
-  it('returns null on an empty food piles array', () => {
-    const world = makeWorld({ foodPiles: [] });
-    expect(findFoodPileAt(world, 0, 0)).toBeNull();
-  });
-
-  it('returns first match when multiple piles share coords (edge case)', () => {
-    const world = makeWorld({
-      foodPiles: [
-        { foodPileId: 1, tileX: 5, tileY: 5, pickupsRemaining: 50, pickupsInitial: 50 },
-        { foodPileId: 2, tileX: 5, tileY: 5, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const result = findFoodPileAt(world, 5, 5);
-    expect(result?.foodPileId).toBe(1);
+    expect(findFoodPileAt(world, 5, 2)?.foodPileId).toBe(1);
+    expect(findFoodPileAt(world, 6, 2)).toBeNull();
   });
 });
-
-// ---------------------------------------------------------------------------
-// handleSurfaceLeftClick — food pile mark
-// ---------------------------------------------------------------------------
-
-describe('handleSurfaceLeftClick — food pile mark', () => {
-  it('pushes MarkFoodPileCommand for a pile at the clicked tile', () => {
-    const world = makeWorld({
-      tick: 5,
-      foodPiles: [
-        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 20, 64, 64);
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as {
-      type: string;
-      colonyId: number;
-      tileX: number;
-      tileY: number;
-      issuedAtTick: number;
-    };
-    expect(cmd.type).toBe('MarkFoodPile');
-    expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
-    expect(cmd.tileX).toBe(10);
-    expect(cmd.tileY).toBe(20);
-    expect(cmd.issuedAtTick).toBe(5);
-  });
-
-  it('pushes no command when no food pile exists at the clicked tile', () => {
-    const world = makeWorld({
-      foodPiles: [{ foodPileId: 1, tileX: 5, tileY: 5, pickupsRemaining: 50, pickupsInitial: 50 }],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(6, 5, 64, 64);
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('is a no-op when activeView is underground', () => {
-    const world = makeWorld({
-      foodPiles: [
-        { foodPileId: 1, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const vs = makeViewState('underground', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 20, 64, 64);
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('is a no-op when pointer is over HUD TRIANGLE zone', () => {
-    const world = makeWorld({
-      foodPiles: [
-        { foodPileId: 1, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    // HUD.TRIANGLE zone — use a point guaranteed inside it.
-    const hudX = HUD.TRIANGLE.x + 5;
-    const hudY = HUD.TRIANGLE.y + 5;
-    handleSurfaceLeftClick(world, vs, hudX, hudY, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('is a no-op while panInputState.spaceHeld is true (Space+left-drag is pan, not world action)', () => {
-    const world = makeWorld({
-      foodPiles: [
-        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 20, 64, 64);
-    panInputState.spaceHeld = true;
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('is a no-op while panInputState.isPanning is true (mid-pan left-click is pan continuation)', () => {
-    const world = makeWorld({
-      foodPiles: [
-        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 20, 64, 64);
-    panInputState.isPanning = true;
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('is a no-op when tileX < 0 (out-of-bounds click)', () => {
-    const world = makeWorld({ foodPiles: [] });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    // Camera at x=64, vw=50 → left edge at tile (64-25)=39, screen 0
-    // Pixel -1 → tileX = floor((-1 + (64-25)*16)/16) = floor(-1/16 + 39) = 38 which is valid
-    // To get tileX<0, we need screenX such that floor(screenX/16 + (64-50/2)) < 0
-    // tileX = floor((screenX + (camX - vw/2) * TS) / TS) < 0 when screenX + (64-25)*16 < 0
-    // screenX < -624; use screenX=-640
-    handleSurfaceLeftClick(world, vs, -640, 0, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// handleSurfaceLeftClick — ant-activity popup dismissal race
-// ---------------------------------------------------------------------------
-
-describe('handleSurfaceLeftClick — ant-activity popup dismissal must not fall through', () => {
-  // Scenario reproduction:
-  //   1. Player opens the HUD ant-activity popup by clicking `Ants`.
-  //   2. Player clicks on the surface map to dismiss the popup.
-  //   3. UIScene's pointerdown handler runs first, detects the outside click,
-  //      calls requestHideAntActivityPanel() (pendingHide=true), and returns.
-  //   4. surface-input's pointerdown handler runs second in the same Phaser
-  //      dispatch — it consults isPointerOverHUD(screenX, screenY).
-  //   5. With the race fix, pendingHide short-circuits isPointerOverHUD to
-  //      return true regardless of (screenX, screenY), so handleSurfaceLeftClick
-  //      early-returns without pushing a MarkFoodPile / SetRallyPoint command.
-  it('does NOT push MarkFoodPile when pendingHide is set (popup click-away race)', async () => {
-    const { showAntActivityPanel, requestHideAntActivityPanel, hideAntActivityPanel } =
-      await import('../render/ant-activity-panel-state.js');
-    const world = makeWorld({
-      tick: 5,
-      foodPiles: [
-        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 20, 64, 64);
-
-    showAntActivityPanel();
-    requestHideAntActivityPanel();
-    try {
-      handleSurfaceLeftClick(world, vs, x, y, state);
-      expect(world.commandQueue).toHaveLength(0);
-    } finally {
-      hideAntActivityPanel();
-    }
-  });
-
-  it('does NOT push SetRallyPoint on empty-tile fallthrough when pendingHide is set', async () => {
-    const { showAntActivityPanel, requestHideAntActivityPanel, hideAntActivityPanel } =
-      await import('../render/ant-activity-panel-state.js');
-    const world = makeWorld({
-      tick: 1,
-      foodPiles: [], // empty tile → would normally trigger SetRallyPoint
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 20, 64, 64);
-
-    showAntActivityPanel();
-    requestHideAntActivityPanel();
-    try {
-      handleSurfaceLeftClick(world, vs, x, y, state);
-      expect(world.commandQueue).toHaveLength(0);
-    } finally {
-      hideAntActivityPanel();
-    }
-  });
-
-  it('does NOT push DesignateEntrance confirmation when pendingHide is set', async () => {
-    const { showAntActivityPanel, requestHideAntActivityPanel, hideAntActivityPanel } =
-      await import('../render/ant-activity-panel-state.js');
-    const world = makeWorld({ tick: 3 });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState(15, 30); // pending entrance preview at (15, 30)
-    const { x, y } = tileToScreen(15, 30, 64, 64);
-
-    showAntActivityPanel();
-    requestHideAntActivityPanel();
-    try {
-      handleSurfaceLeftClick(world, vs, x, y, state);
-      expect(world.commandQueue).toHaveLength(0);
-      // Preview also preserved — a dismissal click should not eat the
-      // player's pending entrance selection.
-      expect(state.pendingEntranceTileX).toBe(15);
-      expect(state.pendingEntranceTileY).toBe(30);
-    } finally {
-      hideAntActivityPanel();
-    }
-  });
-
-  // World-input-first dispatch order: UIScene hasn't called
-  // requestHideAntActivityPanel() yet, so pendingHide is still false while
-  // the surface-input pointerdown runs. The click must still be consumed.
-  // This is the race `isPointerOverHUD` now closes by masking on `visible`
-  // alone (not just pendingHide).
-  it('does NOT push MarkFoodPile when panel is visible and pendingHide=false (world-input-first race)', async () => {
-    const { showAntActivityPanel, hideAntActivityPanel, antActivityPanelState } =
-      await import('../render/ant-activity-panel-state.js');
-    const world = makeWorld({
-      tick: 5,
-      foodPiles: [
-        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 20, 64, 64);
-
-    showAntActivityPanel();
-    try {
-      expect(antActivityPanelState.visible).toBe(true);
-      expect(antActivityPanelState.pendingHide).toBe(false);
-      handleSurfaceLeftClick(world, vs, x, y, state);
-      expect(world.commandQueue).toHaveLength(0);
-    } finally {
-      hideAntActivityPanel();
-    }
-  });
-
-  it('does NOT push SetRallyPoint when panel is visible and pendingHide=false (world-input-first race)', async () => {
-    const { showAntActivityPanel, hideAntActivityPanel } =
-      await import('../render/ant-activity-panel-state.js');
-    const world = makeWorld({ tick: 1, foodPiles: [] });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 20, 64, 64);
-
-    showAntActivityPanel();
-    try {
-      handleSurfaceLeftClick(world, vs, x, y, state);
-      expect(world.commandQueue).toHaveLength(0);
-    } finally {
-      hideAntActivityPanel();
-    }
-  });
-
-  it('does NOT push DesignateEntrance confirmation when panel is visible and pendingHide=false (world-input-first race)', async () => {
-    const { showAntActivityPanel, hideAntActivityPanel } =
-      await import('../render/ant-activity-panel-state.js');
-    const world = makeWorld({ tick: 3 });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState(15, 30);
-    const { x, y } = tileToScreen(15, 30, 64, 64);
-
-    showAntActivityPanel();
-    try {
-      handleSurfaceLeftClick(world, vs, x, y, state);
-      expect(world.commandQueue).toHaveLength(0);
-      // Preview preserved — dismissal must not eat pending entrance state.
-      expect(state.pendingEntranceTileX).toBe(15);
-      expect(state.pendingEntranceTileY).toBe(30);
-    } finally {
-      hideAntActivityPanel();
-    }
-  });
-
-  it('right-click ALSO no-ops when panel is visible and pendingHide=false (entrance preview guard)', async () => {
-    // A right-click that would normally stage an entrance preview must be
-    // suppressed while the panel is up, regardless of listener order.
-    const { showAntActivityPanel, hideAntActivityPanel } =
-      await import('../render/ant-activity-panel-state.js');
-    const { handleSurfaceRightClick } = await import('./surface-input.js');
-    const world = makeWorld({ tick: 4, foodPiles: [] });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 20, 64, 64);
-
-    showAntActivityPanel();
-    try {
-      handleSurfaceRightClick(world, vs, x, y, state);
-      expect(world.commandQueue).toHaveLength(0);
-      expect(state.pendingEntranceTileX).toBeNull();
-      expect(state.pendingEntranceTileY).toBeNull();
-    } finally {
-      hideAntActivityPanel();
-    }
-  });
-
-  it('processes clicks normally after pendingHide is cleared (state cleanup)', async () => {
-    const { showAntActivityPanel, hideAntActivityPanel } =
-      await import('../render/ant-activity-panel-state.js');
-    const world = makeWorld({
-      tick: 5,
-      foodPiles: [
-        { foodPileId: 7, tileX: 10, tileY: 20, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 20, 64, 64);
-
-    // Simulate a full open→dismiss→next-frame cycle.
-    showAntActivityPanel();
-    hideAntActivityPanel(); // simulates applyPendingAntActivityPanelHide at next frame
-    try {
-      handleSurfaceLeftClick(world, vs, x, y, state);
-      expect(world.commandQueue).toHaveLength(1);
-      const cmd = world.commandQueue[0] as { type: string };
-      expect(cmd.type).toBe('MarkFoodPile');
-    } finally {
-      hideAntActivityPanel();
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// handleSurfaceLeftClick — entrance designation confirmation
-// ---------------------------------------------------------------------------
-
-describe('handleSurfaceLeftClick — entrance designation confirmation', () => {
-  it('pushes DesignateEntranceCommand and clears preview when clicked tile matches pending (X and Y)', () => {
-    const world = makeWorld({ tick: 3 });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState(15, 30); // pending entrance at tile (15, 30)
-    const { x, y } = tileToScreen(15, 30, 64, 64);
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as {
-      type: string;
-      colonyId: number;
-      surfaceTileX: number;
-      surfaceTileY: number;
-      issuedAtTick: number;
-    };
-    expect(cmd.type).toBe('DesignateEntrance');
-    expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
-    expect(cmd.surfaceTileX).toBe(15);
-    expect(cmd.surfaceTileY).toBe(30);
-    expect(cmd.issuedAtTick).toBe(3);
-    expect(state.pendingEntranceTileX).toBeNull();
-    expect(state.pendingEntranceTileY).toBeNull();
-  });
-
-  it('does NOT push DesignateEntrance when clicked tileX differs from pending', () => {
-    const world = makeWorld({ foodPiles: [] });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState(15, 30); // pending entrance at (15, 30)
-    const { x, y } = tileToScreen(20, 30, 64, 64); // click at tileX=20
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    // Preview persists (not cleared on mismatch)
-    expect(state.pendingEntranceTileX).toBe(15);
-    expect(state.pendingEntranceTileY).toBe(30);
-  });
-
-  it('does NOT push DesignateEntrance when clicked tileY differs from pending (same column, different row)', () => {
-    // Phase 8.5 regression guard: this was the reported "preview shows on tile
-    // A, but confirm fires on tile B in the same column" bug.
-    const world = makeWorld({ foodPiles: [] });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState(15, 30); // pending entrance at (15, 30)
-    const { x, y } = tileToScreen(15, 45, 64, 64); // same column, row 45
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    // Preview persists (not cleared on mismatch)
-    expect(state.pendingEntranceTileX).toBe(15);
-    expect(state.pendingEntranceTileY).toBe(30);
-  });
-
-  it('falls through to food-pile check when tileX does not match pending', () => {
-    const world = makeWorld({
-      foodPiles: [
-        { foodPileId: 99, tileX: 20, tileY: 30, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState(15, 30); // pending entrance at (15, 30)
-    const { x, y } = tileToScreen(20, 30, 64, 64); // click at food pile tileX=20 != 15
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    // Should push MarkFoodPile (not DesignateEntrance)
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string };
-    expect(cmd.type).toBe('MarkFoodPile');
-    // Preview still persists
-    expect(state.pendingEntranceTileX).toBe(15);
-    expect(state.pendingEntranceTileY).toBe(30);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// handleSurfaceRightClick
-// ---------------------------------------------------------------------------
-
-describe('handleSurfaceRightClick', () => {
-  it('sets pendingEntranceTileX and pendingEntranceTileY to the clicked tile', () => {
-    const world = makeWorld({ surfaceWidth: 128, surfaceHeight: 128 });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(40, 50, 64, 64);
-    handleSurfaceRightClick(world, vs, x, y, state);
-    expect(state.pendingEntranceTileX).toBe(40);
-    expect(state.pendingEntranceTileY).toBe(50);
-  });
-
-  // PR 4 — the preview must match the stricter DesignateEntrance gate, which
-  // rejects tiles outside the connected component or with a blocked clearance
-  // halo (terrain can no longer be carved at designation time). Previewing those
-  // would advertise a target confirmation silently drops.
-  it('shows NO preview when the target tile is not in the walkable component (HardBlock)', () => {
-    const world = makeWorld({ surfaceWidth: 128, surfaceHeight: 128 });
-    world.bakedSurfaceEffect[50 * SURFACE_GRID_WIDTH + 40] = 2; // HardBlock at (40,50)
-    expect(isValidEntranceTarget(world, 40, 50)).toBe(false);
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(40, 50, 64, 64);
-    handleSurfaceRightClick(world, vs, x, y, state);
-    expect(state.pendingEntranceTileX).toBeNull();
-  });
-
-  it('never mutates the world: a null component-mask cache stays null (sim/render boundary)', () => {
-    // Codex P1 regression: the preview used isSurfaceTileInComponent, whose lazy
-    // ensure wrote the memoised mask back to the world — an input-layer world
-    // mutation. The read-only path computes a transient mask and must not fill
-    // the cache.
-    const world = makeWorld({ surfaceWidth: 128, surfaceHeight: 128 });
-    expect(world.surfaceComponentMask).toBeNull();
-    expect(isValidEntranceTarget(world, 40, 50)).toBe(true);
-    expect(world.surfaceComponentMask).toBeNull();
-  });
-
-  it('shows NO preview when a clearance-halo tile is blocked (candidate itself walkable)', () => {
-    const world = makeWorld({ surfaceWidth: 128, surfaceHeight: 128 });
-    world.bakedSurfaceEffect[50 * SURFACE_GRID_WIDTH + 41] = 2; // HardBlock adjacent to (40,50)
-    expect(isValidEntranceTarget(world, 40, 50)).toBe(false); // halo not all in-component
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(40, 50, 64, 64);
-    handleSurfaceRightClick(world, vs, x, y, state);
-    expect(state.pendingEntranceTileX).toBeNull();
-  });
-
-  it('is a no-op when activeView is underground', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(40, 50, 64, 64);
-    handleSurfaceRightClick(world, vs, x, y, state);
-    expect(state.pendingEntranceTileX).toBeNull();
-  });
-
-  it('is a no-op when pointer is over HUD', () => {
-    const world = makeWorld();
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    handleSurfaceRightClick(world, vs, HUD.STATS.x + 5, HUD.STATS.y + 5, state);
-    expect(state.pendingEntranceTileX).toBeNull();
-  });
-
-  it('is a no-op when tile coords are out of bounds (tileX < 0)', () => {
-    const world = makeWorld();
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    handleSurfaceRightClick(world, vs, -640, 0, state);
-    expect(state.pendingEntranceTileX).toBeNull();
-  });
-
-  it('overwrites an existing pending entrance with the new tile (X and Y)', () => {
-    const world = makeWorld({ surfaceWidth: 128, surfaceHeight: 128 });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState(10, 20); // previous pending at (10, 20)
-    const { x, y } = tileToScreen(40, 50, 64, 64);
-    handleSurfaceRightClick(world, vs, x, y, state);
-    expect(state.pendingEntranceTileX).toBe(40);
-    expect(state.pendingEntranceTileY).toBe(50);
-  });
-
-  // Phase 9 playability bug: right-clicking a food pile was previewing an
-  // entrance box even though DesignateEntrance rejects food-pile tiles. The
-  // preview is now suppressed on any tile the sim will reject.
-  it('does NOT set entrance preview on a food pile tile', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 128,
-      foodPiles: [
-        { foodPileId: 1, tileX: 40, tileY: 50, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(40, 50, 64, 64);
-    handleSurfaceRightClick(world, vs, x, y, state);
-    expect(state.pendingEntranceTileX).toBeNull();
-    expect(state.pendingEntranceTileY).toBeNull();
-  });
-
-  it('does NOT set entrance preview on a tile already occupied by an entrance', () => {
-    const colony = makeColony({ entrances: [{ surfaceTileX: 40, surfaceTileY: 50 }] });
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 128,
-      colonies: { [PLAYER_COLONY_ID]: colony } as unknown as WorldState['colonies'],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState();
-    const { x, y } = tileToScreen(40, 50, 64, 64);
-    handleSurfaceRightClick(world, vs, x, y, state);
-    expect(state.pendingEntranceTileX).toBeNull();
-    expect(state.pendingEntranceTileY).toBeNull();
-  });
-
-  it('previewing an invalid tile does NOT clear an existing valid preview', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 128,
-      foodPiles: [
-        { foodPileId: 1, tileX: 40, tileY: 50, pickupsRemaining: 50, pickupsInitial: 50 },
-      ],
-    });
-    const vs = makeViewState('surface', 64, 64);
-    const state = makeState(10, 20); // prior valid preview
-    const { x, y } = tileToScreen(40, 50, 64, 64);
-    handleSurfaceRightClick(world, vs, x, y, state);
-    // Invalid click is a no-op — prior preview survives for the player's follow-up
-    expect(state.pendingEntranceTileX).toBe(10);
-    expect(state.pendingEntranceTileY).toBe(20);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// isEmptySurfaceTile
-// ---------------------------------------------------------------------------
 
 describe('isEmptySurfaceTile', () => {
-  it('returns true for a tile within bounds with no food pile or entrance', () => {
-    const world = makeWorld({ surfaceWidth: 128, surfaceHeight: 4 });
-    expect(isEmptySurfaceTile(world, 10, 1)).toBe(true);
-  });
-
-  it('returns false when tile has a food pile', () => {
+  it('false on a food pile / entrance / out-of-bounds; true on bare ground', () => {
     const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      foodPiles: [{ foodPileId: 1, tileX: 10, tileY: 1, pickupsRemaining: 50, pickupsInitial: 50 }],
+      foodPiles: [{ foodPileId: 1, tileX: 5, tileY: 2, pickupsRemaining: 9, pickupsInitial: 9 }],
+      colonies: {
+        [PLAYER_COLONY_ID]: makeColony({ entrances: [{ surfaceTileX: 7, surfaceTileY: 2 }] }),
+      },
     });
-    expect(isEmptySurfaceTile(world, 10, 1)).toBe(false);
-  });
-
-  it('returns false when tile is a colony entrance (plain-object colonies check)', () => {
-    const colony = makeColony({ entrances: [{ surfaceTileX: 20, surfaceTileY: 0 }] });
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      colonies: { [PLAYER_COLONY_ID]: colony } as unknown as WorldState['colonies'],
-    });
-    expect(isEmptySurfaceTile(world, 20, 0)).toBe(false);
-  });
-
-  it('returns false when tileX < 0 (out of bounds)', () => {
-    const world = makeWorld({ surfaceWidth: 128, surfaceHeight: 4 });
-    expect(isEmptySurfaceTile(world, -1, 1)).toBe(false);
-  });
-
-  it('returns false when tile is beyond surface width', () => {
-    const world = makeWorld({ surfaceWidth: 128, surfaceHeight: 4 });
-    expect(isEmptySurfaceTile(world, 128, 1)).toBe(false);
+    expect(isEmptySurfaceTile(world, 5, 2)).toBe(false); // food
+    expect(isEmptySurfaceTile(world, 7, 2)).toBe(false); // entrance
+    expect(isEmptySurfaceTile(world, -1, 2)).toBe(false); // oob
+    expect(isEmptySurfaceTile(world, 10, 2)).toBe(true); // bare
   });
 });
-
-// ---------------------------------------------------------------------------
-// surface-input rally-point fall-through (SURF-04)
-// ---------------------------------------------------------------------------
-
-describe('surface-input rally-point fall-through (SURF-04)', () => {
-  it('left-click on empty surface tile pushes SetRallyPointCommand for player colony', () => {
-    const world = makeWorld({ tick: 5, surfaceWidth: 128, surfaceHeight: 4 });
-    const vs = makeViewState('surface', 64, 2);
-    const state = makeState();
-    // Click on tile (10, 1) — within surface bounds, no food pile, no entrance
-    const { x, y } = tileToScreen(10, 1, 64, 2);
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as {
-      type: string;
-      colonyId: number;
-      tileX: number;
-      tileY: number;
-      issuedAtTick: number;
-    };
-    expect(cmd.type).toBe('SetRallyPoint');
-    expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
-    expect(cmd.tileX).toBe(10);
-    expect(cmd.tileY).toBe(1);
-    expect(cmd.issuedAtTick).toBe(5);
-  });
-
-  it('pushed SetRallyPointCommand carries issuedAtTick = world.tick', () => {
-    const world = makeWorld({ tick: 42, surfaceWidth: 128, surfaceHeight: 4 });
-    const vs = makeViewState('surface', 64, 2);
-    const state = makeState();
-    const { x, y } = tileToScreen(5, 1, 64, 2);
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    const cmd = world.commandQueue[0] as { issuedAtTick: number };
-    expect(cmd.issuedAtTick).toBe(42);
-  });
-
-  it('does NOT push SetRallyPoint when tile has a food pile', () => {
-    const world = makeWorld({
-      tick: 0,
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      foodPiles: [{ foodPileId: 1, tileX: 10, tileY: 1, pickupsRemaining: 50, pickupsInitial: 50 }],
-    });
-    const vs = makeViewState('surface', 64, 2);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 1, 64, 2);
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    // Should push MarkFoodPile, not SetRallyPoint
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string };
-    expect(cmd.type).toBe('MarkFoodPile');
-  });
-
-  it('does NOT push SetRallyPoint when tile is an existing entrance', () => {
-    const colony = makeColony({ entrances: [{ surfaceTileX: 10, surfaceTileY: 0 }] });
-    const world = makeWorld({
-      tick: 0,
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      colonies: { [PLAYER_COLONY_ID]: colony } as unknown as WorldState['colonies'],
-    });
-    const vs = makeViewState('surface', 64, 2);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 0, 64, 2);
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('right-click on current rallyPoint pushes ClearRallyPointCommand', () => {
-    const colony = makeColony({ rallyPoint: { tileX: 15, tileY: 1 } });
-    const world = makeWorld({
-      tick: 7,
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      colonies: { [PLAYER_COLONY_ID]: colony } as unknown as WorldState['colonies'],
-    });
-    const vs = makeViewState('surface', 64, 2);
-    const state = makeState();
-    const { x, y } = tileToScreen(15, 1, 64, 2);
-    handleSurfaceRightClick(world, vs, x, y, state, PLAYER_COLONY_ID as ColonyId);
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; colonyId: number; issuedAtTick: number };
-    expect(cmd.type).toBe('ClearRallyPoint');
-    expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
-    expect(cmd.issuedAtTick).toBe(7);
-  });
-
-  it('right-click elsewhere does NOT clear rally (sets entrance preview instead)', () => {
-    const colony = makeColony({ rallyPoint: { tileX: 15, tileY: 1 } });
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      colonies: { [PLAYER_COLONY_ID]: colony } as unknown as WorldState['colonies'],
-    });
-    const vs = makeViewState('surface', 64, 2);
-    const state = makeState();
-    // Click at different tile (20, 1) — not the rally point
-    const { x, y } = tileToScreen(20, 1, 64, 2);
-    handleSurfaceRightClick(world, vs, x, y, state, PLAYER_COLONY_ID as ColonyId);
-    expect(world.commandQueue).toHaveLength(0);
-    // Should set entrance preview instead
-    expect(state.pendingEntranceTileX).toBe(20);
-  });
-
-  it('empty-tile click has colonyId === playerColonyId (never AI colonyId)', () => {
-    const world = makeWorld({ tick: 0, surfaceWidth: 128, surfaceHeight: 4 });
-    const vs = makeViewState('surface', 64, 2);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 1, 64, 2);
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    if (world.commandQueue.length > 0) {
-      const cmd = world.commandQueue[0] as { colonyId: number };
-      expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
-    }
-  });
-
-  it('handleSetRallyPoint pushes SetRallyPointCommand with correct fields', () => {
-    const world = makeWorld({ tick: 3 });
-    handleSetRallyPoint(world, 7, 2, PLAYER_COLONY_ID as ColonyId);
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as {
-      type: string;
-      colonyId: number;
-      tileX: number;
-      tileY: number;
-      issuedAtTick: number;
-    };
-    expect(cmd.type).toBe('SetRallyPoint');
-    expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
-    expect(cmd.tileX).toBe(7);
-    expect(cmd.tileY).toBe(2);
-    expect(cmd.issuedAtTick).toBe(3);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Issue #14 — invade enemy hive: rally on enemy entrance
-// ---------------------------------------------------------------------------
 
 describe('isForeignColonyEntrance', () => {
-  it('returns true for an enemy entrance tile', () => {
-    const enemy = makeColony({
-      colonyId: ENEMY_COLONY_ID as ColonyId,
-      entrances: [{ surfaceTileX: 100, surfaceTileY: 0 }],
-    });
+  it('true only for an entrance owned by another colony', () => {
+    const ENEMY = 2 as ColonyId;
     const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
-    });
-    expect(isForeignColonyEntrance(world, 100, 0, PLAYER_COLONY_ID as ColonyId)).toBe(true);
-  });
-
-  it('returns false for the own-colony entrance tile (preserves designation flow)', () => {
-    const own = makeColony({ entrances: [{ surfaceTileX: 20, surfaceTileY: 0 }] });
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      colonies: { [PLAYER_COLONY_ID]: own } as unknown as WorldState['colonies'],
-    });
-    expect(isForeignColonyEntrance(world, 20, 0, PLAYER_COLONY_ID as ColonyId)).toBe(false);
-  });
-
-  it('returns false for a tile with no entrance on it', () => {
-    const enemy = makeColony({
-      colonyId: ENEMY_COLONY_ID as ColonyId,
-      entrances: [{ surfaceTileX: 100, surfaceTileY: 0 }],
-    });
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
-    });
-    expect(isForeignColonyEntrance(world, 50, 1, PLAYER_COLONY_ID as ColonyId)).toBe(false);
-  });
-
-  it('returns false for out-of-bounds tile', () => {
-    const enemy = makeColony({
-      colonyId: ENEMY_COLONY_ID as ColonyId,
-      entrances: [{ surfaceTileX: 100, surfaceTileY: 0 }],
-    });
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
-    });
-    expect(isForeignColonyEntrance(world, -1, 0, PLAYER_COLONY_ID as ColonyId)).toBe(false);
-    expect(isForeignColonyEntrance(world, 200, 0, PLAYER_COLONY_ID as ColonyId)).toBe(false);
-  });
-});
-
-describe('handleSurfaceLeftClick — rally on enemy entrance (issue #14)', () => {
-  it('left-click on enemy entrance pushes SetRallyPointCommand for the player colony', () => {
-    const enemy = makeColony({
-      colonyId: ENEMY_COLONY_ID as ColonyId,
-      entrances: [{ surfaceTileX: 100, surfaceTileY: 0 }],
-    });
-    const world = makeWorld({
-      tick: 7,
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      colonies: { [ENEMY_COLONY_ID]: enemy } as unknown as WorldState['colonies'],
-    });
-    const vs = makeViewState('surface', 64, 2);
-    const state = makeState();
-    const { x, y } = tileToScreen(100, 0, 64, 2);
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as {
-      type: string;
-      colonyId: number;
-      tileX: number;
-      tileY: number;
-      issuedAtTick: number;
-    };
-    expect(cmd.type).toBe('SetRallyPoint');
-    expect(cmd.colonyId).toBe(PLAYER_COLONY_ID); // rally is the PLAYER's, not the enemy's
-    expect(cmd.tileX).toBe(100);
-    expect(cmd.tileY).toBe(0);
-    expect(cmd.issuedAtTick).toBe(7);
-  });
-
-  it('left-click on own entrance is still a no-op (entrance designation right-click flow undisturbed)', () => {
-    const own = makeColony({ entrances: [{ surfaceTileX: 20, surfaceTileY: 0 }] });
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 4,
-      colonies: { [PLAYER_COLONY_ID]: own } as unknown as WorldState['colonies'],
-    });
-    const vs = makeViewState('surface', 64, 2);
-    const state = makeState();
-    const { x, y } = tileToScreen(20, 0, 64, 2);
-    handleSurfaceLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// resetSurfaceInputState — Phase 9 session reset
-// ---------------------------------------------------------------------------
-
-describe('resetSurfaceInputState', () => {
-  it('clears a pending entrance-preview set by a prior right-click', () => {
-    const state: SurfaceInputState = { pendingEntranceTileX: 12, pendingEntranceTileY: 3 };
-    resetSurfaceInputState(state);
-    expect(state.pendingEntranceTileX).toBeNull();
-    expect(state.pendingEntranceTileY).toBeNull();
-  });
-
-  it('preserves the state object identity (mutates in place)', () => {
-    // Required so registerSurfaceInput's closure keeps seeing the same state.
-    const state: SurfaceInputState = { pendingEntranceTileX: 1, pendingEntranceTileY: 1 };
-    const ref = state;
-    resetSurfaceInputState(state);
-    expect(state).toBe(ref);
-  });
-
-  it('is idempotent on an already-cleared state', () => {
-    const state: SurfaceInputState = { pendingEntranceTileX: null, pendingEntranceTileY: null };
-    resetSurfaceInputState(state);
-    expect(state.pendingEntranceTileX).toBeNull();
-    expect(state.pendingEntranceTileY).toBeNull();
-  });
-
-  it('restart simulation: after reset a fresh right-click still sets preview', () => {
-    const state: SurfaceInputState = { pendingEntranceTileX: 5, pendingEntranceTileY: 5 };
-    resetSurfaceInputState(state);
-    const world = makeWorld({ surfaceWidth: 128, surfaceHeight: 64 });
-    const vs = makeViewState('surface', 64, 32);
-    const tile = tileToScreen(20, 10, 64, 32);
-    handleSurfaceRightClick(world, vs, tile.x, tile.y, state);
-    expect(state.pendingEntranceTileX).toBe(20);
-    expect(state.pendingEntranceTileY).toBe(10);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// handleSurfaceRightClick — spider priority (S7/D1)
-// ---------------------------------------------------------------------------
-// Spider at tile (10, 10). FP_ONE=256, so posX=2560, posY=2560.
-// camLeft = floor(64 - 25) = 39, camTop = floor(32 - 18.5) = 13
-// spiderScrX = (10 - 39) * 16 = -464, spiderScrY = (10 - 13) * 16 = -48
-// Stationary hit box (prevWorld=null): sprite half = 24 on each side.
-// Inclusive left edge: spiderScrX - 24 = -488; exclusive right: spiderScrX + 24 = -440
-// Moving hit box (prevWorld with spider 1 tile to the left): union expands left by 16px.
-
-describe('handleSurfaceRightClick — spider priority toggle (S7/D1)', () => {
-  const CAM_X = 64;
-  const CAM_Y = 32;
-  const FP_ONE_VAL = 256;
-  const SPIDER_TILE_X = 10;
-  const SPIDER_TILE_Y = 10;
-  const CAMERA_LEFT = Math.floor(CAM_X - VIEWPORT_WIDTH_TILES / 2); // 39
-  const CAMERA_TOP = Math.floor(CAM_Y - VIEWPORT_HEIGHT_TILES / 2); // 13
-  const SPIDER_SCR_X = (SPIDER_TILE_X - CAMERA_LEFT) * TILE_SIZE_PX; // -464
-  const SPIDER_SCR_Y = (SPIDER_TILE_Y - CAMERA_TOP) * TILE_SIZE_PX; // -48
-  // Sprite half: hit box for stationary spider (prevWorld=null)
-  const HIT_HALF_W = SPIDER_SPRITE_WIDTH / 2; // 24
-  const HIT_HALF_H = SPIDER_SPRITE_HEIGHT / 2; // 24
-
-  function makeSpider() {
-    return {
-      posX: SPIDER_TILE_X * FP_ONE_VAL,
-      posY: SPIDER_TILE_Y * FP_ONE_VAL,
-    } as WorldState['spider'];
-  }
-
-  it('center click dispatches MarkSpiderPriority { isPriority: true } when not yet prioritized', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X, SPIDER_SCR_Y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    expect(world.commandQueue[0]).toMatchObject({ type: 'MarkSpiderPriority', isPriority: true });
-  });
-
-  it('center click dispatches MarkSpiderPriority { isPriority: false } when already prioritized', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: PLAYER_COLONY_ID,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X, SPIDER_SCR_Y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    expect(world.commandQueue[0]).toMatchObject({ type: 'MarkSpiderPriority', isPriority: false });
-  });
-
-  it('click at inclusive left sprite edge (spiderScrX - HIT_HALF_W) dispatches spider priority', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X - HIT_HALF_W, SPIDER_SCR_Y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    expect(world.commandQueue[0]).toMatchObject({ type: 'MarkSpiderPriority' });
-  });
-
-  it('click one pixel outside left sprite edge (spiderScrX - HIT_HALF_W - 1) falls through to entrance preview', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    // screenX = -489 → tileX = floor(-489/16) + 39 = -31 + 39 = 8; tileY = 10
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X - HIT_HALF_W - 1, SPIDER_SCR_Y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.pendingEntranceTileX).toBe(8);
-  });
-
-  it('click at last pixel inside right sprite edge (spiderScrX + HIT_HALF_W - 1) dispatches spider priority', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X + HIT_HALF_W - 1, SPIDER_SCR_Y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    expect(world.commandQueue[0]).toMatchObject({ type: 'MarkSpiderPriority' });
-  });
-
-  it('click at exclusive right sprite edge (spiderScrX + HIT_HALF_W) falls through to entrance preview', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    // screenX = -440 → tileX = floor(-440/16) + 39 = -28 + 39 = 11; tileY = 10
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X + HIT_HALF_W, SPIDER_SCR_Y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.pendingEntranceTileX).toBe(11);
-  });
-
-  it('click at inclusive top sprite edge (spiderScrY - HIT_HALF_H) dispatches spider priority', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X, SPIDER_SCR_Y - HIT_HALF_H, state);
-    expect(world.commandQueue).toHaveLength(1);
-    expect(world.commandQueue[0]).toMatchObject({ type: 'MarkSpiderPriority' });
-  });
-
-  it('click one pixel outside top sprite edge (spiderScrY - HIT_HALF_H - 1) falls through to entrance preview', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    // screenY = -73 → tileY = floor(-73/16) + 13 = -5 + 13 = 8; tileX = 10
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X, SPIDER_SCR_Y - HIT_HALF_H - 1, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.pendingEntranceTileY).toBe(8);
-  });
-
-  it('click at exclusive bottom sprite edge (spiderScrY + HIT_HALF_H) falls through to entrance preview', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    // screenY = -24 → tileY = floor(-24/16) + 13 = -2 + 13 = 11; tileX = 10
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X, SPIDER_SCR_Y + HIT_HALF_H, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.pendingEntranceTileY).toBe(11);
-  });
-
-  it('union hit box: trailing edge covered when spider moved right by 1 tile', () => {
-    // Spider moved from tile 9 to tile 10. prevScrX = (9-39)*16 = -480.
-    // Union left = min(-480, -464) - 24 = -504 (inclusive).
-    // Without prevWorld the left boundary is -488 — so [-504, -488) is only in the union box.
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const prevWorld = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: {
-        posX: (SPIDER_TILE_X - 1) * FP_ONE_VAL,
-        posY: SPIDER_TILE_Y * FP_ONE_VAL,
-      } as WorldState['spider'],
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    // Click at screenX = -504 (inclusive union left edge) → should dispatch
-    handleSurfaceRightClick(world, vs, -504, SPIDER_SCR_Y, state, PLAYER_COLONY_ID, prevWorld);
-    expect(world.commandQueue).toHaveLength(1);
-    expect(world.commandQueue[0]).toMatchObject({ type: 'MarkSpiderPriority' });
-  });
-
-  it('union hit box: one pixel outside trailing edge (-505) still falls through', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const prevWorld = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: {
-        posX: (SPIDER_TILE_X - 1) * FP_ONE_VAL,
-        posY: SPIDER_TILE_Y * FP_ONE_VAL,
-      } as WorldState['spider'],
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    // screenX = -505 → tileX = floor(-505/16) + 39 = -32 + 39 = 7; tileY = 10
-    handleSurfaceRightClick(world, vs, -505, SPIDER_SCR_Y, state, PLAYER_COLONY_ID, prevWorld);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.pendingEntranceTileX).toBe(7);
-  });
-
-  it('center click does NOT set pendingEntrance or push ClearRallyPoint', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
       colonies: {
-        [PLAYER_COLONY_ID]: makeColony({
-          rallyPoint: { tileX: SPIDER_TILE_X, tileY: SPIDER_TILE_Y },
-        }),
-      } as unknown as WorldState['colonies'],
+        [PLAYER_COLONY_ID]: makeColony({ entrances: [{ surfaceTileX: 3, surfaceTileY: 1 }] }),
+        [ENEMY]: makeColony({ colonyId: ENEMY, entrances: [{ surfaceTileX: 9, surfaceTileY: 1 }] }),
+      },
     });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X, SPIDER_SCR_Y, state);
-    // Only MarkSpiderPriority, no ClearRallyPoint
+    expect(isForeignColonyEntrance(world, 9, 1, PLAYER_COLONY_ID)).toBe(true);
+    expect(isForeignColonyEntrance(world, 3, 1, PLAYER_COLONY_ID)).toBe(false); // own
+    expect(isForeignColonyEntrance(world, 5, 1, PLAYER_COLONY_ID)).toBe(false); // none
+  });
+});
+
+describe('isValidEntranceTarget', () => {
+  it('true on fully-walkable empty ground, false on a food pile', () => {
+    const world = makeWorld({
+      foodPiles: [{ foodPileId: 1, tileX: 5, tileY: 2, pickupsRemaining: 9, pickupsInitial: 9 }],
+    });
+    expect(isValidEntranceTarget(world, 20, 2)).toBe(true);
+    expect(isValidEntranceTarget(world, 5, 2)).toBe(false);
+  });
+});
+
+describe('isSpiderHit', () => {
+  it('true within the sprite half-extent, false outside', () => {
+    const vs = makeViewState('surface', 64, 64);
+    const world = makeWorld({ spider: makeSpider(64, 64) });
+    const { x, y } = tileToScreen(64, 64, 64, 64);
+    expect(isSpiderHit(world, vs, x, y, null)).toBe(true);
+    expect(isSpiderHit(world, vs, x + SPIDER_SPRITE_WIDTH, y, null)).toBe(false);
+  });
+  it('false when there is no spider', () => {
+    const vs = makeViewState('surface', 64, 64);
+    const world = makeWorld({ spider: null });
+    expect(isSpiderHit(world, vs, 100, 100, null)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleSurfaceCommandTap — priority order
+// ---------------------------------------------------------------------------
+
+function lastCmd(world: WorldState): SimCommand | undefined {
+  return world.commandQueue[world.commandQueue.length - 1];
+}
+
+describe('handleSurfaceCommandTap priority', () => {
+  it('1. spider hit → MarkSpiderPriority (toggles isPriority)', () => {
+    const world = makeWorld({ spider: makeSpider(10, 2), spiderPriorityColonyId: null });
+    handleSurfaceCommandTap(world, 10, 2, true /* spiderHit */, false);
+    const cmd = lastCmd(world) as { type: string; isPriority: boolean };
+    expect(cmd.type).toBe('MarkSpiderPriority');
+    expect(cmd.isPriority).toBe(true);
+  });
+
+  it('2. food pile → MarkFoodPile (when no spider hit)', () => {
+    const world = makeWorld({
+      foodPiles: [{ foodPileId: 1, tileX: 5, tileY: 2, pickupsRemaining: 9, pickupsInitial: 9 }],
+    });
+    handleSurfaceCommandTap(world, 5, 2, false, false);
+    expect((lastCmd(world) as { type: string }).type).toBe('MarkFoodPile');
+  });
+
+  it('3. clear-rally fires only when the down-tile IS the current rally point', () => {
+    const world = makeWorld({
+      colonies: { [PLAYER_COLONY_ID]: makeColony({ rallyPoint: { tileX: 8, tileY: 2 } }) },
+    });
+    handleSurfaceCommandTap(world, 8, 2, false, false);
+    expect((lastCmd(world) as { type: string }).type).toBe('ClearRallyPoint');
+  });
+
+  it('3 precedes 4: a rally placed ON an enemy entrance is clearable (Codex R1-4)', () => {
+    const ENEMY = 2 as ColonyId;
+    const world = makeWorld({
+      colonies: {
+        [PLAYER_COLONY_ID]: makeColony({ rallyPoint: { tileX: 9, tileY: 1 } }),
+        [ENEMY]: makeColony({ colonyId: ENEMY, entrances: [{ surfaceTileX: 9, surfaceTileY: 1 }] }),
+      },
+    });
+    handleSurfaceCommandTap(world, 9, 1, false, false);
+    // Down-tile == rally → clear wins over the foreign-entrance rally.
+    expect((lastCmd(world) as { type: string }).type).toBe('ClearRallyPoint');
+  });
+
+  it('4. foreign entrance (not the rally tile) → SetRallyPoint', () => {
+    const ENEMY = 2 as ColonyId;
+    const world = makeWorld({
+      colonies: {
+        [PLAYER_COLONY_ID]: makeColony({ rallyPoint: null }),
+        [ENEMY]: makeColony({ colonyId: ENEMY, entrances: [{ surfaceTileX: 9, surfaceTileY: 1 }] }),
+      },
+    });
+    handleSurfaceCommandTap(world, 9, 1, false, false);
+    const cmd = lastCmd(world) as { type: string; tileX: number; tileY: number };
+    expect(cmd.type).toBe('SetRallyPoint');
+    expect([cmd.tileX, cmd.tileY]).toEqual([9, 1]);
+  });
+
+  it('5. empty tile → SetRallyPoint', () => {
+    const world = makeWorld({ colonies: { [PLAYER_COLONY_ID]: makeColony() } });
+    handleSurfaceCommandTap(world, 20, 2, false, false);
+    expect((lastCmd(world) as { type: string }).type).toBe('SetRallyPoint');
+  });
+
+  it('negative tile is a no-op', () => {
+    const world = makeWorld({ colonies: { [PLAYER_COLONY_ID]: makeColony() } });
+    handleSurfaceCommandTap(world, -1, 2, false, false);
+    expect(world.commandQueue).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleSurfaceDigTap
+// ---------------------------------------------------------------------------
+
+describe('handleSurfaceDigTap', () => {
+  it('valid target → DesignateEntrance', () => {
+    const world = makeWorld({ colonies: { [PLAYER_COLONY_ID]: makeColony() } });
+    handleSurfaceDigTap(world, 20, 2, false);
+    const cmd = lastCmd(world) as { type: string; surfaceTileX: number; surfaceTileY: number };
+    expect(cmd.type).toBe('DesignateEntrance');
+    expect([cmd.surfaceTileX, cmd.surfaceTileY]).toEqual([20, 2]);
+  });
+
+  it('invalid target (food pile) → no-op', () => {
+    const world = makeWorld({
+      foodPiles: [{ foodPileId: 1, tileX: 5, tileY: 2, pickupsRemaining: 9, pickupsInitial: 9 }],
+    });
+    handleSurfaceDigTap(world, 5, 2, false);
+    expect(world.commandQueue).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Paused-cap (enqueueCommand) — across this producer
+// ---------------------------------------------------------------------------
+
+describe('paused-queue cap', () => {
+  it('drops a Dig-tap entrance command once the queue is at the cap while paused', () => {
+    // Pre-fill with MAX non-Sync commands.
+    const pre: SimCommand[] = Array.from({ length: MAX_COMMANDS_PER_TICK }, (_, i) => ({
+      type: 'NoOp',
+      issuedAtTick: i,
+    }));
+    const world = makeWorld({ commandQueue: pre, colonies: { [PLAYER_COLONY_ID]: makeColony() } });
+    const dropped = handleSurfaceDigTap(world, 20, 2, true /* paused */);
+    expect(dropped).toBe(true);
+    expect(world.commandQueue).toHaveLength(MAX_COMMANDS_PER_TICK); // not pushed
+  });
+
+  it('still enqueues when under the cap while paused', () => {
+    const world = makeWorld({ colonies: { [PLAYER_COLONY_ID]: makeColony() } });
+    const dropped = handleSurfaceDigTap(world, 20, 2, true);
+    expect(dropped).toBe(false);
     expect(world.commandQueue).toHaveLength(1);
-    expect(world.commandQueue[0]!.type).toBe('MarkSpiderPriority');
-    // No entrance preview
-    expect(state.pendingEntranceTileX).toBeNull();
-    expect(state.pendingEntranceTileY).toBeNull();
-  });
-
-  it('center click clears a pre-existing entrance preview', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState(30, 30);
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X, SPIDER_SCR_Y, state);
-    expect(world.commandQueue[0]!.type).toBe('MarkSpiderPriority');
-    expect(state.pendingEntranceTileX).toBeNull();
-    expect(state.pendingEntranceTileY).toBeNull();
-  });
-
-  it('click well outside sprite still sets entrance preview on empty tile', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: makeSpider(),
-      spiderPriorityColonyId: null,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    // Tile (20, 20) is well outside the spider sprite
-    const { x, y } = tileToScreen(20, 20, CAM_X, CAM_Y);
-    handleSurfaceRightClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.pendingEntranceTileX).toBe(20);
-    expect(state.pendingEntranceTileY).toBe(20);
-  });
-
-  it('click on spider sprite location with no spider falls through to entrance preview', () => {
-    const world = makeWorld({
-      surfaceWidth: 128,
-      surfaceHeight: 64,
-      spider: null,
-      spiderPriorityColonyId: null,
-    });
-    const vs = makeViewState('surface', CAM_X, CAM_Y);
-    const state = makeState();
-    handleSurfaceRightClick(world, vs, SPIDER_SCR_X, SPIDER_SCR_Y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.pendingEntranceTileX).toBe(SPIDER_TILE_X);
-    expect(state.pendingEntranceTileY).toBe(SPIDER_TILE_Y);
   });
 });

--- a/src/input/surface-input.ts
+++ b/src/input/surface-input.ts
@@ -1,28 +1,30 @@
-// surface-input.ts — Phase 9 surface-click dispatcher.
+// surface-input.ts — Stage 1 controls rework (issue #18): pure surface tap
+// handlers, called by the single left-button gesture arbiter.
 //
-// Handles left-click (food-pile mark + entrance designation confirmation + rally point set)
-// and right-click (entrance preview + rally point clear + spider priority toggle) on the surface view.
+// The arbiter (gesture-arbiter.ts) exclusively owns the LEFT pointer button. It
+// classifies a press as a pan / paint / tap, and on a tap-without-drag calls the
+// pure handler matching the snapshotted tool + view. This file no longer
+// registers its own Phaser pointer listeners — it exports the pure tap logic and
+// the pure helpers the arbiter and renderer depend on.
 //
-// Priority order for left-click:
-//   1. Entrance designation confirmation (if pendingEntrance matches both X+Y)
-//   2. Food-pile mark (if tile has a food pile)
-//   3. (empty) fall-through: SetRallyPoint (SURF-04)
+// Tap handlers by tool (surface):
+//   - Command tap → priority: spider (sprite bounds) → food pile →
+//     clear-rally (iff down-tile == current rally) → foreign/enemy entrance rally
+//     → empty-tile set-rally. (PLAN §B5, Codex R1-4.)
+//   - Dig tap → DesignateEntrance on a valid target (one tap; PLAN §B6).
+//   - Chamber → underground-only, so there is no surface Chamber tap.
 //
-// Priority order for right-click:
-//   1. Spider priority toggle (if tile is within spider's 3×3 bounding box) — S7/D1
-//   2. Rally-point clear (if tile matches current rally point)
-//   3. Entrance preview (if tile is a valid entrance target)
+// All commands emitted here are the SAME SimCommands as before the rework and
+// are pushed through enqueueCommand (the paused-cap guard); a handler reports
+// whether its command was dropped at the cap so the arbiter can surface the
+// "paused queue full" hint.
 //
-// Guards:
-//   - viewState.activeView must be 'surface' before dispatching any command.
-//   - isPointerOverHUD rejects clicks that land on HUD zones (Pitfall 2).
-//   - Tile bounds check (tileX/Y >= 0) before pushing commands.
-//   - ADR-0006: world.colonies accessed via plain-object bracket notation — never .get().
+// Guards: the arbiter has already rejected HUD / pan / wrong-view presses before
+// calling these. Each handler still bounds-checks the tile defensively.
+// ADR-0006: world.colonies accessed via plain-object bracket notation — never .get().
 
-import * as Phaser from 'phaser';
 import type { WorldState } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
-import { screenToTile } from '../render/camera.js';
 import type { FoodPile } from '../sim/food.js';
 import type {
   MarkFoodPileCommand,
@@ -42,36 +44,7 @@ import { getSurfaceComponentMaskReadOnly } from '../sim/surface-features.js';
 import { FP_SHIFT } from '../sim/fixed.js';
 import { TILE_SIZE_PX } from '../render/sprites.js';
 import { SPIDER_SPRITE_WIDTH, SPIDER_SPRITE_HEIGHT } from '../render/ant-sprite-layer.js';
-import { isPointerOverHUD, panInputState } from './camera-input.js';
-
-// ---------------------------------------------------------------------------
-// SurfaceInputState — mutable per-registration state
-// ---------------------------------------------------------------------------
-
-/**
- * Exported so the render layer (draw-surface.ts) can read `pendingEntranceTileX`
- * / `pendingEntranceTileY` and draw a preview outline on the tile the player
- * right-clicked. Phase 8.5 interaction-feedback fix: before, the right-click
- * preview was invisible and players had to remember the exact tile between
- * right-click and the confirming left-click.
- */
-export interface SurfaceInputState {
-  /** Right-click preview state: null = no pending designation, number = tileX of pending entrance. */
-  pendingEntranceTileX: number | null;
-  /** TileY companion to pendingEntranceTileX — needed so the render layer can outline the right cell. */
-  pendingEntranceTileY: number | null;
-}
-
-/**
- * Reset a SurfaceInputState in-place so the new session starts without any
- * pending entrance-preview left over from the previous game. Called at
- * session-restart boundaries; preserves the object identity captured by
- * registerSurfaceInput's pointerdown closure and by the render layer.
- */
-export function resetSurfaceInputState(state: SurfaceInputState): void {
-  state.pendingEntranceTileX = null;
-  state.pendingEntranceTileY = null;
-}
+import { enqueueCommand } from './command-queue.js';
 
 // ---------------------------------------------------------------------------
 // isEmptySurfaceTile — checks whether a tile is empty (not entrance, not food pile)
@@ -147,22 +120,15 @@ export function isValidEntranceTarget(world: WorldState, tileX: number, tileY: n
 /**
  * Returns true when (tileX, tileY) is the surface tile of an entrance owned
  * by a colony OTHER than `ownColonyId`. Bounds and food-pile checks are not
- * required here — handleSurfaceLeftClick has already evaluated those.
+ * required here — the Command-tap handler has already evaluated those.
  *
- * Issue #14: enables the player to left-click an enemy entrance to rally
- * Fighting ants there. The Phase 09.1 cross-grid descent + combat path is
- * already wired (REQ-C3a, REQ-C4a); the rally input was the missing seam.
+ * Issue #14: enables the player to tap an enemy entrance to rally Fighting ants
+ * there. Closed enemy entrances are intentionally still eligible — the
+ * rally-tile carve-out in updateFightAntTargets walks fighters onto the exact
+ * tile, but the descent-intent gate requires `isOpen` before crossing into the
+ * enemy grid, so a rally on a closed enemy entrance piles fighters at the door.
  *
- * Closed enemy entrances are intentionally still eligible — the rally-tile
- * carve-out in updateFightAntTargets walks fighters onto the exact tile,
- * but the descent-intent gate in tickAntMovement requires `isOpen` before
- * crossing into the enemy grid. So a rally on a closed enemy entrance
- * piles fighters at the door, ready to invade the moment the enemy AI
- * opens it. That's the right read of "I want to attack here" — no need
- * for the input layer to second-guess open/closed.
- *
- * ADR-0006: world.colonies is a PLAIN OBJECT. Uses Object.keys (per the
- * existing isEmptySurfaceTile pattern).
+ * ADR-0006: world.colonies is a PLAIN OBJECT. Uses Object.keys.
  */
 export function isForeignColonyEntrance(
   world: WorldState,
@@ -190,7 +156,7 @@ export function isForeignColonyEntrance(
 
 /**
  * Returns the FoodPile at (tileX, tileY) or null if none.
- * Called by handleSurfaceLeftClick when no entrance confirmation is pending.
+ * Called by handleSurfaceCommandTap when no spider was hit.
  */
 export function findFoodPileAt(world: WorldState, tileX: number, tileY: number): FoodPile | null {
   for (const pile of world.foodPiles) {
@@ -200,104 +166,49 @@ export function findFoodPileAt(world: WorldState, tileX: number, tileY: number):
 }
 
 // ---------------------------------------------------------------------------
-// handleSurfaceLeftClick
+// isSpiderHit — pure spider sprite-bounds hit test (snapshotted at pointer-down)
 // ---------------------------------------------------------------------------
 
 /**
- * Handles a left-click on the surface view.
+ * Returns true if screen point (screenX, screenY) lands within the spider's
+ * rendered sprite bounds. The hit box is the union of the current-tick and
+ * previous-tick 48×48px bounding boxes, so the trailing visual edge (which lags
+ * the sim position during interpolation) always registers. When prevWorld is
+ * null (stationary or unavailable) the box is exactly the current sprite.
  *
- * Priority order:
- *   1. If the clicked tile matches the pending entrance preview in BOTH X and Y,
- *      push DesignateEntranceCommand and clear the preview.
- *   2. Else → try food-pile mark at the clicked tile.
- *
- * No-ops if: activeView !== 'surface', pointer over HUD, or tile out of bounds.
- *
- * Phase 8.5 fix: confirmation previously matched only `tileX`, which meant a
- * player could right-click to preview tile (X, Y1), left-click a different row
- * (X, Y2) on the same column, and still confirm — but the command fired with
- * the second tile's Y. The preview frame and the placed entrance could
- * disagree. Confirmation now requires both tile coordinates to match the
- * previewed tile exactly; a non-matching left-click falls through to food-pile
- * mark and leaves the preview intact so the player can try again.
+ * Extracted unchanged from the former right-click spider-priority path so the
+ * Command-tap snapshot can record "did this press start on the spider?" at
+ * pointer-down. Returns false when there is no spider.
  */
-export function handleSurfaceLeftClick(
+export function isSpiderHit(
   world: WorldState,
   viewState: ViewState,
   screenX: number,
   screenY: number,
-  state: SurfaceInputState,
-): void {
-  if (viewState.activeView !== 'surface') return;
-  if (isPointerOverHUD(screenX, screenY, viewState)) return;
-  // Pan-mode guard: while Space is held or a pan gesture is already in flight,
-  // the left-click is the pan trigger — not a world action.
-  if (panInputState.spaceHeld || panInputState.isPanning) return;
-  const { tileX, tileY } = screenToTile(screenX, screenY, viewState.surfaceCamera);
-  if (tileX < 0 || tileY < 0) return;
-
-  // Entrance designation confirmation: left-click on the exact tile that was
-  // previewed by a prior right-click (both X and Y must match).
-  if (
-    state.pendingEntranceTileX !== null &&
-    state.pendingEntranceTileY !== null &&
-    state.pendingEntranceTileX === tileX &&
-    state.pendingEntranceTileY === tileY
-  ) {
-    const cmd: DesignateEntranceCommand = {
-      type: 'DesignateEntrance',
-      colonyId: PLAYER_COLONY_ID,
-      surfaceTileX: tileX,
-      surfaceTileY: tileY,
-      issuedAtTick: world.tick,
-    };
-    world.commandQueue.push(cmd);
-    state.pendingEntranceTileX = null;
-    state.pendingEntranceTileY = null;
-    return;
-  }
-
-  // Food-pile mark at clicked tile (priority 2).
-  const pile = findFoodPileAt(world, tileX, tileY);
-  if (pile) {
-    const cmd: MarkFoodPileCommand = {
-      type: 'MarkFoodPile',
-      colonyId: PLAYER_COLONY_ID,
-      tileX: pile.tileX,
-      tileY: pile.tileY,
-      issuedAtTick: world.tick,
-    };
-    world.commandQueue.push(cmd);
-    return;
-  }
-
-  // Foreign-colony entrance rally (priority 3 — issue #14): left-click on an
-  // enemy colony's open entrance tile sets the player's rally point there.
-  // This is the input piece that unlocks Phase 09.1's invasion mechanic —
-  // Fighting ants rally to the tile, the rally-on-entrance carve-out in
-  // updateFightAntTargets keeps them walking onto it, and the descent-intent
-  // gate in tickAntMovement crosses them into the enemy underground grid.
-  // Own-colony entrance left-click stays a no-op so the right-click → left-
-  // click entrance designation flow is undisturbed.
-  //
-  // Ordering note: food-pile mark (priority 2) wins over foreign-entrance
-  // rally if a food pile and an enemy entrance somehow share a tile. The
-  // scenario seeder (createScenario) places enemy entrances at the colony
-  // start tile and food piles at distinct tiles, so this collision can't
-  // arise in practice today. If a future feature lets food piles spawn
-  // anywhere, prefer the food-mark — the player can always rally on an
-  // adjacent tile (the rally-on-entrance carve-out only requires the EXACT
-  // entrance tile, but a one-tile-off rally still routes fighters to the
-  // entrance via the existing path-to-rally walk).
-  if (isForeignColonyEntrance(world, tileX, tileY, PLAYER_COLONY_ID)) {
-    handleSetRallyPoint(world, tileX, tileY, PLAYER_COLONY_ID);
-    return;
-  }
-
-  // Empty-tile fallthrough (priority 4): set rally point for player colony (SURF-04).
-  if (isEmptySurfaceTile(world, tileX, tileY)) {
-    handleSetRallyPoint(world, tileX, tileY, PLAYER_COLONY_ID);
-  }
+  prevWorld: WorldState | null = null,
+): boolean {
+  if (world.spider === null) return false;
+  const cam = viewState.surfaceCamera;
+  const camLeft = Math.floor(cam.x - cam.viewportWidth / 2);
+  const camTop = Math.floor(cam.y - cam.viewportHeight / 2);
+  const currScrX = (world.spider.posX >> FP_SHIFT) * TILE_SIZE_PX - camLeft * TILE_SIZE_PX;
+  const currScrY = (world.spider.posY >> FP_SHIFT) * TILE_SIZE_PX - camTop * TILE_SIZE_PX;
+  const prevScrX =
+    prevWorld?.spider != null
+      ? (prevWorld.spider.posX >> FP_SHIFT) * TILE_SIZE_PX - camLeft * TILE_SIZE_PX
+      : currScrX;
+  const prevScrY =
+    prevWorld?.spider != null
+      ? (prevWorld.spider.posY >> FP_SHIFT) * TILE_SIZE_PX - camTop * TILE_SIZE_PX
+      : currScrY;
+  const halfW = SPIDER_SPRITE_WIDTH / 2;
+  const halfH = SPIDER_SPRITE_HEIGHT / 2;
+  return (
+    screenX >= Math.min(currScrX, prevScrX) - halfW &&
+    screenX < Math.max(currScrX, prevScrX) + halfW &&
+    screenY >= Math.min(currScrY, prevScrY) - halfH &&
+    screenY < Math.max(currScrY, prevScrY) + halfH
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -305,16 +216,17 @@ export function handleSurfaceLeftClick(
 // ---------------------------------------------------------------------------
 
 /**
- * Pushes SetRallyPointCommand for the given colony at (tileX, tileY).
- * Called by handleSurfaceLeftClick's empty-tile fallthrough (SURF-04).
+ * Enqueues SetRallyPointCommand for the given colony at (tileX, tileY).
  * colonyId argument is always the player colony — AI colonies are never passed here.
+ * Returns true iff the command was dropped at the paused cap.
  */
 export function handleSetRallyPoint(
   world: WorldState,
   tileX: number,
   tileY: number,
   playerColonyId: ColonyId,
-): void {
+  isPaused: boolean,
+): boolean {
   const cmd: SetRallyPointCommand = {
     type: 'SetRallyPoint',
     colonyId: playerColonyId,
@@ -322,165 +234,116 @@ export function handleSetRallyPoint(
     tileY,
     issuedAtTick: world.tick,
   };
-  world.commandQueue.push(cmd);
+  return !enqueueCommand(world, cmd, isPaused);
 }
 
 // ---------------------------------------------------------------------------
-// handleSurfaceRightClick
+// handleSurfaceCommandTap — the Command-tool tap on the surface view
 // ---------------------------------------------------------------------------
 
 /**
- * Handles a right-click on the surface view.
+ * Surface Command tap. Priority (PLAN §B5, Codex R1-4):
+ *   1. spider hit (snapshotted at pointer-down) → toggle MarkSpiderPriority
+ *   2. food pile at the down-tile → MarkFoodPile
+ *   3. clear-rally — ONLY if the down-tile is the current rally point → ClearRallyPoint
+ *   4. foreign/enemy entrance at the down-tile → SetRallyPoint (invasion rally)
+ *   5. empty tile → SetRallyPoint
  *
- * Priority order:
- *   1. Spider priority toggle (S7/D1): right-click within the spider's rendered sprite bounds
- *      dispatches MarkSpiderPriority and suppresses all other right-click actions.
- *   2. If the clicked tile matches the current rally-point tile, push ClearRallyPointCommand.
- *   3. Otherwise, if the tile is a valid entrance target, set pendingEntranceTileX/Y
- *      for entrance designation preview. A subsequent left-click on the same tile
- *      confirms and pushes DesignateEntranceCommand.
- *   4. Invalid entrance tiles (food piles, existing colony entrances, out-of-bounds) do nothing —
- *      the preview is suppressed so the UI never advertises a target the sim would reject.
- *
- * No-ops if: activeView !== 'surface', pointer over HUD, or tile out of bounds.
- *
- * ADR-0006: world.colonies accessed via plain-object bracket notation.
- *
- * @param prevWorld  Previous-tick world state, used to widen the spider hit box to cover the
- *                   full interpolated path between ticks. Pass null when unavailable (tests,
- *                   stationary spider).
+ * `spiderHit` is passed in (snapshotted at down by the arbiter) rather than
+ * recomputed, so a camera pan between down and up can't move the spider out from
+ * under the press. Returns true iff a command was dropped at the paused cap.
  */
-export function handleSurfaceRightClick(
+export function handleSurfaceCommandTap(
   world: WorldState,
-  viewState: ViewState,
-  screenX: number,
-  screenY: number,
-  state: SurfaceInputState,
+  tileX: number,
+  tileY: number,
+  spiderHit: boolean,
+  isPaused: boolean,
   playerColonyId: ColonyId = PLAYER_COLONY_ID,
-  prevWorld: WorldState | null = null,
-): void {
-  if (viewState.activeView !== 'surface') return;
-  if (isPointerOverHUD(screenX, screenY, viewState)) return;
-  const { tileX, tileY } = screenToTile(screenX, screenY, viewState.surfaceCamera);
-  if (tileX < 0 || tileY < 0) return;
+): boolean {
+  if (tileX < 0 || tileY < 0) return false;
 
-  // Spider priority toggle (S7/D1): right-click within the spider sprite bounds.
-  // Hit box is the union of the current-tick and previous-tick bounding boxes, so the
-  // trailing visual edge (which lags behind the sim position during interpolation) always
-  // registers. When prevWorld is null (stationary or unavailable) the box is exactly the
-  // 48×48px sprite; when the spider moved it expands by one tile in the movement direction.
-  if (world.spider !== null) {
-    const camLeft = Math.floor(
-      viewState.surfaceCamera.x - viewState.surfaceCamera.viewportWidth / 2,
-    );
-    const camTop = Math.floor(
-      viewState.surfaceCamera.y - viewState.surfaceCamera.viewportHeight / 2,
-    );
-    const currScrX = (world.spider.posX >> FP_SHIFT) * TILE_SIZE_PX - camLeft * TILE_SIZE_PX;
-    const currScrY = (world.spider.posY >> FP_SHIFT) * TILE_SIZE_PX - camTop * TILE_SIZE_PX;
-    const prevScrX =
-      prevWorld?.spider != null
-        ? (prevWorld.spider.posX >> FP_SHIFT) * TILE_SIZE_PX - camLeft * TILE_SIZE_PX
-        : currScrX;
-    const prevScrY =
-      prevWorld?.spider != null
-        ? (prevWorld.spider.posY >> FP_SHIFT) * TILE_SIZE_PX - camTop * TILE_SIZE_PX
-        : currScrY;
-    const halfW = SPIDER_SPRITE_WIDTH / 2;
-    const halfH = SPIDER_SPRITE_HEIGHT / 2;
-    if (
-      screenX >= Math.min(currScrX, prevScrX) - halfW &&
-      screenX < Math.max(currScrX, prevScrX) + halfW &&
-      screenY >= Math.min(currScrY, prevScrY) - halfH &&
-      screenY < Math.max(currScrY, prevScrY) + halfH
-    ) {
-      state.pendingEntranceTileX = null;
-      state.pendingEntranceTileY = null;
-      const cmd: MarkSpiderPriorityCommand = {
-        type: 'MarkSpiderPriority',
-        colonyId: playerColonyId,
-        isPriority: world.spiderPriorityColonyId !== playerColonyId,
-        issuedAtTick: world.tick,
-      };
-      world.commandQueue.push(cmd);
-      return;
-    }
+  // 1. Spider priority toggle (was right-click pre-rework; now a Command tap).
+  if (spiderHit && world.spider !== null) {
+    const cmd: MarkSpiderPriorityCommand = {
+      type: 'MarkSpiderPriority',
+      colonyId: playerColonyId,
+      isPriority: world.spiderPriorityColonyId !== playerColonyId,
+      issuedAtTick: world.tick,
+    };
+    return !enqueueCommand(world, cmd, isPaused);
   }
 
-  // Rally-point clear: right-click on the current rally point tile (SURF-04)
+  // 2. Food-pile mark.
+  const pile = findFoodPileAt(world, tileX, tileY);
+  if (pile) {
+    const cmd: MarkFoodPileCommand = {
+      type: 'MarkFoodPile',
+      colonyId: playerColonyId,
+      tileX: pile.tileX,
+      tileY: pile.tileY,
+      issuedAtTick: world.tick,
+    };
+    return !enqueueCommand(world, cmd, isPaused);
+  }
+
+  // 3. Clear-rally — only when the tapped tile IS the current rally point. This
+  //    precedes foreign-entrance so a rally placed ON an enemy entrance can be
+  //    cleared by tapping it again (Codex R1-4: enemy-entrance rallies were
+  //    otherwise unclearable).
   const playerColony = world.colonies[playerColonyId]; // plain-object bracket access (ADR-0006)
-  if (playerColony !== undefined && playerColony.rallyPoint !== null) {
-    if (playerColony.rallyPoint.tileX === tileX && playerColony.rallyPoint.tileY === tileY) {
-      const cmd: ClearRallyPointCommand = {
-        type: 'ClearRallyPoint',
-        colonyId: playerColonyId,
-        issuedAtTick: world.tick,
-      };
-      world.commandQueue.push(cmd);
-      return;
-    }
+  if (
+    playerColony !== undefined &&
+    playerColony.rallyPoint !== null &&
+    playerColony.rallyPoint.tileX === tileX &&
+    playerColony.rallyPoint.tileY === tileY
+  ) {
+    const cmd: ClearRallyPointCommand = {
+      type: 'ClearRallyPoint',
+      colonyId: playerColonyId,
+      issuedAtTick: world.tick,
+    };
+    return !enqueueCommand(world, cmd, isPaused);
   }
 
-  // Entrance preview — only on tiles DesignateEntrance will actually accept. The
-  // sim rejects food piles, occupied entrances, and (PR 4) any tile whose
-  // candidate+clearance neighbourhood is not in the single connected walkable
-  // component of the frozen terrain. Previewing those would advertise a target
-  // the sim silently drops, so confirmation would do nothing. Invalid click: no
-  // preview, no state change.
-  if (!isValidEntranceTarget(world, tileX, tileY)) return;
-  state.pendingEntranceTileX = tileX;
-  state.pendingEntranceTileY = tileY;
+  // 4. Foreign/enemy entrance rally (issue #14): tap an enemy entrance tile to
+  //    rally Fighting ants there. Own-colony entrances fall through (no-op).
+  if (isForeignColonyEntrance(world, tileX, tileY, playerColonyId)) {
+    return handleSetRallyPoint(world, tileX, tileY, playerColonyId, isPaused);
+  }
+
+  // 5. Empty-tile set-rally (SURF-04).
+  if (isEmptySurfaceTile(world, tileX, tileY)) {
+    return handleSetRallyPoint(world, tileX, tileY, playerColonyId, isPaused);
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
-// registerSurfaceInput — wires Phaser pointer events
+// handleSurfaceDigTap — the Dig-tool tap on the surface view
 // ---------------------------------------------------------------------------
 
 /**
- * registerSurfaceInput — attach surface-click handlers to a Phaser.Scene.
- *
- * Called from GameScene.create() (Plan 06 Task 3). Each handler internally
- * guards on viewState.activeView === 'surface', so surface + underground
- * handlers may both be registered without interference.
- *
- * getWorld is a LAZY accessor — called on every pointer event — so the
- * handler always dispatches against the live WorldState even if
- * GameScene swaps references mid-session (bootFresh, bootFromSave,
- * restartGame). Direct world-reference capture was a stale-closure bug:
- * the world assigned after registration was invisible to the handler.
- * Returns undefined pre-boot; all handlers short-circuit.
- *
- * @param scene     - Phaser.Scene (GameScene) providing the input event bus.
- * @param getWorld  - Lazy accessor for the live WorldState.
- * @param viewState - Render-layer ViewState; activeView is read for guard.
+ * Surface Dig tap → DesignateEntrance on a valid target (PLAN §B6). One tap,
+ * irreversible in Stage 1 (entrance undo is a deferred sim-touch). A tap on an
+ * invalid target is a no-op (the hover outline already shows red there). Returns
+ * true iff the command was dropped at the paused cap.
  */
-export function registerSurfaceInput(
-  scene: Phaser.Scene,
-  getWorld: () => WorldState | undefined,
-  viewState: ViewState,
-  getPrevWorld?: () => WorldState | null,
-): SurfaceInputState {
-  const state: SurfaceInputState = {
-    pendingEntranceTileX: null,
-    pendingEntranceTileY: null,
+export function handleSurfaceDigTap(
+  world: WorldState,
+  tileX: number,
+  tileY: number,
+  isPaused: boolean,
+  playerColonyId: ColonyId = PLAYER_COLONY_ID,
+): boolean {
+  if (tileX < 0 || tileY < 0) return false;
+  if (!isValidEntranceTarget(world, tileX, tileY)) return false;
+  const cmd: DesignateEntranceCommand = {
+    type: 'DesignateEntrance',
+    colonyId: playerColonyId,
+    surfaceTileX: tileX,
+    surfaceTileY: tileY,
+    issuedAtTick: world.tick,
   };
-  scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
-    const world = getWorld();
-    if (!world) return;
-    if (pointer.leftButtonDown()) {
-      handleSurfaceLeftClick(world, viewState, pointer.x, pointer.y, state);
-    } else if (pointer.rightButtonDown()) {
-      const prevWorld = getPrevWorld?.() ?? null;
-      handleSurfaceRightClick(
-        world,
-        viewState,
-        pointer.x,
-        pointer.y,
-        state,
-        PLAYER_COLONY_ID,
-        prevWorld,
-      );
-    }
-  });
-  return state;
+  return !enqueueCommand(world, cmd, isPaused);
 }

--- a/src/input/surface-input.ts
+++ b/src/input/surface-input.ts
@@ -212,6 +212,42 @@ export function isSpiderHit(
 }
 
 // ---------------------------------------------------------------------------
+// effectiveSpiderPriority — pure, queue-aware current-priority resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the EFFECTIVE spider-priority flag for `playerColonyId`, folding in any
+ * MarkSpiderPriority command ALREADY queued but not yet applied (Codex P2 —
+ * mirrors `effectiveDigState` in underground-input.ts).
+ *
+ * While bare-user-paused the sim never advances, so `world.spiderPriorityColonyId`
+ * stays frozen: two Command-taps on the spider would both read the same value and
+ * both enqueue `isPriority: true` (the second never toggles OFF). The toggle must
+ * instead resolve against what the queue WILL do — scan back-to-front for the
+ * LATEST queued MarkSpiderPriority for the player colony (tick.ts drains FIFO, so
+ * the last-queued command wins) and return its `isPriority`; with none pending,
+ * fall back to the live `world.spiderPriorityColonyId === playerColonyId`.
+ *
+ * Pure + read-only: never mutates the queue or any sim state. Unpaused this is a
+ * near-no-op — the queue drains every tick so it is usually empty of pending
+ * priority commands, and the live flag is already current — so the caller can use
+ * it unconditionally.
+ */
+export function effectiveSpiderPriority(world: WorldState, playerColonyId: ColonyId): boolean {
+  const queue = world.commandQueue;
+  // Walk back-to-front so the FIRST match is the LATEST-queued command (the one
+  // tick.ts applies last, hence the one that wins).
+  for (let i = queue.length - 1; i >= 0; i--) {
+    const cmd = queue[i];
+    if (!cmd) continue;
+    if (cmd.type === 'MarkSpiderPriority' && cmd.colonyId === playerColonyId) {
+      return cmd.isPriority;
+    }
+  }
+  return world.spiderPriorityColonyId === playerColonyId;
+}
+
+// ---------------------------------------------------------------------------
 // handleSetRallyPoint — inner helper (pure dispatch, extracted for testability)
 // ---------------------------------------------------------------------------
 
@@ -264,11 +300,16 @@ export function handleSurfaceCommandTap(
   if (tileX < 0 || tileY < 0) return false;
 
   // 1. Spider priority toggle (was right-click pre-rework; now a Command tap).
+  //    Toggle against the EFFECTIVE priority (effectiveSpiderPriority) — the live
+  //    flag folded with any already-queued MarkSpiderPriority for this colony — so
+  //    a bare-user-paused tap-tap nets priority-on-then-off (Codex P2). Unpaused
+  //    the queue drains each tick, so the effective value equals
+  //    spiderPriorityColonyId === playerColonyId and behaviour is unchanged.
   if (spiderHit && world.spider !== null) {
     const cmd: MarkSpiderPriorityCommand = {
       type: 'MarkSpiderPriority',
       colonyId: playerColonyId,
-      isPriority: world.spiderPriorityColonyId !== playerColonyId,
+      isPriority: !effectiveSpiderPriority(world, playerColonyId),
       issuedAtTick: world.tick,
     };
     return !enqueueCommand(world, cmd, isPaused);

--- a/src/input/surface-input.ts
+++ b/src/input/surface-input.ts
@@ -248,6 +248,53 @@ export function effectiveSpiderPriority(world: WorldState, playerColonyId: Colon
 }
 
 // ---------------------------------------------------------------------------
+// effectiveRallyState — pure, queue-aware current-rally resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the EFFECTIVE rally point for `playerColonyId`, folding in any
+ * SetRallyPoint / ClearRallyPoint command ALREADY queued but not yet applied
+ * (Codex P2 — the last member of the paused-optimistic-state toggle class, after
+ * `effectiveDigState` and `effectiveSpiderPriority`).
+ *
+ * While bare-user-paused the sim never advances, so `playerColony.rallyPoint`
+ * stays frozen: after a first tap queues SetRallyPoint, a second tap on the same
+ * tile would still read `rallyPoint === null` and queue ANOTHER set (never a
+ * clear); two taps on an existing rally would queue two clears. The clear-vs-set
+ * decision must instead resolve against what the queue WILL do — scan back-to-
+ * front for the LATEST queued command for this colony (tick.ts drains FIFO, so
+ * the last-queued command wins):
+ *   - latest queued SetRallyPoint  ⇒ effective rally at that tile
+ *   - latest queued ClearRallyPoint ⇒ no rally (null)
+ *   - neither queued               ⇒ the live `playerColony.rallyPoint`
+ *
+ * Pure + read-only: never mutates the queue or any sim state. Unpaused this is a
+ * near-no-op — the queue drains every tick so it is usually empty of pending
+ * rally commands, and the live field is already current — so the caller can use
+ * it unconditionally.
+ */
+export function effectiveRallyState(
+  world: WorldState,
+  playerColonyId: ColonyId,
+): { tileX: number; tileY: number } | null {
+  const queue = world.commandQueue;
+  // Walk back-to-front so the FIRST match is the LATEST-queued command (the one
+  // tick.ts applies last, hence the one that wins).
+  for (let i = queue.length - 1; i >= 0; i--) {
+    const cmd = queue[i];
+    if (!cmd) continue;
+    if (cmd.type === 'SetRallyPoint' && cmd.colonyId === playerColonyId) {
+      return { tileX: cmd.tileX, tileY: cmd.tileY };
+    }
+    if (cmd.type === 'ClearRallyPoint' && cmd.colonyId === playerColonyId) {
+      return null;
+    }
+  }
+  const playerColony = world.colonies[playerColonyId]; // plain-object bracket access (ADR-0006)
+  return playerColony?.rallyPoint ?? null;
+}
+
+// ---------------------------------------------------------------------------
 // handleSetRallyPoint — inner helper (pure dispatch, extracted for testability)
 // ---------------------------------------------------------------------------
 
@@ -332,13 +379,17 @@ export function handleSurfaceCommandTap(
   //    precedes foreign-entrance so a rally placed ON an enemy entrance can be
   //    cleared by tapping it again (Codex R1-4: enemy-entrance rallies were
   //    otherwise unclearable).
-  const playerColony = world.colonies[playerColonyId]; // plain-object bracket access (ADR-0006)
-  if (
-    playerColony !== undefined &&
-    playerColony.rallyPoint !== null &&
-    playerColony.rallyPoint.tileX === tileX &&
-    playerColony.rallyPoint.tileY === tileY
-  ) {
+  //
+  //    Compare against the EFFECTIVE rally (effectiveRallyState) — the live
+  //    rallyPoint folded with any already-queued Set/Clear for this colony — so a
+  //    bare-user-paused tap-tap nets set-then-clear (Codex P2): the first tap on
+  //    an empty tile queues SetRallyPoint, making that tile the effective rally,
+  //    so the second tap matches here and queues ClearRallyPoint (instead of a
+  //    second set). Re-tapping the effective rally tile clears it. Unpaused the
+  //    queue drains each tick, so the effective rally equals playerColony.rallyPoint
+  //    and behaviour is unchanged.
+  const effectiveRally = effectiveRallyState(world, playerColonyId);
+  if (effectiveRally !== null && effectiveRally.tileX === tileX && effectiveRally.tileY === tileY) {
     const cmd: ClearRallyPointCommand = {
       type: 'ClearRallyPoint',
       colonyId: playerColonyId,

--- a/src/input/underground-input.test.ts
+++ b/src/input/underground-input.test.ts
@@ -1,100 +1,73 @@
-// underground-input.test.ts — Vitest unit tests for src/input/underground-input.ts
+// underground-input.test.ts — Vitest unit tests for the Stage 1 controls-rework
+// underground tap + paint handlers (issue #18).
 //
-// Tests cover pure dispatch logic only.
-// Phaser scene integration (registerUndergroundInput) is verified by Plan 07 Playwright smoke test.
-//
-// Key invariants:
-//   - isTunnelEnd: Open + at least one Solid 4-neighbor → true.
-//   - Left-click on Solid/Open tile → MarkDigTileCommand; Marked/BeingDug → no command.
-//   - Drag debounce: only new tile coordinates emit commands.
-//   - Right-click on Marked → CancelDigMarkCommand (CTRL-04: BeingDug NOT cancellable).
-//   - Right-click on Open tunnel-end → contextMenuState.visible=true.
-//   - Right-click on BeingDug → no state change.
-//   - contextMenuState reset between tests using hideContextMenu().
-//
-// UndergroundTileState values (terrain.ts): Solid=0, Marked=1, BeingDug=2, Open=3
+// Tests cover:
+//   - isTunnelEnd (pure topology helper, retained)
+//   - handleUndergroundCommandTap: CancelDigMark on Marked; no-op otherwise;
+//     player-grid-only guard
+//   - handleUndergroundDigTap: Solid/Open → MarkDigTile; Marked → CancelDigMark;
+//     BeingDug → no-op; player-grid-only guard; ceiling-row guard
+//   - paint stroke: beginPaintStroke + continuePaintStroke 4-connected Bresenham,
+//     first-tile-once, enemy-view abort
+//   - tryOpenChamberMenu: Solid/Open eligibility + anchor; Marked/BeingDug
+//     excluded; enemy-view read-only
+//   - paused cap across the paint producer
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   isTunnelEnd,
-  handleUndergroundLeftClick,
-  handleUndergroundDrag,
-  handleUndergroundRightClick,
-  resetUndergroundInputState,
-  type UndergroundInputState,
+  handleUndergroundCommandTap,
+  handleUndergroundDigTap,
+  beginPaintStroke,
+  continuePaintStroke,
+  createPaintStrokeState,
+  resetPaintStrokeState,
+  tryOpenChamberMenu,
+  type PaintStrokeState,
 } from './underground-input.js';
-import {
-  contextMenuState,
-  hideContextMenu,
-  applyPendingContextMenuShow,
-} from '../render/context-menu-state.js';
-import { panInputState, resetPanInputStateForTests } from './camera-input.js';
 import { UndergroundTileState, ugSet, createUndergroundGrid } from '../sim/terrain.js';
+import { contextMenuState, hideContextMenu } from '../render/context-menu-state.js';
 import type { WorldState } from '../sim/types.js';
-import { LEGACY_SIM_VERSION, SIM_VERSION_V5_CHAMBER_ON_MARKED } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
 import { VIEWPORT_WIDTH_TILES, VIEWPORT_HEIGHT_TILES } from '../render/camera.js';
-import { HUD, TILE_SIZE_PX } from '../render/sprites.js';
-import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
-import type { SimCommand } from '../sim/commands.js';
+import { PLAYER_COLONY_ID, ENEMY_COLONY_ID, UNDERGROUND_CEILING_ROW_Y } from '../sim/constants.js';
+import { MAX_COMMANDS_PER_TICK, type SimCommand } from '../sim/commands.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Build a minimal ViewState for tests. */
 function makeViewState(
-  view: 'surface' | 'underground' = 'underground',
-  camX = 64,
-  camY = 32,
+  colonyId: number = PLAYER_COLONY_ID,
+  tool: 'command' | 'dig' | 'chamber' = 'dig',
 ): ViewState {
   return {
-    activeView: view,
+    activeView: 'underground',
+    activeTool: tool,
     surfaceCamera: {
-      x: camX,
-      y: camY,
+      x: 10,
+      y: 10,
       viewportWidth: VIEWPORT_WIDTH_TILES,
       viewportHeight: VIEWPORT_HEIGHT_TILES,
     },
     undergroundCamera: {
-      x: camX,
-      y: camY,
+      x: 10,
+      y: 10,
       viewportWidth: VIEWPORT_WIDTH_TILES,
       viewportHeight: VIEWPORT_HEIGHT_TILES,
     },
     undergroundVisited: true,
-    activeUndergroundColonyId: PLAYER_COLONY_ID,
+    activeUndergroundColonyId: colonyId,
     showPheromoneOverlay: true,
   };
 }
 
-/**
- * Convert tile coords to screen pixel coords for the underground camera.
- * Mirrors the renderer's integer-tile snap so tests hit the pixel the player
- * sees the tile at.
- */
-function tileToScreen(
-  tileX: number,
-  tileY: number,
-  camX: number,
-  camY: number,
-): { x: number; y: number } {
-  const left = Math.floor(camX - VIEWPORT_WIDTH_TILES / 2);
-  const top = Math.floor(camY - VIEWPORT_HEIGHT_TILES / 2);
-  const px = (tileX - left) * TILE_SIZE_PX;
-  const py = (tileY - top) * TILE_SIZE_PX;
-  return { x: px, y: py };
-}
-
-/**
- * Build a WorldState stub with a single underground grid for PLAYER_COLONY_ID.
- * gridWidth/gridHeight default to 20x20 for test convenience.
- */
 function makeWorld(
   overrides: {
     tick?: number;
     gridWidth?: number;
     gridHeight?: number;
+    commandQueue?: SimCommand[];
   } = {},
 ): WorldState {
   const w = overrides.gridWidth ?? 20;
@@ -102,31 +75,10 @@ function makeWorld(
   const grid = createUndergroundGrid(w, h);
   return {
     tick: overrides.tick ?? 0,
-    // Default to LEGACY so existing right-click-on-Solid is-a-no-op tests
-    // pass. Issue #38 v5+ tests set simVersion explicitly.
-    simVersion: LEGACY_SIM_VERSION,
     rngState: 0,
     nextEntityId: 0,
-    commandQueue: [] as SimCommand[],
-    ants: {
-      posX: new Int32Array(0),
-      posY: new Int32Array(0),
-      colonyId: new Int32Array(0),
-      task: new Int32Array(0),
-      subTask: new Int32Array(0),
-      speed: new Int32Array(0),
-      foodCarrying: new Int32Array(0),
-      starvationTimer: new Int32Array(0),
-      age: new Int32Array(0),
-      alive: new Int32Array(0),
-      lifespan: new Int32Array(0),
-      zone: new Int32Array(0),
-      digTileX: new Int32Array(0),
-      digTileY: new Int32Array(0),
-      digTicksRemaining: new Int32Array(0),
-      targetPosX: new Int32Array(0),
-      targetPosY: new Int32Array(0),
-    },
+    commandQueue: overrides.commandQueue ?? ([] as SimCommand[]),
+    ants: {} as WorldState['ants'],
     colonies: {},
     pheromoneGrids: {},
     surface: { data: new Uint8Array(0), width: 0, height: 0 },
@@ -136,23 +88,20 @@ function makeWorld(
   } as unknown as WorldState;
 }
 
-/** UndergroundInputState equivalent (the private interface in underground-input.ts). */
-function makeState(isDragging = false, lastX = -1, lastY = -1) {
-  return { isDragging, lastMarkedTileX: lastX, lastMarkedTileY: lastY };
+function grid(world: WorldState) {
+  return world.undergroundGrids[PLAYER_COLONY_ID]!;
+}
+function lastCmd(world: WorldState): SimCommand | undefined {
+  return world.commandQueue[world.commandQueue.length - 1];
+}
+function markCount(world: WorldState): number {
+  return world.commandQueue.filter((c) => c.type === 'MarkDigTile').length;
 }
 
-// ---------------------------------------------------------------------------
-// Reset contextMenuState singleton between tests
-// ---------------------------------------------------------------------------
-
 beforeEach(() => {
-  // hideContextMenu clears visible + pendingHide + pendingShow.
   hideContextMenu();
-  contextMenuState.screenX = 0;
-  contextMenuState.screenY = 0;
   contextMenuState.anchorTileX = 0;
   contextMenuState.anchorTileY = 0;
-  resetPanInputStateForTests();
 });
 
 // ---------------------------------------------------------------------------
@@ -160,1113 +109,241 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('isTunnelEnd', () => {
-  it('returns true for an Open tile surrounded by 4 Solid neighbors', () => {
+  it('true for an Open tile with at least one Solid 4-neighbor', () => {
     const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    // Center tile (5,5): set Open; all 4 neighbors remain Solid (default)
-    ugSet(grid, 5, 5, UndergroundTileState.Open);
+    ugSet(grid(world), 5, 5, UndergroundTileState.Open); // neighbors stay Solid
     expect(isTunnelEnd(world, 5, 5, PLAYER_COLONY_ID)).toBe(true);
   });
-
-  it('returns false for an Open tile with no Solid neighbors (surrounded by Open)', () => {
+  it('false for an Open tile fully surrounded by Open', () => {
     const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    // Set (5,5) and all 4 neighbors to Open
-    ugSet(grid, 5, 5, UndergroundTileState.Open);
-    ugSet(grid, 5, 4, UndergroundTileState.Open); // N
-    ugSet(grid, 6, 5, UndergroundTileState.Open); // E
-    ugSet(grid, 5, 6, UndergroundTileState.Open); // S
-    ugSet(grid, 4, 5, UndergroundTileState.Open); // W
+    const cells: Array<[number, number]> = [
+      [5, 5],
+      [5, 4],
+      [6, 5],
+      [5, 6],
+      [4, 5],
+    ];
+    for (const [x, y] of cells) {
+      ugSet(grid(world), x, y, UndergroundTileState.Open);
+    }
     expect(isTunnelEnd(world, 5, 5, PLAYER_COLONY_ID)).toBe(false);
-  });
-
-  it('returns false for a Solid tile (must be Open)', () => {
-    const world = makeWorld();
-    // (5,5) stays Solid by default
-    expect(isTunnelEnd(world, 5, 5, PLAYER_COLONY_ID)).toBe(false);
-  });
-
-  it('returns false for a Marked tile (must be Open)', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.Marked);
-    expect(isTunnelEnd(world, 5, 5, PLAYER_COLONY_ID)).toBe(false);
-  });
-
-  it('returns false for a BeingDug tile (must be Open)', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.BeingDug);
-    expect(isTunnelEnd(world, 5, 5, PLAYER_COLONY_ID)).toBe(false);
-  });
-
-  it('returns true when Open tile is at the left edge with a valid Solid neighbor (not skipping valid neighbors at boundary)', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    // (0, 5) at the left edge: W neighbor (−1, 5) is out-of-bounds (skipped),
-    // but N (0,4), E (1,5), S (0,6) remain Solid — so still true.
-    ugSet(grid, 0, 5, UndergroundTileState.Open);
-    expect(isTunnelEnd(world, 0, 5, PLAYER_COLONY_ID)).toBe(true);
-  });
-
-  it('returns false when all valid (in-bounds) neighbors are Open at an edge tile', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    // (0, 5): W is out-of-bounds; set N, E, S all to Open → no Solid neighbors
-    ugSet(grid, 0, 5, UndergroundTileState.Open);
-    ugSet(grid, 0, 4, UndergroundTileState.Open); // N
-    ugSet(grid, 1, 5, UndergroundTileState.Open); // E
-    ugSet(grid, 0, 6, UndergroundTileState.Open); // S
-    expect(isTunnelEnd(world, 0, 5, PLAYER_COLONY_ID)).toBe(false);
-  });
-
-  it('returns false when the undergroundGrid for colonyId is missing', () => {
-    const world = makeWorld();
-    // Query a non-existent colony (2)
-    expect(isTunnelEnd(world, 5, 5, 2)).toBe(false);
   });
 });
 
 // ---------------------------------------------------------------------------
-// handleUndergroundLeftClick
+// handleUndergroundCommandTap
 // ---------------------------------------------------------------------------
 
-describe('handleUndergroundLeftClick', () => {
-  it('pushes MarkDigTileCommand for a Solid tile', () => {
-    const world = makeWorld({ tick: 7 });
-    // (5,10) stays Solid by default
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as {
-      type: string;
-      colonyId: number;
-      tileX: number;
-      tileY: number;
-      issuedAtTick: number;
-    };
-    expect(cmd.type).toBe('MarkDigTile');
-    expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
-    expect(cmd.tileX).toBe(5);
-    expect(cmd.tileY).toBe(10);
-    expect(cmd.issuedAtTick).toBe(7);
-  });
-
-  it('pushes MarkDigTileCommand for an Open tile', () => {
+describe('handleUndergroundCommandTap', () => {
+  it('Marked tile → CancelDigMark', () => {
     const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 10, UndergroundTileState.Open);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    expect((world.commandQueue[0] as { type: string }).type).toBe('MarkDigTile');
+    ugSet(grid(world), 5, 10, UndergroundTileState.Marked);
+    handleUndergroundCommandTap(world, makeViewState(), 5, 10, false);
+    expect((lastCmd(world) as { type: string }).type).toBe('CancelDigMark');
   });
-
-  it('is a no-op when activeView is surface', () => {
+  it('Solid / Open / BeingDug → no-op', () => {
     const world = makeWorld();
-    const vs = makeViewState('surface', 64, 32);
-    const state = makeState();
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
+    ugSet(grid(world), 6, 10, UndergroundTileState.Open);
+    ugSet(grid(world), 7, 10, UndergroundTileState.BeingDug);
+    handleUndergroundCommandTap(world, makeViewState(), 5, 10, false); // Solid
+    handleUndergroundCommandTap(world, makeViewState(), 6, 10, false); // Open
+    handleUndergroundCommandTap(world, makeViewState(), 7, 10, false); // BeingDug
     expect(world.commandQueue).toHaveLength(0);
   });
-
-  it('is a no-op when pointer is over a HUD zone', () => {
+  it('enemy-view read-only: no command on the enemy grid', () => {
     const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    handleUndergroundLeftClick(world, vs, HUD.TRIANGLE.x + 5, HUD.TRIANGLE.y + 5, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('does not push a command for a Marked tile but still arms drag state', () => {
-    // Click on already-Marked tile must arm isDragging + lastMarkedTile so a
-    // continuation drag into adjacent Solid still marks dirt. Without the
-    // arming, the subsequent pointermove would observe isDragging=false and
-    // silently no-op for the rest of the gesture (the bug this fix addresses).
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 10, UndergroundTileState.Marked);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(true);
-    expect(state.lastMarkedTileX).toBe(5);
-    expect(state.lastMarkedTileY).toBe(10);
-  });
-
-  it('does not push a command for a BeingDug tile but still arms drag state', () => {
-    // Same arming contract as the Marked case — BeingDug tiles are also
-    // already-claimed, so no command is emitted, but a click that lands on
-    // one must arm the drag so the rest of the stroke can mark dirt.
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 10, UndergroundTileState.BeingDug);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(true);
-    expect(state.lastMarkedTileX).toBe(5);
-    expect(state.lastMarkedTileY).toBe(10);
-  });
-
-  it('is a no-op for out-of-bounds tile coordinates and does not arm drag state', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    // screen coord that maps to tileX < 0
-    handleUndergroundLeftClick(world, vs, -640, 0, state);
-    expect(world.commandQueue).toHaveLength(0);
-    // Out-of-bounds is a rejection, not an accept-and-skip — drag must NOT arm.
-    expect(state.isDragging).toBe(false);
-    expect(state.lastMarkedTileX).toBe(-1);
-    expect(state.lastMarkedTileY).toBe(-1);
-  });
-
-  it('sets isDragging=true and records lastMarkedTile after a successful click', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(state.isDragging).toBe(true);
-    expect(state.lastMarkedTileX).toBe(5);
-    expect(state.lastMarkedTileY).toBe(10);
-  });
-
-  it('does NOT push MarkDigTile when ant-activity panel pendingHide is set (UIScene-first race)', async () => {
-    // Scenario: player opens HUD ant-activity popup, then clicks on the
-    // underground map to dismiss it. UIScene's pointerdown handler sets
-    // pendingHide=true before returning. The subsequent underground-input
-    // pointerdown must observe the click as HUD-consumed and drop it —
-    // otherwise the dismissal click would also mark the tile for digging.
-    const { showAntActivityPanel, requestHideAntActivityPanel, hideAntActivityPanel } =
-      await import('../render/ant-activity-panel-state.js');
-    const world = makeWorld({ tick: 7 });
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-
-    showAntActivityPanel();
-    requestHideAntActivityPanel();
-    try {
-      handleUndergroundLeftClick(world, vs, x, y, state);
-      expect(world.commandQueue).toHaveLength(0);
-      expect(state.isDragging).toBe(false);
-    } finally {
-      hideAntActivityPanel();
-    }
-  });
-
-  it('does NOT push MarkDigTile when panel is visible and pendingHide=false (world-input-first race)', async () => {
-    // World-input-first dispatch ordering: UIScene has NOT yet called
-    // requestHideAntActivityPanel(), so pendingHide is still false when the
-    // underground-input pointerdown runs. The click must still be consumed
-    // — otherwise the dismissal click would also mark a dig tile. isPointer-
-    // OverHUD now masks on `visible` alone (not just pendingHide) to close
-    // both listener orderings.
-    const { showAntActivityPanel, hideAntActivityPanel, antActivityPanelState } =
-      await import('../render/ant-activity-panel-state.js');
-    const world = makeWorld({ tick: 7 });
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-
-    showAntActivityPanel();
-    try {
-      expect(antActivityPanelState.visible).toBe(true);
-      expect(antActivityPanelState.pendingHide).toBe(false);
-      handleUndergroundLeftClick(world, vs, x, y, state);
-      expect(world.commandQueue).toHaveLength(0);
-      expect(state.isDragging).toBe(false);
-    } finally {
-      hideAntActivityPanel();
-    }
-  });
-
-  it('right-click also no-ops when panel is visible and pendingHide=false (world-input-first race)', async () => {
-    // Right-click on Marked or Open-tunnel-end would normally emit
-    // CancelDigMark / open a context menu. Must be suppressed while the
-    // panel is up, regardless of listener order.
-    const { showAntActivityPanel, hideAntActivityPanel } =
-      await import('../render/ant-activity-panel-state.js');
-    const world = makeWorld({ tick: 4 });
-    // Seed a Marked tile at (5, 10) so a normal right-click would emit
-    // CancelDigMarkCommand.
-    ugSet(world.undergroundGrids[PLAYER_COLONY_ID]!, 5, 10, UndergroundTileState.Marked);
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-
-    showAntActivityPanel();
-    try {
-      handleUndergroundRightClick(world, vs, x, y);
-      expect(world.commandQueue).toHaveLength(0);
-    } finally {
-      hideAntActivityPanel();
-    }
-  });
-
-  it('suppresses click without mutating menu state when menu is visible', () => {
-    // UIScene owns menu dismissal (requestHideContextMenu → applied next frame).
-    // handleUndergroundLeftClick must NOT flip `visible` synchronously or it
-    // races with UIScene's pointerdown handler on the same event.
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    contextMenuState.visible = true;
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(contextMenuState.visible).toBe(true);
-    expect(contextMenuState.pendingHide).toBe(false);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(false);
-  });
-
-  it('is a no-op while panInputState.spaceHeld is true (Space+left-drag is pan, not dig-mark)', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    panInputState.spaceHeld = true;
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(false);
-  });
-
-  it('is a no-op while panInputState.isPanning is true (mid-pan clicks are pan continuation)', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    panInputState.isPanning = true;
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(false);
-  });
-
-  // The eager arm-on-click for already-claimed tiles must NOT bypass the
-  // rejection guards (HUD / pan / context menu). These are symmetric
-  // counterparts to the Solid-tile guard tests above — they pin the contract
-  // that arming only happens AFTER all guards have passed, regardless of
-  // tile state. A future refactor that moves arming above a guard would
-  // break these.
-  it('Marked-tile click does NOT arm drag when context menu is visible', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 10, UndergroundTileState.Marked);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    contextMenuState.visible = true;
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(state.isDragging).toBe(false);
-    expect(state.lastMarkedTileX).toBe(-1);
-    expect(state.lastMarkedTileY).toBe(-1);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('Marked-tile click does NOT arm drag when panInputState.spaceHeld is true', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 10, UndergroundTileState.Marked);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    panInputState.spaceHeld = true;
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(state.isDragging).toBe(false);
-    expect(state.lastMarkedTileX).toBe(-1);
-    expect(state.lastMarkedTileY).toBe(-1);
-  });
-
-  it('Marked-tile click does NOT arm drag when pointer is over HUD', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    // HUD-overlap rejection runs before screenToTile, so the underlying tile
-    // state at the world coord is irrelevant here — we just verify that the
-    // arm code never executes when HUD eats the click.
-    handleUndergroundLeftClick(world, vs, HUD.TRIANGLE.x + 5, HUD.TRIANGLE.y + 5, state);
-    expect(state.isDragging).toBe(false);
-    expect(state.lastMarkedTileX).toBe(-1);
-    expect(state.lastMarkedTileY).toBe(-1);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// handleUndergroundDrag
-// ---------------------------------------------------------------------------
-
-describe('handleUndergroundDrag', () => {
-  it('pushes MarkDigTileCommand when drag enters a new tile', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    // Start dragging from (5,10), move to (6,10)
-    const state = makeState(true, 5, 10);
-    const { x, y } = tileToScreen(6, 10, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; tileX: number; tileY: number };
-    expect(cmd.type).toBe('MarkDigTile');
-    expect(cmd.tileX).toBe(6);
-    expect(cmd.tileY).toBe(10);
-    expect(state.lastMarkedTileX).toBe(6);
-    expect(state.lastMarkedTileY).toBe(10);
-  });
-
-  it('does NOT push a command when pointer stays on the same tile (debounce)', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    // isDragging=true, last tile was (5,10), drag stays at (5,10)
-    const state = makeState(true, 5, 10);
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('is a no-op when isDragging is false', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState(false, 5, 10);
-    const { x, y } = tileToScreen(6, 10, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('sets isDragging=false when activeView switches to surface mid-drag', () => {
-    const world = makeWorld();
-    const vs = makeViewState('surface', 64, 32); // view switched
-    const state = makeState(true, 5, 10);
-    const { x, y } = tileToScreen(6, 10, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    expect(state.isDragging).toBe(false);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('does NOT push a command for a Marked tile during drag', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 6, 10, UndergroundTileState.Marked);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState(true, 5, 10);
-    const { x, y } = tileToScreen(6, 10, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('cancels drag and no-ops when Space is pressed mid-drag (gesture switches to pan)', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState(true, 5, 10);
-    panInputState.spaceHeld = true;
-    const { x, y } = tileToScreen(6, 10, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(false);
-  });
-
-  // 09 backlog memo — drag interpolation must emit a 4-connected (Manhattan-
-  // adjacent) tile sequence. A pure diagonal between successive tiles would
-  // leave them touching only by a corner, which breaks the 4-connected
-  // underground movement/dig graph and creates unreachable tunnel segments.
-  // Each diagonal step is split into an orthogonal bridge + the destination.
-  it('single-step diagonal drag from (10,10) to (11,11) emits an orthogonal bridge tile plus the final tile', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState(true, 10, 10);
-    const { x, y } = tileToScreen(11, 11, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    const marks = world.commandQueue.map((c) => {
-      const cc = c as { type: string; tileX: number; tileY: number };
-      return `${cc.tileX},${cc.tileY}`;
-    });
-    // At least one bridge tile (11,10) or (10,11) must be emitted; the
-    // destination (11,11) is always emitted. Starting tile is not re-emitted.
-    const bridgeEmitted = marks.includes('11,10') || marks.includes('10,11');
-    expect(bridgeEmitted).toBe(true);
-    expect(marks).toContain('11,11');
-    expect(marks).not.toContain('10,10');
-    // Every successive emitted tile — measured from the prior marked tile
-    // (10,10) — must be Manhattan-adjacent (4-connected).
-    const prev: Array<[number, number]> = [[10, 10]];
-    for (const m of marks) {
-      const [xs, ys] = m.split(',').map(Number) as [number, number];
-      const [px, py] = prev[prev.length - 1]!;
-      expect(Math.abs(xs - px) + Math.abs(ys - py)).toBe(1);
-      prev.push([xs, ys]);
-    }
-    expect(state.lastMarkedTileX).toBe(11);
-    expect(state.lastMarkedTileY).toBe(11);
-  });
-
-  it('diagonal drag from (10,10) to (12,12) produces a continuous 4-connected path', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState(true, 10, 10);
-    const { x, y } = tileToScreen(12, 12, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    const marks = world.commandQueue.map((c) => {
-      const cc = c as { type: string; tileX: number; tileY: number };
-      return `${cc.tileX},${cc.tileY}`;
-    });
-    expect(marks).toContain('12,12');
-    expect(marks).not.toContain('10,10');
-    // Continuous 4-connected sequence starting from (10,10).
-    const prev: Array<[number, number]> = [[10, 10]];
-    for (const m of marks) {
-      const [xs, ys] = m.split(',').map(Number) as [number, number];
-      const [px, py] = prev[prev.length - 1]!;
-      expect(Math.abs(xs - px) + Math.abs(ys - py)).toBe(1);
-      prev.push([xs, ys]);
-    }
-    expect(state.lastMarkedTileX).toBe(12);
-    expect(state.lastMarkedTileY).toBe(12);
-  });
-
-  it('shallow diagonal drag from (10,10) to (13,11) emits a continuous 4-connected path', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState(true, 10, 10);
-    const { x, y } = tileToScreen(13, 11, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    const marks = world.commandQueue.map((c) => {
-      const cc = c as { tileX: number; tileY: number };
-      return `${cc.tileX},${cc.tileY}`;
-    });
-    // Final tile is (13,11).
-    expect(marks[marks.length - 1]).toBe('13,11');
-    // Every successive tile is Manhattan-adjacent (4-connectivity), not just
-    // 8-connected. This is the contract the underground grid requires.
-    const prev: Array<[number, number]> = [[10, 10]];
-    for (const m of marks) {
-      const [xs, ys] = m.split(',').map(Number) as [number, number];
-      const [px, py] = prev[prev.length - 1]!;
-      expect(Math.abs(xs - px) + Math.abs(ys - py)).toBe(1);
-      prev.push([xs, ys]);
-    }
-  });
-
-  it('diagonal drag skips non-markable tiles without aborting the stroke', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    // Put a Marked tile somewhere along the path from (10,10) to (12,12).
-    ugSet(grid, 11, 11, UndergroundTileState.Marked);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState(true, 10, 10);
-    const { x, y } = tileToScreen(12, 12, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    const marks = world.commandQueue.map((c) => {
-      const cc = c as { tileX: number; tileY: number };
-      return `${cc.tileX},${cc.tileY}`;
-    });
-    // (11,11) was Marked already → no command emitted. (12,12) still emitted.
-    expect(marks).not.toContain('11,11');
-    expect(marks).toContain('12,12');
-    expect(state.lastMarkedTileX).toBe(12);
-    expect(state.lastMarkedTileY).toBe(12);
-  });
-
-  it('same-tile drag does not emit extra commands (debounce)', () => {
-    const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState(true, 10, 10);
-    const { x, y } = tileToScreen(10, 10, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
+    ugSet(grid(world), 5, 10, UndergroundTileState.Marked);
+    handleUndergroundCommandTap(world, makeViewState(ENEMY_COLONY_ID), 5, 10, false);
     expect(world.commandQueue).toHaveLength(0);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Click + drag handoff: starting on an already-claimed tile must still mark
-// newly-entered Solid tiles. Regression coverage for the "click on blue
-// to-be-dug tile then drag through dirt" bug.
+// handleUndergroundDigTap
 // ---------------------------------------------------------------------------
 
-describe('left-click + drag handoff', () => {
-  it('click on Marked then drag into adjacent Solid emits MarkDigTile on the Solid tile', () => {
-    const world = makeWorld({ tick: 3 });
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    // Player previously marked (5,10); now they click there and drag east
-    // through Solid dirt at (6,10). The dirt must end up marked.
-    ugSet(grid, 5, 10, UndergroundTileState.Marked);
-    // (6,10) stays Solid by default
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-
-    // 1. pointerdown on the Marked tile.
-    const start = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, start.x, start.y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(true);
-
-    // 2. pointermove into the adjacent Solid tile.
-    const dragTo = tileToScreen(6, 10, 64, 32);
-    handleUndergroundDrag(world, vs, dragTo.x, dragTo.y, state);
-
-    // The Solid tile must have been marked.
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; tileX: number; tileY: number };
-    expect(cmd.type).toBe('MarkDigTile');
-    expect(cmd.tileX).toBe(6);
-    expect(cmd.tileY).toBe(10);
-  });
-
-  it('click on BeingDug then drag into adjacent Solid emits MarkDigTile on the Solid tile', () => {
-    // Same contract for BeingDug — the click is on an already-claimed tile,
-    // but the drag must still mark dirt encountered after the start.
-    const world = makeWorld({ tick: 5 });
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 10, UndergroundTileState.BeingDug);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-
-    const start = tileToScreen(5, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, start.x, start.y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(true);
-
-    const dragTo = tileToScreen(6, 10, 64, 32);
-    handleUndergroundDrag(world, vs, dragTo.x, dragTo.y, state);
-
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; tileX: number; tileY: number };
-    expect(cmd.type).toBe('MarkDigTile');
-    expect(cmd.tileX).toBe(6);
-    expect(cmd.tileY).toBe(10);
-  });
-
-  it('click on Marked then drag across multiple Solid tiles produces a continuous 4-connected mark sequence', () => {
-    // Multi-tile stroke variant — exercises the Bresenham interpolation
-    // starting from a Marked tile. Covers the realistic gesture: player taps
-    // an already-marked tile and sweeps through dirt to mark a corridor.
+describe('handleUndergroundDigTap', () => {
+  it('Solid → MarkDigTile', () => {
     const world = makeWorld();
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 10, 10, UndergroundTileState.Marked);
-    // (11,10) through (13,10) stay Solid by default
-
-    const start = tileToScreen(10, 10, 64, 32);
-    handleUndergroundLeftClick(world, vs, start.x, start.y, state);
+    handleUndergroundDigTap(world, makeViewState(), 5, 10, false);
+    expect((lastCmd(world) as { type: string }).type).toBe('MarkDigTile');
+  });
+  it('Open → MarkDigTile', () => {
+    const world = makeWorld();
+    ugSet(grid(world), 5, 10, UndergroundTileState.Open);
+    handleUndergroundDigTap(world, makeViewState(), 5, 10, false);
+    expect((lastCmd(world) as { type: string }).type).toBe('MarkDigTile');
+  });
+  it('Marked → CancelDigMark', () => {
+    const world = makeWorld();
+    ugSet(grid(world), 5, 10, UndergroundTileState.Marked);
+    handleUndergroundDigTap(world, makeViewState(), 5, 10, false);
+    expect((lastCmd(world) as { type: string }).type).toBe('CancelDigMark');
+  });
+  it('BeingDug → no-op', () => {
+    const world = makeWorld();
+    ugSet(grid(world), 5, 10, UndergroundTileState.BeingDug);
+    handleUndergroundDigTap(world, makeViewState(), 5, 10, false);
     expect(world.commandQueue).toHaveLength(0);
-
-    const dragTo = tileToScreen(13, 10, 64, 32);
-    handleUndergroundDrag(world, vs, dragTo.x, dragTo.y, state);
-
-    const marks = world.commandQueue.map((c) => {
-      const cc = c as { tileX: number; tileY: number };
-      return `${cc.tileX},${cc.tileY}`;
-    });
-    // Every dirt tile crossed during the drag must be in the queue. The
-    // starting (Marked) tile is not re-emitted.
-    expect(marks).toContain('11,10');
-    expect(marks).toContain('12,10');
-    expect(marks).toContain('13,10');
-    expect(marks).not.toContain('10,10');
+  });
+  it('ceiling row → no-op', () => {
+    const world = makeWorld();
+    handleUndergroundDigTap(world, makeViewState(), 5, UNDERGROUND_CEILING_ROW_Y, false);
+    expect(world.commandQueue).toHaveLength(0);
+  });
+  it('enemy view → no-op', () => {
+    const world = makeWorld();
+    handleUndergroundDigTap(world, makeViewState(ENEMY_COLONY_ID), 5, 10, false);
+    expect(world.commandQueue).toHaveLength(0);
   });
 });
 
 // ---------------------------------------------------------------------------
-// handleUndergroundRightClick
+// Paint stroke
 // ---------------------------------------------------------------------------
 
-describe('handleUndergroundRightClick', () => {
-  it('pushes CancelDigMarkCommand for a Marked tile', () => {
-    const world = makeWorld({ tick: 2 });
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 10, UndergroundTileState.Marked);
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 10, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as {
-      type: string;
-      colonyId: number;
-      tileX: number;
-      tileY: number;
-      issuedAtTick: number;
-    };
-    expect(cmd.type).toBe('CancelDigMark');
-    expect(cmd.colonyId).toBe(PLAYER_COLONY_ID);
-    expect(cmd.tileX).toBe(5);
-    expect(cmd.tileY).toBe(10);
-    expect(cmd.issuedAtTick).toBe(2);
+describe('paint stroke', () => {
+  let stroke: PaintStrokeState;
+  beforeEach(() => {
+    stroke = createPaintStrokeState();
   });
 
-  it('requests a deferred show for an Open tunnel-end tile (anchor stored immediately, visible flipped on next update)', () => {
-    // Deferred show is required because UIScene's pointerdown handler runs in
-    // the same dispatch as this one. If visible flipped synchronously, UIScene
-    // would see visible=true on the SAME right-click event and interpret it as
-    // a menu item selection — the bug this deferred-show pattern exists to fix.
+  it('beginPaintStroke marks the Solid down-tile once and arms the cursor', () => {
     const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    // (5,5) Open; N (5,4) stays Solid → tunnel end
-    ugSet(grid, 5, 5, UndergroundTileState.Open);
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    // Immediately after the handler: visible is still false, pendingShow is true,
-    // and the anchor (tile + screen coords) is stored for rendering on next frame.
-    expect(contextMenuState.visible).toBe(false);
+    beginPaintStroke(stroke, world, makeViewState(), 5, 10, false);
+    expect(markCount(world)).toBe(1);
+    expect(stroke.active).toBe(true);
+    expect([stroke.lastMarkedTileX, stroke.lastMarkedTileY]).toEqual([5, 10]);
+  });
+
+  it('a straight horizontal stroke marks each newly-entered tile (first tile once)', () => {
+    const world = makeWorld();
+    beginPaintStroke(stroke, world, makeViewState(), 5, 10, false); // marks (5,10)
+    continuePaintStroke(stroke, world, makeViewState(), 8, 10, false); // marks 6,7,8
+    expect(markCount(world)).toBe(4);
+    const marks = world.commandQueue
+      .filter((c) => c.type === 'MarkDigTile')
+      .map((c) => [(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
+    expect(marks).toEqual([
+      [5, 10],
+      [6, 10],
+      [7, 10],
+      [8, 10],
+    ]);
+  });
+
+  it('diagonal stroke stays 4-connected (Manhattan-adjacent successive tiles)', () => {
+    const world = makeWorld();
+    beginPaintStroke(stroke, world, makeViewState(), 5, 10, false);
+    continuePaintStroke(stroke, world, makeViewState(), 7, 12, false);
+    const marks: Array<[number, number]> = world.commandQueue
+      .filter((c) => c.type === 'MarkDigTile')
+      .map((c) => [(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
+    for (let i = 1; i < marks.length; i++) {
+      const a = marks[i]!;
+      const b = marks[i - 1]!;
+      const dManhattan = Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]);
+      expect(dManhattan).toBe(1);
+    }
+  });
+
+  it('continue is a debounce no-op when the target is the same tile', () => {
+    const world = makeWorld();
+    beginPaintStroke(stroke, world, makeViewState(), 5, 10, false);
+    const before = markCount(world);
+    continuePaintStroke(stroke, world, makeViewState(), 5, 10, false);
+    expect(markCount(world)).toBe(before);
+  });
+
+  it('aborts (active=false) if the colony switches to enemy mid-stroke', () => {
+    const world = makeWorld();
+    beginPaintStroke(stroke, world, makeViewState(), 5, 10, false);
+    const before = markCount(world);
+    continuePaintStroke(stroke, world, makeViewState(ENEMY_COLONY_ID), 8, 10, false);
+    expect(stroke.active).toBe(false);
+    expect(markCount(world)).toBe(before); // no new marks on the enemy grid
+  });
+
+  it('does not arm a stroke on the ceiling row', () => {
+    const world = makeWorld();
+    beginPaintStroke(stroke, world, makeViewState(), 5, UNDERGROUND_CEILING_ROW_Y, false);
+    expect(stroke.active).toBe(false);
+    expect(markCount(world)).toBe(0);
+  });
+
+  it('resetPaintStrokeState clears it in place', () => {
+    const world = makeWorld();
+    beginPaintStroke(stroke, world, makeViewState(), 5, 10, false);
+    const ref = stroke;
+    resetPaintStrokeState(stroke);
+    expect(stroke).toBe(ref);
+    expect(stroke.active).toBe(false);
+    expect([stroke.lastMarkedTileX, stroke.lastMarkedTileY]).toEqual([-1, -1]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tryOpenChamberMenu
+// ---------------------------------------------------------------------------
+
+describe('tryOpenChamberMenu', () => {
+  it('Solid tile → requests the menu, anchored at the tile + screen coords', () => {
+    const world = makeWorld();
+    const ok = tryOpenChamberMenu(world, makeViewState(), 120, 80, 5, 10);
+    expect(ok).toBe(true);
     expect(contextMenuState.pendingShow).toBe(true);
-    expect(contextMenuState.anchorTileX).toBe(5);
-    expect(contextMenuState.anchorTileY).toBe(5);
-    expect(contextMenuState.screenX).toBeCloseTo(x);
-    expect(contextMenuState.screenY).toBeCloseTo(y);
-    expect(world.commandQueue).toHaveLength(0);
-    // On the next frame, UIScene.update calls applyPendingContextMenuShow and
-    // the menu becomes visible to the renderer.
-    applyPendingContextMenuShow();
-    expect(contextMenuState.visible).toBe(true);
+    expect([contextMenuState.anchorTileX, contextMenuState.anchorTileY]).toEqual([5, 10]);
+    expect([contextMenuState.screenX, contextMenuState.screenY]).toEqual([120, 80]);
+  });
+
+  it('Open tile → eligible', () => {
+    const world = makeWorld();
+    ugSet(grid(world), 5, 10, UndergroundTileState.Open);
+    expect(tryOpenChamberMenu(world, makeViewState(), 120, 80, 5, 10)).toBe(true);
+  });
+
+  it('Marked tile → NOT eligible (excluded)', () => {
+    const world = makeWorld();
+    ugSet(grid(world), 5, 10, UndergroundTileState.Marked);
+    expect(tryOpenChamberMenu(world, makeViewState(), 120, 80, 5, 10)).toBe(false);
     expect(contextMenuState.pendingShow).toBe(false);
   });
 
-  it('cross-scene race: a pointerdown handler running after handleUndergroundRightClick sees visible=false for this same dispatch', () => {
-    // This is the exact scenario the deferred-show pattern defends against.
-    // UIScene's pointerdown handler runs in the same JS dispatch as the
-    // underground-input pointerdown handler. It MUST NOT see visible=true from
-    // the show that is pending for the next frame, or it would misinterpret
-    // the right-click as a menu-item selection (the menu anchor is at the
-    // pointer, so the click lands on the first item).
+  it('BeingDug tile → NOT eligible', () => {
     const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.Open);
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-
-    handleUndergroundRightClick(world, vs, x, y);
-
-    // Simulate the "UIScene handler running second in the same dispatch"
-    // observing the state. It must see visible=false so its menu-selection
-    // branch does not fire on this right-click.
-    const visibleAtSecondHandlerEntry = contextMenuState.visible;
-    expect(visibleAtSecondHandlerEntry).toBe(false);
-
-    // No PlaceChamberCommand should have been pushed by either handler
-    // on this dispatch — only the anchor metadata is set for next-frame render.
-    expect(world.commandQueue).toHaveLength(0);
+    ugSet(grid(world), 5, 10, UndergroundTileState.BeingDug);
+    expect(tryOpenChamberMenu(world, makeViewState(), 120, 80, 5, 10)).toBe(false);
   });
 
-  it('menu remains visible across multiple frames after pendingShow applies (no auto-hide)', () => {
-    // Once the menu is shown on frame N+1, it stays visible until an explicit
-    // hide is requested (menu selection, click outside, or view toggle). This
-    // gives the player time to read the items and pick one.
+  it('enemy view → read-only, never opens', () => {
     const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.Open);
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    applyPendingContextMenuShow();
-    expect(contextMenuState.visible).toBe(true);
-    // Multiple frames pass with no pointerdown — menu stays visible.
-    applyPendingContextMenuShow(); // no-op on second call
-    expect(contextMenuState.visible).toBe(true);
-    applyPendingContextMenuShow();
-    expect(contextMenuState.visible).toBe(true);
+    expect(tryOpenChamberMenu(world, makeViewState(ENEMY_COLONY_ID), 120, 80, 5, 10)).toBe(false);
   });
 
-  it('does NOT open context menu for an Open tile that is NOT a tunnel end', () => {
+  it('ceiling row → not eligible', () => {
     const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    // (5,5) Open; all 4 neighbors Open → not a tunnel end
-    ugSet(grid, 5, 5, UndergroundTileState.Open);
-    ugSet(grid, 5, 4, UndergroundTileState.Open);
-    ugSet(grid, 6, 5, UndergroundTileState.Open);
-    ugSet(grid, 5, 6, UndergroundTileState.Open);
-    ugSet(grid, 4, 5, UndergroundTileState.Open);
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    expect(contextMenuState.visible).toBe(false);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('is a no-op for a Solid tile', () => {
-    const world = makeWorld();
-    // (5,5) stays Solid by default
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    expect(contextMenuState.visible).toBe(false);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('is a no-op for a BeingDug tile (CTRL-04: finish-then-switch)', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.BeingDug);
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    expect(contextMenuState.visible).toBe(false);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('is a no-op when activeView is surface', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.Marked);
-    const vs = makeViewState('surface', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('is a no-op when pointer is over HUD', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.Marked);
-    const vs = makeViewState('underground', 64, 32);
-    handleUndergroundRightClick(world, vs, HUD.STATS.x + 5, HUD.STATS.y + 5);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  // -------------------------------------------------------------------------
-  // Issue #38 — v5+ right-click on Solid OR Open opens the chamber menu.
-  // -------------------------------------------------------------------------
-
-  it('v5+: right-click on a Solid tile opens the chamber-placement menu (issue #38)', () => {
-    const world = makeWorld();
-    world.simVersion = SIM_VERSION_V5_CHAMBER_ON_MARKED;
-    // (5,5) stays Solid by default. Pre-v5 this was a no-op; v5 should
-    // surface the menu so the player can plan a chamber in untouched dirt.
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    expect(contextMenuState.pendingShow).toBe(true);
-    expect(contextMenuState.anchorTileX).toBe(5);
-    expect(contextMenuState.anchorTileY).toBe(5);
-  });
-
-  it('v5+: right-click on an Open tile that is NOT a tunnel end opens the menu (issue #38)', () => {
-    const world = makeWorld();
-    world.simVersion = SIM_VERSION_V5_CHAMBER_ON_MARKED;
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    // 3×3 Open region — interior tile (5,5) has no Solid 4-neighbor, so
-    // pre-v5 isTunnelEnd would reject. v5 should still open the menu.
-    for (let dy = -1; dy <= 1; dy++) {
-      for (let dx = -1; dx <= 1; dx++) {
-        ugSet(grid, 5 + dx, 5 + dy, UndergroundTileState.Open);
-      }
-    }
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    expect(contextMenuState.pendingShow).toBe(true);
-  });
-
-  it('v5+: right-click on a Marked tile still pushes CancelDigMark (existing UX preserved)', () => {
-    const world = makeWorld();
-    world.simVersion = SIM_VERSION_V5_CHAMBER_ON_MARKED;
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.Marked);
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    // CancelDigMark wins over chamber-placement menu on Marked tiles —
-    // the existing right-click muscle memory is preserved.
-    const cancelCmd = world.commandQueue.find((c) => c.type === 'CancelDigMark');
-    expect(cancelCmd).toBeDefined();
-    expect(contextMenuState.pendingShow).toBe(false);
-  });
-
-  it('v5+: right-click on a BeingDug tile is still a no-op (sim would reject)', () => {
-    const world = makeWorld();
-    world.simVersion = SIM_VERSION_V5_CHAMBER_ON_MARKED;
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.BeingDug);
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    expect(contextMenuState.pendingShow).toBe(false);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('v5+: right-click on the ceiling row is a no-op (sim ceiling guard mirrored)', () => {
-    const world = makeWorld();
-    world.simVersion = SIM_VERSION_V5_CHAMBER_ON_MARKED;
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 0, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    expect(contextMenuState.pendingShow).toBe(false);
-    expect(world.commandQueue).toHaveLength(0);
+    expect(tryOpenChamberMenu(world, makeViewState(), 120, 80, 5, UNDERGROUND_CEILING_ROW_Y)).toBe(
+      false,
+    );
   });
 });
 
 // ---------------------------------------------------------------------------
-// resetUndergroundInputState — Phase 9 session reset
+// Paused cap (paint producer)
 // ---------------------------------------------------------------------------
 
-describe('resetUndergroundInputState', () => {
-  it('ends an in-flight drag and clears the last-marked debounce', () => {
-    const state: UndergroundInputState = {
-      isDragging: true,
-      lastMarkedTileX: 12,
-      lastMarkedTileY: 7,
-    };
-    resetUndergroundInputState(state);
-    expect(state.isDragging).toBe(false);
-    expect(state.lastMarkedTileX).toBe(-1);
-    expect(state.lastMarkedTileY).toBe(-1);
-  });
-
-  it('preserves the state object identity (mutates in place)', () => {
-    // registerUndergroundInput closed over this reference; must not swap it.
-    const state: UndergroundInputState = {
-      isDragging: true,
-      lastMarkedTileX: 5,
-      lastMarkedTileY: 5,
-    };
-    const ref = state;
-    resetUndergroundInputState(state);
-    expect(state).toBe(ref);
-  });
-
-  it('is idempotent on an already-reset state', () => {
-    const state: UndergroundInputState = {
-      isDragging: false,
-      lastMarkedTileX: -1,
-      lastMarkedTileY: -1,
-    };
-    resetUndergroundInputState(state);
-    expect(state).toEqual({ isDragging: false, lastMarkedTileX: -1, lastMarkedTileY: -1 });
-  });
-
-  it('restart simulation: a post-reset drag does not inherit the old debounce', () => {
-    // Starting state after restart — no prior drag, no prior tile mark.
-    const state: UndergroundInputState = {
-      isDragging: true,
-      lastMarkedTileX: 5,
-      lastMarkedTileY: 5,
-    };
-    resetUndergroundInputState(state);
-    // After reset: a pointerdown on tile (5,5) in the new session must mark
-    // it, because lastMarkedTile was cleared. handleUndergroundLeftClick
-    // issues the command unconditionally on a Solid tile so we model the
-    // drag-debounce contract directly: the next tile differs from (-1,-1).
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.Solid);
-    const vs = makeViewState('underground', 64, 32);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    expect(state.isDragging).toBe(true);
-    expect(state.lastMarkedTileX).toBe(5);
-    expect(state.lastMarkedTileY).toBe(5);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Issue #14 — read-only when viewing enemy underground
-// ---------------------------------------------------------------------------
-
-describe('underground-input read-only when activeUndergroundColonyId !== PLAYER_COLONY_ID', () => {
-  // Helper: viewport pointing at the enemy underground.
-  function makeEnemyView(): ViewState {
-    return {
-      activeView: 'underground',
-      surfaceCamera: {
-        x: 64,
-        y: 32,
-        viewportWidth: VIEWPORT_WIDTH_TILES,
-        viewportHeight: VIEWPORT_HEIGHT_TILES,
-      },
-      undergroundCamera: {
-        x: 64,
-        y: 32,
-        viewportWidth: VIEWPORT_WIDTH_TILES,
-        viewportHeight: VIEWPORT_HEIGHT_TILES,
-      },
-      undergroundVisited: true,
-      activeUndergroundColonyId: ENEMY_COLONY_ID,
-      showPheromoneOverlay: true,
-    };
-  }
-
-  it('handleUndergroundLeftClick is a no-op while viewing the enemy hive', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.Solid);
-    const vs = makeEnemyView();
-    const state = makeState();
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    // No command emitted, no drag armed. The click was rejected silently —
-    // dispatching a MarkDigTile against PLAYER_COLONY_ID at the same coords
-    // would silently scribble on the player's grid the player can't see.
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(false);
-  });
-
-  it('handleUndergroundLeftClick on the enemy view clears any lingering isDragging flag', () => {
-    // Defensive: a prior gesture that didn't see a clean mouseup (e.g.,
-    // focus-loss) could leave isDragging=true. The enemy-view guard must
-    // also reset it so a subsequent flip back to the player view doesn't
-    // resume the stale stroke from a stale lastMarkedTile.
-    const world = makeWorld();
-    ugSet(world.undergroundGrids[PLAYER_COLONY_ID]!, 5, 5, UndergroundTileState.Solid);
-    const vs = makeEnemyView();
-    const state = makeState(/*isDragging*/ true, 4, 4);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(state.isDragging).toBe(false);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-
-  it('handleUndergroundDrag aborts and clears isDragging when activeUndergroundColonyId flips to enemy mid-drag', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.Solid);
-    const vs = makeEnemyView();
-    const state = makeState(/*isDragging*/ true, 4, 5);
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(false);
-  });
-
-  it('handleUndergroundRightClick is a no-op while viewing the enemy hive', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 5, 5, UndergroundTileState.Marked);
-    const vs = makeEnemyView();
-    const { x, y } = tileToScreen(5, 5, 64, 32);
-    handleUndergroundRightClick(world, vs, x, y);
-    expect(world.commandQueue).toHaveLength(0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Issue #30 — ceiling-strip click rejection
-// ---------------------------------------------------------------------------
-
-describe('underground-input — ceiling-strip row gate (issue #30)', () => {
-  it('handleUndergroundLeftClick on tileY=0 is a no-op (no MarkDigTile, no drag arm)', () => {
-    // The renderer paints the topmost underground row with the grass texture
-    // as a "this is the surface boundary, not a diggable wall" cue. Without
-    // this gate, a click on the visible grass dispatched MarkDigTile against
-    // the tile beneath, the renderer kept painting grass on top, and the
-    // mark was effectively invisible to the player. See draw-underground.ts
-    // (`ty === 0` branch) for the matching renderer logic.
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 10, 0, UndergroundTileState.Solid);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 0, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(false);
-  });
-
-  it('handleUndergroundLeftClick on the ceiling strip clears any stale isDragging flag (codex P2)', () => {
-    // Defensive: a prior gesture that didn't see a clean pointerup (focus-
-    // loss) could leave isDragging=true. The ceiling-row guard must also
-    // reset it so a subsequent pointermove doesn't resume the stale stroke
-    // from a stale lastMarkedTile and emit hidden marks — the exact
-    // pre-fix behavior this PR is supposed to eliminate.
-    const world = makeWorld();
-    ugSet(world.undergroundGrids[PLAYER_COLONY_ID]!, 10, 0, UndergroundTileState.Solid);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState(/*isDragging*/ true, 4, 4);
-    const { x, y } = tileToScreen(10, 0, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.isDragging).toBe(false);
-  });
-
-  it('handleUndergroundLeftClick on tileY=1 still emits MarkDigTile (sanity — only y=0 is gated)', () => {
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 10, 1, UndergroundTileState.Solid);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState();
-    const { x, y } = tileToScreen(10, 1, 64, 32);
-    handleUndergroundLeftClick(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(1);
-    const cmd = world.commandQueue[0] as { type: string; tileY: number };
-    expect(cmd.type).toBe('MarkDigTile');
-    expect(cmd.tileY).toBe(1);
-  });
-
-  it('handleUndergroundDrag stroke that crosses tileY=0 skips the row-0 tiles but continues on row 1+', () => {
-    // Drag stroke from (10, 1) → (20, 0) → (20, 1) (synthesized via two
-    // emit calls). The row-0 tile must NOT emit a MarkDigTile; the row-1
-    // tiles bracketing it MUST emit. Bresenham continues across the gap.
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    // Solid corridor along the path so each tile would otherwise be markable.
-    for (let x = 10; x <= 20; x++) {
-      ugSet(grid, x, 0, UndergroundTileState.Solid);
-      ugSet(grid, x, 1, UndergroundTileState.Solid);
-    }
-    const vs = makeViewState('underground', 64, 32);
-    // Seed drag at (10, 1) with isDragging=true (sentinel-free path).
-    const state = makeState(/*isDragging*/ true, 10, 1);
-    // Drag to (20, 0) — Bresenham stroke runs along row 0 and row 1.
-    const { x, y } = tileToScreen(20, 0, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    // Every emitted command must have tileY > 0 — no ceiling-row marks.
-    const tileYsEmitted = world.commandQueue.map((c) => (c as { tileY: number }).tileY);
-    expect(tileYsEmitted.length).toBeGreaterThan(0); // sanity — some marks fired
-    expect(tileYsEmitted.every((ty) => ty > 0)).toBe(true);
-  });
-
-  it('handleUndergroundDrag stroke that grazes ty=0 mid-stroke still emits row-1+ tiles past the crossing', () => {
-    // Strengthens the prior "crosses ceiling" test by ending the stroke on
-    // a regular row, not on row 0. The Bresenham loop must keep emitting
-    // for tiles past the row-0 crossing — the row-0 gate must be a
-    // per-tile skip inside emitTile, not a stroke-level early return.
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    for (let x = 5; x <= 15; x++) {
-      for (let y = 0; y <= 2; y++) {
-        ugSet(grid, x, y, UndergroundTileState.Solid);
-      }
-    }
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState(/*isDragging*/ true, 5, 2);
-    // Drag end at (15, 2) — Bresenham line passes through tiles at multiple
-    // rows including y=0 if the stepper takes a diagonal turn through it.
-    // For our straight-row stroke (5,2)→(15,2), no row-0 tiles are touched,
-    // but we explicitly synthesize a stroke that does cross y=0 by routing
-    // through (10, 0).
-    let { x: x1, y: y1 } = tileToScreen(10, 0, 64, 32);
-    handleUndergroundDrag(world, vs, x1, y1, state); // first leg dips through row 0
-    ({ x: x1, y: y1 } = tileToScreen(15, 2, 64, 32));
-    handleUndergroundDrag(world, vs, x1, y1, state); // second leg returns to row 2
-    const tileYsEmitted = world.commandQueue.map((c) => (c as { tileY: number }).tileY);
-    expect(tileYsEmitted.length).toBeGreaterThan(0);
-    expect(tileYsEmitted.every((ty) => ty > 0)).toBe(true);
-    // Specifically: (15, 2) reached and emitted past the ceiling crossing.
-    expect(tileYsEmitted).toContain(2);
-  });
-
-  it('handleUndergroundDrag from sentinel (-1,-1) into tileY=0 is a no-op but rebases the cursor', () => {
-    // First-tick drag fall-back: when lastMarkedTile is the (-1,-1) sentinel
-    // and the pointer lands on the ceiling strip, we don't mark anything
-    // but we DO rebase the cursor so a subsequent drag onto a regular row
-    // can interpolate from a valid origin.
-    const world = makeWorld();
-    const grid = world.undergroundGrids[PLAYER_COLONY_ID]!;
-    ugSet(grid, 10, 0, UndergroundTileState.Solid);
-    const vs = makeViewState('underground', 64, 32);
-    const state = makeState(/*isDragging*/ true, -1, -1);
-    const { x, y } = tileToScreen(10, 0, 64, 32);
-    handleUndergroundDrag(world, vs, x, y, state);
-    expect(world.commandQueue).toHaveLength(0);
-    expect(state.lastMarkedTileX).toBe(10);
-    expect(state.lastMarkedTileY).toBe(0);
-    expect(state.isDragging).toBe(true);
+describe('paused-queue cap (paint)', () => {
+  it('beginPaintStroke drops the mark at the cap while paused but still arms the cursor', () => {
+    const pre: SimCommand[] = Array.from({ length: MAX_COMMANDS_PER_TICK }, (_, i) => ({
+      type: 'NoOp',
+      issuedAtTick: i,
+    }));
+    const world = makeWorld({ commandQueue: pre });
+    const stroke = createPaintStrokeState();
+    const dropped = beginPaintStroke(stroke, world, makeViewState(), 5, 10, true /* paused */);
+    expect(dropped).toBe(true);
+    expect(markCount(world)).toBe(0);
+    // Cursor still armed so the gesture is coherent on resume.
+    expect(stroke.active).toBe(true);
   });
 });

--- a/src/input/underground-input.test.ts
+++ b/src/input/underground-input.test.ts
@@ -347,3 +347,105 @@ describe('paused-queue cap (paint)', () => {
     expect(stroke.active).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Fast-stroke cap deferral (Fix 1): the cap is enforced UNPAUSED too, and the
+// stroke cursor HOLDS at the last enqueued tile on a cap refusal so the
+// remainder re-emits later with NO lost tiles. Non-markable skips still advance.
+// ---------------------------------------------------------------------------
+
+describe('fast-stroke cap deferral (unpaused)', () => {
+  it('a single >64-tile segment enqueues exactly the cap and HOLDS the cursor', () => {
+    const world = makeWorld({ gridWidth: 100, gridHeight: 20 });
+    const stroke = createPaintStrokeState();
+    // Begin at (0,10): one mark for the down-tile.
+    beginPaintStroke(stroke, world, makeViewState(), 0, 10, false);
+    expect(markCount(world)).toBe(1);
+    // One fast move spanning 80 new tiles (x=1..80). The queue holds 1 mark, so
+    // 63 more fit before the cap → 64 total enqueued, the rest deferred.
+    const capHit = continuePaintStroke(stroke, world, makeViewState(), 80, 10, false);
+    expect(capHit).toBe(true);
+    expect(markCount(world)).toBe(MAX_COMMANDS_PER_TICK); // exactly the cap
+    // Cursor HELD at the last successfully-enqueued tile, NOT advanced to 80.
+    // 1 (begin) + 63 (continue) = 64 marks → last enqueued tile is x=63.
+    expect(stroke.lastMarkedTileX).toBe(63);
+    expect(stroke.lastMarkedTileY).toBe(10);
+  });
+
+  it('the deferred remainder re-emits on a subsequent flush with NO lost tiles', () => {
+    const world = makeWorld({ gridWidth: 100, gridHeight: 20 });
+    const stroke = createPaintStrokeState();
+    beginPaintStroke(stroke, world, makeViewState(), 0, 10, false);
+    continuePaintStroke(stroke, world, makeViewState(), 80, 10, false); // caps at 64, holds at 63
+    // Collect the first batch's tiles, then simulate tick() draining the queue.
+    const firstBatch = world.commandQueue
+      .filter((c) => c.type === 'MarkDigTile')
+      .map((c) => (c as { tileX: number }).tileX);
+    world.commandQueue.length = 0; // drain
+    // Re-drive toward the SAME target (what flushPaint does each frame).
+    const capHit2 = continuePaintStroke(stroke, world, makeViewState(), 80, 10, false);
+    expect(capHit2).toBe(false); // remainder (16 tiles) fits now
+    const secondBatch = world.commandQueue
+      .filter((c) => c.type === 'MarkDigTile')
+      .map((c) => (c as { tileX: number }).tileX);
+    // Cursor finally reaches the target.
+    expect(stroke.lastMarkedTileX).toBe(80);
+    // Union of both batches covers x=0..80 contiguously — no lost tiles, no dupes.
+    const allX = [...firstBatch, ...secondBatch].sort((a, b) => a - b);
+    const expected = Array.from({ length: 81 }, (_, i) => i); // 0..80
+    expect(allX).toEqual(expected);
+  });
+
+  it('a further flush once the cursor has reached the target is a debounce no-op', () => {
+    const world = makeWorld({ gridWidth: 100, gridHeight: 20 });
+    const stroke = createPaintStrokeState();
+    beginPaintStroke(stroke, world, makeViewState(), 0, 10, false);
+    continuePaintStroke(stroke, world, makeViewState(), 80, 10, false);
+    world.commandQueue.length = 0;
+    continuePaintStroke(stroke, world, makeViewState(), 80, 10, false); // reaches 80
+    const before = markCount(world);
+    const capHit = continuePaintStroke(stroke, world, makeViewState(), 80, 10, false); // same tile
+    expect(capHit).toBe(false);
+    expect(markCount(world)).toBe(before); // no new marks
+  });
+
+  it('non-markable (BeingDug) tiles are SKIPPED but the cursor ADVANCES past them', () => {
+    const world = makeWorld({ gridWidth: 20, gridHeight: 20 });
+    ugSet(grid(world), 3, 10, UndergroundTileState.BeingDug); // a hole in the row
+    const stroke = createPaintStrokeState();
+    beginPaintStroke(stroke, world, makeViewState(), 0, 10, false); // mark (0,10)
+    const capHit = continuePaintStroke(stroke, world, makeViewState(), 6, 10, false);
+    // Not a cap event — BeingDug is a silent skip, not a deferral.
+    expect(capHit).toBe(false);
+    const marks = world.commandQueue
+      .filter((c) => c.type === 'MarkDigTile')
+      .map((c) => (c as { tileX: number }).tileX);
+    expect(marks).toEqual([0, 1, 2, 4, 5, 6]); // 3 skipped, rest marked
+    // Cursor advanced all the way to the target despite the skip.
+    expect(stroke.lastMarkedTileX).toBe(6);
+    expect(stroke.lastMarkedTileY).toBe(10);
+  });
+
+  it('the sentinel single-tile path HOLDS the cursor at the sentinel on a cap refusal', () => {
+    // No prior cursor (lastMarkedTile = -1): the single-tile branch. A cap
+    // refusal must NOT advance the sentinel, so the tile re-emits next flush.
+    const pre: SimCommand[] = Array.from({ length: MAX_COMMANDS_PER_TICK }, (_, i) => ({
+      type: 'NoOp',
+      issuedAtTick: i,
+    }));
+    const world = makeWorld({ commandQueue: pre });
+    const stroke = createPaintStrokeState();
+    stroke.active = true; // armed but no cursor recorded yet (sentinel)
+    const capHit = continuePaintStroke(stroke, world, makeViewState(), 5, 10, false /* unpaused */);
+    expect(capHit).toBe(true);
+    expect(markCount(world)).toBe(0);
+    expect(stroke.lastMarkedTileX).toBe(-1); // sentinel held
+    expect(stroke.lastMarkedTileY).toBe(-1);
+    // Drain and retry: now it enqueues and advances.
+    world.commandQueue.length = 0;
+    const capHit2 = continuePaintStroke(stroke, world, makeViewState(), 5, 10, false);
+    expect(capHit2).toBe(false);
+    expect(markCount(world)).toBe(1);
+    expect([stroke.lastMarkedTileX, stroke.lastMarkedTileY]).toEqual([5, 10]);
+  });
+});

--- a/src/input/underground-input.test.ts
+++ b/src/input/underground-input.test.ts
@@ -333,7 +333,7 @@ describe('tryOpenChamberMenu', () => {
 // ---------------------------------------------------------------------------
 
 describe('paused-queue cap (paint)', () => {
-  it('beginPaintStroke drops the mark at the cap while paused but still arms the cursor', () => {
+  it('beginPaintStroke drops the mark at the cap while paused but still arms the stroke', () => {
     const pre: SimCommand[] = Array.from({ length: MAX_COMMANDS_PER_TICK }, (_, i) => ({
       type: 'NoOp',
       issuedAtTick: i,
@@ -343,8 +343,150 @@ describe('paused-queue cap (paint)', () => {
     const dropped = beginPaintStroke(stroke, world, makeViewState(), 5, 10, true /* paused */);
     expect(dropped).toBe(true);
     expect(markCount(world)).toBe(0);
-    // Cursor still armed so the gesture is coherent on resume.
+    // Stroke armed so subsequent moves still paint; the cursor is NOT advanced
+    // onto the refused down-tile (Fix 2) — see the dedicated block below.
     expect(stroke.active).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 2: beginPaintStroke must NOT advance the cursor onto a markable down-tile
+// whose MarkDigTile was REFUSED at the cap — it leaves the cursor at the
+// sentinel so the first continuePaintStroke/flush re-emits the down-tile (no
+// silently lost begin-tile). A non-markable down-tile still advances the cursor.
+// ---------------------------------------------------------------------------
+
+describe('beginPaintStroke cap-refusal holds the cursor (Fix 2)', () => {
+  it('a Solid down-tile refused at the cap holds the cursor at the sentinel, re-emits after drain', () => {
+    const pre: SimCommand[] = Array.from({ length: MAX_COMMANDS_PER_TICK }, (_, i) => ({
+      type: 'NoOp',
+      issuedAtTick: i,
+    }));
+    const world = makeWorld({ commandQueue: pre });
+    const stroke = createPaintStrokeState();
+    const dropped = beginPaintStroke(stroke, world, makeViewState(), 5, 10, false /* unpaused */);
+    expect(dropped).toBe(true);
+    expect(markCount(world)).toBe(0);
+    expect(stroke.active).toBe(true);
+    // Cursor NOT advanced onto the refused down-tile — held at the sentinel.
+    expect([stroke.lastMarkedTileX, stroke.lastMarkedTileY]).toEqual([-1, -1]);
+
+    // Drain the queue, then re-drive toward the SAME down-tile (what the arbiter's
+    // flushPaint does). The down-tile (5,10) now enqueues and the cursor advances.
+    world.commandQueue.length = 0;
+    const capHit = continuePaintStroke(stroke, world, makeViewState(), 5, 10, false);
+    expect(capHit).toBe(false);
+    const marks = world.commandQueue
+      .filter((c) => c.type === 'MarkDigTile')
+      .map((c) => [(c as { tileX: number }).tileX, (c as { tileY: number }).tileY]);
+    expect(marks).toEqual([[5, 10]]); // the begin-tile is not lost
+    expect([stroke.lastMarkedTileX, stroke.lastMarkedTileY]).toEqual([5, 10]);
+  });
+
+  it('a non-markable (BeingDug) down-tile still advances the cursor (not a loss)', () => {
+    const world = makeWorld();
+    ugSet(grid(world), 5, 10, UndergroundTileState.BeingDug);
+    const stroke = createPaintStrokeState();
+    const dropped = beginPaintStroke(stroke, world, makeViewState(), 5, 10, false);
+    expect(dropped).toBe(false); // no command to defer — not a cap event
+    expect(markCount(world)).toBe(0);
+    expect(stroke.active).toBe(true);
+    // Cursor ADVANCES so the first drag segment interpolates from the down-tile.
+    expect([stroke.lastMarkedTileX, stroke.lastMarkedTileY]).toEqual([5, 10]);
+  });
+
+  it('a Solid down-tile that enqueues (queue NOT full) advances the cursor as before', () => {
+    const world = makeWorld();
+    const stroke = createPaintStrokeState();
+    const dropped = beginPaintStroke(stroke, world, makeViewState(), 5, 10, false);
+    expect(dropped).toBe(false);
+    expect(markCount(world)).toBe(1);
+    expect([stroke.lastMarkedTileX, stroke.lastMarkedTileY]).toEqual([5, 10]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 4: paused dig/command taps resolve the EFFECTIVE tile state against
+// PENDING queued commands (not just the frozen grid), so a paused tap-tap
+// toggles correctly instead of double-marking / double-cancelling. The sim is
+// frozen while bare-user-paused, so ugGet alone would read stale state.
+// ---------------------------------------------------------------------------
+
+describe('paused dig-tap effective state (Fix 4)', () => {
+  it('paused tap-tap on a Solid tile → MarkDigTile then CancelDigMark (not two marks)', () => {
+    const world = makeWorld();
+    const vs = makeViewState();
+    // First tap: Solid → MarkDigTile (grid stays Solid; sim is paused/frozen).
+    handleUndergroundDigTap(world, vs, 5, 10, true);
+    // Second tap on the SAME tile: effective state is Marked (pending MarkDigTile)
+    // → CancelDigMark, netting back to Solid on resume.
+    handleUndergroundDigTap(world, vs, 5, 10, true);
+    const types = world.commandQueue.map((c) => c.type);
+    expect(types).toEqual(['MarkDigTile', 'CancelDigMark']);
+  });
+
+  it('paused tap-tap-tap on a Solid tile nets Mark/Cancel/Mark (toggles each tap)', () => {
+    const world = makeWorld();
+    const vs = makeViewState();
+    handleUndergroundDigTap(world, vs, 5, 10, true); // Solid → Mark
+    handleUndergroundDigTap(world, vs, 5, 10, true); // eff Marked → Cancel
+    handleUndergroundDigTap(world, vs, 5, 10, true); // eff Solid → Mark
+    expect(world.commandQueue.map((c) => c.type)).toEqual([
+      'MarkDigTile',
+      'CancelDigMark',
+      'MarkDigTile',
+    ]);
+  });
+
+  it('paused tap-tap on a Marked tile → CancelDigMark then MarkDigTile (nets correctly)', () => {
+    const world = makeWorld();
+    const vs = makeViewState();
+    ugSet(grid(world), 5, 10, UndergroundTileState.Marked); // grid already Marked
+    handleUndergroundDigTap(world, vs, 5, 10, true); // Marked → Cancel
+    handleUndergroundDigTap(world, vs, 5, 10, true); // eff Solid (pending cancel) → Mark
+    expect(world.commandQueue.map((c) => c.type)).toEqual(['CancelDigMark', 'MarkDigTile']);
+  });
+
+  it('the effective state is keyed per-tile: a tap on a different tile is unaffected', () => {
+    const world = makeWorld();
+    const vs = makeViewState();
+    handleUndergroundDigTap(world, vs, 5, 10, true); // (5,10) Solid → Mark
+    handleUndergroundDigTap(world, vs, 6, 10, true); // (6,10) Solid → Mark (different tile)
+    expect(world.commandQueue.map((c) => c.type)).toEqual(['MarkDigTile', 'MarkDigTile']);
+  });
+
+  it('unpaused behaviour is unchanged: each tap reads the live (drained) grid', () => {
+    // Unpaused, the queue drains every tick, so a second tap sees an empty queue
+    // and the (still-Solid, pre-apply) grid → another MarkDigTile, exactly as
+    // before Fix 4. We emulate the drain between taps.
+    const world = makeWorld();
+    const vs = makeViewState();
+    handleUndergroundDigTap(world, vs, 5, 10, false);
+    expect(world.commandQueue.map((c) => c.type)).toEqual(['MarkDigTile']);
+    world.commandQueue.length = 0; // tick() drained it
+    handleUndergroundDigTap(world, vs, 5, 10, false);
+    expect(world.commandQueue.map((c) => c.type)).toEqual(['MarkDigTile']);
+  });
+
+  it('Command-tap respects a pending MarkDigTile (effectively Marked → CancelDigMark)', () => {
+    const world = makeWorld();
+    const vs = makeViewState(PLAYER_COLONY_ID, 'command');
+    // A Dig-tap queued a MarkDigTile on a Solid tile while paused; the grid is
+    // still Solid. A Command-tap on it must see effective=Marked and cancel.
+    handleUndergroundDigTap(world, makeViewState(), 5, 10, true); // queue: MarkDigTile
+    handleUndergroundCommandTap(world, vs, 5, 10, true);
+    expect(world.commandQueue.map((c) => c.type)).toEqual(['MarkDigTile', 'CancelDigMark']);
+  });
+
+  it('Command-tap does NOT double-cancel when a CancelDigMark is already pending', () => {
+    const world = makeWorld();
+    const vs = makeViewState(PLAYER_COLONY_ID, 'command');
+    ugSet(grid(world), 5, 10, UndergroundTileState.Marked); // grid Marked
+    handleUndergroundCommandTap(world, vs, 5, 10, true); // Marked → Cancel
+    // Second Command-tap: effective state is Solid (pending cancel) → no-op, NOT
+    // a redundant second CancelDigMark.
+    handleUndergroundCommandTap(world, vs, 5, 10, true);
+    expect(world.commandQueue.map((c) => c.type)).toEqual(['CancelDigMark']);
   });
 });
 

--- a/src/input/underground-input.ts
+++ b/src/input/underground-input.ts
@@ -20,8 +20,12 @@
 // switch by the arbiter's cancelGesture.
 //
 // All commands emitted are the SAME SimCommands as before the rework, pushed via
-// enqueueCommand (paused-cap guard). A handler returns whether its command was
-// dropped at the cap so the arbiter can surface the "paused queue full" hint.
+// enqueueCommand (non-Sync cap guard, enforced paused OR running). A tap handler
+// returns whether its command was refused at the cap; the paint handlers return
+// a capHit flag the arbiter uses to defer the un-enqueued tiles (re-emitting on a
+// later flush/move) and — only while paused — to surface the "paused queue full"
+// hint. An unpaused cap hit is silent transient throttling that catches up next
+// tick as the queue drains.
 //
 // UndergroundTileState enum (terrain.ts): Solid=0, Marked=1, BeingDug=2, Open=3
 
@@ -130,7 +134,7 @@ function isEditableUndergroundTile(
 /**
  * Underground Command tap: cancel a queued dig mark (Codex R2-7). A tap on a
  * Marked tile → CancelDigMark; every other tile is a no-op in Stage 1.
- * Player-grid-only. Returns true iff the command was dropped at the paused cap.
+ * Player-grid-only. Returns true iff the command was refused at the cap.
  */
 export function handleUndergroundCommandTap(
   world: WorldState,
@@ -161,7 +165,7 @@ export function handleUndergroundCommandTap(
 /**
  * Underground Dig tap (Codex R1-2): Solid/Open → MarkDigTile; Marked →
  * CancelDigMark; BeingDug → no-op (already claimed). Player-grid-only. Returns
- * true iff a command was dropped at the paused cap.
+ * true iff a command was refused at the cap.
  */
 export function handleUndergroundDigTap(
   world: WorldState,
@@ -208,7 +212,14 @@ export function handleUndergroundDigTap(
  * drag segment interpolates from a real coordinate) and emits MarkDigTile for
  * the down-tile itself when it is Solid/Open. Marked/BeingDug down-tiles seed the
  * cursor without emitting (matching the prior eager-arm behavior). Player-grid-
- * only. Returns true iff a command was dropped at the paused cap.
+ * only. Returns true iff a command was refused at the cap.
+ *
+ * Note: unlike continuePaintStroke, the cursor is ALWAYS armed at the down-tile
+ * even on a cap refusal — begin marks a single tile, and the first
+ * continuePaintStroke segment re-interpolates from the down-tile, so a refused
+ * down-tile mark is recovered by the stroke's own subsequent segments (and a
+ * stroke that never moves was a single-tile gesture whose one refused mark
+ * re-emits on the per-frame flush).
  */
 export function beginPaintStroke(
   state: PaintStrokeState,
@@ -254,10 +265,21 @@ export function beginPaintStroke(
  * target. Any Bresenham step advancing both axes is split into a horizontal
  * bridge then a vertical step so successive emitted tiles stay Manhattan-
  * adjacent (4-connected underground movement requires it). The starting tile is
- * skipped (already emitted by begin/prior segment). Non-markable / out-of-bounds
- * / ceiling tiles are skipped silently; the stroke continues past them.
- * Player-grid-only. Returns true iff ANY command in this segment was dropped at
- * the paused cap.
+ * skipped (already emitted by begin/prior segment).
+ *
+ * Two distinct kinds of "didn't enqueue" are handled differently so a fast
+ * stroke past the MAX_COMMANDS_PER_TICK cap never silently loses tiles:
+ *   - NON-MARKABLE skip (out-of-bounds / ceiling / not Solid/Open): not a loss —
+ *     there was no command to defer. The cursor ADVANCES past it and the stroke
+ *     continues (matching the prior behaviour).
+ *   - CAP REFUSAL (enqueueCommand returned false): the command was deferred, not
+ *     emitted. The cursor is LEFT at the last successfully-handled tile (it is
+ *     NOT advanced onto the refused tile), the loop STOPS, and `capHit` is set
+ *     so the refused tile + the remainder re-emit on a later flush/move (the
+ *     arbiter re-drives toward the stored target as the queue drains).
+ *
+ * Player-grid-only. Returns true iff a command in this segment was refused at the
+ * cap (capHit). A non-markable skip never sets the return.
  */
 export function continuePaintStroke(
   state: PaintStrokeState,
@@ -281,12 +303,13 @@ export function continuePaintStroke(
   const y0 = state.lastMarkedTileY;
   const x1 = tileX;
   const y1 = tileY;
-  let droppedAtCap = false;
+  let capHit = false;
 
   // Sentinel start (no prior cursor): single-tile emission.
   if (x0 === -1 && y0 === -1) {
     if (x1 < 0 || y1 < 0 || x1 >= grid.width || y1 >= grid.height) return false;
     if (y1 === UNDERGROUND_CEILING_ROW_Y) {
+      // Non-markable: advance the cursor past it (not a loss).
       state.lastMarkedTileX = x1;
       state.lastMarkedTileY = y1;
       return false;
@@ -300,11 +323,16 @@ export function continuePaintStroke(
         tileY: y1,
         issuedAtTick: world.tick,
       };
-      if (!enqueueCommand(world, cmd, isPaused)) droppedAtCap = true;
+      if (!enqueueCommand(world, cmd, isPaused)) {
+        // Cap refusal: do NOT advance the cursor onto the refused tile, so the
+        // next flush/move re-emits it. Leave lastMarkedTile at the sentinel.
+        return true;
+      }
     }
+    // Enqueued OR non-markable: advance the cursor.
     state.lastMarkedTileX = x1;
     state.lastMarkedTileY = y1;
-    return droppedAtCap;
+    return false;
   }
 
   const dx = x1 > x0 ? x1 - x0 : x0 - x1;
@@ -317,15 +345,26 @@ export function continuePaintStroke(
   let finalX = x0;
   let finalY = y0;
 
-  // Emit one tile: advances finalX/Y always (stroke-cursor semantics), pushes a
-  // MarkDigTile only for in-bounds, non-ceiling, Solid/Open tiles.
-  const emitTile = (tx: number, ty: number): void => {
-    finalX = tx;
-    finalY = ty;
-    if (tx < 0 || ty < 0 || tx >= grid.width || ty >= grid.height) return;
-    if (ty === UNDERGROUND_CEILING_ROW_Y) return;
+  // Emit one tile. Returns false to signal a CAP REFUSAL (caller must stop and
+  // NOT advance the cursor onto this tile); returns true otherwise (enqueued OR
+  // a non-markable skip — both advance the cursor past the tile).
+  const emitTile = (tx: number, ty: number): boolean => {
+    if (tx < 0 || ty < 0 || tx >= grid.width || ty >= grid.height) {
+      finalX = tx;
+      finalY = ty;
+      return true; // out-of-bounds: not a loss, advance past it
+    }
+    if (ty === UNDERGROUND_CEILING_ROW_Y) {
+      finalX = tx;
+      finalY = ty;
+      return true; // ceiling: not a loss, advance past it
+    }
     const ts = ugGet(grid, tx, ty);
-    if (ts !== UndergroundTileState.Solid && ts !== UndergroundTileState.Open) return;
+    if (ts !== UndergroundTileState.Solid && ts !== UndergroundTileState.Open) {
+      finalX = tx;
+      finalY = ty;
+      return true; // non-markable terrain: not a loss, advance past it
+    }
     const cmd: MarkDigTileCommand = {
       type: 'MarkDigTile',
       colonyId: PLAYER_COLONY_ID,
@@ -333,7 +372,15 @@ export function continuePaintStroke(
       tileY: ty,
       issuedAtTick: world.tick,
     };
-    if (!enqueueCommand(world, cmd, isPaused)) droppedAtCap = true;
+    if (!enqueueCommand(world, cmd, isPaused)) {
+      // Cap refusal: leave finalX/Y at the prior (successfully-handled) tile so
+      // this tile re-emits later. Signal the loop to stop.
+      capHit = true;
+      return false;
+    }
+    finalX = tx;
+    finalY = ty;
+    return true;
   };
 
   while (cx !== x1 || cy !== y1) {
@@ -343,25 +390,25 @@ export function continuePaintStroke(
     if (advanceX && advanceY) {
       err -= dy;
       cx += sx;
-      emitTile(cx, cy); // orthogonal bridge tile
+      if (!emitTile(cx, cy)) break; // orthogonal bridge tile (cap refusal → stop)
       err += dx;
       cy += sy;
-      emitTile(cx, cy); // diagonal destination
+      if (!emitTile(cx, cy)) break; // diagonal destination (cap refusal → stop)
     } else if (advanceX) {
       err -= dy;
       cx += sx;
-      emitTile(cx, cy);
+      if (!emitTile(cx, cy)) break;
     } else if (advanceY) {
       err += dx;
       cy += sy;
-      emitTile(cx, cy);
+      if (!emitTile(cx, cy)) break;
     } else {
       break;
     }
   }
   state.lastMarkedTileX = finalX;
   state.lastMarkedTileY = finalY;
-  return droppedAtCap;
+  return capHit;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/input/underground-input.ts
+++ b/src/input/underground-input.ts
@@ -1,85 +1,80 @@
-// underground-input.ts — Phase 8 underground-click dispatcher.
+// underground-input.ts — Stage 1 controls rework (issue #18): pure underground
+// tap + paint handlers, called by the single left-button gesture arbiter.
 //
-// Handles:
-//   - Left-click / drag: MarkDigTileCommand on Solid or Open tiles (debounced per tile).
-//   - Right-click on Marked tile: CancelDigMarkCommand (CTRL-04: BeingDug is NOT cancellable).
-//   - Right-click on Open tunnel-end: contextMenuState mutation (UNDR-04).
-//   - Right-click on other tiles: no-op.
+// This file no longer registers its own Phaser pointer listeners. The arbiter
+// (gesture-arbiter.ts) owns the LEFT button, classifies pan/paint/tap, and calls
+// these pure functions; right-click (handled by the arbiter's secondary path)
+// opens the chamber menu via the shared tryOpenChamberMenu.
 //
-// Guards:
-//   - viewState.activeView must be 'underground' before dispatching any command.
-//   - isPointerOverHUD rejects clicks that land on HUD zones (Pitfall 2).
-//   - Tile bounds check before accessing grid or pushing commands.
-//   - When contextMenuState.visible is true, left-click is suppressed (no dig-mark).
-//     Dismissal is owned by UIScene (requestHideContextMenu → applied next frame),
-//     which prevents a scene-order race with chamber-placement selection.
+// Tap handlers by tool (underground):
+//   - Command tap → CancelDigMark on a Marked tile (player view only); otherwise
+//     a no-op (no ant-inspect in Stage 1). (PLAN §B5, Codex R2-7.)
+//   - Dig tap     → Solid/Open → MarkDigTile (single tile); Marked → CancelDigMark.
+//                   Drag → paint (4-connected Bresenham). (PLAN §B6, Codex R1-2.)
+//   - Chamber tap → tryOpenChamberMenu (Solid/Open eligibility). (PLAN §B8.)
 //
-// UndergroundTileState enum (terrain.ts):
-//   Solid=0, Marked=1, BeingDug=2, Open=3
+// Player-grid-only invariant (PLAN §B10, Codex R3-2): EVERY underground command
+// path — Dig mark/cancel, Command-tap cancel, Chamber-tool tap, and right-click —
+// requires activeUndergroundColonyId === PLAYER_COLONY_ID. The enemy underground
+// view (X-toggle) is read-only; an in-flight paint stroke is aborted on colony
+// switch by the arbiter's cancelGesture.
+//
+// All commands emitted are the SAME SimCommands as before the rework, pushed via
+// enqueueCommand (paused-cap guard). A handler returns whether its command was
+// dropped at the cap so the arbiter can surface the "paused queue full" hint.
+//
+// UndergroundTileState enum (terrain.ts): Solid=0, Marked=1, BeingDug=2, Open=3
 
-import * as Phaser from 'phaser';
 import type { WorldState } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
-import { screenToTile } from '../render/camera.js';
 import { ugGet, UndergroundTileState } from '../sim/terrain.js';
 import type { MarkDigTileCommand, CancelDigMarkCommand } from '../sim/commands.js';
 import { PLAYER_COLONY_ID, UNDERGROUND_CEILING_ROW_Y } from '../sim/constants.js';
-import { isPointerOverHUD, panInputState } from './camera-input.js';
-import { contextMenuState, requestShowContextMenu } from '../render/context-menu-state.js';
+import { requestShowContextMenu } from '../render/context-menu-state.js';
+import { enqueueCommand } from './command-queue.js';
 
 // ---------------------------------------------------------------------------
-// UndergroundInputState — mutable per-registration state
+// PaintStrokeState — mutable per-stroke state owned by the arbiter
 // ---------------------------------------------------------------------------
 
 /**
- * Exported so GameScene can hold the reference returned by
- * registerUndergroundInput and call resetUndergroundInputState at session
- * restart boundaries. Direct external callers (tests) also use the shape to
- * assert reset semantics.
+ * Tracks an in-flight underground Dig paint stroke. Created and owned by the
+ * gesture arbiter (one per scene); the pure paint functions below read/advance
+ * it. `lastMarkedTileX/Y` is the debounce + Bresenham interpolation cursor;
+ * -1 is the "no stroke in progress" sentinel.
  */
-export interface UndergroundInputState {
-  /** True from the first pointerdown until pointerup — enables drag tile-mark. */
-  isDragging: boolean;
-  /**
-   * X coord of the last tile the drag cursor has visited (debounce + Bresenham
-   * interpolation start). Seeded by the pointerdown click — including clicks
-   * on Marked/BeingDug tiles where no MarkDigTileCommand was emitted — so the
-   * subsequent drag interpolates from the actual click point, not from the
-   * last *emitted* mark. -1 sentinel means no drag in progress.
-   */
+export interface PaintStrokeState {
+  /** True while a paint stroke is active (from begin until cancel/end). */
+  active: boolean;
+  /** X of the last tile the stroke cursor visited (debounce + Bresenham start). */
   lastMarkedTileX: number;
-  /** Y coord counterpart to lastMarkedTileX. Same semantics — see above. */
+  /** Y counterpart to lastMarkedTileX. */
   lastMarkedTileY: number;
 }
 
-/**
- * Reset an UndergroundInputState in-place: ends any in-flight drag and
- * clears the last-marked debounce. Preserves the object identity captured
- * by registerUndergroundInput's pointerdown / pointermove closures.
- */
-export function resetUndergroundInputState(state: UndergroundInputState): void {
-  state.isDragging = false;
+/** Construct an idle PaintStrokeState. */
+export function createPaintStrokeState(): PaintStrokeState {
+  return { active: false, lastMarkedTileX: -1, lastMarkedTileY: -1 };
+}
+
+/** Reset a PaintStrokeState in-place: end any stroke and clear the cursor. */
+export function resetPaintStrokeState(state: PaintStrokeState): void {
+  state.active = false;
   state.lastMarkedTileX = -1;
   state.lastMarkedTileY = -1;
 }
 
 // ---------------------------------------------------------------------------
-// isTunnelEnd
+// isTunnelEnd — pure helper (retained for completeness / tests)
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true if (tileX, tileY) in the given colony's underground grid is:
- *   (a) Open (UndergroundTileState.Open === 3), AND
- *   (b) at least one orthogonal 4-neighbor is Solid (UndergroundTileState.Solid === 0).
+ * Returns true if (tileX, tileY) in the given colony's underground grid is Open
+ * AND at least one orthogonal 4-neighbor is Solid. Out-of-bounds neighbors are
+ * skipped. Returns false if the grid does not exist.
  *
- * Used by handleUndergroundRightClick to decide whether to open the chamber
- * context menu (UNDR-04 / PRD §8b).
- *
- * Out-of-bounds neighbors are skipped (not counted as Solid) — this preserves
- * correctness for tiles on the grid boundary, but a boundary-adjacent Open tile
- * with valid Solid neighbors still returns true.
- *
- * Returns false if the undergroundGrid for colonyId does not exist.
+ * Stage-1 chamber eligibility is Solid/Open (this is no longer the gate), but the
+ * helper is kept for callers/tests that reason about tunnel topology.
  */
 export function isTunnelEnd(
   world: WorldState,
@@ -91,10 +86,10 @@ export function isTunnelEnd(
   if (!grid) return false;
   if (ugGet(grid, tileX, tileY) !== UndergroundTileState.Open) return false;
   const neighbors: Array<[number, number]> = [
-    [tileX, tileY - 1], // N
-    [tileX + 1, tileY], // E
-    [tileX, tileY + 1], // S
-    [tileX - 1, tileY], // W
+    [tileX, tileY - 1],
+    [tileX + 1, tileY],
+    [tileX, tileY + 1],
+    [tileX - 1, tileY],
   ];
   for (const [nx, ny] of neighbors) {
     if (nx < 0 || ny < 0 || nx >= grid.width || ny >= grid.height) continue;
@@ -104,99 +99,145 @@ export function isTunnelEnd(
 }
 
 // ---------------------------------------------------------------------------
-// handleUndergroundLeftClick
+// Internal guards
 // ---------------------------------------------------------------------------
 
 /**
- * Handles a left-click (or drag initiation) on the underground view.
- *
- * If context menu is open, suppresses the world click entirely — no dig mark,
- * no state mutation. UIScene owns menu dismissal so the dismissal happens on
- * a deterministic frame boundary, not mid-pointerdown dispatch.
- *
- * Otherwise, arms the drag state (isDragging + lastMarkedTile) on every
- * pointerdown that lands on a valid in-bounds tile, regardless of whether the
- * tile is markable. This is intentional: a click-then-drag stroke that starts
- * on an already-Marked or BeingDug tile must still mark newly-entered Solid
- * tiles. Without the eager arm, the subsequent pointermove would observe
- * isDragging=false and silently no-op for the rest of the gesture.
- *
- * Pushes MarkDigTileCommand only when the clicked tile is Solid or Open;
- * Marked/BeingDug tiles are already claimed so emitting a command would just
- * clutter the queue and replay log (the sim's MarkDigTile handler also drops
- * non-Solid tiles, so a duplicate would be a no-op there too).
- *
- * No-ops entirely if: activeView !== 'underground', pointer over HUD, pan
- * mode active, context menu visible, missing grid, or out of bounds. In all
- * those cases the drag state is NOT armed — the gesture was rejected, not
- * accepted-and-skipped.
+ * True iff underground command paths are allowed: the underground view must be
+ * showing the PLAYER's own grid. The enemy view (X-toggle) is read-only.
  */
-export function handleUndergroundLeftClick(
+function isPlayerUndergroundEditable(viewState: ViewState): boolean {
+  return viewState.activeUndergroundColonyId === PLAYER_COLONY_ID;
+}
+
+/** True iff (tileX,tileY) is in-bounds and not the surface-boundary ceiling row. */
+function isEditableUndergroundTile(
+  grid: { width: number; height: number },
+  tileX: number,
+  tileY: number,
+): boolean {
+  if (tileX < 0 || tileY < 0 || tileX >= grid.width || tileY >= grid.height) return false;
+  // Issue #30: the renderer paints row 0 with the grass "surface boundary" cue;
+  // a mark there gives no visual feedback, so it is excluded everywhere.
+  if (tileY === UNDERGROUND_CEILING_ROW_Y) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// handleUndergroundCommandTap — Command tool tap
+// ---------------------------------------------------------------------------
+
+/**
+ * Underground Command tap: cancel a queued dig mark (Codex R2-7). A tap on a
+ * Marked tile → CancelDigMark; every other tile is a no-op in Stage 1.
+ * Player-grid-only. Returns true iff the command was dropped at the paused cap.
+ */
+export function handleUndergroundCommandTap(
   world: WorldState,
   viewState: ViewState,
-  screenX: number,
-  screenY: number,
-  state: UndergroundInputState,
-): void {
-  if (viewState.activeView !== 'underground') return;
-  // Issue #14: when the player flips to view the enemy underground (X
-  // keybind), all underground commands target the PLAYER's grid (every
-  // dispatch below uses PLAYER_COLONY_ID as the colonyId). A click on the
-  // enemy view at screen coords (sx, sy) would silently mark a dig tile in
-  // the player's grid at the same world coords — the player can't see it,
-  // and replay would diverge from the visual state on screen. Treat the
-  // enemy view as read-only.
-  //
-  // Defensive: clear any lingering `isDragging` flag from a prior gesture
-  // that didn't get a clean mouseup (e.g., focus-loss). Without the
-  // explicit reset, a stale `isDragging=true` paired with a stale
-  // lastMarkedTile from the player view could resume scribbling dig
-  // marks if the player flips back via X. Symmetric with the abort path
-  // in handleUndergroundDrag.
-  if (viewState.activeUndergroundColonyId !== PLAYER_COLONY_ID) {
-    state.isDragging = false;
-    return;
-  }
-  if (isPointerOverHUD(screenX, screenY, viewState)) return;
-  // Pan-mode guard: while Space is held or a pan gesture is already in flight,
-  // the left-click/drag is the pan trigger — not a dig-mark.
-  if (panInputState.spaceHeld || panInputState.isPanning) return;
-  // If context menu is visible, suppress this click — UIScene handles the
-  // interaction (selection or dismissal) on its own pointerdown and applies
-  // the hide on the next frame. No state mutation here: modifying visibility
-  // mid-dispatch races with UIScene's handler on the same event.
-  if (contextMenuState.visible) return;
-  const { tileX, tileY } = screenToTile(screenX, screenY, viewState.undergroundCamera);
+  tileX: number,
+  tileY: number,
+  isPaused: boolean,
+): boolean {
+  if (!isPlayerUndergroundEditable(viewState)) return false;
   const grid = world.undergroundGrids[PLAYER_COLONY_ID];
-  if (!grid) return;
-  if (tileX < 0 || tileY < 0 || tileX >= grid.width || tileY >= grid.height) return;
-  // Issue #30: skip the ceiling-strip row. The renderer paints `tileY === 0`
-  // with the grass texture as a "this is the surface boundary" cue (see
-  // `ty === 0` branch in draw-underground.ts:137-153). Without this gate a
-  // click on the visible grass silently dispatches MarkDigTile against the
-  // tile beneath, which the renderer keeps painting as grass — the player
-  // gets no visual feedback the click did anything.
-  //
-  // Codex P2 follow-up: also clear any stale drag state on this guard
-  // path. If a prior gesture left `isDragging=true` (focus-loss / missed
-  // pointerup), simply returning here without the reset would let the
-  // next pointermove resume the stale stroke from the old cursor — the
-  // exact "hidden marking" behavior this fix is supposed to eliminate.
-  // Symmetric with the enemy-view guard's defensive reset.
-  if (tileY === UNDERGROUND_CEILING_ROW_Y) {
-    state.isDragging = false;
-    return;
+  if (!grid) return false;
+  if (!isEditableUndergroundTile(grid, tileX, tileY)) return false;
+  if (ugGet(grid, tileX, tileY) !== UndergroundTileState.Marked) return false;
+  const cmd: CancelDigMarkCommand = {
+    type: 'CancelDigMark',
+    colonyId: PLAYER_COLONY_ID,
+    tileX,
+    tileY,
+    issuedAtTick: world.tick,
+  };
+  return !enqueueCommand(world, cmd, isPaused);
+}
+
+// ---------------------------------------------------------------------------
+// handleUndergroundDigTap — Dig tool single-tile tap
+// ---------------------------------------------------------------------------
+
+/**
+ * Underground Dig tap (Codex R1-2): Solid/Open → MarkDigTile; Marked →
+ * CancelDigMark; BeingDug → no-op (already claimed). Player-grid-only. Returns
+ * true iff a command was dropped at the paused cap.
+ */
+export function handleUndergroundDigTap(
+  world: WorldState,
+  viewState: ViewState,
+  tileX: number,
+  tileY: number,
+  isPaused: boolean,
+): boolean {
+  if (!isPlayerUndergroundEditable(viewState)) return false;
+  const grid = world.undergroundGrids[PLAYER_COLONY_ID];
+  if (!grid) return false;
+  if (!isEditableUndergroundTile(grid, tileX, tileY)) return false;
+  const tileState = ugGet(grid, tileX, tileY);
+  if (tileState === UndergroundTileState.Marked) {
+    const cmd: CancelDigMarkCommand = {
+      type: 'CancelDigMark',
+      colonyId: PLAYER_COLONY_ID,
+      tileX,
+      tileY,
+      issuedAtTick: world.tick,
+    };
+    return !enqueueCommand(world, cmd, isPaused);
   }
-  // Arm drag state up front (before the tile-state branch) so a stroke that
-  // begins on a Marked/BeingDug tile still marks subsequent Solid tiles. The
-  // debounce cursor is seeded to the clicked tile so the first Bresenham
-  // interpolation in handleUndergroundDrag starts from a real coordinate.
-  state.isDragging = true;
+  if (tileState === UndergroundTileState.Solid || tileState === UndergroundTileState.Open) {
+    const cmd: MarkDigTileCommand = {
+      type: 'MarkDigTile',
+      colonyId: PLAYER_COLONY_ID,
+      tileX,
+      tileY,
+      issuedAtTick: world.tick,
+    };
+    return !enqueueCommand(world, cmd, isPaused);
+  }
+  // BeingDug — no-op.
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Paint stroke (underground Dig drag)
+// ---------------------------------------------------------------------------
+
+/**
+ * Begin a paint stroke at the down-tile. Seeds the stroke cursor (so the first
+ * drag segment interpolates from a real coordinate) and emits MarkDigTile for
+ * the down-tile itself when it is Solid/Open. Marked/BeingDug down-tiles seed the
+ * cursor without emitting (matching the prior eager-arm behavior). Player-grid-
+ * only. Returns true iff a command was dropped at the paused cap.
+ */
+export function beginPaintStroke(
+  state: PaintStrokeState,
+  world: WorldState,
+  viewState: ViewState,
+  tileX: number,
+  tileY: number,
+  isPaused: boolean,
+): boolean {
+  if (!isPlayerUndergroundEditable(viewState)) {
+    state.active = false;
+    return false;
+  }
+  const grid = world.undergroundGrids[PLAYER_COLONY_ID];
+  if (!grid) return false;
+  if (!isEditableUndergroundTile(grid, tileX, tileY)) {
+    // Reject: do not arm a stroke on an out-of-bounds / ceiling down-tile.
+    state.active = false;
+    return false;
+  }
+  // Arm the stroke cursor up front so a stroke that begins on a Marked/BeingDug
+  // tile still marks subsequently-entered Solid tiles.
+  state.active = true;
   state.lastMarkedTileX = tileX;
   state.lastMarkedTileY = tileY;
-  // Only mark Solid or Open tiles (Marked/BeingDug are already claimed).
   const tileState = ugGet(grid, tileX, tileY);
-  if (tileState !== UndergroundTileState.Solid && tileState !== UndergroundTileState.Open) return;
+  if (tileState !== UndergroundTileState.Solid && tileState !== UndergroundTileState.Open) {
+    return false;
+  }
   const cmd: MarkDigTileCommand = {
     type: 'MarkDigTile',
     colonyId: PLAYER_COLONY_ID,
@@ -204,91 +245,54 @@ export function handleUndergroundLeftClick(
     tileY,
     issuedAtTick: world.tick,
   };
-  world.commandQueue.push(cmd);
+  return !enqueueCommand(world, cmd, isPaused);
 }
 
-// ---------------------------------------------------------------------------
-// handleUndergroundDrag
-// ---------------------------------------------------------------------------
-
 /**
- * Handles pointer-move-while-down (drag) on the underground view.
- *
- * Emits MarkDigTileCommand for every tile along a 4-connected (supercover)
- * integer line from (lastMarkedTileX, lastMarkedTileY) to the current tile.
- * Any Bresenham step that would advance both axes at once is split into two
- * emissions — a horizontal bridge tile followed by the vertical step — so
- * successive emitted tiles are always Manhattan-adjacent (|Δx|+|Δy| === 1).
- * Underground movement and dig-task connectivity are 4-connected, so an
- * 8-connected (corner-touching) path would leave broken tunnels. The
- * starting tile is skipped (the prior click/drag emission already marked it).
- *
- * Non-markable path tiles (already Marked or BeingDug, out of bounds) are
- * skipped silently; the stroke continues past them. After processing,
- * lastMarkedTileX/Y tracks the final tile of the stroke so subsequent drags
- * interpolate from there.
- *
- * Flips isDragging to false and returns if the active view has changed
- * since drag started (prevents ghost tile marks on view-toggle mid-drag).
+ * Continue a paint stroke to (tileX, tileY): emit MarkDigTile for every tile
+ * along a 4-connected (supercover) integer line from the stroke cursor to the
+ * target. Any Bresenham step advancing both axes is split into a horizontal
+ * bridge then a vertical step so successive emitted tiles stay Manhattan-
+ * adjacent (4-connected underground movement requires it). The starting tile is
+ * skipped (already emitted by begin/prior segment). Non-markable / out-of-bounds
+ * / ceiling tiles are skipped silently; the stroke continues past them.
+ * Player-grid-only. Returns true iff ANY command in this segment was dropped at
+ * the paused cap.
  */
-export function handleUndergroundDrag(
+export function continuePaintStroke(
+  state: PaintStrokeState,
   world: WorldState,
   viewState: ViewState,
-  screenX: number,
-  screenY: number,
-  state: UndergroundInputState,
-): void {
-  if (!state.isDragging) return;
-  if (viewState.activeView !== 'underground') {
-    state.isDragging = false;
-    return;
+  tileX: number,
+  tileY: number,
+  isPaused: boolean,
+): boolean {
+  if (!state.active) return false;
+  if (!isPlayerUndergroundEditable(viewState)) {
+    state.active = false;
+    return false;
   }
-  // Issue #14: same read-only guard as handleUndergroundLeftClick. If the
-  // player flipped to the enemy view mid-drag (X keybind), abort the stroke
-  // so it can't write through to the player's grid silently.
-  if (viewState.activeUndergroundColonyId !== PLAYER_COLONY_ID) {
-    state.isDragging = false;
-    return;
-  }
-  if (isPointerOverHUD(screenX, screenY, viewState)) return;
-  // Pan-mode guard: if the player pressed Space mid-drag, treat it as a
-  // clean cancel of the excavation drag so further pointer movement goes
-  // through the pan handler exclusively.
-  if (panInputState.spaceHeld || panInputState.isPanning) {
-    state.isDragging = false;
-    return;
-  }
-  const { tileX, tileY } = screenToTile(screenX, screenY, viewState.undergroundCamera);
   // Debounce: same tile as last emission → no work.
-  if (tileX === state.lastMarkedTileX && tileY === state.lastMarkedTileY) return;
+  if (tileX === state.lastMarkedTileX && tileY === state.lastMarkedTileY) return false;
   const grid = world.undergroundGrids[PLAYER_COLONY_ID];
-  if (!grid) return;
+  if (!grid) return false;
 
-  // Bresenham integer line from (lastMarkedTileX/Y) to (tileX, tileY).
-  // Skip the starting tile (already handled by the prior click/drag emission).
-  // If lastMarked is the sentinel (-1,-1), fall back to single-tile emission.
   const x0 = state.lastMarkedTileX;
   const y0 = state.lastMarkedTileY;
   const x1 = tileX;
   const y1 = tileY;
+  let droppedAtCap = false;
 
-  let finalX = x0;
-  let finalY = y0;
-
+  // Sentinel start (no prior cursor): single-tile emission.
   if (x0 === -1 && y0 === -1) {
-    if (x1 < 0 || y1 < 0 || x1 >= grid.width || y1 >= grid.height) return;
+    if (x1 < 0 || y1 < 0 || x1 >= grid.width || y1 >= grid.height) return false;
     if (y1 === UNDERGROUND_CEILING_ROW_Y) {
-      // Issue #30: drag-into-ceiling-strip silently rebases the cursor without
-      // emitting a mark. The stroke can continue from here onto regular rows.
       state.lastMarkedTileX = x1;
       state.lastMarkedTileY = y1;
-      return;
+      return false;
     }
-    const tileStateSingle = ugGet(grid, x1, y1);
-    if (
-      tileStateSingle === UndergroundTileState.Solid ||
-      tileStateSingle === UndergroundTileState.Open
-    ) {
+    const ts = ugGet(grid, x1, y1);
+    if (ts === UndergroundTileState.Solid || ts === UndergroundTileState.Open) {
       const cmd: MarkDigTileCommand = {
         type: 'MarkDigTile',
         colonyId: PLAYER_COLONY_ID,
@@ -296,11 +300,11 @@ export function handleUndergroundDrag(
         tileY: y1,
         issuedAtTick: world.tick,
       };
-      world.commandQueue.push(cmd);
+      if (!enqueueCommand(world, cmd, isPaused)) droppedAtCap = true;
     }
     state.lastMarkedTileX = x1;
     state.lastMarkedTileY = y1;
-    return;
+    return droppedAtCap;
   }
 
   const dx = x1 > x0 ? x1 - x0 : x0 - x1;
@@ -310,20 +314,15 @@ export function handleUndergroundDrag(
   let err = dx - dy;
   let cx = x0;
   let cy = y0;
+  let finalX = x0;
+  let finalY = y0;
 
-  // Emit one tile — advances finalX/Y (always, even for out-of-bounds or
-  // non-markable tiles — matches the stroke-cursor semantics the drag tests
-  // exercise). Pushes a MarkDigTileCommand only when the tile is Solid/Open
-  // and in bounds; returns silently otherwise so the stroke continues.
+  // Emit one tile: advances finalX/Y always (stroke-cursor semantics), pushes a
+  // MarkDigTile only for in-bounds, non-ceiling, Solid/Open tiles.
   const emitTile = (tx: number, ty: number): void => {
     finalX = tx;
     finalY = ty;
     if (tx < 0 || ty < 0 || tx >= grid.width || ty >= grid.height) return;
-    // Issue #30: skip the ceiling-strip row inside the stroke — same gate as
-    // handleUndergroundLeftClick. The stroke cursor still advances (finalX/Y
-    // already updated above) so a drag that starts on a regular row, crosses
-    // the ceiling, and continues on the other side keeps interpolating; only
-    // the row-0 tiles themselves are skipped.
     if (ty === UNDERGROUND_CEILING_ROW_Y) return;
     const ts = ugGet(grid, tx, ty);
     if (ts !== UndergroundTileState.Solid && ts !== UndergroundTileState.Open) return;
@@ -334,17 +333,9 @@ export function handleUndergroundDrag(
       tileY: ty,
       issuedAtTick: world.tick,
     };
-    world.commandQueue.push(cmd);
+    if (!enqueueCommand(world, cmd, isPaused)) droppedAtCap = true;
   };
 
-  // Supercover / 4-connected Bresenham. Each iteration inspects the classic
-  // Bresenham "advance X" and "advance Y" flags. When BOTH fire on the same
-  // step we deterministically insert an orthogonal bridge tile before the
-  // diagonal completes: horizontal step first (emit the (cx+sx, cy) bridge),
-  // then the vertical step (emit (cx+sx, cy+sy)). This keeps successive
-  // emissions Manhattan-adjacent, which is what the 4-connected underground
-  // grid requires for a continuous tunnel. When only one axis advances the
-  // behavior is identical to plain Bresenham.
   while (cx !== x1 || cy !== y1) {
     const e2 = err * 2;
     const advanceX = e2 > -dy;
@@ -365,149 +356,50 @@ export function handleUndergroundDrag(
       cy += sy;
       emitTile(cx, cy);
     } else {
-      // Degenerate state (both axes already at target) — break defensively
-      // so a malformed input can never spin. In practice the loop guard
-      // (cx !== x1 || cy !== y1) prevents entry when both are at target.
       break;
     }
   }
-  // Update debounce cursor to the last tile we actually visited (may be
-  // outside bounds only if the entire stroke was clipped; in that case
-  // finalX/Y stay at the start, which is fine — the next drag call will
-  // re-run the debounce check).
   state.lastMarkedTileX = finalX;
   state.lastMarkedTileY = finalY;
+  return droppedAtCap;
 }
 
 // ---------------------------------------------------------------------------
-// handleUndergroundRightClick
+// tryOpenChamberMenu — shared by the Chamber-tool tap AND right-click (PLAN §B8/§B9)
 // ---------------------------------------------------------------------------
 
 /**
- * Handles a right-click on the underground view.
+ * Open the chamber-placement context menu anchored at (screenX, screenY) for the
+ * world tile (tileX, tileY), iff that tile is eligible. Stage-1 eligibility is
+ * Solid OR Open (Marked and BeingDug excluded; bare-dirt/Solid placement is
+ * preserved). Player-grid-only — the enemy view never opens the menu.
  *
- * Dispatch (v4 / pre-v5):
- *   - Marked tile → push CancelDigMarkCommand.
- *   - Open tunnel-end tile → open chamber-placement context menu.
- *   - Solid / BeingDug / non-tunnel-end Open → no-op.
+ * One guarded entry point used by BOTH the Chamber-tool tap and the right-click
+ * path so the eligibility + anchor logic can't drift between them. The screen
+ * coords are required by requestShowContextMenu (the menu anchors to the click).
  *
- * Dispatch (v5+, issue #38):
- *   - Marked tile → push CancelDigMarkCommand (unchanged — preserves the
- *     existing "right-click cancels a queued dig" muscle memory).
- *   - Solid OR Open tile → open chamber-placement context menu. The sim
- *     layer's reachability gate decides whether the placement actually
- *     lands; the UI just needs to surface the option. Tunnel-end check
- *     dropped because v5 chambers can be planned in untouched dirt.
- *   - BeingDug → no-op (active excavation conflict; sim would reject).
- *
- * The pre-v5 strict path is preserved so legacy saves keep their UX
- * contract (right-click on Solid does nothing). simVersion is sticky on
- * load, so a player who loads a v3/v4 save sees the legacy gate.
- *
- * No-ops if: activeView !== 'underground', pointer over HUD, or out of bounds.
+ * Returns true iff the menu was requested. No SimCommand is emitted here — the
+ * PlaceChamber command is pushed by UIScene when the player picks an item (and
+ * that push goes through enqueueCommand for the paused cap).
  */
-export function handleUndergroundRightClick(
+export function tryOpenChamberMenu(
   world: WorldState,
   viewState: ViewState,
   screenX: number,
   screenY: number,
-): void {
-  if (viewState.activeView !== 'underground') return;
-  // Issue #14: read-only guard for the enemy underground view (X-toggle).
-  // Mirrors handleUndergroundLeftClick — every dispatch below targets
-  // PLAYER_COLONY_ID, so a right-click on the enemy view would silently
-  // hit the player's grid at the matching coords.
-  if (viewState.activeUndergroundColonyId !== PLAYER_COLONY_ID) return;
-  if (isPointerOverHUD(screenX, screenY, viewState)) return;
-  const { tileX, tileY } = screenToTile(screenX, screenY, viewState.undergroundCamera);
+  tileX: number,
+  tileY: number,
+): boolean {
+  if (viewState.activeView !== 'underground') return false;
+  if (!isPlayerUndergroundEditable(viewState)) return false;
   const grid = world.undergroundGrids[PLAYER_COLONY_ID];
-  if (!grid) return;
-  if (tileX < 0 || tileY < 0 || tileX >= grid.width || tileY >= grid.height) return;
-  // Reject ceiling-row right-clicks symmetric with the sim's ceiling guard
-  // (issue #30): the chamber-placement command would always be rejected
-  // anyway, so don't open a menu the player can't act on.
-  if (tileY === UNDERGROUND_CEILING_ROW_Y) return;
+  if (!grid) return false;
+  if (!isEditableUndergroundTile(grid, tileX, tileY)) return false;
   const tileState = ugGet(grid, tileX, tileY);
-  if (tileState === UndergroundTileState.Marked) {
-    // CancelDigMark — only on Marked tiles (CTRL-04: BeingDug finish-then-switch).
-    const cmd: CancelDigMarkCommand = {
-      type: 'CancelDigMark',
-      colonyId: PLAYER_COLONY_ID,
-      tileX,
-      tileY,
-      issuedAtTick: world.tick,
-    };
-    world.commandQueue.push(cmd);
-    return;
+  if (tileState !== UndergroundTileState.Solid && tileState !== UndergroundTileState.Open) {
+    // Marked / BeingDug excluded (PLAN §B8).
+    return false;
   }
-
-  // BeingDug: no-op on either path (sim would reject the placement
-  // anyway via gate (e); avoid surfacing a doomed menu).
-  if (tileState === UndergroundTileState.BeingDug) return;
-
-  // Issue #38 — Solid OR Open. The sim handles reachability rejection
-  // post-selection. Pre-flight check: bounds were already validated above,
-  // ceiling row excluded above. Defer the actual show by a frame to keep
-  // the UIScene pointerdown SHOW-race defense (see below).
   requestShowContextMenu(screenX, screenY, tileX, tileY);
-}
-
-// ---------------------------------------------------------------------------
-// registerUndergroundInput — wires Phaser pointer events
-// ---------------------------------------------------------------------------
-
-/**
- * registerUndergroundInput — attach underground-click + drag handlers to a Phaser.Scene.
- *
- * Called from GameScene.create() (Plan 06 Task 3).
- *
- * getWorld is a LAZY accessor — called on every pointer event — so the
- * handler always dispatches against the live WorldState even if
- * GameScene swaps references mid-session (bootFresh, bootFromSave,
- * restartGame). Direct world-reference capture was a stale-closure bug.
- * Returns undefined pre-boot; all handlers short-circuit.
- *
- * Coexistence with registerDragPan: both register pointerdown/pointermove/pointerup.
- * Phaser fires multiple handlers; drag-pan guards on middle-button only, so left-click
- * and right-click reach only the world-input handlers here. Both sets of handlers
- * also guard on isPointerOverHUD so HUD widgets never receive world-click fallthrough.
- *
- * @param scene     - Phaser.Scene (GameScene) providing the input event bus.
- * @param getWorld  - Lazy accessor for the live WorldState.
- * @param viewState - Render-layer ViewState; activeView is read for guard.
- */
-export function registerUndergroundInput(
-  scene: Phaser.Scene,
-  getWorld: () => WorldState | undefined,
-  viewState: ViewState,
-): UndergroundInputState {
-  const state: UndergroundInputState = {
-    isDragging: false,
-    lastMarkedTileX: -1,
-    lastMarkedTileY: -1,
-  };
-
-  scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
-    const world = getWorld();
-    if (!world) return;
-    if (pointer.leftButtonDown()) {
-      handleUndergroundLeftClick(world, viewState, pointer.x, pointer.y, state);
-    } else if (pointer.rightButtonDown()) {
-      handleUndergroundRightClick(world, viewState, pointer.x, pointer.y);
-    }
-  });
-
-  scene.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
-    if (pointer.isDown && pointer.leftButtonDown()) {
-      const world = getWorld();
-      if (!world) return;
-      handleUndergroundDrag(world, viewState, pointer.x, pointer.y, state);
-    }
-  });
-
-  scene.input.on('pointerup', () => {
-    state.isDragging = false;
-  });
-
-  return state;
+  return true;
 }

--- a/src/input/underground-input.ts
+++ b/src/input/underground-input.ts
@@ -127,6 +127,51 @@ function isEditableUndergroundTile(
   return true;
 }
 
+/**
+ * Resolve the EFFECTIVE underground dig-state of (tileX,tileY) for `colonyId`,
+ * accounting for dig commands ALREADY queued but not yet applied (Fix 4).
+ *
+ * While bare-user-paused the sim never advances, so `ugGet` returns the frozen
+ * grid state — two taps on the same Solid tile would both read Solid and enqueue
+ * two MarkDigTile (instead of mark-then-cancel), and two taps on a Marked tile
+ * would enqueue two CancelDigMark. Tapping must instead toggle against what the
+ * queue WILL do: scan for the LATEST queued MarkDigTile/CancelDigMark on this
+ * tile+colony and fold it over the grid state, mirroring tick.ts's FIFO apply
+ * order (the last queued command wins because the drain applies them in order):
+ *   - latest queued MarkDigTile  ⇒ Marked  (tick.ts flips Solid→Marked)
+ *   - latest queued CancelDigMark ⇒ Solid   (tick.ts flips Marked→Solid)
+ *   - neither queued              ⇒ the live grid state
+ *
+ * Pure + read-only: never mutates the queue or any sim state. Unpaused this is a
+ * near-no-op — the queue drains every tick so it is usually empty for the tile,
+ * and the grid state is already current — so callers can use it unconditionally.
+ */
+function effectiveDigState(
+  world: WorldState,
+  tileX: number,
+  tileY: number,
+  colonyId: number,
+  gridState: UndergroundTileState,
+): UndergroundTileState {
+  const queue = world.commandQueue;
+  // Walk back-to-front so the FIRST match is the LATEST-queued command for the
+  // tile (the one tick.ts applies last, hence the one that wins).
+  for (let i = queue.length - 1; i >= 0; i--) {
+    const cmd = queue[i];
+    if (!cmd) continue;
+    if (cmd.type === 'MarkDigTile') {
+      if (cmd.colonyId === colonyId && cmd.tileX === tileX && cmd.tileY === tileY) {
+        return UndergroundTileState.Marked;
+      }
+    } else if (cmd.type === 'CancelDigMark') {
+      if (cmd.colonyId === colonyId && cmd.tileX === tileX && cmd.tileY === tileY) {
+        return UndergroundTileState.Solid;
+      }
+    }
+  }
+  return gridState;
+}
+
 // ---------------------------------------------------------------------------
 // handleUndergroundCommandTap — Command tool tap
 // ---------------------------------------------------------------------------
@@ -135,6 +180,13 @@ function isEditableUndergroundTile(
  * Underground Command tap: cancel a queued dig mark (Codex R2-7). A tap on a
  * Marked tile → CancelDigMark; every other tile is a no-op in Stage 1.
  * Player-grid-only. Returns true iff the command was refused at the cap.
+ *
+ * Resolves against the EFFECTIVE dig-state (effectiveDigState) so a bare-user-
+ * paused Command-tap respects already-queued Mark/Cancel commands (Fix 4): a
+ * tile with a pending MarkDigTile is effectively Marked (→ CancelDigMark fires),
+ * and a tile with a pending CancelDigMark is effectively Solid (→ no second,
+ * redundant cancel). Unpaused the queue drains each tick so this equals the grid
+ * state and behaviour is unchanged.
  */
 export function handleUndergroundCommandTap(
   world: WorldState,
@@ -147,7 +199,14 @@ export function handleUndergroundCommandTap(
   const grid = world.undergroundGrids[PLAYER_COLONY_ID];
   if (!grid) return false;
   if (!isEditableUndergroundTile(grid, tileX, tileY)) return false;
-  if (ugGet(grid, tileX, tileY) !== UndergroundTileState.Marked) return false;
+  const tileState = effectiveDigState(
+    world,
+    tileX,
+    tileY,
+    PLAYER_COLONY_ID,
+    ugGet(grid, tileX, tileY),
+  );
+  if (tileState !== UndergroundTileState.Marked) return false;
   const cmd: CancelDigMarkCommand = {
     type: 'CancelDigMark',
     colonyId: PLAYER_COLONY_ID,
@@ -166,6 +225,13 @@ export function handleUndergroundCommandTap(
  * Underground Dig tap (Codex R1-2): Solid/Open → MarkDigTile; Marked →
  * CancelDigMark; BeingDug → no-op (already claimed). Player-grid-only. Returns
  * true iff a command was refused at the cap.
+ *
+ * The mark-vs-cancel branch resolves against the EFFECTIVE dig-state
+ * (effectiveDigState) — the grid state folded with any already-queued
+ * Mark/Cancel for this tile — so a bare-user-paused tap-tap toggles correctly
+ * (Solid→MarkDigTile→CancelDigMark) instead of double-marking against the frozen
+ * grid (Fix 4). Unpaused the queue drains each tick, so the effective state
+ * equals the grid state and behaviour is unchanged.
  */
 export function handleUndergroundDigTap(
   world: WorldState,
@@ -178,7 +244,13 @@ export function handleUndergroundDigTap(
   const grid = world.undergroundGrids[PLAYER_COLONY_ID];
   if (!grid) return false;
   if (!isEditableUndergroundTile(grid, tileX, tileY)) return false;
-  const tileState = ugGet(grid, tileX, tileY);
+  const tileState = effectiveDigState(
+    world,
+    tileX,
+    tileY,
+    PLAYER_COLONY_ID,
+    ugGet(grid, tileX, tileY),
+  );
   if (tileState === UndergroundTileState.Marked) {
     const cmd: CancelDigMarkCommand = {
       type: 'CancelDigMark',
@@ -214,12 +286,15 @@ export function handleUndergroundDigTap(
  * cursor without emitting (matching the prior eager-arm behavior). Player-grid-
  * only. Returns true iff a command was refused at the cap.
  *
- * Note: unlike continuePaintStroke, the cursor is ALWAYS armed at the down-tile
- * even on a cap refusal — begin marks a single tile, and the first
- * continuePaintStroke segment re-interpolates from the down-tile, so a refused
- * down-tile mark is recovered by the stroke's own subsequent segments (and a
- * stroke that never moves was a single-tile gesture whose one refused mark
- * re-emits on the per-frame flush).
+ * Cap-refusal handling mirrors continuePaintStroke (Fix 2): the stroke is armed
+ * (state.active = true) either way, but the CURSOR is only advanced onto the
+ * down-tile when that tile is non-markable (ceiling already rejected above; a
+ * Marked/BeingDug down-tile is not a loss) OR its MarkDigTile actually enqueues.
+ * If the down-tile IS markable (Solid/Open) but the enqueue is REFUSED at the
+ * cap, the cursor is LEFT at the sentinel (-1,-1) so the first
+ * continuePaintStroke/flush re-emits the refused down-tile via its sentinel
+ * single-tile path — no silently lost begin-tile. (Previously the cursor was
+ * advanced unconditionally, so a down-tile refused at the cap was never retried.)
  */
 export function beginPaintStroke(
   state: PaintStrokeState,
@@ -240,13 +315,15 @@ export function beginPaintStroke(
     state.active = false;
     return false;
   }
-  // Arm the stroke cursor up front so a stroke that begins on a Marked/BeingDug
-  // tile still marks subsequently-entered Solid tiles.
+  // Arm the stroke so subsequently-entered Solid tiles still mark. The cursor is
+  // advanced below only on a non-markable down-tile or a successful enqueue.
   state.active = true;
-  state.lastMarkedTileX = tileX;
-  state.lastMarkedTileY = tileY;
   const tileState = ugGet(grid, tileX, tileY);
   if (tileState !== UndergroundTileState.Solid && tileState !== UndergroundTileState.Open) {
+    // Non-markable (Marked / BeingDug) down-tile: not a loss. Advance the cursor
+    // so the first drag segment interpolates from here.
+    state.lastMarkedTileX = tileX;
+    state.lastMarkedTileY = tileY;
     return false;
   }
   const cmd: MarkDigTileCommand = {
@@ -256,7 +333,18 @@ export function beginPaintStroke(
     tileY,
     issuedAtTick: world.tick,
   };
-  return !enqueueCommand(world, cmd, isPaused);
+  if (!enqueueCommand(world, cmd, isPaused)) {
+    // Cap refusal: do NOT advance the cursor onto the refused down-tile. Leave it
+    // at the sentinel so continuePaintStroke's sentinel path re-emits it once the
+    // queue drains (mirrors continuePaintStroke's hold-on-cap).
+    state.lastMarkedTileX = -1;
+    state.lastMarkedTileY = -1;
+    return true;
+  }
+  // Enqueued: advance the cursor to the down-tile.
+  state.lastMarkedTileX = tileX;
+  state.lastMarkedTileY = tileY;
+  return false;
 }
 
 /**

--- a/src/input/underground-input.ts
+++ b/src/input/underground-input.ts
@@ -362,9 +362,18 @@ export function beginPaintStroke(
  *     continues (matching the prior behaviour).
  *   - CAP REFUSAL (enqueueCommand returned false): the command was deferred, not
  *     emitted. The cursor is LEFT at the last successfully-handled tile (it is
- *     NOT advanced onto the refused tile), the loop STOPS, and `capHit` is set
- *     so the refused tile + the remainder re-emit on a later flush/move (the
- *     arbiter re-drives toward the stored target as the queue drains).
+ *     NOT advanced onto the refused tile), the loop STOPS, and `capHit` is set.
+ *
+ * The held cursor is the whole deferral mechanism: the refused tile + remainder
+ * re-emit when the NEXT pointermove calls continuePaintStroke from that same held
+ * cursor (the sim drains the queue between moves, so the next move has fresh cap
+ * budget). During a continuous drag this loses nothing. ACCEPTED narrow residual:
+ * a single coalesced >64-tile pointermove followed by an IMMEDIATE release with NO
+ * intervening move drops the tail past the cap — there is no later move to re-emit
+ * it from the held cursor, and there is deliberately no per-frame flush / post-
+ * release drain to paper over it (that machinery caused worse bugs: it redrew a
+ * curved stroke as a straight line to the latest target, and refilled all 64
+ * slots every tick, starving the AI controller's commands).
  *
  * Player-grid-only. Returns true iff a command in this segment was refused at the
  * cap (capHit). A non-markable skip never sets the return.

--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -75,6 +75,27 @@ export const EDGE_PAN_THRESHOLD_PX = 32;
 export const UNDERGROUND_INITIAL_CAMERA_Y = VIEWPORT_HEIGHT_TILES / 2;
 
 // ---------------------------------------------------------------------------
+// Tool palette (Stage 1 controls rework — issue #18)
+// ---------------------------------------------------------------------------
+
+/**
+ * The active input tool. Render/input-only state; lives on ViewState (not a
+ * module singleton — it resets on every view switch, so the view already owns
+ * its lifecycle; Codex R1-16). `chamber` is underground-only.
+ */
+export type ToolId = 'command' | 'dig' | 'chamber';
+
+/**
+ * Per-view default tool. The active tool RESETS to this on every view switch
+ * (toggleView): surface is command-first (direct taps), underground is
+ * dig-first (immediately paint-ready). Within a view the tool persists until
+ * the player changes it.
+ */
+export function defaultToolForView(view: 'surface' | 'underground'): ToolId {
+  return view === 'surface' ? 'command' : 'dig';
+}
+
+// ---------------------------------------------------------------------------
 // ViewState
 // ---------------------------------------------------------------------------
 
@@ -121,6 +142,12 @@ export interface ViewState {
    * Skipped at draw time in game-scene.ts; never round-trips through save.ts.
    */
   showPheromoneOverlay: boolean;
+  /**
+   * Stage 1 controls rework (issue #18) — the active input tool. Resets to the
+   * view default on every `toggleView`; persists within a view. `chamber` is
+   * underground-only (selecting it on the surface is a no-op upstream).
+   */
+  activeTool: ToolId;
 }
 
 // ---------------------------------------------------------------------------
@@ -144,6 +171,7 @@ export interface ViewState {
 export function createViewState(startTileX: number, startTileY: number): ViewState {
   return {
     activeView: 'surface',
+    activeTool: 'command',
     surfaceCamera: {
       x: startTileX,
       y: startTileY,
@@ -185,6 +213,7 @@ export function createViewState(startTileX: number, startTileY: number): ViewSta
  */
 export function resetViewState(viewState: ViewState, startTileX: number, startTileY: number): void {
   viewState.activeView = 'surface';
+  viewState.activeTool = 'command';
   viewState.surfaceCamera.x = startTileX;
   viewState.surfaceCamera.y = startTileY;
   viewState.surfaceCamera.viewportWidth = VIEWPORT_WIDTH_TILES;
@@ -234,9 +263,11 @@ export function toggleView(viewState: ViewState): void {
       viewState.undergroundVisited = true;
     }
     viewState.activeView = 'underground';
+    viewState.activeTool = defaultToolForView('underground');
   } else {
     viewState.surfaceCamera.x = viewState.undergroundCamera.x;
     viewState.activeView = 'surface';
+    viewState.activeTool = defaultToolForView('surface');
   }
 }
 

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -28,8 +28,9 @@ import {
   COLOR_SURFACE_ENTRANCE_HOLE,
   COLOR_PLAYER_COLONY,
   COLOR_ENEMY_COLONY,
-  COLOR_QUEEN_OUTLINE,
   COLOR_RALLY_POINT,
+  COLOR_ENTRANCE_HOVER_VALID,
+  COLOR_ENTRANCE_HOVER_INVALID,
   COLOR_FIGHTER_TINT,
   COLOR_NEUTRAL_CONTESTED_GLOW,
   lerpColor,
@@ -121,9 +122,12 @@ export function drawSurfaceTerrain(gfx: GfxLike, world: WorldState, cam: CameraS
  * Moving entities (ants) are interpolated between prev and curr state at alpha.
  * Static entities (food piles, entrances) read directly from curr. (VIEW-03)
  *
- * `pendingEntrance` is the Phase 8.5 right-click preview: when non-null, a
- * gold frame is drawn on that tile so the player can see which tile a
- * confirming left-click will place the entrance at.
+ * `entranceHover` is the Stage 1 controls-rework hover outline (issue #18):
+ * when non-null, a 2-px frame is drawn on the tile under the pointer while the
+ * Dig tool is active on the surface — GREEN when `valid` (DesignateEntrance
+ * would accept) or RED when not. GameScene recomputes both the tile and its
+ * validity from the live camera every frame, so the outline tracks the pointer
+ * even when keyboard/drag pan moves the camera beneath a stationary cursor.
  */
 export function drawSurfaceEntities(
   gfx: GfxLike,
@@ -132,7 +136,7 @@ export function drawSurfaceEntities(
   curr: WorldState,
   alpha: number,
   cam: CameraState,
-  pendingEntrance: { tileX: number; tileY: number } | null = null,
+  entranceHover: { tileX: number; tileY: number; valid: boolean } | null = null,
   facing?: AntFacingCache,
   frameTimeMs: number = 0,
   contestedGlowFrames?: Map<number, number>,
@@ -548,15 +552,20 @@ export function drawSurfaceEntities(
     }
   }
 
-  // --- Pending-entrance preview (Phase 8.5) ---
-  // A 2-px gold frame drawn on the tile the player right-clicked. Reads from
-  // the mutable SurfaceInputState exposed by registerSurfaceInput. Clears
-  // automatically once the player left-clicks the same tileX to confirm.
-  if (pendingEntrance !== null) {
-    const sx = (pendingEntrance.tileX - left) * TILE_SIZE_PX;
-    const sy = (pendingEntrance.tileY - top) * TILE_SIZE_PX;
+  // --- Entrance hover outline (Stage 1 controls rework, issue #18) ---
+  // A 2-px frame on the tile under the pointer while the Dig tool is active on
+  // the surface: GREEN when DesignateEntrance would accept the tile, RED when
+  // not. GameScene re-resolves the tile + validity from the live camera every
+  // frame (Codex R1-9/R2-9/R3-4), so the outline never goes stale and tracks the
+  // pointer even when the camera pans beneath a stationary cursor.
+  if (entranceHover !== null) {
+    const sx = (entranceHover.tileX - left) * TILE_SIZE_PX;
+    const sy = (entranceHover.tileY - top) * TILE_SIZE_PX;
     if (sx > -TILE_SIZE_PX && sx < canvasW && sy > -TILE_SIZE_PX && sy < canvasH) {
-      gfx.fillStyle(COLOR_QUEEN_OUTLINE, 0.7);
+      gfx.fillStyle(
+        entranceHover.valid ? COLOR_ENTRANCE_HOVER_VALID : COLOR_ENTRANCE_HOVER_INVALID,
+        0.8,
+      );
       gfx.fillRect(sx, sy, TILE_SIZE_PX, 2); // top
       gfx.fillRect(sx, sy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2); // bottom
       gfx.fillRect(sx, sy, 2, TILE_SIZE_PX); // left
@@ -575,8 +584,8 @@ export function drawSurfaceEntities(
  * Note: pheromone overlay is drawn by GameScene between terrain and entities;
  * it is NOT called from here.
  *
- * `pendingEntrance` (Phase 8.5) is forwarded to drawSurfaceEntities so the
- * right-click preview frame renders on top of all other surface layers.
+ * `entranceHover` (Stage 1 controls rework) is forwarded to drawSurfaceEntities
+ * so the Dig-tool hover outline renders on top of all other surface layers.
  */
 export function drawSurface(
   gfx: GfxLike,
@@ -585,9 +594,9 @@ export function drawSurface(
   curr: WorldState,
   alpha: number,
   cam: CameraState,
-  pendingEntrance: { tileX: number; tileY: number } | null = null,
+  entranceHover: { tileX: number; tileY: number; valid: boolean } | null = null,
   facing?: AntFacingCache,
 ): void {
   drawSurfaceTerrain(gfx, curr, cam);
-  drawSurfaceEntities(gfx, sprites, prev, curr, alpha, cam, pendingEntrance, facing);
+  drawSurfaceEntities(gfx, sprites, prev, curr, alpha, cam, entranceHover, facing);
 }

--- a/src/render/game-scene-logic.ts
+++ b/src/render/game-scene-logic.ts
@@ -6,6 +6,7 @@
 import type { WorldState } from '../sim/types.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
 import type { SimCommand } from '../sim/commands.js';
+import type { ToolId, ViewState } from './camera.js';
 
 // ---------------------------------------------------------------------------
 // GamePhase state machine (object-const per project convention — not enum)
@@ -18,6 +19,93 @@ export const GamePhase = {
   SavePrompt: 3,
 } as const;
 export type GamePhase = (typeof GamePhase)[keyof typeof GamePhase];
+
+// ---------------------------------------------------------------------------
+// canArbiterPan — gesture-arbiter left-drag pan gate (Stage 1 controls rework)
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether the gesture arbiter's left-drag pan may run.
+ *
+ * The arbiter's pan is driven by Phaser pointermove handlers that fire
+ * INDEPENDENTLY of GameScene.update() (they mutate the camera directly), so an
+ * update()-level early-return does NOT stop a pan — the gate must be explicit.
+ *
+ * Pan is a pure camera move (no world effect), so it stays available exactly
+ * when the world is interactive: while Playing, AND during a bare user-pause
+ * (Space / the ⏸ button) where tools, taps and pan are all still live. It must
+ * be BLOCKED while a modal owns input — the Esc pause menu (pause reason
+ * 'menu'), SavePrompt, or GameOver — because closePauseMenu()/reconcilePause()
+ * never reset the camera, so a pan behind the menu would persist after Resume.
+ *
+ * `isModalOpen` already encodes exactly that non-interactive set
+ * (GameOver || SavePrompt || pauseReasons.menu) and is false for a bare
+ * user-pause, so the gate is simply its negation.
+ */
+export function canArbiterPan(isModalOpen: boolean): boolean {
+  return !isModalOpen;
+}
+
+// ---------------------------------------------------------------------------
+// Tool cursor resolution + memoization (Stage 1 controls rework)
+// ---------------------------------------------------------------------------
+
+/** The cursor key applied to the canvas: a real tool, or the 'default' sentinel. */
+export type CursorTool = ToolId | 'default';
+
+/** Inputs to resolveCursorTool — plain flags so it is unit-testable without Phaser. */
+export interface CursorToolDeps {
+  /** The active tool from ViewState. */
+  activeTool: ToolId;
+  /** The active view — Chamber is underground-only. */
+  activeView: ViewState['activeView'];
+  /**
+   * True when a modal owns input (GameOver / SavePrompt / Esc 'menu' pause).
+   * Deliberately NOT `gamePhase !== Playing`: a bare user-pause keeps tools,
+   * taps and the entrance-hover outline LIVE (canEditWorld = !isModalOpen), so
+   * the tool cursor must persist then too — otherwise the cursor shows a plain
+   * arrow while a click would still queue an edit (a contradictory affordance).
+   */
+  isModalOpen: boolean;
+  /** contextMenuState.visible — the chamber context menu is up. */
+  contextMenuVisible: boolean;
+  /** antActivityPanelState.visible — the inspector panel is up. */
+  antActivityPanelVisible: boolean;
+  /** True when the pointer is currently over a HUD zone. */
+  overHud: boolean;
+}
+
+/**
+ * Resolve the effective cursor tool. Returns the 'default' sentinel whenever the
+ * cursor must read as the OS arrow — over chrome (HUD / context menu / panel) or
+ * while a modal owns input — and otherwise the active tool (Chamber collapses to
+ * 'command' outside the underground view). The 'default' sentinel is returned as
+ * the literal string (NOT null) so it round-trips through cursorToolChanged.
+ */
+export function resolveCursorTool(deps: CursorToolDeps): CursorTool {
+  const overChrome =
+    deps.isModalOpen || deps.contextMenuVisible || deps.antActivityPanelVisible || deps.overHud;
+  if (overChrome) return 'default';
+  if (deps.activeTool === 'chamber' && deps.activeView !== 'underground') return 'command';
+  return deps.activeTool;
+}
+
+/**
+ * Whether the resolved (tool, view) differs from the last applied pair — i.e.
+ * whether a DOM cursor write is actually needed this frame. The previous code
+ * stored the 'default' case as `null` while comparing against the 'default'
+ * string, so `'default' === null` was always false and setDefaultCursor ran
+ * EVERY frame over chrome. Comparing the sentinel consistently (store and
+ * compare the literal 'default') restores the intended single-write behaviour.
+ */
+export function cursorToolChanged(
+  effectiveTool: CursorTool,
+  view: ViewState['activeView'],
+  lastTool: CursorTool | null,
+  lastView: ViewState['activeView'] | null,
+): boolean {
+  return effectiveTool !== lastTool || view !== lastView;
+}
 
 // ---------------------------------------------------------------------------
 // decideBootMode — pure boot-path decider

--- a/src/render/game-scene.test.ts
+++ b/src/render/game-scene.test.ts
@@ -104,7 +104,10 @@ describe('GamePhase object-const', () => {
 });
 
 // ---------------------------------------------------------------------------
-// canArbiterPan — left-drag pan gate (advisory fix: block behind modal/menu)
+// canArbiterPan — shared pan gate (block behind modal/menu). Used by the
+// left-drag arbiter pan AND, since Fix 3 (Codex P2), the per-frame keyboard
+// (WASD/arrow) pan in GameScene.update — both gate on canArbiterPan(isModalOpen)
+// so all pan paths (keyboard, left-drag, middle-button) move together.
 // ---------------------------------------------------------------------------
 
 describe('canArbiterPan', () => {
@@ -118,6 +121,16 @@ describe('canArbiterPan', () => {
   it('blocks pan when a modal owns input (Esc menu / SavePrompt / GameOver)', () => {
     // isModalOpen=true is the GameOver || SavePrompt || pauseReasons.menu set.
     expect(canArbiterPan(true)).toBe(false);
+  });
+
+  // Fix 3 (Codex P2): the keyboard PAN gate is this exact predicate. Behind the
+  // Esc pause menu (a modal, isModalOpen=true) held WASD/arrows must NOT pan —
+  // previously processCameraInput ran whenever gamePhase !== GameOver, so it kept
+  // panning the camera behind the menu (gamePhase=Paused) and the move persisted
+  // after Resume. A bare user-pause is NOT a modal, so pan still works there.
+  it('keyboard pan: blocked behind the Esc menu, allowed during a bare user-pause', () => {
+    expect(canArbiterPan(true)).toBe(false); // menu pause / SavePrompt / GameOver
+    expect(canArbiterPan(false)).toBe(true); // bare user-pause (Space) — look-around live
   });
 });
 

--- a/src/render/game-scene.test.ts
+++ b/src/render/game-scene.test.ts
@@ -17,6 +17,10 @@ import {
   resetInputLog,
   generateFreshSeed,
   GamePhase,
+  canArbiterPan,
+  resolveCursorTool,
+  cursorToolChanged,
+  type CursorTool,
 } from './game-scene-logic.js';
 import {
   createViewState,
@@ -24,17 +28,14 @@ import {
   toggleView,
   UNDERGROUND_INITIAL_CAMERA_Y,
 } from './camera.js';
-import { resetSurfaceInputState, type SurfaceInputState } from '../input/surface-input.js';
-import {
-  resetUndergroundInputState,
-  type UndergroundInputState,
-} from '../input/underground-input.js';
+import { resetPaintStrokeState, type PaintStrokeState } from '../input/underground-input.js';
 import {
   panInputState,
   resetPanInputState,
   resetDragState,
   type DragState,
 } from '../input/camera-input.js';
+import { clearAllPauseReasons, type PauseReasonState } from './pause-reasons.js';
 import { contextMenuState, hideContextMenu } from './context-menu-state.js';
 import { PLAYER_START_X, PLAYER_START_Y } from '../sim/constants.js';
 import type { WorldState } from '../sim/types.js';
@@ -99,6 +100,108 @@ describe('GamePhase object-const', () => {
     for (const v of values) {
       expect(typeof v).toBe('number');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canArbiterPan — left-drag pan gate (advisory fix: block behind modal/menu)
+// ---------------------------------------------------------------------------
+
+describe('canArbiterPan', () => {
+  // The gate is the negation of isModalOpen(). isModalOpen() is FALSE while
+  // Playing and during a bare user-pause, and TRUE for GameOver/SavePrompt/menu.
+  it('allows pan when no modal is open (Playing or bare user-pause)', () => {
+    // isModalOpen=false covers both Playing and a bare 'user'-only pause.
+    expect(canArbiterPan(false)).toBe(true);
+  });
+
+  it('blocks pan when a modal owns input (Esc menu / SavePrompt / GameOver)', () => {
+    // isModalOpen=true is the GameOver || SavePrompt || pauseReasons.menu set.
+    expect(canArbiterPan(true)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveCursorTool — tool cursor over chrome / during pause (advisory fix)
+// ---------------------------------------------------------------------------
+
+describe('resolveCursorTool', () => {
+  function cursorDeps(
+    overrides: Partial<Parameters<typeof resolveCursorTool>[0]> = {},
+  ): Parameters<typeof resolveCursorTool>[0] {
+    return {
+      activeTool: 'dig',
+      activeView: 'surface',
+      isModalOpen: false,
+      contextMenuVisible: false,
+      antActivityPanelVisible: false,
+      overHud: false,
+      ...overrides,
+    };
+  }
+
+  it('returns the active tool when interactive and not over chrome', () => {
+    expect(resolveCursorTool(cursorDeps({ activeTool: 'dig' }))).toBe('dig');
+    expect(
+      resolveCursorTool(cursorDeps({ activeTool: 'chamber', activeView: 'underground' })),
+    ).toBe('chamber');
+    expect(resolveCursorTool(cursorDeps({ activeTool: 'command' }))).toBe('command');
+  });
+
+  it("collapses Chamber to 'command' outside the underground view", () => {
+    expect(resolveCursorTool(cursorDeps({ activeTool: 'chamber', activeView: 'surface' }))).toBe(
+      'command',
+    );
+  });
+
+  it("returns 'default' over HUD / context menu / inspector panel", () => {
+    expect(resolveCursorTool(cursorDeps({ overHud: true }))).toBe('default');
+    expect(resolveCursorTool(cursorDeps({ contextMenuVisible: true }))).toBe('default');
+    expect(resolveCursorTool(cursorDeps({ antActivityPanelVisible: true }))).toBe('default');
+  });
+
+  it("returns 'default' while a modal owns input (menu / SavePrompt / GameOver)", () => {
+    expect(resolveCursorTool(cursorDeps({ isModalOpen: true }))).toBe('default');
+  });
+
+  // Advisory fix (line 1727): a bare user-pause is NOT a modal, so tap/paint and
+  // entrance-hover stay live — the tool cursor must persist, not revert to arrow.
+  it('keeps the active tool during a bare user-pause (isModalOpen=false)', () => {
+    expect(resolveCursorTool(cursorDeps({ activeTool: 'dig', isModalOpen: false }))).toBe('dig');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cursorToolChanged — memoization short-circuit (advisory fix: 'default' sentinel)
+// ---------------------------------------------------------------------------
+
+describe('cursorToolChanged', () => {
+  it('reports a change when the resolved tool differs', () => {
+    expect(cursorToolChanged('dig', 'surface', 'command', 'surface')).toBe(true);
+  });
+
+  it('reports a change when the view differs', () => {
+    expect(cursorToolChanged('command', 'underground', 'command', 'surface')).toBe(true);
+  });
+
+  it('reports NO change when tool and view are unchanged (dedups the DOM write)', () => {
+    expect(cursorToolChanged('dig', 'surface', 'dig', 'surface')).toBe(false);
+  });
+
+  // The core advisory bug: the 'default' sentinel was previously stored as null
+  // while compared against the 'default' string, so 'default' === null was always
+  // false and setDefaultCursor ran EVERY frame over chrome. Storing/comparing the
+  // literal 'default' makes consecutive default frames short-circuit.
+  it("short-circuits consecutive 'default' frames (sentinel round-trips)", () => {
+    const effective: CursorTool = 'default';
+    // First default frame: last is null → a write is needed.
+    expect(cursorToolChanged(effective, 'surface', null, 'surface')).toBe(true);
+    // After storing 'default' (literal, not null), the next frame must dedup.
+    expect(cursorToolChanged(effective, 'surface', 'default', 'surface')).toBe(false);
+  });
+
+  it('initial frame always writes (lastTool/lastView null)', () => {
+    expect(cursorToolChanged('dig', 'surface', null, null)).toBe(true);
   });
 });
 
@@ -279,19 +382,24 @@ describe('resetInputLog', () => {
 // seeing the live state, as established by the Phase 9 stale-world fix).
 
 describe('session reset orchestration (bootFresh / bootFromSave precondition)', () => {
+  // Stage 1 controls rework (issue #18): resetSessionState's fan-out changed —
+  // the surface/underground input-state resets are replaced by the gesture
+  // arbiter's cancelGesture (modeled here as a PaintStrokeState reset) and the
+  // pause-reason set is cleared entirely. The object-identity contract is
+  // unchanged (in-place resets so captured closures keep seeing live state).
   interface SessionState {
     inputLog: SimCommand[];
     viewState: ReturnType<typeof createViewState>;
-    surfaceInputState: SurfaceInputState;
-    undergroundInputState: UndergroundInputState;
+    paintStroke: PaintStrokeState;
+    pauseReasons: PauseReasonState;
     dragState: DragState;
     /** GameScene scalar — modeled here so the harness exercises the same fan-out. */
     speedMultiplier: number;
   }
 
   function makeDirtySession(): SessionState {
-    // Emulate a mid-session GameScene: mid-game, mid-drag, context menu open,
-    // entrance previewed, pan in flight, game sped up.
+    // Emulate a mid-session GameScene: mid-game, mid-paint-stroke, context menu
+    // open, pan in flight, paused via Esc + Space, game sped up.
     const inputLog: SimCommand[] = [
       { type: 'NoOp', issuedAtTick: 0 },
       { type: 'NoOp', issuedAtTick: 1 },
@@ -301,38 +409,36 @@ describe('session reset orchestration (bootFresh / bootFromSave precondition)', 
     viewState.undergroundCamera.x = 100;
     viewState.undergroundCamera.y = 40;
     viewState.surfaceCamera.x = 90;
-    const surfaceInputState: SurfaceInputState = {
-      pendingEntranceTileX: 22,
-      pendingEntranceTileY: 8,
-    };
-    const undergroundInputState: UndergroundInputState = {
-      isDragging: true,
+    viewState.activeTool = 'chamber'; // non-default tool
+    const paintStroke: PaintStrokeState = {
+      active: true,
       lastMarkedTileX: 14,
       lastMarkedTileY: 6,
     };
+    const pauseReasons: PauseReasonState = { user: true, menu: true };
     const dragState: DragState = { isDragging: true, lastX: 42, lastY: 99, active: true };
-    panInputState.spaceHeld = true;
     panInputState.isPanning = true;
     contextMenuState.visible = true;
     contextMenuState.screenX = 300;
     return {
       inputLog,
       viewState,
-      surfaceInputState,
-      undergroundInputState,
+      paintStroke,
+      pauseReasons,
       dragState,
       speedMultiplier: 4, // player had sped up to 4x before the restart
     };
   }
 
-  // Matches resetSessionState's fan-out exactly — kept here so the contract
-  // is covered by a real test even though the owning method lives on the Phaser-
-  // coupled GameScene.
+  // Matches resetSessionState's fan-out exactly — kept here so the contract is
+  // covered by a real test even though the owning method lives on the Phaser-
+  // coupled GameScene. (arbiter.cancelGesture() == resetPaintStrokeState +
+  // isPanning=false, both exercised here.)
   function runSessionReset(s: SessionState): void {
     resetInputLog(s.inputLog);
     resetViewState(s.viewState, PLAYER_START_X, PLAYER_START_Y);
-    resetSurfaceInputState(s.surfaceInputState);
-    resetUndergroundInputState(s.undergroundInputState);
+    resetPaintStrokeState(s.paintStroke);
+    clearAllPauseReasons(s.pauseReasons);
     resetDragState(s.dragState);
     resetPanInputState();
     hideContextMenu();
@@ -345,27 +451,40 @@ describe('session reset orchestration (bootFresh / bootFromSave precondition)', 
 
     expect(s.inputLog).toHaveLength(0);
     expect(s.viewState.activeView).toBe('surface');
+    expect(s.viewState.activeTool).toBe('command'); // surface default
     expect(s.viewState.surfaceCamera.x).toBe(PLAYER_START_X);
     expect(s.viewState.surfaceCamera.y).toBe(PLAYER_START_Y);
     expect(s.viewState.undergroundCamera.x).toBe(PLAYER_START_X);
     expect(s.viewState.undergroundCamera.y).toBe(UNDERGROUND_INITIAL_CAMERA_Y);
     expect(s.viewState.undergroundVisited).toBe(false);
-    expect(s.surfaceInputState.pendingEntranceTileX).toBeNull();
-    expect(s.surfaceInputState.pendingEntranceTileY).toBeNull();
-    expect(s.undergroundInputState.isDragging).toBe(false);
-    expect(s.undergroundInputState.lastMarkedTileX).toBe(-1);
-    expect(s.undergroundInputState.lastMarkedTileY).toBe(-1);
+    expect(s.paintStroke.active).toBe(false);
+    expect(s.paintStroke.lastMarkedTileX).toBe(-1);
+    expect(s.paintStroke.lastMarkedTileY).toBe(-1);
+    expect(s.pauseReasons.user).toBe(false);
+    expect(s.pauseReasons.menu).toBe(false);
     expect(s.dragState).toEqual({ isDragging: false, lastX: 0, lastY: 0, active: false });
-    expect(panInputState.spaceHeld).toBe(false);
     expect(panInputState.isPanning).toBe(false);
     expect(contextMenuState.visible).toBe(false);
     expect(s.speedMultiplier).toBe(1);
   });
 
+  it('clears the ENTIRE pause-reason set (Codex R2-1 — no stuck menu/user pause)', () => {
+    // A new-game-from-Esc / Save-Load path must not leave 'menu' (or 'user') set.
+    for (const reasons of [
+      { user: true, menu: false },
+      { user: false, menu: true },
+      { user: true, menu: true },
+    ]) {
+      const s = makeDirtySession();
+      s.pauseReasons.user = reasons.user;
+      s.pauseReasons.menu = reasons.menu;
+      runSessionReset(s);
+      expect(s.pauseReasons.user).toBe(false);
+      expect(s.pauseReasons.menu).toBe(false);
+    }
+  });
+
   it('speedMultiplier resets to 1x regardless of prior 2x / 4x setting', () => {
-    // Phase 4 contract: every new session boots at 1x. Save files do not
-    // persist speed so continue-from-save also restarts at 1x — the reset
-    // runs unconditionally at the top of bootFresh and bootFromSave.
     for (const prior of [1, 2, 4]) {
       const s = makeDirtySession();
       s.speedMultiplier = prior;
@@ -375,16 +494,13 @@ describe('session reset orchestration (bootFresh / bootFromSave precondition)', 
   });
 
   it('preserves every object identity — no captured handler is stranded', () => {
-    // This is the invariant that gets the Phase 9 bug right on the second try.
-    // If any of these identities change, a closure captured in create() will
-    // silently dispatch against the old object.
     const s = makeDirtySession();
     const inputLogRef = s.inputLog;
     const viewStateRef = s.viewState;
     const surfaceCamRef = s.viewState.surfaceCamera;
     const undergroundCamRef = s.viewState.undergroundCamera;
-    const surfaceInputRef = s.surfaceInputState;
-    const undergroundInputRef = s.undergroundInputState;
+    const paintStrokeRef = s.paintStroke;
+    const pauseReasonsRef = s.pauseReasons;
     const dragStateRef = s.dragState;
 
     runSessionReset(s);
@@ -393,8 +509,8 @@ describe('session reset orchestration (bootFresh / bootFromSave precondition)', 
     expect(s.viewState).toBe(viewStateRef);
     expect(s.viewState.surfaceCamera).toBe(surfaceCamRef);
     expect(s.viewState.undergroundCamera).toBe(undergroundCamRef);
-    expect(s.surfaceInputState).toBe(surfaceInputRef);
-    expect(s.undergroundInputState).toBe(undergroundInputRef);
+    expect(s.paintStroke).toBe(paintStrokeRef);
+    expect(s.pauseReasons).toBe(pauseReasonsRef);
     expect(s.dragState).toBe(dragStateRef);
   });
 
@@ -416,17 +532,16 @@ describe('session reset orchestration (bootFresh / bootFromSave precondition)', 
     runSessionReset(s);
     appendInputLog(s.inputLog, [{ type: 'NoOp', issuedAtTick: 5 }]);
     s.viewState.surfaceCamera.x = 70;
-    s.surfaceInputState.pendingEntranceTileX = 12;
-    s.surfaceInputState.pendingEntranceTileY = 4;
-    s.undergroundInputState.isDragging = true;
+    s.paintStroke.active = true;
+    s.pauseReasons.user = true;
     s.speedMultiplier = 2;
 
     runSessionReset(s);
 
     expect(s.inputLog).toHaveLength(0);
     expect(s.viewState.surfaceCamera.x).toBe(PLAYER_START_X);
-    expect(s.surfaceInputState.pendingEntranceTileX).toBeNull();
-    expect(s.undergroundInputState.isDragging).toBe(false);
+    expect(s.paintStroke.active).toBe(false);
+    expect(s.pauseReasons.user).toBe(false);
     expect(s.speedMultiplier).toBe(1);
   });
 });

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -1599,19 +1599,6 @@ export class GameScene extends Phaser.Scene {
     // context. Also refreshes the arbiter's context fingerprint.
     this.arbiter.reconcileContext();
 
-    // Stage 1 (Fix 1): drain any dig tiles a fast paint stroke deferred past the
-    // MAX_COMMANDS_PER_TICK cap. flushPaint re-drives the active stroke toward
-    // its stored target so the deferred tail emits as the queue drains (≤64/tick)
-    // even if the pointer has stopped; it is a no-op when no paint stroke is
-    // active or the cursor has already reached the target. Runs before
-    // gameLoop.update below so this frame's enqueue is drained by this frame's
-    // tick(s). Guarded by canEditWorld defence-in-depth: a modal already cancels
-    // the gesture via openPauseMenu/restartGame, but this keeps a stray active
-    // stroke from enqueueing under a modal that didn't go through cancelGesture.
-    if (this.world && !this.isModalOpen()) {
-      this.arbiter.flushPaint(this.world, isPausedByAny(this.pauseReasons));
-    }
-
     // Track active view for anything that needs to diff on toggle.
     if (this.viewState.activeView !== this.lastActiveView) {
       this.lastActiveView = this.viewState.activeView;

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -52,14 +52,20 @@ import {
   generateFreshSeed,
   decideBootMode,
   resetInputLog,
+  canArbiterPan,
+  resolveCursorTool,
+  cursorToolChanged,
+  type CursorTool,
 } from './game-scene-logic.js';
 import {
   type ViewState,
+  type ToolId,
   createViewState,
   resetViewState,
   toggleView,
   toggleUndergroundColony,
   clampCamera,
+  screenToTile,
 } from './camera.js';
 import {
   PLAYER_COLONY_ID,
@@ -120,18 +126,22 @@ import {
   registerDragPan,
   resetDragState,
   resetPanInputState,
+  isPointerOverHUD,
 } from '../input/camera-input.js';
+import { isValidEntranceTarget } from '../input/surface-input.js';
+import { registerGestureArbiter, type GestureArbiter } from '../input/gesture-arbiter.js';
 import {
-  registerSurfaceInput,
-  resetSurfaceInputState,
-  type SurfaceInputState,
-} from '../input/surface-input.js';
-import {
-  registerUndergroundInput,
-  resetUndergroundInputState,
-  type UndergroundInputState,
-} from '../input/underground-input.js';
-import { hideContextMenu } from './context-menu-state.js';
+  type PauseReasonState,
+  createPauseReasonState,
+  setPauseReason,
+  clearPauseReason,
+  togglePauseReason,
+  isPausedByAny,
+  clearAllPauseReasons,
+} from './pause-reasons.js';
+import { canAcceptWorldHotkey, type HotkeyGamePhase } from '../input/hotkey-policy.js';
+import { contextMenuState, hideContextMenu } from './context-menu-state.js';
+import { antActivityPanelState } from './ant-activity-panel-state.js';
 import { buildPlaytraceSummary, type GameOutcomeLabel } from './summary-builder.js';
 import { captionForEvent, checkAndTrigger, resetCaptions } from './onboarding-captions.js';
 import {
@@ -195,6 +205,10 @@ interface UIScenePhase9 {
   hideDifficultySelectOverlay(): void;
   // S6 — first-occurrence caption overlay (light onboarding).
   showCaption(text: string, screenX: number, screenY: number): void;
+  // Stage 1 controls rework (issue #18) — surface the "paused queue full" hint
+  // when enqueueCommand drops a command at the paused cap. Optional so other
+  // UIScene consumers (tests) need not implement it.
+  flashPausedQueueFull?(): void;
 }
 import type { SimCommand } from '../sim/commands.js';
 
@@ -248,8 +262,24 @@ export class GameScene extends Phaser.Scene {
   };
   private tabKey!: Phaser.Input.Keyboard.Key;
   private dragState!: { isDragging: boolean; lastX: number; lastY: number; active: boolean };
-  private surfaceInputState!: SurfaceInputState;
-  private undergroundInputState!: UndergroundInputState;
+  // Stage 1 controls rework (issue #18) — the single left-button gesture arbiter
+  // replaces the old surface/underground pointer listener sets.
+  private arbiter!: GestureArbiter;
+  // Reconciled pause-reason set: the loop is paused iff any reason is set.
+  // 'user' = Space / ⏸; 'menu' = Esc-driven overlay. Reconciled to
+  // gameLoop.pause()/resume() centrally so the two pause independently.
+  private readonly pauseReasons: PauseReasonState = createPauseReasonState();
+  // Entrance hover (Dig + surface): the POINTER screen coords, re-resolved to a
+  // tile + validity every render frame (Codex R1-9/R2-9/R3-4). null when the
+  // pointer is off-canvas / over HUD / not in Dig+surface mode.
+  private hoverScreenX: number | null = null;
+  private hoverScreenY: number | null = null;
+  // Last tool/view we set the canvas cursor for, so update() only writes the
+  // cursor when it actually changes. Stores the 'default' sentinel as the literal
+  // string (CursorTool), NOT null, so the change-detection compare short-circuits
+  // on consecutive default frames instead of re-issuing setDefaultCursor.
+  private lastCursorTool: CursorTool | null = null;
+  private lastCursorView: ViewState['activeView'] | null = null;
   private lastActiveView: ViewState['activeView'] | null = null;
 
   // Phase 9 — GamePhase FSM + session fields
@@ -287,6 +317,18 @@ export class GameScene extends Phaser.Scene {
   private setSpeedMultiplier(next: 1 | 2 | 4): void {
     this.speedMultiplier = next;
     publishSpeedMultiplier(next);
+  }
+
+  /**
+   * Step the speed multiplier among {1, 2, 4}. dir=+1 steps up (clamped at 4),
+   * dir=-1 steps down (clamped at 1). Used by the =/-/numpad keys and the speed
+   * widget. Never changes pause reasons (Codex R2-11).
+   */
+  private stepSpeed(dir: 1 | -1): void {
+    const order: Array<1 | 2 | 4> = [1, 2, 4];
+    const idx = order.indexOf(this.speedMultiplier);
+    const nextIdx = Math.max(0, Math.min(order.length - 1, idx + dir));
+    this.setSpeedMultiplier(order[nextIdx]!);
   }
 
   /** DEV/E2E-only render-order trace (issue #193). The draw section of update()
@@ -404,7 +446,19 @@ export class GameScene extends Phaser.Scene {
     this.input.keyboard!.addCapture('TAB');
     this.input.mouse!.disableContextMenu();
 
-    // Drag-pan registration — returns dragState ref for processCameraInput
+    // Stage 1 controls rework (issue #18): Space is now the pause toggle, not a
+    // pan modifier. addKey creates a real Key object (the second arg also adds
+    // the global capture so Space never scrolls the host page while focused,
+    // replacing the bare addCapture this used to do). The Key is required so
+    // Phaser de-dupes OS key auto-repeat on the scene-level keydown-SPACE event:
+    // without a Key, KeyboardPlugin emits keydown-SPACE every repeat tick and a
+    // held Space strobes the pause toggle on/off (see handler below). We only
+    // need the Key to exist in the plugin's key map, so we don't retain the ref.
+    this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE, true);
+
+    // Middle-button drag-pan registration (left/Space pan paths removed —
+    // left is now exclusively the gesture arbiter's). Returns dragState ref
+    // for processCameraInput. Suspended during GameOver.
     this.dragState = registerDragPan(
       this,
       this.viewState,
@@ -429,17 +483,38 @@ export class GameScene extends Phaser.Scene {
     // captures the label at render time and would no longer match), and
     // prevents Resume from snapping the camera to the enemy nest because
     // X was pressed while paused.
-    this.input.keyboard!.on('keydown-ONE', () => {
-      if (this.gamePhase !== GamePhase.Playing) return;
-      this.setSpeedMultiplier(1);
-    });
-    this.input.keyboard!.on('keydown-TWO', () => {
-      if (this.gamePhase !== GamePhase.Playing) return;
-      this.setSpeedMultiplier(2);
-    });
-    this.input.keyboard!.on('keydown-FOUR', () => {
-      if (this.gamePhase !== GamePhase.Playing) return;
-      this.setSpeedMultiplier(4);
+    // Stage 1 controls rework (issue #18) — tool palette hotkeys. 1/2/4 no
+    // longer set speed (freed for tools): 1→Command, 2→Dig, 3→Chamber. All
+    // gated through canAcceptWorldHotkey (selectTool enforces the gate + the
+    // Chamber-is-underground-only rule).
+    this.input.keyboard!.on('keydown-ONE', () => this.selectTool('command'));
+    this.input.keyboard!.on('keydown-TWO', () => this.selectTool('dig'));
+    this.input.keyboard!.on('keydown-THREE', () => this.selectTool('chamber'));
+
+    // Speed step keys: top-row '='/'+' (keycode 187) and numpad-add step UP;
+    // top-row '-' (keycode 189) and numpad-subtract step DOWN, among {1,2,4}.
+    // Ctrl/Cmd combos are ignored so browser zoom shortcuts pass through
+    // (Codex R1-13/R4-3). Gated like the other world hotkeys; speed changes
+    // never touch pause reasons (Codex R2-11).
+    const stepSpeedKey = (dir: 1 | -1) => (ev: KeyboardEvent) => {
+      if (ev.ctrlKey || ev.metaKey) return;
+      if (!this.canAcceptWorldHotkey()) return;
+      this.stepSpeed(dir);
+    };
+    this.input.keyboard!.on('keydown-PLUS', stepSpeedKey(1)); // keycode 187 ('='/'+')
+    this.input.keyboard!.on('keydown-MINUS', stepSpeedKey(-1)); // keycode 189 (top-row '-')
+    this.input.keyboard!.on('keydown-NUMPAD_ADD', stepSpeedKey(1));
+    this.input.keyboard!.on('keydown-NUMPAD_SUBTRACT', stepSpeedKey(-1));
+
+    // Space toggles the 'user' pause (edge-triggered on keydown; the Key
+    // registered above makes Phaser de-dupe OS auto-repeat on this event). The
+    // event.repeat guard is belt-and-suspenders so a held Space can never strobe
+    // the pause on/off. Gated through canAcceptWorldHotkey so a Space behind a
+    // modal/menu can't flip the pause reason underneath it.
+    this.input.keyboard!.on('keydown-SPACE', (ev: KeyboardEvent) => {
+      if (ev.repeat) return;
+      if (!this.canAcceptWorldHotkey()) return;
+      this.toggleUserPause();
     });
     // Issue #114 — P toggles the player's pheromone overlay. Render-only:
     // the flag lives on ViewState (so the next frame skips drawPheromoneOverlay)
@@ -455,7 +530,7 @@ export class GameScene extends Phaser.Scene {
     // stuck OFF. ViewState is the authoritative in-mem source; persist is
     // best-effort and survives reload only when storage cooperates.
     this.input.keyboard!.on('keydown-P', () => {
-      if (this.gamePhase !== GamePhase.Playing) return;
+      if (!this.canAcceptWorldHotkey()) return;
       const next = !this.viewState.showPheromoneOverlay;
       this.viewState.showPheromoneOverlay = next;
       const persisted = loadSettings();
@@ -472,7 +547,7 @@ export class GameScene extends Phaser.Scene {
     // Tab via JustDown. Gated on Playing so a paused player doesn't Resume
     // into a surprise camera flip onto the enemy nest.
     this.input.keyboard!.on('keydown-X', () => {
-      if (this.gamePhase !== GamePhase.Playing) return;
+      if (!this.canAcceptWorldHotkey()) return;
       if (this.viewState.activeView !== 'underground') return;
       toggleUndergroundColony(this.viewState);
       // Clear stale glow entries from the previous colony grid — tile keys are
@@ -508,15 +583,84 @@ export class GameScene extends Phaser.Scene {
       // menu. GameScene was previously binding keydown-ESC alongside
       // UIScene's escKey handler, which raced (open → close in one press).
       onEscape: () => this.openPauseMenu(),
+      // Stage 1 controls rework (issue #18) — the HUD tool palette + speed widget
+      // route through these GameScene-owned, gated handlers so a palette/speed
+      // click obeys the same gate as the 1/2/3 and =/- hotkeys.
+      onSelectTool: (tool: ToolId) => this.selectTool(tool),
+      onSpeedControl: (control: 'pause' | 1 | 2 | 4) => {
+        if (!this.canAcceptWorldHotkey()) return;
+        if (control === 'pause') {
+          // ⏸ toggles the 'user' pause (same as Space). canAcceptWorldHotkey is
+          // true during a bare user-pause (no menu) so ⏸ can also un-pause.
+          this.toggleUserPause();
+        } else {
+          // 1×/2×/4× set the multiplier WITHOUT changing pause reasons (Codex R2-11).
+          this.setSpeedMultiplier(control);
+        }
+      },
+      isPaused: () => isPausedByAny(this.pauseReasons),
+      getSpeedMultiplier: () => this.speedMultiplier,
     });
     this.scene.bringToTop('UIScene');
 
-    // World input dispatchers — internally guard on viewState.activeView.
-    // Both return the per-registration state object so restartGame / boot
-    // helpers can reset them in place without invalidating the closures that
-    // Phaser now holds on pointerdown/pointermove/pointerup.
-    this.surfaceInputState = registerSurfaceInput(this, getWorld, this.viewState, getPrevWorld);
-    this.undergroundInputState = registerUndergroundInput(this, getWorld, this.viewState);
+    // Stage 1 controls rework (issue #18): the single left-button gesture
+    // arbiter replaces registerSurfaceInput + registerUndergroundInput. It owns
+    // the left button exclusively (and the right-click chamber path); the
+    // middle-button pan stays on registerDragPan above. Tap logic lives in the
+    // pure surface/underground handlers the arbiter calls.
+    this.arbiter = registerGestureArbiter(this, {
+      getWorld,
+      getPrevWorld,
+      viewState: this.viewState,
+      isPointerOverHUD: (x, y) => isPointerOverHUD(x, y, this.viewState),
+      isPaused: () => isPausedByAny(this.pauseReasons),
+      // World edits (tap / paint / chamber) are allowed whenever no modal is up —
+      // crucially that INCLUDES a bare user-pause, so a click/dig-paint while
+      // paused queues through enqueueCommand for application on resume (the
+      // paused-cap behaviour). isModalOpen() already covers GameOver/SavePrompt
+      // and the Esc menu pause, which DO block edits.
+      canEditWorld: () => !this.isModalOpen(),
+      // Pan is a pure camera move with no world effect, so — like keyboard /
+      // middle-button pan — it stays available whenever the world is interactive:
+      // while Playing AND during a bare user-pause (Space / ⏸). It is BLOCKED
+      // while a modal owns input: the Esc pause menu, SavePrompt, or GameOver.
+      // The arbiter's pan runs from Phaser pointermove handlers that fire
+      // independently of update() (and no overlay calls stopPropagation here), so
+      // this gate is the ONLY thing stopping a left-drag from panning behind a
+      // modal — and closePauseMenu()/reconcilePause() never reset the camera, so
+      // an un-gated pan would persist after Resume. isModalOpen() is exactly the
+      // non-interactive set (GameOver/SavePrompt/menu) and is false for a bare
+      // user-pause, so `!isModalOpen()` is the correct gate. Do NOT revert this to
+      // a GameOver-only check: SavePrompt and the menu DO reach here.
+      canPan: () => canArbiterPan(this.isModalOpen()),
+      // The chamber context menu is anchored at an arbitrary WORLD tile (not a
+      // HUD zone), so isPointerOverHUD can't catch it and canEditWorld stays true
+      // while it's open. Gate left taps on it directly: a click that selects /
+      // dismisses a menu item (UIScene owns that on its own pointerdown) must not
+      // ALSO fire a world tap. pendingShow/pendingHide cover the deferred-(dis)appear
+      // race where `visible` lags a frame behind a same-dispatch request.
+      isContextMenuActive: () =>
+        contextMenuState.visible || contextMenuState.pendingShow || contextMenuState.pendingHide,
+      onPausedQueueFull: () => {
+        const ui = this.scene.get('UIScene') as unknown as UIScenePhase9 | null;
+        ui?.flashPausedQueueFull?.();
+      },
+    });
+
+    // Entrance hover (Dig + surface): track the POINTER screen coords so the
+    // hover outline can be re-resolved to a tile + validity from the LIVE camera
+    // every frame (Codex R3-4 — a stationary cursor over a panning camera must
+    // still highlight the tile under it). Cleared on pointer-out.
+    this.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+      this.hoverScreenX = pointer.x;
+      this.hoverScreenY = pointer.y;
+    });
+    this.input.on('pointerout', () => {
+      this.hoverScreenX = null;
+      this.hoverScreenY = null;
+    });
+    // Cancel any in-flight gesture if the canvas loses focus (blur).
+    this.game.events.on('blur', () => this.arbiter.cancelGesture());
 
     // Phase 9 boot: classify any existing save ONCE. A loadable ('compatible')
     // save shows the Continue/New Game SavePrompt. Everything else boots fresh —
@@ -578,15 +722,22 @@ export class GameScene extends Phaser.Scene {
    *     files don't persist speed, so continue-from-save also restarts at 1x
    *
    * All mutations are in-place so references already captured by UIScene
-   * and by registerSurfaceInput / registerUndergroundInput / registerDragPan
-   * stay valid. Reassigning would strand those references (same failure
-   * class as the stale-world bug fixed earlier in Phase 9).
+   * and by the gesture arbiter / registerDragPan stay valid. Reassigning would
+   * strand those references (same failure class as the stale-world bug fixed
+   * earlier in Phase 9). The pause-reason set is cleared entirely here.
    */
   private resetSessionState(): void {
     resetInputLog(this.inputLog);
     resetViewState(this.viewState, PLAYER_START_X, PLAYER_START_Y);
-    resetSurfaceInputState(this.surfaceInputState);
-    resetUndergroundInputState(this.undergroundInputState);
+    // Stage 1 controls rework (issue #18): abandon any in-flight gesture and
+    // clear the whole pause-reason set so a new game can't inherit a stuck
+    // 'menu'/'user' pause (Codex R2-1). Hover outline + cursor caches reset too.
+    this.arbiter.cancelGesture();
+    clearAllPauseReasons(this.pauseReasons);
+    this.hoverScreenX = null;
+    this.hoverScreenY = null;
+    this.lastCursorTool = null;
+    this.lastCursorView = null;
     resetDragState(this.dragState);
     resetPanInputState();
     hideContextMenu();
@@ -962,9 +1113,11 @@ export class GameScene extends Phaser.Scene {
         this.gamePhase = GamePhase.GameOver;
         // W2: first-class pause via Plan 06 Task 1 API — no setMsPerTick(Infinity)
         this.gameLoop.pause();
-        // Issue #129 — clear any in-flight pan/drag so spaceHeld and dragState.active
-        // don't leak into the GameOver overlay state (drag-pan event handlers are
-        // independent of processCameraInput and otherwise fire unguarded).
+        // Issue #129 — clear any in-flight pan/drag/gesture so it doesn't leak
+        // into the GameOver overlay state (the middle-button drag-pan handlers
+        // are independent of processCameraInput and otherwise fire unguarded; the
+        // gesture arbiter must also abandon any pending tap/paint/pan).
+        this.arbiter.cancelGesture();
         resetPanInputState();
         resetDragState(this.dragState);
 
@@ -1179,21 +1332,119 @@ export class GameScene extends Phaser.Scene {
     uiScene.hideGameOverOverlay();
   }
 
+  // ---------------------------------------------------------------------------
+  // Stage 1 controls rework (issue #18) — pause reason reconciliation
+  //
+  // The render loop is paused iff ANY reason is set (pause-reasons.ts). Two
+  // reasons pause independently: 'user' (Space / ⏸) and 'menu' (Esc overlay).
+  // reconcilePause() maps the set to the imperative gameLoop.pause()/resume() and
+  // keeps gamePhase in sync (Paused iff any reason set, while Playing-eligible).
+  // Pausing here never touches speedMultiplier (Codex R2-11). The Esc-driven
+  // overlays toggle 'menu'; Space/⏸ toggle 'user'. resetSessionState clears all.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Map GameScene's state to the hotkey-policy phase string. A BARE 'user' pause
+   * (Space / ⏸ with no Esc overlay open) reports 'playing' so Space can un-pause
+   * and speed/tool hotkeys still work while user-paused — the loop being frozen
+   * is not a modal. Only GameOver / SavePrompt / a 'menu'-driven overlay report a
+   * non-playing phase that blocks world hotkeys.
+   */
+  private hotkeyPhase(): HotkeyGamePhase {
+    if (this.gamePhase === GamePhase.GameOver) return 'gameover';
+    if (this.gamePhase === GamePhase.SavePrompt) return 'saveprompt';
+    // Paused-by-menu blocks; paused-by-user-only does not.
+    if (this.pauseReasons.menu) return 'paused';
+    return 'playing';
+  }
+
+  /**
+   * True if a modal overlay (Esc pause menu / Save-Load dialog / survey /
+   * game-over / save-prompt) is up. A bare 'user' pause is NOT a modal.
+   */
+  private isModalOpen(): boolean {
+    if (this.gamePhase === GamePhase.GameOver || this.gamePhase === GamePhase.SavePrompt) {
+      return true;
+    }
+    return this.pauseReasons.menu;
+  }
+
+  /**
+   * canAcceptWorldHotkey — the single gate for 1/2/3 (tools), the speed keys,
+   * Space (user pause), Tab (view toggle), and X/P. Delegates to the pure policy
+   * predicate (hotkey-policy.ts) with today's flag values.
+   */
+  private canAcceptWorldHotkey(): boolean {
+    return canAcceptWorldHotkey({
+      gamePhase: this.hotkeyPhase(),
+      modalOpen: this.isModalOpen(),
+      contextMenuVisible: contextMenuState.visible,
+      contextMenuPendingShow: contextMenuState.pendingShow,
+      contextMenuPendingHide: contextMenuState.pendingHide,
+      antActivityPanelVisible: antActivityPanelState.visible,
+      antActivityPanelPendingHide: antActivityPanelState.pendingHide,
+    });
+  }
+
+  /**
+   * selectTool — set the active input tool from a hotkey / palette click. Gated
+   * by canAcceptWorldHotkey. Chamber is underground-only: selecting it on the
+   * surface is a no-op (PLAN §A1/A4). Cancels any in-flight gesture and a deferred
+   * context-menu show on a tool transition (Codex R4-2).
+   */
+  private selectTool(tool: ToolId): void {
+    if (!this.canAcceptWorldHotkey()) return;
+    if (tool === 'chamber' && this.viewState.activeView !== 'underground') return;
+    if (this.viewState.activeTool === tool) return;
+    this.viewState.activeTool = tool;
+    // A tool change must abort any pending tap / paint / pan and cancel a menu
+    // that was about to appear under the old tool.
+    this.arbiter.cancelGesture();
+    if (contextMenuState.pendingShow) hideContextMenu();
+  }
+
+  /** Reconcile the pause-reason set to the game loop + gamePhase. */
+  private reconcilePause(): void {
+    // Never override the terminal/transitional phases — GameOver/SavePrompt own
+    // the loop, and bootFromSave/restart flip Playing themselves.
+    if (this.gamePhase === GamePhase.GameOver || this.gamePhase === GamePhase.SavePrompt) {
+      return;
+    }
+    if (isPausedByAny(this.pauseReasons)) {
+      this.gamePhase = GamePhase.Paused;
+      this.gameLoop.pause();
+    } else {
+      this.gamePhase = GamePhase.Playing;
+      this.gameLoop.resume();
+    }
+  }
+
+  /** Space / ⏸ — edge-triggered toggle of the 'user' pause reason. */
+  private toggleUserPause(): void {
+    togglePauseReason(this.pauseReasons, 'user');
+    // Toggling 'user' off while 'menu' is still set must NOT resume — the menu is
+    // still up. reconcilePause handles that (paused iff any reason set). But if
+    // the 'menu' reason is set we should leave the menu chrome alone; Space only
+    // moves the 'user' bit.
+    this.reconcilePause();
+  }
+
   private openPauseMenu(): void {
-    if (this.gamePhase !== GamePhase.Playing) return;
-    this.gamePhase = GamePhase.Paused;
-    this.gameLoop.pause();
+    if (this.gamePhase !== GamePhase.Playing && this.gamePhase !== GamePhase.Paused) return;
+    setPauseReason(this.pauseReasons, 'menu');
+    this.reconcilePause();
     const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
     uiScene.showPauseMenuOverlay(this.buildPauseMenuCallbacks());
   }
 
   private closePauseMenu(): void {
-    if (this.gamePhase !== GamePhase.Paused) return;
     const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
     uiScene.hidePauseMenuOverlay();
     uiScene.hideSaveLoadDialogOverlay();
-    this.gamePhase = GamePhase.Playing;
-    this.gameLoop.resume();
+    // Esc-close clears ONLY the 'menu' reason; a concurrent Space ('user') pause
+    // survives (Codex R1-5). reconcilePause resumes only if no reason remains.
+    clearPauseReason(this.pauseReasons, 'menu');
+    this.reconcilePause();
   }
 
   // Issue #115 — opens the Save/Load dialog on top of the pause menu. Hides
@@ -1311,10 +1562,18 @@ export class GameScene extends Phaser.Scene {
     // panning while paused is expected behaviour.
     const keyboardActive = this.gamePhase !== GamePhase.GameOver;
 
-    // Tab toggles view (JustDown handles key-press edge, not held).
-    if (keyboardActive && Phaser.Input.Keyboard.JustDown(this.tabKey)) {
+    // Tab toggles view (JustDown handles key-press edge, not held). Stage 1
+    // controls rework (issue #18): Tab now goes through canAcceptWorldHotkey so a
+    // Tab behind the Esc pause menu can no longer slip a view change underneath
+    // it (Codex R4-4 — previously Tab polled even while Paused).
+    if (Phaser.Input.Keyboard.JustDown(this.tabKey) && this.canAcceptWorldHotkey()) {
       toggleView(this.viewState);
     }
+
+    // Stage 1: detect tool/view/colony transitions (incl. keyboard-driven ones
+    // between pointer events) and cancel any in-flight gesture under the old
+    // context. Also refreshes the arbiter's context fingerprint.
+    this.arbiter.reconcileContext();
 
     // Track active view for anything that needs to diff on toggle.
     if (this.viewState.activeView !== this.lastActiveView) {
@@ -1343,6 +1602,11 @@ export class GameScene extends Phaser.Scene {
     const worldH =
       this.viewState.activeView === 'surface' ? SURFACE_GRID_HEIGHT : UNDERGROUND_GRID_HEIGHT;
     clampCamera(cam, worldW, worldH);
+
+    // Stage 1 controls rework (issue #18): set the per-tool canvas cursor. Reset
+    // to the default cursor over any HUD zone / the context menu / any modal so
+    // the Dig/Chamber cursors never bleed onto chrome (Codex R1-12/R2-10).
+    this.updateToolCursor();
 
     // S6: advance render frame counter and drain events for render effects.
     this.renderFrame++;
@@ -1383,14 +1647,12 @@ export class GameScene extends Phaser.Scene {
         drawPheromoneOverlay(gfx, this.world, cam, 'surface');
       }
       this.recordDrawLayer('entities');
-      const pending =
-        this.surfaceInputState.pendingEntranceTileX !== null &&
-        this.surfaceInputState.pendingEntranceTileY !== null
-          ? {
-              tileX: this.surfaceInputState.pendingEntranceTileX,
-              tileY: this.surfaceInputState.pendingEntranceTileY,
-            }
-          : null;
+      // Stage 1 controls rework (issue #18): the entrance hover outline. Shown
+      // only while the Dig tool is active on the surface and the pointer is on
+      // canvas (and not over HUD). Re-resolve the tile + validity from the LIVE
+      // camera every frame so a keyboard/drag pan under a stationary cursor keeps
+      // the outline under the pointer and never stale (Codex R1-9/R2-9/R3-4).
+      const entranceHover = this.computeEntranceHover(cam);
       drawSurfaceEntities(
         gfx,
         this.antSprites,
@@ -1398,7 +1660,7 @@ export class GameScene extends Phaser.Scene {
         this.world,
         alpha,
         cam,
-        pending,
+        entranceHover,
         this.antFacingCache,
         this.time.now, // S6: frameTimeMs for reticle/hunger pulse
         this.contestedGlowFrames, // S6: surface glow fade map
@@ -1443,11 +1705,89 @@ export class GameScene extends Phaser.Scene {
     }
   }
 
+  /**
+   * Compute the entrance hover outline for the current frame, or null when it
+   * should not show. Shown only for Dig + surface, with the pointer on canvas
+   * and not over HUD. The tile + validity are recomputed here every frame from
+   * the LIVE camera so the outline tracks the pointer even under a moving camera.
+   */
+  private computeEntranceHover(
+    cam: import('./camera.js').CameraState,
+  ): { tileX: number; tileY: number; valid: boolean } | null {
+    if (this.viewState.activeView !== 'surface') return null;
+    if (this.viewState.activeTool !== 'dig') return null;
+    if (this.hoverScreenX === null || this.hoverScreenY === null) return null;
+    if (isPointerOverHUD(this.hoverScreenX, this.hoverScreenY, this.viewState)) return null;
+    if (this.world === undefined) return null;
+    const { tileX, tileY } = screenToTile(this.hoverScreenX, this.hoverScreenY, cam);
+    if (tileX < 0 || tileY < 0) return null;
+    const valid = isValidEntranceTarget(this.world, tileX, tileY);
+    return { tileX, tileY, valid };
+  }
+
+  /**
+   * Set the canvas cursor for the active tool, resetting to the default cursor
+   * over any HUD zone, the context menu, the inspector panel, or while a modal
+   * owns input. GameScene is the single owner of the tool-cursor (Codex
+   * R1-12/R2-10). Only writes when the resolved cursor changes, to avoid
+   * per-frame DOM churn.
+   *
+   * Note: the modal check is isModalOpen(), NOT gamePhase !== Playing. A bare
+   * user-pause keeps tools/taps/entrance-hover live (canEditWorld = !isModalOpen),
+   * so the tool cursor must persist while user-paused — otherwise the cursor
+   * shows a plain arrow while a click would still queue an edit.
+   */
+  private updateToolCursor(): void {
+    const overHud =
+      this.hoverScreenX !== null &&
+      this.hoverScreenY !== null &&
+      isPointerOverHUD(this.hoverScreenX, this.hoverScreenY, this.viewState);
+    const effectiveTool: CursorTool = resolveCursorTool({
+      activeTool: this.viewState.activeTool,
+      activeView: this.viewState.activeView,
+      isModalOpen: this.isModalOpen(),
+      contextMenuVisible: contextMenuState.visible,
+      antActivityPanelVisible: antActivityPanelState.visible,
+      overHud,
+    });
+
+    // Diff against the last applied (tool, view) so we only touch the DOM cursor
+    // on a real change. The 'default' sentinel is stored as the literal string
+    // (not null) so consecutive default frames compare equal and short-circuit.
+    if (
+      !cursorToolChanged(
+        effectiveTool,
+        this.viewState.activeView,
+        this.lastCursorTool,
+        this.lastCursorView,
+      )
+    ) {
+      return;
+    }
+    this.lastCursorTool = effectiveTool;
+    this.lastCursorView = this.viewState.activeView;
+
+    const cursorCss: Record<CursorTool, string> = {
+      // 'command' uses the OS default arrow; dig/chamber use crosshair so the
+      // commit/paint affordance reads as "place precisely".
+      command: 'default',
+      dig: 'crosshair',
+      chamber: 'cell',
+      default: 'default',
+    };
+    this.input.setDefaultCursor(cursorCss[effectiveTool]);
+  }
+
   /** Accessor for UIScene / Plan 05 / Plan 06 — safe read-only reference. */
   getWorld(): WorldState {
     return this.world;
   }
   getViewState(): ViewState {
     return this.viewState;
+  }
+
+  /** Test/Playwright accessor for the gesture arbiter. */
+  getArbiter(): GestureArbiter {
+    return this.arbiter;
   }
 }

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -1431,6 +1431,13 @@ export class GameScene extends Phaser.Scene {
 
   private openPauseMenu(): void {
     if (this.gamePhase !== GamePhase.Playing && this.gamePhase !== GamePhase.Paused) return;
+    // Codex P1 (PR #210): cancel any in-flight left gesture as the modal opens.
+    // The arbiter checks canPan/canEditWorld only at drag CLASSIFICATION; once a
+    // pan/paint is in flight, panMove/paintMove don't re-gate, so without this an
+    // active drag would keep panning the camera / enqueuing dig marks behind the
+    // pause menu, and a pending tap could survive an open→close and fire on
+    // release. Mirrors the GameOver and resetSessionState cancel paths.
+    this.arbiter.cancelGesture();
     setPauseReason(this.pauseReasons, 'menu');
     this.reconcilePause();
     const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -660,6 +660,16 @@ export class GameScene extends Phaser.Scene {
       this.hoverScreenX = null;
       this.hoverScreenY = null;
     });
+    // Fix 2: 'pointerout' fires only when the pointer leaves an interactive game
+    // OBJECT — it does NOT fire when the pointer leaves the CANVAS. Phaser emits
+    // 'gameout' for canvas exits (Phaser.Input.Events.GAME_OUT, since 3.16.1;
+    // we're on 3.90). Without this, leaving the canvas while surface Dig is
+    // selected left stale hover coords, so the entrance hover outline lingered
+    // and drifted across tiles during keyboard pan. Clear the hover here too.
+    this.input.on('gameout', () => {
+      this.hoverScreenX = null;
+      this.hoverScreenY = null;
+    });
     // Cancel any in-flight gesture if the canvas loses focus (blur).
     this.game.events.on('blur', () => this.arbiter.cancelGesture());
 
@@ -1582,6 +1592,19 @@ export class GameScene extends Phaser.Scene {
     // between pointer events) and cancel any in-flight gesture under the old
     // context. Also refreshes the arbiter's context fingerprint.
     this.arbiter.reconcileContext();
+
+    // Stage 1 (Fix 1): drain any dig tiles a fast paint stroke deferred past the
+    // MAX_COMMANDS_PER_TICK cap. flushPaint re-drives the active stroke toward
+    // its stored target so the deferred tail emits as the queue drains (≤64/tick)
+    // even if the pointer has stopped; it is a no-op when no paint stroke is
+    // active or the cursor has already reached the target. Runs before
+    // gameLoop.update below so this frame's enqueue is drained by this frame's
+    // tick(s). Guarded by canEditWorld defence-in-depth: a modal already cancels
+    // the gesture via openPauseMenu/restartGame, but this keeps a stray active
+    // stroke from enqueueing under a modal that didn't go through cancelGesture.
+    if (this.world && !this.isModalOpen()) {
+      this.arbiter.flushPaint(this.world, isPausedByAny(this.pauseReasons));
+    }
 
     // Track active view for anything that needs to diff on toggle.
     if (this.viewState.activeView !== this.lastActiveView) {

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -1449,6 +1449,15 @@ export class GameScene extends Phaser.Scene {
     // pause menu, and a pending tap could survive an open→close and fire on
     // release. Mirrors the GameOver and resetSessionState cancel paths.
     this.arbiter.cancelGesture();
+    // Codex P2: also reset the MIDDLE-button drag-pan synchronously. cancelGesture
+    // only clears the LEFT arbiter; registerDragPan's dragState.active and
+    // panInputState.isPanning stay set, and its modal gate (isBlocked → releaseDrag)
+    // only clears them on the NEXT pointermove. So opening + closing the menu via
+    // Esc WITHOUT moving, while still holding the middle button, would let the next
+    // movement resume the old drag and apply the accumulated delta as a camera jump.
+    // Clearing both here makes the suspend synchronous with the modal open.
+    resetDragState(this.dragState);
+    resetPanInputState();
     setPauseReason(this.pauseReasons, 'menu');
     this.reconcilePause();
     const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -205,10 +205,11 @@ interface UIScenePhase9 {
   hideDifficultySelectOverlay(): void;
   // S6 — first-occurrence caption overlay (light onboarding).
   showCaption(text: string, screenX: number, screenY: number): void;
-  // Stage 1 controls rework (issue #18) — surface the "paused queue full" hint
-  // when enqueueCommand drops a command at the paused cap. Optional so other
-  // UIScene consumers (tests) need not implement it.
-  flashPausedQueueFull?(): void;
+  // Stage 1 controls rework (issue #18) — surface the queue-full hint when
+  // enqueueCommand drops a command at the cap. `paused` selects the message:
+  // paused → "resume to continue"; running → "try again" (transient burst).
+  // Optional so other UIScene consumers (tests) need not implement it.
+  flashPausedQueueFull?(paused: boolean): void;
 }
 import type { SimCommand } from '../sim/commands.js';
 
@@ -642,9 +643,9 @@ export class GameScene extends Phaser.Scene {
       // race where `visible` lags a frame behind a same-dispatch request.
       isContextMenuActive: () =>
         contextMenuState.visible || contextMenuState.pendingShow || contextMenuState.pendingHide,
-      onPausedQueueFull: () => {
+      onPausedQueueFull: (paused: boolean) => {
         const ui = this.scene.get('UIScene') as unknown as UIScenePhase9 | null;
-        ui?.flashPausedQueueFull?.();
+        ui?.flashPausedQueueFull?.(paused);
       },
     });
 

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -458,12 +458,13 @@ export class GameScene extends Phaser.Scene {
 
     // Middle-button drag-pan registration (left/Space pan paths removed —
     // left is now exclusively the gesture arbiter's). Returns dragState ref
-    // for processCameraInput. Suspended during GameOver.
-    this.dragState = registerDragPan(
-      this,
-      this.viewState,
-      () => this.gamePhase === GamePhase.GameOver,
-    );
+    // for processCameraInput. Suspended during any modal (menu / SavePrompt /
+    // GameOver): isModalOpen() is exactly the left arbiter's pan gate
+    // (canPan: () => canArbiterPan(this.isModalOpen())), so an Esc menu opened
+    // mid middle-drag suspends the camera move and it doesn't persist after
+    // Resume (Codex P2). A bare user-pause (Space) is NOT modal, so middle-pan
+    // still works while paused — intended.
+    this.dragState = registerDragPan(this, this.viewState, () => this.isModalOpen());
 
     // Issue #116 — Esc opens the pause menu overlay (which also pauses the
     // sim). The Esc keybinding itself lives in UIScene (which already owned

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -1571,14 +1571,20 @@ export class GameScene extends Phaser.Scene {
     // SavePrompt phase: overlay handles input; no tick updates expected.
     if (this.gamePhase === GamePhase.SavePrompt) return;
 
-    // Issue #129 — suppress keyboard input while the GameOver overlay (survey or
-    // game-over panel) is visible. WASD/Space/Tab fire through to the world
-    // beneath the modal otherwise, which the player can feel even though the
-    // canvas is obscured. Tab and processCameraInput are the two per-frame
-    // keyboard consumers; both are skipped in GameOver. The Paused phase is
-    // intentionally left untouched: the pause menu is not full-screen and
-    // panning while paused is expected behaviour.
-    const keyboardActive = this.gamePhase !== GamePhase.GameOver;
+    // Keyboard PAN gate (Fix 3 / Codex P2). processCameraInput applies held
+    // WASD/arrow pan every frame; it must be BLOCKED whenever a modal owns input
+    // — GameOver, SavePrompt, OR the Esc pause menu (pauseReasons.menu) — and
+    // STILL run during a bare user-pause (Space), where look-around is expected.
+    // Reuse the SAME pure gate the left-arbiter pan uses (canArbiterPan, the
+    // negation of isModalOpen) so all three pan paths — keyboard, left-drag, and
+    // middle-button (registerDragPan, also wired to !isModalOpen) — move together.
+    //
+    // This supersedes the prior GameOver-only check (issue #129): that left
+    // held WASD/arrows panning the camera behind the Esc menu (gamePhase=Paused,
+    // not GameOver) and persisting after Resume, because nothing resets the
+    // camera on close. SavePrompt is also covered now. Tab is gated separately
+    // via canAcceptWorldHotkey() below; this only governs the pan.
+    const keyboardPanActive = canArbiterPan(this.isModalOpen());
 
     // Tab toggles view (JustDown handles key-press edge, not held). Stage 1
     // controls rework (issue #18): Tab now goes through canAcceptWorldHotkey so a
@@ -1615,8 +1621,9 @@ export class GameScene extends Phaser.Scene {
     // freezes tick execution via its internal flag — update() is safe to call.
     this.gameLoop.update(delta);
 
-    // Apply keyboard-pan + final clamp.
-    if (keyboardActive) {
+    // Apply keyboard-pan + final clamp. Blocked behind any modal (menu /
+    // SavePrompt / GameOver); still active during a bare user-pause (Fix 3).
+    if (keyboardPanActive) {
       processCameraInput(this.viewState, {
         cursors: this.cursors,
         wasd: this.wasd,

--- a/src/render/hud-controls.test.ts
+++ b/src/render/hud-controls.test.ts
@@ -1,0 +1,75 @@
+// hud-controls.test.ts — Vitest unit tests for the HUD palette / speed / hint
+// geometry + hit-testing (Stage 1 controls rework, issue #18).
+
+import { describe, it, expect } from 'vitest';
+import {
+  TOOL_ORDER,
+  toolButtonRect,
+  toolButtonAt,
+  SPEED_CONTROL_ORDER,
+  speedControlRect,
+  speedControlAt,
+  hintTextFor,
+} from './hud-controls.js';
+import { HUD } from './sprites.js';
+
+function center(r: { x: number; y: number; w: number; h: number }): [number, number] {
+  return [r.x + r.w / 2, r.y + r.h / 2];
+}
+
+describe('tool palette geometry + hit-testing', () => {
+  it('lays out 3 buttons inside HUD.TOOLS, left → right', () => {
+    expect(TOOL_ORDER).toEqual(['command', 'dig', 'chamber']);
+    const r0 = toolButtonRect(0);
+    const r2 = toolButtonRect(2);
+    expect(r0.x).toBe(HUD.TOOLS.x);
+    expect(r2.x + r2.w).toBeLessThanOrEqual(HUD.TOOLS.x + HUD.TOOLS.w);
+  });
+
+  it('hits each tool by its button center', () => {
+    expect(toolButtonAt(...center(toolButtonRect(0)), 'underground')).toBe('command');
+    expect(toolButtonAt(...center(toolButtonRect(1)), 'underground')).toBe('dig');
+    expect(toolButtonAt(...center(toolButtonRect(2)), 'underground')).toBe('chamber');
+  });
+
+  it('Chamber is inert on the surface (returns null there)', () => {
+    expect(toolButtonAt(...center(toolButtonRect(2)), 'surface')).toBeNull();
+    // Command/Dig still hittable on the surface.
+    expect(toolButtonAt(...center(toolButtonRect(0)), 'surface')).toBe('command');
+  });
+
+  it('returns null outside every button', () => {
+    expect(toolButtonAt(0, 0, 'underground')).toBeNull();
+  });
+});
+
+describe('speed widget geometry + hit-testing', () => {
+  it('lays out ⏸ + three presets inside HUD.SPEED', () => {
+    expect(SPEED_CONTROL_ORDER).toEqual(['pause', 1, 2, 4]);
+    const rPause = speedControlRect(0);
+    expect(rPause.x).toBe(HUD.SPEED.x);
+    expect(rPause.w).toBe(HUD.SPEED.PAUSE_BUTTON_W);
+    const rLast = speedControlRect(3);
+    expect(rLast.x + rLast.w).toBeLessThanOrEqual(HUD.SPEED.x + HUD.SPEED.w);
+  });
+
+  it('hits ⏸ / 1× / 2× / 4× by their centers', () => {
+    expect(speedControlAt(...center(speedControlRect(0)))).toBe('pause');
+    expect(speedControlAt(...center(speedControlRect(1)))).toBe(1);
+    expect(speedControlAt(...center(speedControlRect(2)))).toBe(2);
+    expect(speedControlAt(...center(speedControlRect(3)))).toBe(4);
+  });
+
+  it('returns null outside the widget', () => {
+    expect(speedControlAt(0, 0)).toBeNull();
+  });
+});
+
+describe('hintTextFor', () => {
+  it('returns a non-empty per-tool/per-view legend', () => {
+    expect(hintTextFor('command', 'surface').length).toBeGreaterThan(0);
+    expect(hintTextFor('dig', 'surface')).toContain('entrance');
+    expect(hintTextFor('dig', 'underground')).toContain('mark');
+    expect(hintTextFor('chamber', 'underground')).toContain('chamber');
+  });
+});

--- a/src/render/hud-controls.test.ts
+++ b/src/render/hud-controls.test.ts
@@ -10,6 +10,9 @@ import {
   speedControlRect,
   speedControlAt,
   hintTextFor,
+  queueFullHint,
+  PAUSED_QUEUE_FULL_HINT,
+  RUNNING_QUEUE_FULL_HINT,
 } from './hud-controls.js';
 import { HUD } from './sprites.js';
 
@@ -71,5 +74,23 @@ describe('hintTextFor', () => {
     expect(hintTextFor('dig', 'surface')).toContain('entrance');
     expect(hintTextFor('dig', 'underground')).toContain('mark');
     expect(hintTextFor('chamber', 'underground')).toContain('chamber');
+  });
+});
+
+describe('queueFullHint (Fix 3 — accurate paused-vs-running message)', () => {
+  it('paused → the resume-to-continue message', () => {
+    expect(queueFullHint(true)).toBe(PAUSED_QUEUE_FULL_HINT);
+    expect(queueFullHint(true)).toContain('resume');
+  });
+
+  it('running → the transient try-again message (NOT the resume message)', () => {
+    expect(queueFullHint(false)).toBe(RUNNING_QUEUE_FULL_HINT);
+    expect(queueFullHint(false)).not.toContain('resume');
+  });
+
+  it('the two messages are distinct and both non-empty', () => {
+    expect(PAUSED_QUEUE_FULL_HINT.length).toBeGreaterThan(0);
+    expect(RUNNING_QUEUE_FULL_HINT.length).toBeGreaterThan(0);
+    expect(PAUSED_QUEUE_FULL_HINT).not.toBe(RUNNING_QUEUE_FULL_HINT);
   });
 });

--- a/src/render/hud-controls.ts
+++ b/src/render/hud-controls.ts
@@ -116,5 +116,23 @@ export function hintTextFor(tool: ToolId, view: 'surface' | 'underground'): stri
   }
 }
 
-/** The "paused queue full" hint surfaced when enqueueCommand drops at the cap. */
+/** The queue-full hint surfaced when enqueueCommand drops a one-shot command at
+ *  the cap WHILE PAUSED — the queue can't drain, so the player must resume. */
 export const PAUSED_QUEUE_FULL_HINT = 'Paused queue full — resume to continue';
+
+/** The queue-full hint surfaced when a one-shot command is dropped at the cap
+ *  while RUNNING (not paused) — a transient burst (e.g. a big dig-paint stroke)
+ *  momentarily filled the queue; it drains on its own, so "resume" would be
+ *  wrong/misleading. The player just retries. */
+export const RUNNING_QUEUE_FULL_HINT = 'Too many commands at once — try again';
+
+/**
+ * queueFullHint — pick the queue-full hint text for the current pause state.
+ * Paused: the queue genuinely can't drain → "resume to continue". Running: it's
+ * transient throttling that self-clears → "try again". Pulled out as a pure
+ * function so the paused-vs-running message choice is unit-testable without
+ * booting a Phaser scene (Stage 1 controls rework, Fix 3 / Codex P2).
+ */
+export function queueFullHint(paused: boolean): string {
+  return paused ? PAUSED_QUEUE_FULL_HINT : RUNNING_QUEUE_FULL_HINT;
+}

--- a/src/render/hud-controls.ts
+++ b/src/render/hud-controls.ts
@@ -1,0 +1,120 @@
+// hud-controls.ts — Stage 1 controls rework (issue #18): pure geometry + hit-
+// testing for the new interactive HUD widgets (tool palette, speed widget) and
+// the static per-tool/per-view hint strip text.
+//
+// No Phaser, no DOM — pure functions over the locked HUD rects in sprites.ts, so
+// they are unit-testable. UIScene draws using these positions and routes clicks
+// through these hit-tests; the gesture arbiter / camera-input mask the same rects
+// via isPointerOverHUD.
+
+import { HUD } from './sprites.js';
+import type { ToolId } from './camera.js';
+
+// ---------------------------------------------------------------------------
+// Tool palette (HUD.TOOLS) — 3 buttons: Command / Dig / Chamber
+// ---------------------------------------------------------------------------
+
+/** The three tools in palette order (left → right). */
+export const TOOL_ORDER: readonly ToolId[] = ['command', 'dig', 'chamber'];
+
+/** Short button glyph/label for each tool. */
+export const TOOL_LABEL: Record<ToolId, string> = {
+  command: 'Cmd',
+  dig: 'Dig',
+  chamber: 'Chmb',
+};
+
+/** Screen rect of the i-th tool button (0..2) within HUD.TOOLS. */
+export function toolButtonRect(index: number): { x: number; y: number; w: number; h: number } {
+  const x = HUD.TOOLS.x + index * (HUD.TOOLS.BUTTON_W + HUD.TOOLS.GAP);
+  return { x, y: HUD.TOOLS.y, w: HUD.TOOLS.BUTTON_W, h: HUD.TOOLS.h };
+}
+
+/**
+ * Hit-test the tool palette. Returns the ToolId at (px, py), or null if the
+ * point is outside every button. On the surface view the Chamber button is
+ * greyed/inert: a click on it returns null (selecting Chamber on the surface is
+ * a no-op — PLAN §A1/A4).
+ */
+export function toolButtonAt(
+  px: number,
+  py: number,
+  view: 'surface' | 'underground',
+): ToolId | null {
+  for (let i = 0; i < TOOL_ORDER.length; i++) {
+    const tool = TOOL_ORDER[i]!;
+    if (tool === 'chamber' && view === 'surface') continue; // greyed on surface
+    const r = toolButtonRect(i);
+    if (px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h) return tool;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Speed widget (HUD.SPEED) — ⏸ / 1× / 2× / 4×
+// ---------------------------------------------------------------------------
+
+/** A speed-widget control: the pause toggle or a multiplier preset. */
+export type SpeedControl = 'pause' | 1 | 2 | 4;
+
+/** The four speed-widget controls in left → right order. */
+export const SPEED_CONTROL_ORDER: readonly SpeedControl[] = ['pause', 1, 2, 4];
+
+/** Screen rect of the i-th speed control (0=⏸, 1=1×, 2=2×, 3=4×) within HUD.SPEED. */
+export function speedControlRect(index: number): { x: number; y: number; w: number; h: number } {
+  // ⏸ button is PAUSE_BUTTON_W wide; each multiplier is SPEED_BUTTON_W wide.
+  if (index <= 0) {
+    return { x: HUD.SPEED.x, y: HUD.SPEED.y, w: HUD.SPEED.PAUSE_BUTTON_W, h: HUD.SPEED.h };
+  }
+  const x = HUD.SPEED.x + HUD.SPEED.PAUSE_BUTTON_W + (index - 1) * HUD.SPEED.SPEED_BUTTON_W;
+  return { x, y: HUD.SPEED.y, w: HUD.SPEED.SPEED_BUTTON_W, h: HUD.SPEED.h };
+}
+
+/**
+ * Hit-test the speed widget. Returns the control at (px, py): 'pause' for the ⏸
+ * button, or 1/2/4 for the multiplier presets; null if outside.
+ */
+export function speedControlAt(px: number, py: number): SpeedControl | null {
+  for (let i = 0; i < SPEED_CONTROL_ORDER.length; i++) {
+    const r = speedControlRect(i);
+    if (px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h) {
+      return SPEED_CONTROL_ORDER[i]!;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Hint strip (HUD.HINTS) — static per-tool / per-view legend
+// ---------------------------------------------------------------------------
+
+/**
+ * The static hint string for the active tool + view. Stage 1 is a fixed legend
+ * (hover-sensitive hints are Stage 3). Surface Chamber is unreachable, so the
+ * surface map has no Chamber entry — callers pass the effective tool.
+ */
+export function hintTextFor(tool: ToolId, view: 'surface' | 'underground'): string {
+  if (view === 'surface') {
+    switch (tool) {
+      case 'command':
+        return 'Cmd: click food to forage, empty ground to rally, the spider to target it';
+      case 'dig':
+        return 'Dig: click valid ground to designate an entrance';
+      default:
+        // Chamber on the surface is inert; show the Command legend as a fallback.
+        return 'Cmd: click food to forage, empty ground to rally, the spider to target it';
+    }
+  }
+  // underground
+  switch (tool) {
+    case 'command':
+      return 'Cmd: click a marked tile to cancel its dig';
+    case 'dig':
+      return 'Dig: click or drag to mark tunnels; click a marked tile to cancel';
+    case 'chamber':
+      return 'Chamber: click dug-out or solid ground to place a chamber';
+  }
+}
+
+/** The "paused queue full" hint surfaced when enqueueCommand drops at the cap. */
+export const PAUSED_QUEUE_FULL_HINT = 'Paused queue full — resume to continue';

--- a/src/render/pause-reasons.test.ts
+++ b/src/render/pause-reasons.test.ts
@@ -1,0 +1,70 @@
+// pause-reasons.test.ts — Vitest unit tests for the reconciled pause-reason set
+// (Stage 1 controls rework, issue #18). Covers the reconciliation + full-reset
+// contract (Codex R1-5, R2-1).
+
+import { describe, it, expect } from 'vitest';
+import {
+  createPauseReasonState,
+  setPauseReason,
+  clearPauseReason,
+  togglePauseReason,
+  hasPauseReason,
+  isPausedByAny,
+  clearAllPauseReasons,
+} from './pause-reasons.js';
+
+describe('pause-reasons', () => {
+  it('starts empty (nothing paused)', () => {
+    const s = createPauseReasonState();
+    expect(isPausedByAny(s)).toBe(false);
+  });
+
+  it('isPausedByAny is true iff any reason is set', () => {
+    const s = createPauseReasonState();
+    setPauseReason(s, 'user');
+    expect(isPausedByAny(s)).toBe(true);
+    clearPauseReason(s, 'user');
+    expect(isPausedByAny(s)).toBe(false);
+    setPauseReason(s, 'menu');
+    expect(isPausedByAny(s)).toBe(true);
+  });
+
+  it('clearing one reason does not resume while the other is still set (Codex R1-5)', () => {
+    const s = createPauseReasonState();
+    setPauseReason(s, 'user');
+    setPauseReason(s, 'menu');
+    // Esc closes the menu → clear 'menu' only; a concurrent Space ('user') stays.
+    clearPauseReason(s, 'menu');
+    expect(hasPauseReason(s, 'menu')).toBe(false);
+    expect(hasPauseReason(s, 'user')).toBe(true);
+    expect(isPausedByAny(s)).toBe(true);
+  });
+
+  it('togglePauseReason flips and returns the new value (edge-triggered Space)', () => {
+    const s = createPauseReasonState();
+    expect(togglePauseReason(s, 'user')).toBe(true);
+    expect(isPausedByAny(s)).toBe(true);
+    expect(togglePauseReason(s, 'user')).toBe(false);
+    expect(isPausedByAny(s)).toBe(false);
+  });
+
+  it('set/clear are idempotent', () => {
+    const s = createPauseReasonState();
+    setPauseReason(s, 'user');
+    setPauseReason(s, 'user');
+    expect(hasPauseReason(s, 'user')).toBe(true);
+    clearPauseReason(s, 'user');
+    clearPauseReason(s, 'user');
+    expect(hasPauseReason(s, 'user')).toBe(false);
+  });
+
+  it('clearAllPauseReasons wipes the entire set (full reset — Codex R2-1)', () => {
+    const s = createPauseReasonState();
+    setPauseReason(s, 'user');
+    setPauseReason(s, 'menu');
+    clearAllPauseReasons(s);
+    expect(hasPauseReason(s, 'user')).toBe(false);
+    expect(hasPauseReason(s, 'menu')).toBe(false);
+    expect(isPausedByAny(s)).toBe(false);
+  });
+});

--- a/src/render/pause-reasons.ts
+++ b/src/render/pause-reasons.ts
@@ -1,0 +1,75 @@
+// pause-reasons.ts — Stage 1 controls rework (issue #18): reconciled pause-reason set.
+//
+// The render loop is paused iff ANY reason is set. Two independent reasons can
+// pause concurrently and must be cleared independently (Codex R1-5, R2-1):
+//   - 'user' — the player pressed Space / clicked the ⏸ speed button.
+//   - 'menu' — an Esc-driven overlay (pause menu / Save-Load dialog) is open.
+//
+// Before this set, Esc-close called gameLoop.resume() unconditionally, which
+// would silently cancel a concurrent Space pause (and vice-versa). Routing both
+// through the same set, then reconciling once to gameLoop.pause()/resume(),
+// makes each reason independent: closing the menu only clears 'menu'; the loop
+// stays paused if 'user' is still set.
+//
+// This module owns ONLY the reason bookkeeping — it is pure render-layer state
+// with no Phaser / game-loop dependency, so it is trivially unit-testable. The
+// caller (GameScene) reconciles the boolean `isPausedByAny()` to the imperative
+// gameLoop.pause()/resume() each time a reason changes. Pausing here never
+// touches speedMultiplier — speed and pause are orthogonal (Codex R2-11).
+
+/** The set of reasons that can independently hold the render loop paused. */
+export type PauseReason = 'user' | 'menu';
+
+/**
+ * PauseReasonState — a tiny set of active pause reasons.
+ *
+ * Modeled as a plain object with one boolean per reason rather than a JS `Set`
+ * so it is JSON-trivial, allocation-free to read, and matches the
+ * structure-of-flags style used elsewhere in the render layer. Not part of
+ * WorldState; never saved.
+ */
+export interface PauseReasonState {
+  user: boolean;
+  menu: boolean;
+}
+
+/** Construct an empty reason set (nothing paused). */
+export function createPauseReasonState(): PauseReasonState {
+  return { user: false, menu: false };
+}
+
+/** Add a reason. Idempotent. */
+export function setPauseReason(state: PauseReasonState, reason: PauseReason): void {
+  state[reason] = true;
+}
+
+/** Remove a reason. Idempotent. */
+export function clearPauseReason(state: PauseReasonState, reason: PauseReason): void {
+  state[reason] = false;
+}
+
+/** Toggle a reason and return its new value. Used by the edge-triggered Space/⏸ 'user' pause. */
+export function togglePauseReason(state: PauseReasonState, reason: PauseReason): boolean {
+  state[reason] = !state[reason];
+  return state[reason];
+}
+
+/** True iff the given reason is currently set. */
+export function hasPauseReason(state: PauseReasonState, reason: PauseReason): boolean {
+  return state[reason];
+}
+
+/** True iff ANY reason is set — i.e. the loop should be paused. */
+export function isPausedByAny(state: PauseReasonState): boolean {
+  return state.user || state.menu;
+}
+
+/**
+ * Clear the ENTIRE reason set (Codex R2-1). Called by resetSessionState so a
+ * new-game-from-Esc / Save-Load path can never leave 'menu' (or 'user') stuck
+ * set on the fresh session.
+ */
+export function clearAllPauseReasons(state: PauseReasonState): void {
+  state.user = false;
+  state.menu = false;
+}

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -51,6 +51,12 @@ export const COLOR_SURFACE_ENTRANCE_HOLE = 0x1a0f00;
 /** PRD §7g — Rally point marker color. */
 export const COLOR_RALLY_POINT = 0xffffff;
 
+/** Stage 1 controls rework (issue #18) — entrance hover outline, VALID target (green). */
+export const COLOR_ENTRANCE_HOVER_VALID = 0x33dd55;
+
+/** Stage 1 controls rework (issue #18) — entrance hover outline, INVALID target (red). */
+export const COLOR_ENTRANCE_HOVER_INVALID = 0xff4040;
+
 /** S1 — Red tint overlay applied to fighter-caste ants (tinted on top of colony color). */
 export const COLOR_FIGHTER_TINT = 0xff4444;
 
@@ -161,6 +167,19 @@ export const HUD = {
    * Phase 9 wires 1×/2×/4× speed buttons and pause button.
    */
   SPEED: { x: 320, y: 552, w: 160, h: 32, PAUSE_BUTTON_W: 40, SPEED_BUTTON_W: 32 },
+  /**
+   * Stage 1 controls rework (issue #18) — tool palette (Command/Dig/Chamber).
+   * Top-right band, clear of STATS (top-left), the ant-activity panel
+   * (8,36,220,264), SAVE_ICON (772,8), and the y≥372 toggles/minimap. Three
+   * 40×40 buttons at x = 632 / 676 / 720 (BUTTON_W 40, GAP 4).
+   */
+  TOOLS: { x: 632, y: 36, w: 128, h: 40, BUTTON_W: 40, GAP: 4 },
+  /**
+   * Stage 1 controls rework (issue #18) — context hint strip (static per-tool/
+   * per-view legend). Lower band: above TRIANGLE/SPEED (y≥532), left of MINIMAP
+   * (x≥632), below the ant-activity panel (y≤300).
+   */
+  HINTS: { x: 8, y: 508, w: 616, h: 18 },
   /** Minimap: full surface overview with colony positions and food sources. */
   MINIMAP: { x: 632, y: 424, w: 160, h: 160 },
   /** View toggle button: switches between surface and underground views. */

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -726,12 +726,12 @@ export class UIScene extends Phaser.Scene {
             };
             // Stage 1 controls rework (issue #18) — route through enqueueCommand
             // so the non-Sync cap is enforced across ALL producers (Codex R2-8).
-            // The cap is now unconditional (paused OR running), so only surface
-            // the "paused queue full" hint when the refusal happened WHILE PAUSED
-            // — an unpaused refusal is silent throttling that drains next tick
-            // (matches the arbiter's notifyCapHit gating).
+            // PlaceChamber is a ONE-SHOT command: it does NOT re-emit, so a drop
+            // at the cap is a real loss. Surface the queue-full hint on ANY drop,
+            // paused OR unpaused (Codex P2) — unlike the re-emitting paint stroke,
+            // which only hints while paused.
             const paused = this.isPausedFn ? this.isPausedFn() : false;
-            if (!enqueueCommand(world, cmd, paused) && paused) this.flashPausedQueueFull();
+            if (!enqueueCommand(world, cmd, paused)) this.flashPausedQueueFull();
           }
           requestHideContextMenu();
           return;
@@ -875,12 +875,13 @@ export class UIScene extends Phaser.Scene {
             issuedAtTick: world.tick,
           };
           // Stage 1 controls rework (issue #18) — route through enqueueCommand
-          // (non-Sync cap across all producers; Codex R2-8). Cap is now
-          // unconditional, so only flash the "paused queue full" hint when the
-          // refusal happened WHILE PAUSED (an unpaused refusal drains next tick;
-          // matches the arbiter's notifyCapHit gating).
+          // (non-Sync cap across all producers; Codex R2-8). SetBehaviorRatio is
+          // a ONE-SHOT command: it does NOT re-emit, so a drop at the cap is a
+          // real loss. Surface the queue-full hint on ANY drop, paused OR unpaused
+          // (Codex P2) — unlike the re-emitting paint stroke, which only hints
+          // while paused.
           const paused = this.isPausedFn ? this.isPausedFn() : false;
-          if (!enqueueCommand(world, cmd, paused) && paused) this.flashPausedQueueFull();
+          if (!enqueueCommand(world, cmd, paused)) this.flashPausedQueueFull();
         }
         this.dragState.isDragging = false;
       }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -160,7 +160,7 @@ import {
   speedControlRect,
   speedControlAt,
   hintTextFor,
-  PAUSED_QUEUE_FULL_HINT,
+  queueFullHint,
 } from './hud-controls.js';
 import {
   contextMenuState,
@@ -367,10 +367,13 @@ export class UIScene extends Phaser.Scene {
   // then so the two don't visually collide (Codex R4-1). Cleared naturally as
   // time passes.
   private hintYieldUntilMs = 0;
-  // "Paused queue full" flash: set to time.now + duration when enqueueCommand
-  // drops a command at the paused cap; the hint strip shows the warning until
-  // then, overriding the static legend.
+  // Queue-full flash: set to time.now + duration when enqueueCommand drops a
+  // command at the cap; the hint strip shows the warning until then, overriding
+  // the static legend. `pausedQueueFullWasPaused` records the pause state at the
+  // moment of the drop so renderHintStrip picks the accurate message (paused →
+  // "resume to continue"; running → "try again"). (Fix 3 / Codex P2.)
   private pausedQueueFullUntilMs = 0;
+  private pausedQueueFullWasPaused = false;
   private gfx!: Phaser.GameObjects.Graphics;
   private antsText!: Phaser.GameObjects.Text;
   private foodText!: Phaser.GameObjects.Text;
@@ -729,9 +732,10 @@ export class UIScene extends Phaser.Scene {
             // PlaceChamber is a ONE-SHOT command: it does NOT re-emit, so a drop
             // at the cap is a real loss. Surface the queue-full hint on ANY drop,
             // paused OR unpaused (Codex P2) — unlike the re-emitting paint stroke,
-            // which only hints while paused.
+            // which only hints while paused. Pass `paused` so the message is
+            // accurate (resume-to-continue vs try-again; Fix 3).
             const paused = this.isPausedFn ? this.isPausedFn() : false;
-            if (!enqueueCommand(world, cmd, paused)) this.flashPausedQueueFull();
+            if (!enqueueCommand(world, cmd, paused)) this.flashPausedQueueFull(paused);
           }
           requestHideContextMenu();
           return;
@@ -879,9 +883,9 @@ export class UIScene extends Phaser.Scene {
           // a ONE-SHOT command: it does NOT re-emit, so a drop at the cap is a
           // real loss. Surface the queue-full hint on ANY drop, paused OR unpaused
           // (Codex P2) — unlike the re-emitting paint stroke, which only hints
-          // while paused.
+          // while paused. Pass `paused` so the message is accurate (Fix 3).
           const paused = this.isPausedFn ? this.isPausedFn() : false;
-          if (!enqueueCommand(world, cmd, paused)) this.flashPausedQueueFull();
+          if (!enqueueCommand(world, cmd, paused)) this.flashPausedQueueFull(paused);
         }
         this.dragState.isDragging = false;
       }
@@ -1272,7 +1276,11 @@ export class UIScene extends Phaser.Scene {
     }
     this.hintText.setVisible(true);
     if (now < this.pausedQueueFullUntilMs) {
-      this.hintText.setText(PAUSED_QUEUE_FULL_HINT);
+      // Accurate message for the pause state captured at the drop (Fix 3): paused
+      // → "resume to continue"; running → "try again" (transient burst). Reading
+      // the live isPausedFn here instead would mis-message a drop whose state has
+      // since flipped, so we use the recorded flag.
+      this.hintText.setText(queueFullHint(this.pausedQueueFullWasPaused));
       this.hintText.setColor('#ffcc66');
       return;
     }
@@ -1298,9 +1306,14 @@ export class UIScene extends Phaser.Scene {
     }
   }
 
-  /** Surface the "paused queue full — resume to continue" hint for a moment. */
-  public flashPausedQueueFull(): void {
+  /**
+   * Surface the queue-full hint for a moment. `paused` selects the message
+   * (paused → "resume to continue"; running → "try again") and is recorded so
+   * renderHintStrip shows the right one for the whole flash window (Fix 3).
+   */
+  public flashPausedQueueFull(paused: boolean): void {
     this.pausedQueueFullUntilMs = this.time.now + PAUSED_QUEUE_FULL_HINT_MS;
+    this.pausedQueueFullWasPaused = paused;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -725,10 +725,13 @@ export class UIScene extends Phaser.Scene {
               issuedAtTick: world.tick,
             };
             // Stage 1 controls rework (issue #18) — route through enqueueCommand
-            // so the paused non-Sync cap is enforced across ALL producers (Codex
-            // R2-8). If dropped at the cap, surface the "paused queue full" hint.
+            // so the non-Sync cap is enforced across ALL producers (Codex R2-8).
+            // The cap is now unconditional (paused OR running), so only surface
+            // the "paused queue full" hint when the refusal happened WHILE PAUSED
+            // — an unpaused refusal is silent throttling that drains next tick
+            // (matches the arbiter's notifyCapHit gating).
             const paused = this.isPausedFn ? this.isPausedFn() : false;
-            if (!enqueueCommand(world, cmd, paused)) this.flashPausedQueueFull();
+            if (!enqueueCommand(world, cmd, paused) && paused) this.flashPausedQueueFull();
           }
           requestHideContextMenu();
           return;
@@ -872,9 +875,12 @@ export class UIScene extends Phaser.Scene {
             issuedAtTick: world.tick,
           };
           // Stage 1 controls rework (issue #18) — route through enqueueCommand
-          // (paused cap across all producers; Codex R2-8).
+          // (non-Sync cap across all producers; Codex R2-8). Cap is now
+          // unconditional, so only flash the "paused queue full" hint when the
+          // refusal happened WHILE PAUSED (an unpaused refusal drains next tick;
+          // matches the arbiter's notifyCapHit gating).
           const paused = this.isPausedFn ? this.isPausedFn() : false;
-          if (!enqueueCommand(world, cmd, paused)) this.flashPausedQueueFull();
+          if (!enqueueCommand(world, cmd, paused) && paused) this.flashPausedQueueFull();
         }
         this.dragState.isDragging = false;
       }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -20,8 +20,9 @@
 // files that touch world fields — check-sim-boundary.sh would false-positive on FNDN-07.
 
 import * as Phaser from 'phaser';
-import type { ViewState } from './camera.js';
+import type { ViewState, ToolId } from './camera.js';
 import { toggleView, toggleUndergroundColony } from './camera.js';
+import type { SpeedControl } from './hud-controls.js';
 import type { WorldState } from '../sim/types.js';
 import { HUD } from './sprites.js';
 import { GameOutcome } from '../sim/game-over.js';
@@ -151,6 +152,17 @@ import {
 } from './triangle-widget.js';
 import { drawMinimap, applyMinimapClick } from './minimap.js';
 import {
+  TOOL_ORDER,
+  TOOL_LABEL,
+  toolButtonRect,
+  toolButtonAt,
+  SPEED_CONTROL_ORDER,
+  speedControlRect,
+  speedControlAt,
+  hintTextFor,
+  PAUSED_QUEUE_FULL_HINT,
+} from './hud-controls.js';
+import {
   contextMenuState,
   hideContextMenu,
   requestHideContextMenu,
@@ -241,10 +253,19 @@ import {
  *  rendered above the dialog's info line. 1500 ms is long enough to be
  *  noticed without slowing down a player who wants to chain Save → Continue. */
 const SAVE_FLASH_MS = 1500;
+
+/** Stage 1 controls rework (issue #18) — total visible lifetime of an onboarding
+ *  caption (300ms fade-in + 800ms hold + 400ms fade-out), used to size the hint-
+ *  strip yield window so the strip reappears exactly as the caption clears. */
+const CAPTION_TOTAL_MS = 1500;
+
+/** Stage 1 controls rework — how long the "paused queue full" hint stays up. */
+const PAUSED_QUEUE_FULL_HINT_MS = 1500;
 import { loadSettings, saveSettings } from '../platform/settings.js';
 import { hasSave, hasIncompatibleSave, getSaveInfo, deleteSave } from '../platform/save.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
 import type { SetBehaviorRatioCommand, PlaceChamberCommand } from '../sim/commands.js';
+import { enqueueCommand } from '../input/command-queue.js';
 
 // ---------------------------------------------------------------------------
 // Pause menu callbacks (issue #116)
@@ -330,6 +351,26 @@ export class UIScene extends Phaser.Scene {
   // call sites (none today, but kept for safety) can still launch UIScene
   // without it; without the callback Esc on a clean canvas is a no-op.
   private onEscape: (() => void) | null = null;
+  // Stage 1 controls rework (issue #18) — gated, GameScene-owned callbacks for
+  // the tool palette + speed widget, and a paused-state accessor for the
+  // enqueueCommand cap on chamber/behavior commands.
+  private onSelectTool: ((tool: ToolId) => void) | null = null;
+  private onSpeedControl: ((control: SpeedControl) => void) | null = null;
+  private isPausedFn: (() => boolean) | null = null;
+  private getSpeedMultiplierFn: (() => 1 | 2 | 4) | null = null;
+  // Tool palette button labels (3) and the hint strip text + speed widget labels.
+  private toolButtonTexts: Phaser.GameObjects.Text[] = [];
+  private hintText!: Phaser.GameObjects.Text;
+  private speedControlTexts: Phaser.GameObjects.Text[] = [];
+  // Caption-yield: showCaption sets this to `time.now + duration` when a caption
+  // that overlaps the hint strip is active; the hint strip yields (hides) until
+  // then so the two don't visually collide (Codex R4-1). Cleared naturally as
+  // time passes.
+  private hintYieldUntilMs = 0;
+  // "Paused queue full" flash: set to time.now + duration when enqueueCommand
+  // drops a command at the paused cap; the hint strip shows the warning until
+  // then, overriding the static legend.
+  private pausedQueueFullUntilMs = 0;
   private gfx!: Phaser.GameObjects.Graphics;
   private antsText!: Phaser.GameObjects.Text;
   private foodText!: Phaser.GameObjects.Text;
@@ -395,10 +436,20 @@ export class UIScene extends Phaser.Scene {
     viewState: ViewState;
     getWorld: () => WorldState | undefined;
     onEscape?: () => void;
+    // Stage 1 controls rework (issue #18) — GameScene-owned, gated callbacks so
+    // the HUD palette/speed widget route through the same gates as the hotkeys.
+    onSelectTool?: (tool: ToolId) => void;
+    onSpeedControl?: (control: SpeedControl) => void;
+    isPaused?: () => boolean;
+    getSpeedMultiplier?: () => 1 | 2 | 4;
   }) {
     this.viewState = data.viewState;
     this.getWorld = data.getWorld;
     this.onEscape = data.onEscape ?? null;
+    this.onSelectTool = data.onSelectTool ?? null;
+    this.onSpeedControl = data.onSpeedControl ?? null;
+    this.isPausedFn = data.isPaused ?? null;
+    this.getSpeedMultiplierFn = data.getSpeedMultiplier ?? null;
   }
 
   create() {
@@ -487,6 +538,41 @@ export class UIScene extends Phaser.Scene {
     );
     this.undergroundLabelText.setScrollFactor(0);
     this.undergroundLabelText.setVisible(false);
+
+    // Stage 1 controls rework (issue #18) — tool palette (HUD.TOOLS), hint strip
+    // (HUD.HINTS), and speed widget (HUD.SPEED). Backgrounds + active-tool
+    // highlight are drawn in update() via gfx; these Text objects carry the
+    // labels. All scroll-locked so they stay pinned to the HUD.
+    this.toolButtonTexts = TOOL_ORDER.map((tool, i) => {
+      const r = toolButtonRect(i);
+      const t = this.add.text(r.x + 4, r.y + r.h / 2 - 6, TOOL_LABEL[tool], {
+        color: '#ffffff',
+        fontSize: '11px',
+        fontFamily: 'monospace',
+      });
+      t.setScrollFactor(0);
+      t.setDepth(5);
+      return t;
+    });
+    this.hintText = this.add.text(HUD.HINTS.x + 2, HUD.HINTS.y + 2, '', {
+      color: '#cfd8dc',
+      fontSize: '11px',
+      fontFamily: 'monospace',
+    });
+    this.hintText.setScrollFactor(0);
+    this.hintText.setDepth(5);
+    this.speedControlTexts = SPEED_CONTROL_ORDER.map((control, i) => {
+      const r = speedControlRect(i);
+      const label = control === 'pause' ? '||' : `${control}x`;
+      const t = this.add.text(r.x + 4, r.y + r.h / 2 - 7, label, {
+        color: '#ffffff',
+        fontSize: '12px',
+        fontFamily: 'monospace',
+      });
+      t.setScrollFactor(0);
+      t.setDepth(5);
+      return t;
+    });
 
     // Context menu item labels — created once, positioned/shown per frame.
     // One Phaser.Text per ChamberType (Queen / Nursery / Food Storage) so the
@@ -638,7 +724,11 @@ export class UIScene extends Phaser.Scene {
               anchorTileY: contextMenuState.anchorTileY,
               issuedAtTick: world.tick,
             };
-            world.commandQueue.push(cmd);
+            // Stage 1 controls rework (issue #18) — route through enqueueCommand
+            // so the paused non-Sync cap is enforced across ALL producers (Codex
+            // R2-8). If dropped at the cap, surface the "paused queue full" hint.
+            const paused = this.isPausedFn ? this.isPausedFn() : false;
+            if (!enqueueCommand(world, cmd, paused)) this.flashPausedQueueFull();
           }
           requestHideContextMenu();
           return;
@@ -680,7 +770,14 @@ export class UIScene extends Phaser.Scene {
           // on the new toggle while the ant-activity panel is up would
           // be classified as "world click", dismissing the panel and
           // dropping the toggle dispatch.
-          this.isInsideRect(pointer.x, pointer.y, HUD.UNDERGROUND_COLONY_TOGGLE);
+          this.isInsideRect(pointer.x, pointer.y, HUD.UNDERGROUND_COLONY_TOGGLE) ||
+          // Stage 1 controls rework (issue #18) — the new interactive HUD zones
+          // (tool palette, hint strip, speed widget) must be on the ant-panel
+          // allow-list too, else a click on them while the panel is up dismisses
+          // the panel and drops the palette/speed dispatch.
+          this.isInsideRect(pointer.x, pointer.y, HUD.TOOLS) ||
+          this.isInsideRect(pointer.x, pointer.y, HUD.HINTS) ||
+          this.isInsideRect(pointer.x, pointer.y, HUD.SPEED);
         if (!overHud) {
           // Click on the world — dismiss and consume. `return` prevents
           // any further UIScene handling; the deferred hide prevents the
@@ -709,6 +806,22 @@ export class UIScene extends Phaser.Scene {
         this.isInsideRect(pointer.x, pointer.y, HUD.UNDERGROUND_COLONY_TOGGLE)
       ) {
         toggleUndergroundColony(this.viewState);
+        return;
+      }
+      // Stage 1 controls rework (issue #18) — tool palette click. Routes through
+      // the GameScene-owned, gated selectTool so a palette pick obeys the same
+      // gate as the 1/2/3 hotkeys (and the Chamber-on-surface no-op). Consume the
+      // click so it never falls through to the world arbiter.
+      const toolHit = toolButtonAt(pointer.x, pointer.y, this.viewState.activeView);
+      if (toolHit !== null) {
+        this.onSelectTool?.(toolHit);
+        return;
+      }
+      // Speed widget click — ⏸ toggles the 'user' pause; 1×/2×/4× set the
+      // multiplier (without changing pause reasons). Both via GameScene.
+      const speedHit = speedControlAt(pointer.x, pointer.y);
+      if (speedHit !== null) {
+        this.onSpeedControl?.(speedHit);
         return;
       }
       // Minimap click
@@ -758,7 +871,10 @@ export class UIScene extends Phaser.Scene {
             ratio: this.dragState.targetRatio,
             issuedAtTick: world.tick,
           };
-          world.commandQueue.push(cmd);
+          // Stage 1 controls rework (issue #18) — route through enqueueCommand
+          // (paused cap across all producers; Codex R2-8).
+          const paused = this.isPausedFn ? this.isPausedFn() : false;
+          if (!enqueueCommand(world, cmd, paused)) this.flashPausedQueueFull();
         }
         this.dragState.isDragging = false;
       }
@@ -893,6 +1009,11 @@ export class UIScene extends Phaser.Scene {
     // Expose regardless of visibility so tests can assert the underlying
     // toggle state even if the surface view is active. Cheap string write.
     setActiveUndergroundLabel(undergroundLabel);
+
+    // Stage 1 controls rework (issue #18) — tool palette + hint strip + speed.
+    this.renderToolPalette();
+    this.renderHintStrip();
+    this.renderSpeedWidget();
 
     // Ant-activity popup — live refresh when visible. Drawn before the
     // context menu so a visible chamber menu stays on top (the underground
@@ -1048,6 +1169,18 @@ export class UIScene extends Phaser.Scene {
 
   // S6 — first-occurrence caption overlay (light onboarding).
   public showCaption(text: string, screenX: number, screenY: number): void {
+    // Stage 1 controls rework (issue #18, Codex R4-1): captions render centered
+    // and can overlap the HUD.HINTS strip (e.g. the command captions at
+    // y≈CANVAS_H-80). When the caption's vertical band overlaps the strip, yield
+    // (hide) the strip for the caption's lifetime so the two don't collide.
+    // Caption height is ~22px (14px font + padding); HINTS is y..y+h.
+    const capTop = screenY - 14;
+    const capBottom = screenY + 14;
+    const stripTop = HUD.HINTS.y;
+    const stripBottom = HUD.HINTS.y + HUD.HINTS.h;
+    if (capTop < stripBottom && capBottom > stripTop) {
+      this.hintYieldUntilMs = this.time.now + CAPTION_TOTAL_MS;
+    }
     const captionText = this.add.text(screenX, screenY, text, {
       fontSize: '14px',
       fontFamily: 'monospace',
@@ -1086,6 +1219,81 @@ export class UIScene extends Phaser.Scene {
     for (const obj of this.gameOverGroup) obj.destroy();
     this.gameOverGroup = [];
     this.recomputeActiveOverlay();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Stage 1 controls rework (issue #18) — tool palette / hint strip / speed
+  // ---------------------------------------------------------------------------
+
+  /** The tool the cursor reflects (Chamber is greyed/inert on the surface). */
+  private effectiveTool(): ToolId {
+    const t = this.viewState.activeTool;
+    if (t === 'chamber' && this.viewState.activeView !== 'underground') return 'command';
+    return t;
+  }
+
+  /** Draw the 3-button tool palette with an active-tool highlight; Chamber is
+   *  greyed on the surface (where it is inert). */
+  private renderToolPalette(): void {
+    const surface = this.viewState.activeView === 'surface';
+    const active = this.viewState.activeTool;
+    for (let i = 0; i < TOOL_ORDER.length; i++) {
+      const tool = TOOL_ORDER[i]!;
+      const r = toolButtonRect(i);
+      const greyed = tool === 'chamber' && surface;
+      const isActive = tool === active && !greyed;
+      // Background: brighter when active, dim when greyed.
+      this.gfx.fillStyle(isActive ? 0x2a6cc0 : greyed ? 0x222222 : 0x444444, 1);
+      this.gfx.fillRect(r.x, r.y, r.w, r.h);
+      if (isActive) {
+        this.gfx.lineStyle(2, 0xffffff, 1);
+        this.gfx.strokeRect(r.x + 1, r.y + 1, r.w - 2, r.h - 2);
+      }
+      const t = this.toolButtonTexts[i];
+      if (t) t.setAlpha(greyed ? 0.35 : 1);
+    }
+  }
+
+  /** Draw the hint strip: the static per-tool/per-view legend, overridden by the
+   *  transient "paused queue full" warning, and yielded while an overlapping
+   *  caption is active. */
+  private renderHintStrip(): void {
+    const now = this.time.now;
+    if (now < this.hintYieldUntilMs) {
+      this.hintText.setVisible(false);
+      return;
+    }
+    this.hintText.setVisible(true);
+    if (now < this.pausedQueueFullUntilMs) {
+      this.hintText.setText(PAUSED_QUEUE_FULL_HINT);
+      this.hintText.setColor('#ffcc66');
+      return;
+    }
+    this.hintText.setText(hintTextFor(this.effectiveTool(), this.viewState.activeView));
+    this.hintText.setColor('#cfd8dc');
+  }
+
+  /** Draw the speed widget (⏸ / 1× / 2× / 4×): highlight the ⏸ button while
+   *  paused, and the multiplier preset matching the live speed. */
+  private renderSpeedWidget(): void {
+    const paused = this.isPausedFn ? this.isPausedFn() : false;
+    const speed = this.getSpeedMultiplierFn ? this.getSpeedMultiplierFn() : 1;
+    for (let i = 0; i < SPEED_CONTROL_ORDER.length; i++) {
+      const control = SPEED_CONTROL_ORDER[i]!;
+      const r = speedControlRect(i);
+      const isActive = control === 'pause' ? paused : control === speed;
+      this.gfx.fillStyle(isActive ? 0x2a6cc0 : 0x444444, 1);
+      this.gfx.fillRect(r.x, r.y, r.w, r.h);
+      if (isActive) {
+        this.gfx.lineStyle(2, 0xffffff, 1);
+        this.gfx.strokeRect(r.x + 1, r.y + 1, r.w - 2, r.h - 2);
+      }
+    }
+  }
+
+  /** Surface the "paused queue full — resume to continue" hint for a moment. */
+  public flashPausedQueueFull(): void {
+    this.pausedQueueFullUntilMs = this.time.now + PAUSED_QUEUE_FULL_HINT_MS;
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/phase-09-session.spec.ts
+++ b/tests/phase-09-session.spec.ts
@@ -329,7 +329,14 @@ test.describe('Phase 09.1 Chunk 2 — enemy underground toggle', () => {
     // SavePrompt tests can leave focus outside the canvas subtree).
     const box = await canvas.boundingBox();
     if (!box) throw new Error('canvas has no bounding box');
-    await page.mouse.click(box.x + 10, box.y + 10);
+    // Click the canvas CENTER, not the top-left: (box.x+10, box.y+10) lands
+    // inside HUD.STATS ({x:8,y:8,w:200,h:24}), whose click toggles the
+    // ant-activity panel OPEN. With X now gated through canAcceptWorldHotkey()
+    // (which blocks while that panel is visible — intended), the later
+    // page.keyboard.press('x') would be suppressed and the "Enemy Colony"
+    // assertion would fail. The center is clear of every HUD zone, so it only
+    // focuses the canvas.
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
     await page.waitForTimeout(100);
 
     // Enter the underground view. Tab edge-triggers the view toggle per

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -99,9 +99,13 @@ test.describe('Phase 8 smoke — boot, toggle, pan', () => {
     });
   });
 
-  test('Space + left-drag pans the surface camera without error (Phase 8.5 primary gesture)', async ({
+  test('left-drag pans the surface camera (Command tool); Space toggles pause — controls rework', async ({
     page,
   }) => {
+    // Stage 1 controls rework (issue #18): Space no longer modifies pan — it is
+    // the pause toggle. On the surface the default Command tool left-drags = pan
+    // (the single gesture arbiter classifies it). This smoke test exercises both
+    // a plain left-drag pan and a Space pause/resume cycle, asserting no errors.
     const consoleErrors: string[] = [];
     page.on('console', (msg) => {
       if (errorFilter(msg)) consoleErrors.push(msg.text());
@@ -113,16 +117,19 @@ test.describe('Phase 8 smoke — boot, toggle, pan', () => {
     await canvas.waitFor({ state: 'attached' });
     await page.waitForTimeout(200);
 
-    // Hold Space → left-button drag over a non-HUD mid-canvas region → release.
+    // Plain left-button drag over a non-HUD mid-canvas region → pan (no Space).
     // Mid-canvas (500, 300) sits clear of HUD.STATS (top-left), HUD.TRIANGLE
     // (bottom-left), HUD.MINIMAP (bottom-right), HUD.VIEW_TOGGLE (above minimap).
     await canvas.focus();
-    await page.keyboard.down('Space');
     await page.mouse.move(500, 300);
     await page.mouse.down();
     await page.mouse.move(300, 300, { steps: 10 });
     await page.mouse.up();
-    await page.keyboard.up('Space');
+
+    // Space toggles the user pause, then again to resume.
+    await page.keyboard.press('Space');
+    await page.waitForTimeout(50);
+    await page.keyboard.press('Space');
 
     await page.waitForTimeout(150);
     await expect(page.locator('canvas').first()).toBeAttached();


### PR DESCRIPTION
## Stage 1 of the Controls Rework (#18) — desktop input model

Part of #18 (Controls Rework). **Stage 1 of 3** — the desktop input-model rework. Zoom (Stage 2) and the teaching/tooltip system (Stage 3) are separate stages; touch is roadmap Phase 6.

### What changed
Replaces the overloaded left/right-click scheme (each button did 3–4 things, varying per view) with a **3-tool palette + a smart default cursor**:

- **Tools** — Command / Dig / Chamber on keys `1`/`2`/`3` (stored in `ViewState`, reset to the view default on every switch: surface→Command, underground→Dig; Chamber is underground-only). Active-tool highlight + per-tool cursor.
- **Single left-button gesture arbiter** — tap = context order, drag = pan **everywhere except underground-Dig (drag = paint)**; one `cancelGesture()` on every tool/view/colony switch, secondary-button down, menu/modal open, phase change, and blur. **`Space`-pan retired.**
- **Command tap** keeps the intuitive direct orders — food / rally / attack-entrance / spider — priority `spider→food→clear-rally→foreign-entrance→empty`; underground Command-tap cancels a dig mark.
- **Dig** — surface tap designates a nest entrance in **one tap** with a live green/red hover outline; underground tap marks/cancels a tile, drag paints.
- **Chamber** — one `tryOpenChamberMenu(screenX,screenY,tileX,tileY)` for both the tool tap and right-click (Solid/Open only, **bare-dirt placement preserved**); surface right-click is a no-op. All underground command paths require the player colony (enemy view stays read-only).
- **Speed** relocated off `1`/`2`/`4` → a HUD speed widget + `=`/`-`/numpad; **`Space` = pause/resume** via a reconciled pause reason-set (never mutates speed). One `enqueueCommand()` enforces the paused 64-command cap across the arbiter, chamber menu, and behavior slider.
- HUD `TOOLS`/`HINTS`/`SPEED` masked in `isPointerOverHUD` + the ant-panel allow-list + UIScene hit-testing; `canAcceptWorldHotkey()` gates `1/2/3`, `=/-`, `Space`, `Tab`; static per-tool/per-view hint strip.

### Constraints
**Pure `src/render` + `src/input` + UI** — **no `src/sim` changes, no `simVersion` bump, no new/changed `SimCommand`s** (replay/determinism unaffected). `git diff main -- src/sim` is empty.

### Review trail
Planned via `/grill-me-codex` (Codex-approved after a 6-round adversarial plan review). Implemented + internally reviewed via the `ship-review` workflow (genuine 4-round pass — found and fixed **4 actionable bugs** + **3 advisory UX bugs**). All **2340** unit tests pass locally.

> **CI note:** the heavy `src/platform/investigation/harness.test.ts` acceptance sweep is timing-sensitive and intermittently times out on a loaded local machine (unrelated to this change — `src/sim` is untouched); it passes on a quiet local run and on CI's dedicated runner. **CI `verify` is the authoritative gate.**

Opened for **UAT** — please don't merge until UAT + green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
