### PR TITLE
feat(render): Stage 2 controls rework (#18) — continuous zoom + pan over baked terrain

### DIFF
--- a/src/input/camera-input.test.ts
+++ b/src/input/camera-input.test.ts
@@ -32,38 +32,31 @@ beforeEach(() => {
   resetPanInputState();
 });
 import type { ViewState } from '../render/camera.js';
-import {
-  VIEWPORT_WIDTH_TILES,
-  VIEWPORT_HEIGHT_TILES,
-  CAMERA_SCROLL_SPEED,
-} from '../render/camera.js';
-import { HUD } from '../render/sprites.js';
-import { SURFACE_GRID_WIDTH, PLAYER_COLONY_ID } from '../sim/constants.js';
+import { SURFACE_WORLD_PX_W } from '../render/camera.js';
+import { makeCameraView, KEYBOARD_PAN_SPEED_PX_PER_SEC } from '../render/camera-adapter.js';
+import { HUD, CANVAS_W } from '../render/sprites.js';
+import { PLAYER_COLONY_ID } from '../sim/constants.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Build a ViewState with world-pixel CameraView cameras centered on
+ * (centerX, centerY) at DEFAULT_ZOOM (1). World-space camera model (issue #18
+ * Stage 2): centerX/centerY are WORLD PIXELS, not tiles. Both cameras are
+ * independent CameraView instances.
+ */
 function makeViewState(
   view: 'surface' | 'underground' = 'surface',
-  camX = 64,
-  camY = 64,
+  centerX = 1024,
+  centerY = 1024,
 ): ViewState {
   return {
     activeView: view,
     activeTool: view === 'surface' ? 'command' : 'dig',
-    surfaceCamera: {
-      x: camX,
-      y: camY,
-      viewportWidth: VIEWPORT_WIDTH_TILES,
-      viewportHeight: VIEWPORT_HEIGHT_TILES,
-    },
-    undergroundCamera: {
-      x: camX,
-      y: camY,
-      viewportWidth: VIEWPORT_WIDTH_TILES,
-      viewportHeight: VIEWPORT_HEIGHT_TILES,
-    },
+    surfaceCamera: makeCameraView(centerX, centerY),
+    undergroundCamera: makeCameraView(centerX, centerY),
     undergroundVisited: false,
     activeUndergroundColonyId: PLAYER_COLONY_ID,
     showPheromoneOverlay: true,
@@ -164,36 +157,55 @@ describe('isPointerOverHUD', () => {
 // processCameraInput
 // ---------------------------------------------------------------------------
 
-describe('processCameraInput', () => {
-  it('pans left/right/up/down by CAMERA_SCROLL_SPEED per held key (arrow keys)', () => {
-    const vs = makeViewState('surface', 100, 100);
-    processCameraInput(vs, makePanInputs({ leftDown: true }));
-    expect(vs.surfaceCamera.x).toBeCloseTo(100 - CAMERA_SCROLL_SPEED);
+// Time-based keyboard pan (issue #18 Stage 2): one frame at 60fps.
+const DT_60FPS = 1 / 60;
+// World-px the camera center moves per held direction at zoom 1, one 60fps frame:
+// KEYBOARD_PAN_SPEED_PX_PER_SEC × dt ÷ zoom. (600/60 = 10 at zoom 1.)
+const PAN_STEP_60FPS = (KEYBOARD_PAN_SPEED_PX_PER_SEC * DT_60FPS) / 1;
+// Clamp half-window in world px at zoom 1: viewWorldWidth(1)/2 = CANVAS_W/2.
+const HALF_VIEW_W_AT_ZOOM_1 = CANVAS_W / 2;
 
-    const vs2 = makeViewState('surface', 100, 100);
-    processCameraInput(vs2, makePanInputs({ downDown: true }));
-    expect(vs2.surfaceCamera.y).toBeCloseTo(100 + CAMERA_SCROLL_SPEED);
+describe('processCameraInput', () => {
+  it('pans left/right/up/down by the time-based step per held key (arrow keys)', () => {
+    // Start well clear of the world edges so the clamp doesn't mask the pan delta.
+    const vs = makeViewState('surface', 1000, 1000);
+    processCameraInput(vs, makePanInputs({ leftDown: true }), DT_60FPS);
+    // Left moves centerX in the −X direction by the time-based step.
+    expect(vs.surfaceCamera.centerX).toBeCloseTo(1000 - PAN_STEP_60FPS);
+
+    const vs2 = makeViewState('surface', 1000, 1000);
+    processCameraInput(vs2, makePanInputs({ downDown: true }), DT_60FPS);
+    // Down moves centerY in the +Y direction by the same step.
+    expect(vs2.surfaceCamera.centerY).toBeCloseTo(1000 + PAN_STEP_60FPS);
   });
 
   it('WASD pans identically to the arrow keys', () => {
-    const vs = makeViewState('surface', 100, 100);
-    processCameraInput(vs, makePanInputs({ wasdD: true }));
-    expect(vs.surfaceCamera.x).toBeCloseTo(100 + CAMERA_SCROLL_SPEED);
+    const vs = makeViewState('surface', 1000, 1000);
+    processCameraInput(vs, makePanInputs({ wasdD: true }), DT_60FPS);
+    expect(vs.surfaceCamera.centerX).toBeCloseTo(1000 + PAN_STEP_60FPS);
+  });
+
+  it('is frame-rate independent: a 2× dt pans 2× as far', () => {
+    const vs = makeViewState('surface', 1000, 1000);
+    processCameraInput(vs, makePanInputs({ wasdD: true }), 2 * DT_60FPS);
+    expect(vs.surfaceCamera.centerX).toBeCloseTo(1000 + 2 * PAN_STEP_60FPS);
   });
 
   it('is suppressed while panInputState.isPanning is true (drag claims the camera)', () => {
-    const vs = makeViewState('surface', 100, 100);
+    const vs = makeViewState('surface', 1000, 1000);
     panInputState.isPanning = true;
-    processCameraInput(vs, makePanInputs({ leftDown: true }));
-    expect(vs.surfaceCamera.x).toBe(100); // unchanged
+    processCameraInput(vs, makePanInputs({ leftDown: true }), DT_60FPS);
+    expect(vs.surfaceCamera.centerX).toBe(1000); // unchanged
   });
 
   it('clamps the camera into world bounds after a pan', () => {
-    // Push left hard against the world edge; clamp pins x at half-viewport.
-    const vs = makeViewState('surface', 0, 100);
-    processCameraInput(vs, makePanInputs({ leftDown: true }));
-    expect(vs.surfaceCamera.x).toBeGreaterThanOrEqual(VIEWPORT_WIDTH_TILES / 2);
-    expect(vs.surfaceCamera.x).toBeLessThanOrEqual(SURFACE_GRID_WIDTH - VIEWPORT_WIDTH_TILES / 2);
+    // Push left hard against the world edge; clamp pins centerX at the half-window.
+    const vs = makeViewState('surface', 0, 1000);
+    processCameraInput(vs, makePanInputs({ leftDown: true }), DT_60FPS);
+    expect(vs.surfaceCamera.centerX).toBeGreaterThanOrEqual(HALF_VIEW_W_AT_ZOOM_1);
+    expect(vs.surfaceCamera.centerX).toBeLessThanOrEqual(
+      SURFACE_WORLD_PX_W - HALF_VIEW_W_AT_ZOOM_1,
+    );
   });
 });
 
@@ -232,15 +244,17 @@ function middlePointer(x: number, y: number): Phaser.Input.Pointer {
 
 describe('registerDragPan (middle-button)', () => {
   it('pans the active camera on a middle-button drag', () => {
-    const vs = makeViewState('surface', 100, 100);
+    // Center clear of the clamp edges so the pan delta isn't masked by clamping.
+    const vs = makeViewState('surface', 1000, 1000);
     const { scene, emit } = makeFakeScene();
     registerDragPan(scene, vs);
     // Non-HUD points (mid play-area, clear of every HUD rect).
     emit('pointerdown', middlePointer(400, 300));
     expect(panInputState.isPanning).toBe(true);
     emit('pointermove', middlePointer(400 + TILE_SIZE_PX, 300));
-    // Pointer moved +1 tile in x → camera pans -1 tile in x (drag-the-world).
-    expect(vs.surfaceCamera.x).toBeCloseTo(100 - 1);
+    // Pointer moved +TILE_SIZE_PX px in x → at zoom 1 the camera center pans
+    // −delta/zoom = −TILE_SIZE_PX world px (drag-the-world: panByScreenDelta).
+    expect(vs.surfaceCamera.centerX).toBeCloseTo(1000 - TILE_SIZE_PX);
     emit('pointerup', middlePointer(400 + TILE_SIZE_PX, 300));
     expect(panInputState.isPanning).toBe(false);
   });
@@ -250,7 +264,7 @@ describe('registerDragPan (middle-button)', () => {
   // flips true mid-gesture; the very next pointermove must release the drag and
   // stop moving the camera (pointermove calls releaseDrag() when isBlocked()).
   it('stops an in-flight middle-drag when isBlocked flips true mid-gesture', () => {
-    const vs = makeViewState('surface', 100, 100);
+    const vs = makeViewState('surface', 1000, 1000);
     const { scene, emit } = makeFakeScene();
     const blocked = { value: false };
     registerDragPan(scene, vs, () => blocked.value);
@@ -258,7 +272,7 @@ describe('registerDragPan (middle-button)', () => {
     // Drag starts and pans while unblocked.
     emit('pointerdown', middlePointer(400, 300));
     emit('pointermove', middlePointer(400 + TILE_SIZE_PX, 300));
-    expect(vs.surfaceCamera.x).toBeCloseTo(100 - 1);
+    expect(vs.surfaceCamera.centerX).toBeCloseTo(1000 - TILE_SIZE_PX);
     expect(panInputState.isPanning).toBe(true);
 
     // Modal opens: isBlocked → true. The next pointermove must release the drag,
@@ -266,11 +280,11 @@ describe('registerDragPan (middle-button)', () => {
     blocked.value = true;
     emit('pointermove', middlePointer(400 + 5 * TILE_SIZE_PX, 300));
     expect(panInputState.isPanning).toBe(false);
-    expect(vs.surfaceCamera.x).toBeCloseTo(100 - 1); // unchanged since the block
+    expect(vs.surfaceCamera.centerX).toBeCloseTo(1000 - TILE_SIZE_PX); // unchanged since the block
 
     // A further move while still blocked is a no-op (drag is no longer active).
     emit('pointermove', middlePointer(400 + 9 * TILE_SIZE_PX, 300));
-    expect(vs.surfaceCamera.x).toBeCloseTo(100 - 1);
+    expect(vs.surfaceCamera.centerX).toBeCloseTo(1000 - TILE_SIZE_PX);
     expect(panInputState.isPanning).toBe(false);
   });
 });

--- a/src/input/camera-input.ts
+++ b/src/input/camera-input.ts
@@ -1,18 +1,20 @@
-// camera-input.ts — camera pan input (Stage 1 controls rework, issue #18).
+// camera-input.ts — camera pan input (Stage 1 controls rework, issue #18;
+// Stage 2 continuous-zoom migration).
 //
-// Pan triggers after the controls rework:
+// Pan triggers:
 //   1. Left-drag — driven by the gesture arbiter (gesture-arbiter.ts), NOT here.
 //      Command / Dig-surface / Chamber drags pan; underground-Dig drags paint.
 //      The arbiter sets/clears `panInputState.isPanning` while a left-drag pan
 //      is active so keyboard pan is suppressed for the duration.
 //   2. Middle-button drag — secondary pan gesture for three-button mice, owned
-//      by registerDragPan below. Independent of the arbiter (the arbiter cancels
-//      any pending left gesture when a middle button goes down).
+//      by registerDragPan below. Independent of the arbiter.
 //   3. Keyboard pan — arrow keys + WASD (per-frame poll in processCameraInput).
 //
-// Space no longer pans (the Space modifier was retired in the rework — Space is
-// now the pause toggle, bound in game-scene.ts). All `spaceHeld` handling is
-// gone; `panInputState` carries only `isPanning`.
+// Stage 2: the camera is now a world-pixel CameraView with continuous zoom. Pan
+// deltas go through the pure adapter — drag uses panByScreenDelta (screen-delta
+// ÷ zoom, so the drag stays 1:1 with the cursor at any zoom) and keyboard pan is
+// time-based (panByKeyboard: screen-px/sec × dt ÷ zoom), replacing the old fixed
+// per-frame tile delta. Clamp is the custom center-aware clampCameraView.
 //
 // `panInputState` remains a module-level singleton so the arbiter and the
 // keyboard-pan poll can coordinate (keyboard pan no-ops while a drag pan claims
@@ -22,20 +24,15 @@
 // type` only so this file is testable without Phaser.
 
 import type * as Phaser from 'phaser';
-import { HUD, TILE_SIZE_PX } from '../render/sprites.js';
+import { HUD } from '../render/sprites.js';
 import { antActivityPanelState } from '../render/ant-activity-panel-state.js';
+import { type ViewState, worldPxDimensions } from '../render/camera.js';
 import {
-  type ViewState,
-  type CameraState,
-  clampCamera,
-  CAMERA_SCROLL_SPEED,
-} from '../render/camera.js';
-import {
-  SURFACE_GRID_WIDTH,
-  SURFACE_GRID_HEIGHT,
-  UNDERGROUND_GRID_WIDTH,
-  UNDERGROUND_GRID_HEIGHT,
-} from '../sim/constants.js';
+  type CameraView,
+  clampCameraView,
+  panByScreenDelta,
+  panByKeyboard,
+} from '../render/camera-adapter.js';
 
 // ---------------------------------------------------------------------------
 // panInputState — module-level singleton
@@ -47,8 +44,6 @@ import {
  * - `isPanning` is true while a drag pan (middle-button via registerDragPan, or
  *   left-drag via the gesture arbiter) is in flight. processCameraInput skips
  *   keyboard pan while it is true so the two pan systems don't stack deltas.
- *
- * The Space modifier was removed in the controls rework, so `spaceHeld` is gone.
  */
 export const panInputState = {
   isPanning: false,
@@ -60,8 +55,6 @@ export const panInputState = {
  * Used at session-restart boundaries (bootFresh / bootFromSave / restartGame)
  * and by the GameOver guard so a pan gesture in flight at the moment of restart
  * does not leak into the new session.
- *
- * Also used by unit tests as `resetPanInputStateForTests` (aliased below).
  */
 export function resetPanInputState(): void {
   panInputState.isPanning = false;
@@ -90,24 +83,16 @@ export function resetDragState(dragState: DragState): void {
  * isPointerOverHUD — return true if the screen-pixel point (px, py) falls
  * inside any *visible* HUD zone rectangle.
  *
- * Used by drag-pan and the gesture arbiter to suppress pointer events that land
- * on HUD widgets.
- *
- * Stage 1 controls rework (issue #18): HUD.TOOLS (tool palette), HUD.HINTS (hint
- * strip), and HUD.SPEED (speed widget) are now DRAWN and interactive, so all
- * three are masked here. HUD.SPEED was deliberately left unmasked pre-rework
- * (reserved/undrawn); now that the speed widget renders there, masking it stops
- * speed-button clicks leaking into the world arbiter (Codex R5-1). HUD.SAVE_ICON
- * stays unmasked (still undrawn).
+ * Used by drag-pan, the gesture arbiter, and the wheel-zoom handler to suppress
+ * pointer/wheel events that land on HUD widgets.
  *
  * Inclusion rule: x in [rect.x, rect.x + rect.w) and y in [rect.y, rect.y + rect.h).
  */
 export function isPointerOverHUD(px: number, py: number, viewState?: ViewState): boolean {
   // Ant-activity popup full-canvas mask — while the panel is visible OR already
-  // dismissing (pendingHide), treat every screen pixel as HUD. (See the long
-  // rationale retained below: Phaser does not guarantee cross-scene dispatch
-  // order, so masking the whole canvas closes both UIScene-first and
-  // world-input-first orderings of the dismissal click.)
+  // dismissing (pendingHide), treat every screen pixel as HUD (Phaser does not
+  // guarantee cross-scene dispatch order, so masking the whole canvas closes both
+  // dismissal-click orderings).
   if (antActivityPanelState.visible || antActivityPanelState.pendingHide) {
     return true;
   }
@@ -122,9 +107,8 @@ export function isPointerOverHUD(px: number, py: number, viewState?: ViewState):
     HUD.VIEW_TOGGLE,
   ];
   // Issue #14 — colony toggle is rendered ONLY on the underground view. Mask the
-  // click zone only when it's actually visible — otherwise a patch above the
-  // minimap on the surface view becomes a silent dead zone. Callers without a
-  // ViewState (legacy/test) pass undefined and the toggle stays unmasked.
+  // click zone only when it's actually visible. Callers without a ViewState
+  // (legacy/test) pass undefined and the toggle stays unmasked.
   if (viewState !== undefined && viewState.activeView === 'underground') {
     zones.push(HUD.UNDERGROUND_COLONY_TOGGLE);
   }
@@ -169,15 +153,8 @@ export interface PanInputs {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Return [worldW, worldH] tile dimensions for the currently active view. */
-function worldDimensions(viewState: ViewState): [number, number] {
-  return viewState.activeView === 'surface'
-    ? [SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT]
-    : [UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT];
-}
-
-/** Return the active camera for the current view. */
-function activeCamera(viewState: ViewState): CameraState {
+/** Return the active CameraView for the current view. */
+function activeCamera(viewState: ViewState): CameraView {
   return viewState.activeView === 'surface' ? viewState.surfaceCamera : viewState.undergroundCamera;
 }
 
@@ -186,39 +163,50 @@ function activeCamera(viewState: ViewState): CameraState {
 // ---------------------------------------------------------------------------
 
 /**
- * processCameraInput — apply keyboard pan triggers then clamp.
+ * processCameraInput — apply time-based keyboard pan then clamp.
  *
  * Called once per frame from GameScene.update(). Drag-pan mutations happen in
  * the event handlers; this applies the keyboard triggers and the single
- * end-of-frame clamp.
+ * end-of-frame clamp. Keyboard pan is frame-rate independent: panByKeyboard
+ * moves screen-px/sec × dtSeconds ÷ zoom world px.
+ *
+ * Returns true when held WASD/arrow keys actually moved the camera this frame,
+ * so the caller can cancel any in-flight cursor-anchored wheel zoom (whose
+ * per-frame re-anchor would otherwise immediately overwrite the keyboard pan).
+ *
+ * @param viewState - current view state (active CameraView is mutated)
+ * @param inputs - per-frame key state
+ * @param dtSeconds - frame delta in seconds (GameScene update delta ÷ 1000)
  */
-export function processCameraInput(viewState: ViewState, inputs: PanInputs): void {
+export function processCameraInput(
+  viewState: ViewState,
+  inputs: PanInputs,
+  dtSeconds: number,
+): boolean {
   const cam = activeCamera(viewState);
-  const [worldW, worldH] = worldDimensions(viewState);
+  const [worldW, worldH] = worldPxDimensions(viewState.activeView);
 
-  // Issue #85 — suppress keyboard pan while a drag pan claims the camera. Drag
-  // is a 'claim the camera' gesture; keyboard resumes as soon as the drag ends.
+  // Issue #85 — suppress keyboard pan while a drag pan claims the camera.
   if (panInputState.isPanning) {
-    clampCamera(cam, worldW, worldH);
-    return;
+    clampCameraView(cam, worldW, worldH);
+    return false;
   }
 
-  // --- Keyboard pan ---
-  if (inputs.cursors.left.isDown || inputs.wasd.A.isDown) {
-    cam.x -= CAMERA_SCROLL_SPEED;
-  }
-  if (inputs.cursors.right.isDown || inputs.wasd.D.isDown) {
-    cam.x += CAMERA_SCROLL_SPEED;
-  }
-  if (inputs.cursors.up.isDown || inputs.wasd.W.isDown) {
-    cam.y -= CAMERA_SCROLL_SPEED;
-  }
-  if (inputs.cursors.down.isDown || inputs.wasd.S.isDown) {
-    cam.y += CAMERA_SCROLL_SPEED;
+  // --- Keyboard pan (time-based) ---
+  let dirX = 0;
+  let dirY = 0;
+  if (inputs.cursors.left.isDown || inputs.wasd.A.isDown) dirX -= 1;
+  if (inputs.cursors.right.isDown || inputs.wasd.D.isDown) dirX += 1;
+  if (inputs.cursors.up.isDown || inputs.wasd.W.isDown) dirY -= 1;
+  if (inputs.cursors.down.isDown || inputs.wasd.S.isDown) dirY += 1;
+  const panned = dirX !== 0 || dirY !== 0;
+  if (panned) {
+    panByKeyboard(cam, dirX, dirY, dtSeconds);
   }
 
   // --- Single clamp at end of frame ---
-  clampCamera(cam, worldW, worldH);
+  clampCameraView(cam, worldW, worldH);
+  return panned;
 }
 
 // ---------------------------------------------------------------------------
@@ -242,19 +230,14 @@ export interface DragState {
 /**
  * registerDragPan — wire MIDDLE-button drag-pan handlers on a Phaser.Scene.
  *
- * The Space+left and plain-left pan paths were removed in the controls rework
- * (left is now exclusively the gesture arbiter's). This retains only the
- * middle-button pan for three-button mice. While it is active it sets
- * `panInputState.isPanning` so keyboard pan is suppressed; the gesture arbiter
- * also cancels any pending left gesture on a middle-button down so the two
- * never run concurrently.
+ * Retains only the middle-button pan for three-button mice (left is the gesture
+ * arbiter's). While active it sets `panInputState.isPanning` so keyboard pan is
+ * suppressed. HUD-zone pointerdown / pointermove are ignored so a drag starting
+ * inside a HUD widget never pans, and a mid-drag HUD crossing doesn't jump the
+ * camera. Stage 2: pan delta goes through panByScreenDelta (÷ zoom).
  *
- * HUD-zone pointerdown / pointermove are ignored so a drag starting inside a HUD
- * widget never pans, and a mid-drag HUD crossing doesn't jump the camera.
- *
- * Returns the shared dragState object (kept for PanInputs back-compat;
- * processCameraInput ignores it). `isBlocked` lets GameScene suspend pan during
- * GameOver.
+ * Returns the shared dragState object. `isBlocked` lets GameScene suspend pan
+ * during GameOver.
  */
 export function registerDragPan(
   scene: Phaser.Scene,
@@ -301,15 +284,11 @@ export function registerDragPan(
       return;
     }
 
-    const dx = (pointer.x - dragState.lastX) / TILE_SIZE_PX;
-    const dy = (pointer.y - dragState.lastY) / TILE_SIZE_PX;
-
     const cam = activeCamera(viewState);
-    cam.x -= dx;
-    cam.y -= dy;
+    panByScreenDelta(cam, pointer.x - dragState.lastX, pointer.y - dragState.lastY);
 
-    const [worldW, worldH] = worldDimensions(viewState);
-    clampCamera(cam, worldW, worldH);
+    const [worldW, worldH] = worldPxDimensions(viewState.activeView);
+    clampCameraView(cam, worldW, worldH);
 
     dragState.lastX = pointer.x;
     dragState.lastY = pointer.y;

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -6,6 +6,14 @@
 // cancelGesture on every trigger; snapshot acts on the DOWN tile; the enemy-view
 // read-only guard; reconcileContext cancelling on a mid-press tool/view/colony
 // change; the right-click chamber path.
+//
+// Stage 2 controls rework: cameras are world-pixel `CameraView`s (centerX,
+// centerY, zoom, targetZoom) instead of tile-based `CameraState`. tileCenter()
+// projects a tile to its screen point via the SAME pure adapter math the arbiter
+// uses (worldToScreen), so a down/up round-trips to the same tile through
+// screenToTileZoom. Pan assertions read centerX/centerY: a screen drag of dx px
+// at zoom 1 moves centerX by dx world px (panByScreenDelta: centerX -= dx/zoom),
+// NOT dx/16 as in the old tile-camera model.
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
@@ -21,7 +29,7 @@ import { contextMenuState, hideContextMenu } from '../render/context-menu-state.
 import { UndergroundTileState, ugSet, createUndergroundGrid } from '../sim/terrain.js';
 import type { WorldState } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
-import { VIEWPORT_WIDTH_TILES, VIEWPORT_HEIGHT_TILES } from '../render/camera.js';
+import { makeCameraView, worldToScreen } from '../render/camera-adapter.js';
 import { TILE_SIZE_PX } from '../render/sprites.js';
 import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
 import { DRAG_THRESHOLD_PX } from './gesture.js';
@@ -34,24 +42,15 @@ import type { SimCommand } from '../sim/commands.js';
 function makeViewState(
   view: 'surface' | 'underground',
   tool: 'command' | 'dig' | 'chamber',
-  camX = 10,
-  camY = 10,
+  // World-pixel camera CENTER. Default frames on tile (10,10): 10 × 16 = 160.
+  centerX = 10 * TILE_SIZE_PX,
+  centerY = 10 * TILE_SIZE_PX,
 ): ViewState {
   return {
     activeView: view,
     activeTool: tool,
-    surfaceCamera: {
-      x: camX,
-      y: camY,
-      viewportWidth: VIEWPORT_WIDTH_TILES,
-      viewportHeight: VIEWPORT_HEIGHT_TILES,
-    },
-    undergroundCamera: {
-      x: camX,
-      y: camY,
-      viewportWidth: VIEWPORT_WIDTH_TILES,
-      viewportHeight: VIEWPORT_HEIGHT_TILES,
-    },
+    surfaceCamera: makeCameraView(centerX, centerY),
+    undergroundCamera: makeCameraView(centerX, centerY),
     undergroundVisited: true,
     activeUndergroundColonyId: PLAYER_COLONY_ID,
     showPheromoneOverlay: true,
@@ -75,12 +74,20 @@ function makeWorld(gridW = 20, gridH = 20): WorldState {
   } as unknown as WorldState;
 }
 
-/** Screen px at the CENTER of a tile, mirroring the renderer's integer snap. */
+/**
+ * Screen px at the CENTER of a tile, projected through the SAME pure adapter math
+ * the arbiter uses (worldToScreen). The tile center in world px is (t+0.5)·16;
+ * projecting it and flooring back via screenToTileZoom returns the same tile, so a
+ * down/up here resolves to (tileX,tileY) exactly.
+ */
 function tileCenter(tileX: number, tileY: number, vs: ViewState) {
   const cam = vs.activeView === 'surface' ? vs.surfaceCamera : vs.undergroundCamera;
-  const left = Math.floor(cam.x - cam.viewportWidth / 2);
-  const top = Math.floor(cam.y - cam.viewportHeight / 2);
-  return { x: (tileX - left) * TILE_SIZE_PX + 1, y: (tileY - top) * TILE_SIZE_PX + 1 };
+  const { screenX, screenY } = worldToScreen(
+    (tileX + 0.5) * TILE_SIZE_PX,
+    (tileY + 0.5) * TILE_SIZE_PX,
+    cam,
+  );
+  return { x: screenX, y: screenY };
 }
 
 interface Harness {
@@ -201,12 +208,12 @@ describe('drag then no tap', () => {
   it('a pan drag (Command surface) moves the camera and fires NO tap on up', () => {
     const h = makeHarness('surface', 'command');
     const start = tileCenter(10, 10, h.vs);
-    const camXBefore = h.vs.surfaceCamera.x;
+    const centerXBefore = h.vs.surfaceCamera.centerX;
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
     h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y)); // crosses threshold → pan
     expect(panInputState.isPanning).toBe(true);
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, start.x + 40, start.y));
-    expect(h.vs.surfaceCamera.x).not.toBe(camXBefore); // camera panned
+    expect(h.vs.surfaceCamera.centerX).not.toBe(centerXBefore); // camera panned
     expect(h.world.commandQueue).toHaveLength(0); // no tap command
     expect(panInputState.isPanning).toBe(false); // cleared on up
   });
@@ -232,16 +239,18 @@ describe('drag then no tap', () => {
 // not 0px. Multi-move drags must then continue incrementally with no first-
 // increment loss and no double-count.
 //
-// The test world is 20×20 but the arbiter clamps against the REAL grid
-// (SURFACE 128×128). Center the camera at (50,30) so a small flick stays inside
-// the clamp window [25,103]×[18.5,109.5] and the assertion is exact.
+// Stage 2: pan is world-px. panByScreenDelta moves centerX -= dx/zoom, so at
+// zoom 1 a dx-px screen drag moves centerX by dx world px (NOT dx/16). The test
+// world is 20×20 but the arbiter clamps against the REAL grid (SURFACE 2048 px
+// wide). Center the camera at world (800,480) so a small flick stays inside the
+// zoom-1 clamp window [400,1648]×[296,1752] and the assertion is exact.
 // ---------------------------------------------------------------------------
 
 describe('flick-pan first-move displacement (Fix 1)', () => {
   it('a single coalesced move past the threshold then up pans by (current − down)', () => {
     const h = makeHarness('surface', 'command');
-    h.vs.surfaceCamera.x = 50;
-    h.vs.surfaceCamera.y = 30;
+    h.vs.surfaceCamera.centerX = 800;
+    h.vs.surfaceCamera.centerY = 480;
     const downX = 200;
     const downY = 200;
     const flickPx = 48; // 3 tiles; well past the 6px threshold
@@ -249,31 +258,32 @@ describe('flick-pan first-move displacement (Fix 1)', () => {
     // ONE move that both crosses the threshold AND is the whole flick, then up.
     h.arbiter.onPointerMove(ev(LEFT_BUTTON, downX + flickPx, downY));
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, downX + flickPx, downY));
-    // cam.x -= (current − down)/TILE_SIZE_PX. The OLD bug seeded panLast to the
-    // current move, making this delta 0 (camera unchanged) — this asserts the fix.
-    expect(h.vs.surfaceCamera.x).toBeCloseTo(50 - flickPx / TILE_SIZE_PX, 10);
-    expect(h.vs.surfaceCamera.y).toBeCloseTo(30, 10); // no vertical flick
+    // centerX -= (current − down)/zoom; at zoom 1 that's −flickPx world px. The OLD
+    // bug seeded panLast to the current move, making this delta 0 (camera
+    // unchanged) — this asserts the fix.
+    expect(h.vs.surfaceCamera.centerX).toBeCloseTo(800 - flickPx, 10);
+    expect(h.vs.surfaceCamera.centerY).toBeCloseTo(480, 10); // no vertical flick
     expect(panInputState.isPanning).toBe(false); // released on up
   });
 
   it('the first increment is not lost on a vertical flick either', () => {
     const h = makeHarness('underground', 'command');
-    h.vs.undergroundCamera.x = 50;
-    h.vs.undergroundCamera.y = 30;
+    h.vs.undergroundCamera.centerX = 800;
+    h.vs.undergroundCamera.centerY = 480;
     const downX = 200;
     const downY = 200;
     const flickPx = 32; // 2 tiles down
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, downX, downY));
     h.arbiter.onPointerMove(ev(LEFT_BUTTON, downX, downY + flickPx));
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, downX, downY + flickPx));
-    expect(h.vs.undergroundCamera.x).toBeCloseTo(50, 10);
-    expect(h.vs.undergroundCamera.y).toBeCloseTo(30 - flickPx / TILE_SIZE_PX, 10);
+    expect(h.vs.undergroundCamera.centerX).toBeCloseTo(800, 10);
+    expect(h.vs.undergroundCamera.centerY).toBeCloseTo(480 - flickPx, 10);
   });
 
   it('a multi-move drag pans by the cumulative delta — no first-increment loss, no double-count', () => {
     const h = makeHarness('surface', 'command');
-    h.vs.surfaceCamera.x = 50;
-    h.vs.surfaceCamera.y = 30;
+    h.vs.surfaceCamera.centerX = 800;
+    h.vs.surfaceCamera.centerY = 480;
     const downX = 200;
     const downY = 200;
     // Three successive moves; total horizontal displacement from DOWN = 96px.
@@ -282,26 +292,27 @@ describe('flick-pan first-move displacement (Fix 1)', () => {
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, downX, downY));
     for (const x of xs) h.arbiter.onPointerMove(ev(LEFT_BUTTON, x, downY));
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, xs[xs.length - 1]!, downY));
-    // Cumulative pan = (last − down)/TILE_SIZE_PX = 96/16 = 6 tiles. If the first
-    // increment were lost the total would be (96−16)/16; if double-counted it
-    // would exceed 6. Exact equality pins both failure modes.
-    expect(h.vs.surfaceCamera.x).toBeCloseTo(50 - 96 / TILE_SIZE_PX, 10);
-    expect(h.vs.surfaceCamera.y).toBeCloseTo(30, 10);
+    // Cumulative pan = (last − down)/zoom = 96 world px at zoom 1. If the first
+    // increment were lost the total would be 96−16; if double-counted it would
+    // exceed 96. Exact equality pins both failure modes.
+    expect(h.vs.surfaceCamera.centerX).toBeCloseTo(800 - 96, 10);
+    expect(h.vs.surfaceCamera.centerY).toBeCloseTo(480, 10);
   });
 
   it('intermediate moves each apply their own increment (cumulative == final − down)', () => {
     // Same as above but assert the camera AFTER each move equals the running
     // (x − down) displacement, proving no per-move double-application.
     const h = makeHarness('surface', 'command');
-    h.vs.surfaceCamera.x = 50;
-    h.vs.surfaceCamera.y = 30;
+    h.vs.surfaceCamera.centerX = 800;
+    h.vs.surfaceCamera.centerY = 480;
     const downX = 200;
     const downY = 200;
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, downX, downY));
     const checkpoints = [downX + 8, downX + 24, downX + 40, downX + 64];
     for (const x of checkpoints) {
       h.arbiter.onPointerMove(ev(LEFT_BUTTON, x, downY));
-      expect(h.vs.surfaceCamera.x).toBeCloseTo(50 - (x - downX) / TILE_SIZE_PX, 10);
+      // centerX -= (x − down)/zoom; at zoom 1 that's −(x − down) world px.
+      expect(h.vs.surfaceCamera.centerX).toBeCloseTo(800 - (x - downX), 10);
     }
   });
 });
@@ -310,10 +321,10 @@ describe('the drag matrix', () => {
   it('Dig + underground drag = paint (no camera move)', () => {
     const h = makeHarness('underground', 'dig');
     const start = tileCenter(5, 8, h.vs);
-    const camBefore = h.vs.undergroundCamera.x;
+    const camBefore = h.vs.undergroundCamera.centerX;
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
     h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y));
-    expect(h.vs.undergroundCamera.x).toBe(camBefore); // paint, not pan
+    expect(h.vs.undergroundCamera.centerX).toBe(camBefore); // paint, not pan
     expect(h.world.commandQueue.some((c) => c.type === 'MarkDigTile')).toBe(true);
   });
 
@@ -326,10 +337,10 @@ describe('the drag matrix', () => {
     const h = makeHarness(view, tool);
     const cam = view === 'surface' ? h.vs.surfaceCamera : h.vs.undergroundCamera;
     const start = tileCenter(10, 10, h.vs);
-    const before = cam.x;
+    const before = cam.centerX;
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
     h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y));
-    expect(cam.x).not.toBe(before); // panned
+    expect(cam.centerX).not.toBe(before); // panned
     expect(panInputState.isPanning).toBe(true);
   });
 });
@@ -796,12 +807,12 @@ describe('canEditWorld / canPan split', () => {
     h.canEditWorld.value = false;
     h.canPan.value = true;
     const start = tileCenter(10, 10, h.vs);
-    const camXBefore = h.vs.surfaceCamera.x;
+    const centerXBefore = h.vs.surfaceCamera.centerX;
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
     h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y)); // crosses threshold → pan
     expect(panInputState.isPanning).toBe(true);
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, start.x + 40, start.y));
-    expect(h.vs.surfaceCamera.x).not.toBe(camXBefore);
+    expect(h.vs.surfaceCamera.centerX).not.toBe(centerXBefore);
     expect(h.world.commandQueue).toHaveLength(0);
   });
 
@@ -810,12 +821,12 @@ describe('canEditWorld / canPan split', () => {
     h.canPan.value = false;
     h.canEditWorld.value = false; // GameOver blocks both
     const start = tileCenter(10, 10, h.vs);
-    const camXBefore = h.vs.surfaceCamera.x;
+    const centerXBefore = h.vs.surfaceCamera.centerX;
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
     h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y));
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, start.x + 40, start.y));
     expect(panInputState.isPanning).toBe(false);
-    expect(h.vs.surfaceCamera.x).toBe(camXBefore);
+    expect(h.vs.surfaceCamera.centerX).toBe(centerXBefore);
   });
 
   it('canEditWorld false: an underground-Dig paint drag paints nothing', () => {

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -56,9 +56,14 @@
 // enqueueCommand, never mutating WorldState. Determinism/replay unaffected.
 
 import type { WorldState } from '../sim/types.js';
-import type { ViewState, ToolId, CameraState } from '../render/camera.js';
-import { clampCamera, screenToTile } from '../render/camera.js';
+import type { ViewState, ToolId } from '../render/camera.js';
 import { TILE_SIZE_PX } from '../render/sprites.js';
+import {
+  type CameraView,
+  clampCameraView,
+  screenToTileZoom,
+  panByScreenDelta,
+} from '../render/camera-adapter.js';
 import {
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
@@ -166,16 +171,16 @@ export interface GestureArbiterDeps {
   onPausedQueueFull?: (paused: boolean) => void;
 }
 
-/** Return the active camera for the current view. */
-function activeCamera(viewState: ViewState): CameraState {
+/** Return the active CameraView for the current view. */
+function activeCamera(viewState: ViewState): CameraView {
   return viewState.activeView === 'surface' ? viewState.surfaceCamera : viewState.undergroundCamera;
 }
 
-/** Return [worldW, worldH] tile dimensions for the active view. */
+/** Return [worldPxW, worldPxH] world-pixel dimensions for the active view. */
 function worldDimensions(viewState: ViewState): [number, number] {
   return viewState.activeView === 'surface'
-    ? [SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT]
-    : [UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT];
+    ? [SURFACE_GRID_WIDTH * TILE_SIZE_PX, SURFACE_GRID_HEIGHT * TILE_SIZE_PX]
+    : [UNDERGROUND_GRID_WIDTH * TILE_SIZE_PX, UNDERGROUND_GRID_HEIGHT * TILE_SIZE_PX];
 }
 
 /**
@@ -334,7 +339,7 @@ export class GestureArbiter {
     if (!world) return;
     const vs = this.deps.viewState;
     const cam = activeCamera(vs);
-    const { tileX, tileY } = screenToTile(ev.x, ev.y, cam);
+    const { tileX, tileY } = screenToTileZoom(ev.x, ev.y, cam);
     const spiderHit =
       vs.activeView === 'surface'
         ? isSpiderHit(world, vs, ev.x, ev.y, this.deps.getPrevWorld())
@@ -547,7 +552,7 @@ export class GestureArbiter {
     const world = this.deps.getWorld();
     if (!world) return;
     const cam = activeCamera(this.deps.viewState);
-    const { tileX, tileY } = screenToTile(ev.x, ev.y, cam);
+    const { tileX, tileY } = screenToTileZoom(ev.x, ev.y, cam);
     // A cap-deferred tail from the previous move stays held at the stroke cursor;
     // this move re-drives continuePaintStroke from that cursor (the queue has
     // drained between moves), so the held tiles re-emit and the stroke advances.
@@ -574,13 +579,10 @@ export class GestureArbiter {
       this.panLastY = ev.y;
       return;
     }
-    const dx = (ev.x - this.panLastX) / TILE_SIZE_PX;
-    const dy = (ev.y - this.panLastY) / TILE_SIZE_PX;
     const cam = activeCamera(vs);
-    cam.x -= dx;
-    cam.y -= dy;
+    panByScreenDelta(cam, ev.x - this.panLastX, ev.y - this.panLastY);
     const [worldW, worldH] = worldDimensions(vs);
-    clampCamera(cam, worldW, worldH);
+    clampCameraView(cam, worldW, worldH);
     this.panLastX = ev.x;
     this.panLastY = ev.y;
   }
@@ -593,7 +595,7 @@ export class GestureArbiter {
     const world = this.deps.getWorld();
     if (!world) return;
     const cam = activeCamera(vs);
-    const { tileX, tileY } = screenToTile(ev.x, ev.y, cam);
+    const { tileX, tileY } = screenToTileZoom(ev.x, ev.y, cam);
     tryOpenChamberMenu(world, vs, ev.x, ev.y, tileX, tileY);
   }
 }

--- a/src/input/surface-input.test.ts
+++ b/src/input/surface-input.test.ts
@@ -24,7 +24,7 @@ import {
 } from './surface-input.js';
 import type { WorldState } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
-import { VIEWPORT_WIDTH_TILES, VIEWPORT_HEIGHT_TILES } from '../render/camera.js';
+import { makeCameraView, worldToScreen } from '../render/camera-adapter.js';
 import { TILE_SIZE_PX } from '../render/sprites.js';
 import { FP_ONE } from '../sim/fixed.js';
 import { SPIDER_SPRITE_WIDTH } from '../render/ant-sprite-layer.js';
@@ -36,37 +36,38 @@ import type { ColonyId } from '../sim/colony/colony-store.js';
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Build a ViewState whose cameras are world-pixel CameraViews centered on tile
+ * (camTileX, camTileY). World-space camera model (issue #18 Stage 2): 1 tile =
+ * TILE_SIZE_PX world px, so centering on a tile is `tile * TILE_SIZE_PX`.
+ */
 function makeViewState(
   view: 'surface' | 'underground' = 'surface',
-  camX = 64,
-  camY = 64,
+  camTileX = 64,
+  camTileY = 64,
 ): ViewState {
   return {
     activeView: view,
     activeTool: view === 'surface' ? 'command' : 'dig',
-    surfaceCamera: {
-      x: camX,
-      y: camY,
-      viewportWidth: VIEWPORT_WIDTH_TILES,
-      viewportHeight: VIEWPORT_HEIGHT_TILES,
-    },
-    undergroundCamera: {
-      x: camX,
-      y: camY,
-      viewportWidth: VIEWPORT_WIDTH_TILES,
-      viewportHeight: VIEWPORT_HEIGHT_TILES,
-    },
+    surfaceCamera: makeCameraView(camTileX * TILE_SIZE_PX, camTileY * TILE_SIZE_PX),
+    undergroundCamera: makeCameraView(camTileX * TILE_SIZE_PX, camTileY * TILE_SIZE_PX),
     undergroundVisited: false,
     activeUndergroundColonyId: PLAYER_COLONY_ID,
     showPheromoneOverlay: true,
   };
 }
 
-/** tile → screen px, mirroring the renderer's integer-tile snap. */
-function tileToScreen(tileX: number, tileY: number, camX: number, camY: number) {
-  const left = Math.floor(camX - VIEWPORT_WIDTH_TILES / 2);
-  const top = Math.floor(camY - VIEWPORT_HEIGHT_TILES / 2);
-  return { x: (tileX - left) * TILE_SIZE_PX, y: (tileY - top) * TILE_SIZE_PX };
+/**
+ * Screen-pixel coordinate that the world-space camera projects a tile's CENTER
+ * to. isSpiderHit projects clicks via screenToWorld and tests against the
+ * spider's world-pixel box, so a click here lands exactly on the spider's
+ * rendered center. Inverse of the adapter's screenToWorld (uses worldToScreen).
+ */
+function tileCenterToScreen(tileX: number, tileY: number, vs: ViewState) {
+  const worldX = tileX * TILE_SIZE_PX;
+  const worldY = tileY * TILE_SIZE_PX;
+  const { screenX, screenY } = worldToScreen(worldX, worldY, vs.surfaceCamera);
+  return { x: screenX, y: screenY };
 }
 
 function makeWorld(
@@ -183,8 +184,11 @@ describe('isSpiderHit', () => {
   it('true within the sprite half-extent, false outside', () => {
     const vs = makeViewState('surface', 64, 64);
     const world = makeWorld({ spider: makeSpider(64, 64) });
-    const { x, y } = tileToScreen(64, 64, 64, 64);
+    // Click that projects (screenToWorld) onto the spider's world-pixel center.
+    const { x, y } = tileCenterToScreen(64, 64, vs);
     expect(isSpiderHit(world, vs, x, y, null)).toBe(true);
+    // At DEFAULT_ZOOM (1) a screen offset of SPIDER_SPRITE_WIDTH (48) px maps to a
+    // world offset of 48 px — clear of the half-extent (24) → miss.
     expect(isSpiderHit(world, vs, x + SPIDER_SPRITE_WIDTH, y, null)).toBe(false);
   });
   it('false when there is no spider', () => {

--- a/src/input/surface-input.ts
+++ b/src/input/surface-input.ts
@@ -25,6 +25,7 @@
 
 import type { WorldState } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
+import { screenToWorld } from '../render/camera-adapter.js';
 import type { FoodPile } from '../sim/food.js';
 import type {
   MarkFoodPileCommand,
@@ -188,26 +189,25 @@ export function isSpiderHit(
   prevWorld: WorldState | null = null,
 ): boolean {
   if (world.spider === null) return false;
-  const cam = viewState.surfaceCamera;
-  const camLeft = Math.floor(cam.x - cam.viewportWidth / 2);
-  const camTop = Math.floor(cam.y - cam.viewportHeight / 2);
-  const currScrX = (world.spider.posX >> FP_SHIFT) * TILE_SIZE_PX - camLeft * TILE_SIZE_PX;
-  const currScrY = (world.spider.posY >> FP_SHIFT) * TILE_SIZE_PX - camTop * TILE_SIZE_PX;
-  const prevScrX =
-    prevWorld?.spider != null
-      ? (prevWorld.spider.posX >> FP_SHIFT) * TILE_SIZE_PX - camLeft * TILE_SIZE_PX
-      : currScrX;
-  const prevScrY =
-    prevWorld?.spider != null
-      ? (prevWorld.spider.posY >> FP_SHIFT) * TILE_SIZE_PX - camTop * TILE_SIZE_PX
-      : currScrY;
+  // Stage 2: project the click to WORLD pixels via the adapter and test there, so
+  // the hit box scales correctly under zoom (no manual camera-relative screen math).
+  const click = screenToWorld(screenX, screenY, viewState.surfaceCamera);
+  // Spider world-pixel position at tile granularity (matches the prior hit test);
+  // union the current + previous-tick boxes so the trailing interpolated edge still
+  // registers. When prevWorld is null the box is exactly the current sprite.
+  const currWorldX = (world.spider.posX >> FP_SHIFT) * TILE_SIZE_PX;
+  const currWorldY = (world.spider.posY >> FP_SHIFT) * TILE_SIZE_PX;
+  const prevWorldX =
+    prevWorld?.spider != null ? (prevWorld.spider.posX >> FP_SHIFT) * TILE_SIZE_PX : currWorldX;
+  const prevWorldY =
+    prevWorld?.spider != null ? (prevWorld.spider.posY >> FP_SHIFT) * TILE_SIZE_PX : currWorldY;
   const halfW = SPIDER_SPRITE_WIDTH / 2;
   const halfH = SPIDER_SPRITE_HEIGHT / 2;
   return (
-    screenX >= Math.min(currScrX, prevScrX) - halfW &&
-    screenX < Math.max(currScrX, prevScrX) + halfW &&
-    screenY >= Math.min(currScrY, prevScrY) - halfH &&
-    screenY < Math.max(currScrY, prevScrY) + halfH
+    click.worldX >= Math.min(currWorldX, prevWorldX) - halfW &&
+    click.worldX < Math.max(currWorldX, prevWorldX) + halfW &&
+    click.worldY >= Math.min(currWorldY, prevWorldY) - halfH &&
+    click.worldY < Math.max(currWorldY, prevWorldY) + halfH
   );
 }
 

--- a/src/input/underground-input.test.ts
+++ b/src/input/underground-input.test.ts
@@ -29,7 +29,7 @@ import { UndergroundTileState, ugSet, createUndergroundGrid } from '../sim/terra
 import { contextMenuState, hideContextMenu } from '../render/context-menu-state.js';
 import type { WorldState } from '../sim/types.js';
 import type { ViewState } from '../render/camera.js';
-import { VIEWPORT_WIDTH_TILES, VIEWPORT_HEIGHT_TILES } from '../render/camera.js';
+import { makeCameraView } from '../render/camera-adapter.js';
 import { PLAYER_COLONY_ID, ENEMY_COLONY_ID, UNDERGROUND_CEILING_ROW_Y } from '../sim/constants.js';
 import { MAX_COMMANDS_PER_TICK, type SimCommand } from '../sim/commands.js';
 
@@ -44,18 +44,10 @@ function makeViewState(
   return {
     activeView: 'underground',
     activeTool: tool,
-    surfaceCamera: {
-      x: 10,
-      y: 10,
-      viewportWidth: VIEWPORT_WIDTH_TILES,
-      viewportHeight: VIEWPORT_HEIGHT_TILES,
-    },
-    undergroundCamera: {
-      x: 10,
-      y: 10,
-      viewportWidth: VIEWPORT_WIDTH_TILES,
-      viewportHeight: VIEWPORT_HEIGHT_TILES,
-    },
+    // The underground tap/paint/chamber handlers take tile coords directly and
+    // never read camera fields; these CameraViews exist only to satisfy the type.
+    surfaceCamera: makeCameraView(160, 160),
+    undergroundCamera: makeCameraView(160, 160),
     undergroundVisited: true,
     activeUndergroundColonyId: colonyId,
     showPheromoneOverlay: true,

--- a/src/render/camera-adapter.test.ts
+++ b/src/render/camera-adapter.test.ts
@@ -1,0 +1,311 @@
+// camera-adapter.test.ts — Vitest tests for the pure zoom-aware camera adapter.
+//
+// Covers PLAN-stage2.md §E18 unit items for the adapter:
+//   - pure screen↔world at several zooms (no Phaser matrix), round-trip + center
+//   - screen→tile (continuous projection, integer tile floor, no camera-pos rounding)
+//   - custom center-aware per-axis clamp (incl. the asymmetric underground Y-only case)
+//   - cursor-anchored zoom recomputed per lerp step (no drift) + lerp convergence/cancel
+//   - pan ÷zoom (grab + sign) and time-based WASD ÷zoom (frame-rate independence)
+//   - per-view settle (lerp cancel + clamp) and minimap-nav (underground preserves depth)
+//   - LOD hysteresis (0.55 / 0.65, band holds prior mode)
+
+import { describe, it, expect } from 'vitest';
+import { CANVAS_W, CANVAS_H, TILE_SIZE_PX } from './sprites.js';
+import {
+  MIN_ZOOM,
+  MAX_ZOOM,
+  DEFAULT_ZOOM,
+  LOD_DOT_ENTER_ZOOM,
+  LOD_SPRITE_RETURN_ZOOM,
+  clampZoom,
+  resolveDotMode,
+  makeCameraView,
+  viewWorldWidth,
+  viewWorldHeight,
+  visibleWorldRect,
+  screenToWorld,
+  worldToScreen,
+  screenToTileZoom,
+  clampCameraView,
+  beginWheelZoom,
+  applyZoomAnchor,
+  stepZoomLerp,
+  cancelZoomLerp,
+  panByScreenDelta,
+  panByKeyboard,
+  settleEnteringView,
+  minimapNavTargets,
+  type CameraView,
+} from './camera-adapter.js';
+
+// World-pixel dimensions used across tests (PLAN grounding facts).
+const SURFACE_PX = 2048; // 128 tiles × 16
+const UG_W_PX = 2048; // 128 tiles × 16
+const UG_H_PX = 1024; // 64 tiles × 16
+
+function view(centerX: number, centerY: number, zoom: number): CameraView {
+  return { centerX, centerY, zoom, targetZoom: zoom };
+}
+
+// ---------------------------------------------------------------------------
+// constants & makeCameraView
+// ---------------------------------------------------------------------------
+
+describe('zoom constants & makeCameraView', () => {
+  it('clampZoom respects [MIN_ZOOM, MAX_ZOOM]', () => {
+    expect(clampZoom(5)).toBe(MAX_ZOOM);
+    expect(clampZoom(0.01)).toBe(MIN_ZOOM);
+    expect(clampZoom(1)).toBe(1);
+  });
+
+  it('makeCameraView clamps zoom and sets targetZoom == zoom', () => {
+    const a = makeCameraView(10, 20, 5);
+    expect(a.zoom).toBe(MAX_ZOOM);
+    expect(a.targetZoom).toBe(MAX_ZOOM);
+    const b = makeCameraView(10, 20, 0.01);
+    expect(b.zoom).toBe(MIN_ZOOM);
+    const c = makeCameraView(10, 20);
+    expect(c.zoom).toBe(DEFAULT_ZOOM);
+    expect(c.centerX).toBe(10);
+    expect(c.centerY).toBe(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// screen↔world projection
+// ---------------------------------------------------------------------------
+
+describe('screenToWorld / worldToScreen', () => {
+  for (const zoom of [0.2, 0.5, 1, 2]) {
+    it(`canvas center maps to camera center at zoom ${zoom}`, () => {
+      const v = view(1000, 500, zoom);
+      const { worldX, worldY } = screenToWorld(CANVAS_W / 2, CANVAS_H / 2, v);
+      expect(worldX).toBeCloseTo(1000, 6);
+      expect(worldY).toBeCloseTo(500, 6);
+      const { screenX, screenY } = worldToScreen(1000, 500, v);
+      expect(screenX).toBeCloseTo(CANVAS_W / 2, 6);
+      expect(screenY).toBeCloseTo(CANVAS_H / 2, 6);
+    });
+
+    it(`screen→world→screen round-trips at zoom ${zoom}`, () => {
+      const v = view(1234, 678, zoom);
+      const sx = 123;
+      const sy = 456;
+      const { worldX, worldY } = screenToWorld(sx, sy, v);
+      const { screenX, screenY } = worldToScreen(worldX, worldY, v);
+      expect(screenX).toBeCloseTo(sx, 6);
+      expect(screenY).toBeCloseTo(sy, 6);
+    });
+  }
+
+  it('1 screen px == 1/zoom world px horizontally', () => {
+    const v = view(0, 0, 0.5);
+    const a = screenToWorld(0, 0, v).worldX;
+    const b = screenToWorld(1, 0, v).worldX;
+    expect(b - a).toBeCloseTo(1 / 0.5, 9); // 2 world px per screen px at 0.5×
+  });
+});
+
+describe('screenToTileZoom', () => {
+  it('floors continuous world coords to the tile grid (no camera-pos rounding)', () => {
+    // centerX chosen so a fractional world X lands inside a known tile.
+    const v = view(446 + CANVAS_W / 2 / 1, 0, 1); // screenToWorld(0,..) = 446
+    const { tileX } = screenToTileZoom(0, CANVAS_H / 2, v);
+    expect(tileX).toBe(Math.floor(446 / TILE_SIZE_PX)); // 27
+  });
+
+  it('a fractional camera center does NOT snap the projection', () => {
+    // Two centers 0.4 tile apart can resolve the same screen px to different tiles —
+    // the projection is continuous, unlike the old floor-the-camera screenToTile.
+    const base = view(1000.0, 500.0, 1);
+    const shifted = view(1000.0 + 0.4 * TILE_SIZE_PX, 500.0, 1);
+    const a = screenToTileZoom(10, 10, base).tileX;
+    const b = screenToTileZoom(10, 10, shifted).tileX;
+    expect(b).toBeGreaterThanOrEqual(a); // monotonic with center, never rounded away
+  });
+});
+
+// ---------------------------------------------------------------------------
+// custom center-aware clamp
+// ---------------------------------------------------------------------------
+
+describe('clampCameraView', () => {
+  it('clamps center to [half, world − half] when world > viewport (zoom 1)', () => {
+    const lo = view(-9999, -9999, 1);
+    clampCameraView(lo, SURFACE_PX, SURFACE_PX);
+    expect(lo.centerX).toBeCloseTo(CANVAS_W / 2, 6); // 400
+    expect(lo.centerY).toBeCloseTo(CANVAS_H / 2, 6); // 296
+    const hi = view(99999, 99999, 1);
+    clampCameraView(hi, SURFACE_PX, SURFACE_PX);
+    expect(hi.centerX).toBeCloseTo(SURFACE_PX - CANVAS_W / 2, 6); // 1648
+    expect(hi.centerY).toBeCloseTo(SURFACE_PX - CANVAS_H / 2, 6); // 1752
+  });
+
+  it('centers an undersized world (strategic zoom-out shows whole 2048 width)', () => {
+    const v = view(50, 50, 0.2); // viewW = 4000 > 2048
+    clampCameraView(v, SURFACE_PX, SURFACE_PX);
+    expect(v.centerX).toBeCloseTo(SURFACE_PX / 2, 6); // 1024
+    expect(v.centerY).toBeCloseTo(SURFACE_PX / 2, 6);
+  });
+
+  it('handles the ASYMMETRIC underground case: clamp X, center Y (the setBounds-killer)', () => {
+    // zoom 0.5 underground: viewW=1600 < 2048 (X clamps), viewH=1184 > 1024 (Y centers).
+    const v = view(99999, 99999, 0.5);
+    clampCameraView(v, UG_W_PX, UG_H_PX);
+    expect(v.centerX).toBeCloseTo(UG_W_PX - viewWorldWidth(0.5) / 2, 6); // 2048 - 800 = 1248
+    expect(v.centerY).toBeCloseTo(UG_H_PX / 2, 6); // centered: 512
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cursor-anchored zoom
+// ---------------------------------------------------------------------------
+
+describe('cursor-anchored zoom (no drift across lerp)', () => {
+  it('beginWheelZoom multiplies & clamps targetZoom and captures the world point under the cursor', () => {
+    const v = view(1000, 500, 1);
+    const anchor = beginWheelZoom(v, 1.1, 600, 400);
+    expect(v.targetZoom).toBeCloseTo(1.1, 6);
+    expect(v.zoom).toBe(1); // zoom itself untouched until the lerp runs
+    expect(anchor.worldX).toBeCloseTo(screenToWorld(600, 400, v).worldX, 6);
+  });
+
+  it('clamps targetZoom at the limits', () => {
+    const v = view(0, 0, MAX_ZOOM);
+    beginWheelZoom(v, 4, 400, 296);
+    expect(v.targetZoom).toBe(MAX_ZOOM);
+    const w = view(0, 0, MIN_ZOOM);
+    beginWheelZoom(w, 0.1, 400, 296);
+    expect(w.targetZoom).toBe(MIN_ZOOM);
+  });
+
+  it('the anchored world point stays under the cursor at EVERY lerp step (no drift)', () => {
+    const v = view(1000, 500, 1);
+    const anchor = beginWheelZoom(v, 1.8, 612, 333);
+    for (let i = 0; i < 40; i++) {
+      stepZoomLerp(v, 0.25);
+      applyZoomAnchor(v, anchor);
+      clampCameraView(v, SURFACE_PX, SURFACE_PX);
+      // before clamping pulls it off-screen, the un-clamped invariant must hold; use a
+      // center well inside bounds so clamp is a no-op here.
+      const back = screenToWorld(anchor.screenX, anchor.screenY, v);
+      expect(back.worldX).toBeCloseTo(anchor.worldX, 4);
+      expect(back.worldY).toBeCloseTo(anchor.worldY, 4);
+    }
+  });
+
+  it('stepZoomLerp converges and snaps exactly to targetZoom', () => {
+    const v = view(0, 0, 1);
+    v.targetZoom = 0.2;
+    let done = false;
+    for (let i = 0; i < 200 && !done; i++) done = stepZoomLerp(v, 0.3);
+    expect(done).toBe(true);
+    expect(v.zoom).toBe(0.2);
+  });
+
+  it('cancelZoomLerp snaps targetZoom to the current zoom', () => {
+    const v = view(0, 0, 0.7);
+    v.targetZoom = 1.9;
+    cancelZoomLerp(v);
+    expect(v.targetZoom).toBe(0.7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pan
+// ---------------------------------------------------------------------------
+
+describe('pan ÷zoom', () => {
+  it('panByScreenDelta divides by zoom and moves the center opposite the cursor', () => {
+    const v = view(1000, 500, 0.5);
+    panByScreenDelta(v, 100, 50);
+    expect(v.centerX).toBeCloseTo(1000 - 100 / 0.5, 6); // 800
+    expect(v.centerY).toBeCloseTo(500 - 50 / 0.5, 6); // 400
+  });
+
+  it('panByKeyboard is frame-rate independent (two half-steps == one full-step)', () => {
+    const a = view(1000, 500, 1);
+    const b = view(1000, 500, 1);
+    panByKeyboard(a, 1, 0, 0.1, 600);
+    panByKeyboard(b, 1, 0, 0.05, 600);
+    panByKeyboard(b, 1, 0, 0.05, 600);
+    expect(a.centerX).toBeCloseTo(b.centerX, 9);
+    expect(a.centerX).toBeCloseTo(1000 + (600 * 0.1) / 1, 6); // +60
+  });
+
+  it('panByKeyboard divides by zoom (slower world travel when zoomed in)', () => {
+    const v = view(0, 0, 2);
+    panByKeyboard(v, 0, 1, 1, 600);
+    expect(v.centerY).toBeCloseTo((600 * 1) / 2, 6); // 300 world px, not 600
+  });
+});
+
+// ---------------------------------------------------------------------------
+// view settle + minimap nav
+// ---------------------------------------------------------------------------
+
+describe('settleEnteringView', () => {
+  it('cancels the in-flight lerp and clamps at the restored zoom', () => {
+    const v: CameraView = { centerX: 99999, centerY: 99999, zoom: 1, targetZoom: 1.7 };
+    settleEnteringView(v, SURFACE_PX, SURFACE_PX);
+    expect(v.targetZoom).toBe(1); // lerp cancelled
+    expect(v.centerX).toBeCloseTo(SURFACE_PX - CANVAS_W / 2, 6);
+    expect(v.centerY).toBeCloseTo(SURFACE_PX - CANVAS_H / 2, 6);
+  });
+});
+
+describe('minimapNavTargets', () => {
+  it('sets surface center to the click and X-links underground while preserving its depth', () => {
+    const surface = view(100, 200, 1);
+    const underground = view(300, 800, 1);
+    const t = minimapNavTargets(surface, underground, 1500, 250);
+    expect(t.surfaceCenterX).toBe(1500);
+    expect(t.surfaceCenterY).toBe(250);
+    expect(t.undergroundCenterX).toBe(1500); // X-link
+    expect(t.undergroundCenterY).toBe(800); // depth preserved, NOT the surface Y
+  });
+});
+
+// ---------------------------------------------------------------------------
+// visibleWorldRect
+// ---------------------------------------------------------------------------
+
+describe('visibleWorldRect', () => {
+  it('is the zoomed window centered on the camera', () => {
+    const v = view(1000, 500, 1);
+    const r = visibleWorldRect(v);
+    expect(r.left).toBeCloseTo(600, 6);
+    expect(r.right).toBeCloseTo(1400, 6);
+    expect(r.top).toBeCloseTo(204, 6);
+    expect(r.bottom).toBeCloseTo(796, 6);
+  });
+
+  it('grows as zoom decreases', () => {
+    const wide = visibleWorldRect(view(0, 0, 0.2));
+    expect(wide.right - wide.left).toBeCloseTo(viewWorldWidth(0.2), 6);
+    expect(wide.bottom - wide.top).toBeCloseTo(viewWorldHeight(0.2), 6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LOD hysteresis (§E18) — the stateful dot/sprite mode resolver for Phase-B
+// ---------------------------------------------------------------------------
+
+describe('resolveDotMode hysteresis', () => {
+  it('enters dot mode at/below LOD_DOT_ENTER_ZOOM regardless of prior mode', () => {
+    expect(resolveDotMode(LOD_DOT_ENTER_ZOOM, false)).toBe(true);
+    expect(resolveDotMode(0.4, false)).toBe(true);
+    expect(resolveDotMode(0.2, true)).toBe(true);
+  });
+
+  it('returns to sprites at/above LOD_SPRITE_RETURN_ZOOM regardless of prior mode', () => {
+    expect(resolveDotMode(LOD_SPRITE_RETURN_ZOOM, true)).toBe(false);
+    expect(resolveDotMode(1, true)).toBe(false);
+    expect(resolveDotMode(2, false)).toBe(false);
+  });
+
+  it('inside the hysteresis band, holds the prior mode (no thrash)', () => {
+    expect(resolveDotMode(0.6, true)).toBe(true);
+    expect(resolveDotMode(0.6, false)).toBe(false);
+  });
+});

--- a/src/render/camera-adapter.ts
+++ b/src/render/camera-adapter.ts
@@ -1,0 +1,410 @@
+// camera-adapter.ts — Stage 2 controls rework (issue #18): the pure, zoom-aware
+// screen↔world projection + camera-control math that is the SINGLE source of truth
+// for the continuous-zoom camera.
+//
+// This file is in src/render/ — float arithmetic is permitted (ARCHITECTURE.md
+// Principle 6). It has NO Phaser imports and NO DOM globals, so it is fully testable
+// under Node + Vitest. The thin Phaser-bound driver (which calls cameras.main.setZoom
+// / centerOn) lives elsewhere (camera-controller / game-scene) and delegates ALL math
+// to these functions.
+//
+// Why a hand-rolled projection rather than Phaser's getWorldPoint()/preRender():
+//   - getWorldPoint() reads matrices that are only refreshed in preRender; right after
+//     an input-driven zoom change they are STALE, so hit-testing against them drifts.
+//   - Input must never call preRender() itself.
+// So we keep an authoritative {centerX, centerY, zoom} in WORLD PIXELS and DRIVE the
+// Phaser camera from it (setZoom + centerOn). Every screen↔world / clamp / cull / pan /
+// zoom computation goes through the pure formulas here, never through Phaser.
+//
+// Plan: plan/controls-rework/PLAN-stage2.md §A (camera adapter, projection, per-view
+// state) and §D (pan/WASD ÷zoom). Grilled via Codex (R1-2/4, R2-1/2/3/4, R3, R4).
+
+import { CANVAS_W, CANVAS_H, TILE_SIZE_PX } from './sprites.js';
+
+// ---------------------------------------------------------------------------
+// Zoom limits
+// ---------------------------------------------------------------------------
+
+/** Minimum (most zoomed-OUT) camera zoom — strategic whole-nest view. PLAN §A3. */
+export const MIN_ZOOM = 0.2;
+
+/** Maximum (most zoomed-IN) camera zoom. PLAN §A3. */
+export const MAX_ZOOM = 2;
+
+/** Default camera zoom on fresh boot / reset — 1 world px = 1 screen px (parity with
+ *  the pre-Stage-2 fixed 50×37-tile viewport). PLAN §A3. */
+export const DEFAULT_ZOOM = 1;
+
+/** Clamp a zoom value to [MIN_ZOOM, MAX_ZOOM]. */
+export function clampZoom(zoom: number): number {
+  return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom));
+}
+
+// ---------------------------------------------------------------------------
+// Ant-dot LOD hysteresis (PLAN §C13)
+// ---------------------------------------------------------------------------
+
+/**
+ * Two thresholds, NOT one, so the smoothed zoom oscillating around a single boundary
+ * cannot thrash the renderer between detailed sprites and strategic dots:
+ *   - zooming OUT, detailed sprites persist until zoom drops to LOD_DOT_ENTER_ZOOM;
+ *   - zooming IN, strategic dots persist until zoom rises to LOD_SPRITE_RETURN_ZOOM.
+ * The worst-case DETAILED frame is therefore at ~LOD_DOT_ENTER_ZOOM (most world still
+ * drawn as sprites), NOT at the upper edge (R5-1). Consumed by the Phase-B dot-LOD
+ * renderer; exported + unit-tested now as the foundation for that wiring (§E18).
+ */
+export const LOD_DOT_ENTER_ZOOM = 0.55;
+export const LOD_SPRITE_RETURN_ZOOM = 0.65;
+
+/**
+ * Resolve the LOD mode from the current zoom and the PREVIOUS mode (hysteresis is
+ * stateful — the band between the two thresholds keeps whatever mode was already
+ * active). Returns true when strategic dot mode should be active.
+ *
+ * @param zoom - current (smoothed) camera zoom
+ * @param wasDotMode - whether dot mode was active last frame
+ */
+export function resolveDotMode(zoom: number, wasDotMode: boolean): boolean {
+  if (zoom <= LOD_DOT_ENTER_ZOOM) return true;
+  if (zoom >= LOD_SPRITE_RETURN_ZOOM) return false;
+  return wasDotMode; // inside the hysteresis band — hold the prior mode
+}
+
+/**
+ * Screen-constant size (px) of a strategic ant/brood dot. Drawn at ANT_DOT_SCREEN_PX /
+ * zoom world px so it stays ~constant on screen as the camera zooms out (§C13).
+ */
+export const ANT_DOT_SCREEN_PX = 2;
+
+// ---------------------------------------------------------------------------
+// CameraView — the authoritative per-view camera state (WORLD PIXELS)
+// ---------------------------------------------------------------------------
+
+/**
+ * CameraView — authoritative camera state for ONE view, in world pixels.
+ *
+ * centerX/centerY are the world-pixel coordinates the viewport is centered on (what
+ * Phaser's centerOn(centerX, centerY) is fed). zoom is the Phaser camera zoom (screen
+ * px per world px). targetZoom is the in-flight wheel-zoom destination; it equals zoom
+ * whenever no zoom-lerp is running. These four fields ARE the per-view snapshot stored
+ * for the inactive view and published read-only for the Playwright hook (PLAN §A4).
+ *
+ * NB: Phaser scrollX/scrollY terminology is deliberately NOT used here — under zoom,
+ * Phaser scrollX ≠ the visible-left world pixel, so exposing it would invite the exact
+ * projection bugs this adapter exists to prevent. scrollX lives only inside the driver.
+ */
+export interface CameraView {
+  centerX: number;
+  centerY: number;
+  zoom: number;
+  targetZoom: number;
+}
+
+/** Construct a CameraView centered on a world-pixel point at a given zoom. */
+export function makeCameraView(
+  centerX: number,
+  centerY: number,
+  zoom: number = DEFAULT_ZOOM,
+): CameraView {
+  const z = clampZoom(zoom);
+  return { centerX, centerY, zoom: z, targetZoom: z };
+}
+
+// ---------------------------------------------------------------------------
+// Visible-window helpers
+// ---------------------------------------------------------------------------
+
+/** Width in world pixels of the visible window at a given zoom (CANVAS_W / zoom). */
+export function viewWorldWidth(zoom: number): number {
+  return CANVAS_W / zoom;
+}
+
+/** Height in world pixels of the visible window at a given zoom (CANVAS_H / zoom). */
+export function viewWorldHeight(zoom: number): number {
+  return CANVAS_H / zoom;
+}
+
+/**
+ * World-pixel rectangle currently visible, for culling dynamic layers. Computed from
+ * the CURRENT {centerX, centerY, zoom} (NOT a stale Phaser worldView). PLAN §C14.
+ */
+export interface WorldRect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+export function visibleWorldRect(v: CameraView): WorldRect {
+  const halfW = viewWorldWidth(v.zoom) / 2;
+  const halfH = viewWorldHeight(v.zoom) / 2;
+  return {
+    left: v.centerX - halfW,
+    top: v.centerY - halfH,
+    right: v.centerX + halfW,
+    bottom: v.centerY + halfH,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure screen↔world projection (the ONLY conversion in the codebase)
+// ---------------------------------------------------------------------------
+
+/**
+ * screen→world (world pixels). Derivation: the visible window is CANVAS_W/zoom world px
+ * wide, centered on centerX; a screen pixel sx maps linearly across it, so
+ *   worldX = centerX + (sx − CANVAS_W/2) / zoom.
+ * This agrees with Phaser's render of camera.centerOn(centerX, centerY) at zoom, but is
+ * computed without touching any Phaser matrix (no staleness after a zoom change).
+ */
+export function screenToWorld(
+  screenX: number,
+  screenY: number,
+  v: CameraView,
+): { worldX: number; worldY: number } {
+  return {
+    worldX: v.centerX + (screenX - CANVAS_W / 2) / v.zoom,
+    worldY: v.centerY + (screenY - CANVAS_H / 2) / v.zoom,
+  };
+}
+
+/** world→screen (screen pixels) — exact inverse of screenToWorld. */
+export function worldToScreen(
+  worldX: number,
+  worldY: number,
+  v: CameraView,
+): { screenX: number; screenY: number } {
+  return {
+    screenX: (worldX - v.centerX) * v.zoom + CANVAS_W / 2,
+    screenY: (worldY - v.centerY) * v.zoom + CANVAS_H / 2,
+  };
+}
+
+/**
+ * screen→tile. Projects to continuous world pixels then floors to the tile grid.
+ *
+ * Unlike the pre-Stage-2 screenToTile, the camera CENTER is NOT floored first: the
+ * baked-RT + Phaser-camera projection is continuous, so flooring the camera position
+ * would reintroduce the sub-pixel snapping PR6 removed. Only the final tile index is
+ * floored (a click resolves to the tile it visually lands on). PLAN §D / Risks.
+ */
+export function screenToTileZoom(
+  screenX: number,
+  screenY: number,
+  v: CameraView,
+): { tileX: number; tileY: number } {
+  const { worldX, worldY } = screenToWorld(screenX, screenY, v);
+  return {
+    tileX: Math.floor(worldX / TILE_SIZE_PX),
+    tileY: Math.floor(worldY / TILE_SIZE_PX),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Custom center-aware clamp (PLAN §A2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Clamp the camera center so the visible window never shows outside the world, with a
+ * PER-AXIS center-when-undersized rule. Mutates v in place.
+ *
+ * Phaser's setBounds can't do this: useBounds is a single flag (not per-axis) and it
+ * PINS (does not center) an undersized world — fatal underground, where at mid zoom
+ * only the Y axis is undersized (2048×1024 world vs a taller-than-1024 window) while X
+ * is not. So we never enable setBounds and run this after every camera mutation:
+ *   - if the world is narrower/shorter than the zoomed viewport on an axis → CENTER it;
+ *   - otherwise clamp the center to [halfView, worldPx − halfView] on that axis.
+ *
+ * @param v - camera view (mutated)
+ * @param worldPxW - world width in pixels (e.g. 128 tiles × 16 = 2048)
+ * @param worldPxH - world height in pixels (e.g. 64 tiles × 16 = 1024 underground)
+ */
+export function clampCameraView(v: CameraView, worldPxW: number, worldPxH: number): void {
+  const viewW = viewWorldWidth(v.zoom);
+  const viewH = viewWorldHeight(v.zoom);
+  const halfW = viewW / 2;
+  const halfH = viewH / 2;
+
+  if (worldPxW <= viewW) {
+    v.centerX = worldPxW / 2;
+  } else {
+    v.centerX = Math.max(halfW, Math.min(worldPxW - halfW, v.centerX));
+  }
+
+  if (worldPxH <= viewH) {
+    v.centerY = worldPxH / 2;
+  } else {
+    v.centerY = Math.max(halfH, Math.min(worldPxH - halfH, v.centerY));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cursor-anchored zoom (PLAN §A3)
+// ---------------------------------------------------------------------------
+
+/**
+ * ZoomAnchor — the fixed screen point + the world point under it at the moment the
+ * wheel fired. Re-applied every interpolation frame so the world point under the cursor
+ * stays put while zoom lerps (anchoring only on the wheel event drifts mid-lerp).
+ */
+export interface ZoomAnchor {
+  screenX: number;
+  screenY: number;
+  worldX: number;
+  worldY: number;
+}
+
+/**
+ * Begin a cursor-anchored zoom. Multiplies targetZoom by `factor` (clamped) and returns
+ * the anchor (the world point currently under the cursor) for the lerp to hold fixed.
+ * Does NOT mutate the current zoom — only the target; the per-frame lerp moves zoom.
+ *
+ * @param v - camera view (only targetZoom is mutated)
+ * @param factor - zoom multiplier (>1 zoom in, <1 zoom out)
+ * @param screenX - cursor screen X (anchor)
+ * @param screenY - cursor screen Y (anchor)
+ */
+export function beginWheelZoom(
+  v: CameraView,
+  factor: number,
+  screenX: number,
+  screenY: number,
+): ZoomAnchor {
+  const { worldX, worldY } = screenToWorld(screenX, screenY, v);
+  v.targetZoom = clampZoom(v.targetZoom * factor);
+  return { screenX, screenY, worldX, worldY };
+}
+
+/**
+ * Re-anchor the camera center so the anchor's world point sits under its screen point at
+ * the current zoom. Solving screenToWorld(screenX) == worldX for centerX:
+ *   worldX = centerX + (screenX − CANVAS_W/2)/zoom  ⇒  centerX = worldX − (screenX − CANVAS_W/2)/zoom.
+ * Mutates v. Call AFTER each zoom-lerp step, then clamp.
+ */
+export function applyZoomAnchor(v: CameraView, anchor: ZoomAnchor): void {
+  v.centerX = anchor.worldX - (anchor.screenX - CANVAS_W / 2) / v.zoom;
+  v.centerY = anchor.worldY - (anchor.screenY - CANVAS_H / 2) / v.zoom;
+}
+
+/** Smallest zoom delta treated as "arrived" — snaps to target and ends the lerp. */
+export const ZOOM_LERP_EPSILON = 0.0005;
+
+/**
+ * Advance the zoom toward targetZoom by interpolation factor t (0..1). Returns true when
+ * the lerp has completed (zoom snapped exactly to targetZoom this step). Mutates v.zoom.
+ *
+ * The caller drives anchoring: after this returns, call applyZoomAnchor + clampCameraView
+ * so the cursor-anchored world point is preserved at the new zoom every frame.
+ */
+export function stepZoomLerp(v: CameraView, t: number): boolean {
+  const diff = v.targetZoom - v.zoom;
+  if (Math.abs(diff) <= ZOOM_LERP_EPSILON) {
+    v.zoom = v.targetZoom;
+    return true;
+  }
+  v.zoom += diff * t;
+  return false;
+}
+
+/** Cancel any in-flight zoom-lerp by snapping targetZoom to the current zoom. */
+export function cancelZoomLerp(v: CameraView): void {
+  v.targetZoom = v.zoom;
+}
+
+// ---------------------------------------------------------------------------
+// Pan (PLAN §D15)
+// ---------------------------------------------------------------------------
+
+/**
+ * Grab-pan by a screen-pixel delta (gesture-arbiter drag + middle-drag). The dragged
+ * world point follows the cursor, so a +dx screen move (pointer →) shifts the camera
+ * center by −dx/zoom world px (content moves right with the cursor). ÷zoom keeps the
+ * drag 1:1 with the cursor at any zoom. Mutates v. Caller clamps afterward.
+ */
+export function panByScreenDelta(v: CameraView, deltaScreenX: number, deltaScreenY: number): void {
+  v.centerX -= deltaScreenX / v.zoom;
+  v.centerY -= deltaScreenY / v.zoom;
+}
+
+/** Keyboard pan speed in SCREEN pixels per second (frame-rate independent). PLAN §D15. */
+export const KEYBOARD_PAN_SPEED_PX_PER_SEC = 600;
+
+/**
+ * Time-based WASD/arrow pan. Applies speed × dt ÷ zoom world px along the unit-ish
+ * direction (dirX/dirY ∈ {−1,0,1}). Replaces the old fixed per-frame tile delta, which
+ * was frame-rate dependent. Mutates v. Caller clamps afterward.
+ *
+ * @param v - camera view (mutated)
+ * @param dirX - −1 (left) / 0 / +1 (right)
+ * @param dirY - −1 (up) / 0 / +1 (down)
+ * @param dtSeconds - frame delta in seconds
+ * @param speedPxPerSec - screen px/sec (defaults to KEYBOARD_PAN_SPEED_PX_PER_SEC)
+ */
+export function panByKeyboard(
+  v: CameraView,
+  dirX: number,
+  dirY: number,
+  dtSeconds: number,
+  speedPxPerSec: number = KEYBOARD_PAN_SPEED_PX_PER_SEC,
+): void {
+  const stepWorld = (speedPxPerSec * dtSeconds) / v.zoom;
+  v.centerX += dirX * stepWorld;
+  v.centerY += dirY * stepWorld;
+}
+
+// ---------------------------------------------------------------------------
+// Per-view toggle (PLAN §A5) and minimap nav (PLAN §A6)
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply the entering-view restore half of the atomic toggle algorithm (PLAN §A5). The
+ * leaving view's snapshot is preserved automatically because both CameraViews persist
+ * (mutated in place). For the entering view we:
+ *   1. cancel any in-flight zoom-lerp (targetZoom ← zoom) so the toggle doesn't carry a
+ *      stale zoom destination across views;
+ *   2. (caller has already restored the entering view's stored zoom and, for a first
+ *      underground visit, its initial center BEFORE the X-link — see game-scene wiring);
+ *   3. clamp the restored center at the restored zoom.
+ * Restoring zoom BEFORE clamping matters: the clamp's center-when-undersized test
+ * depends on the zoomed viewport size, which depends on zoom.
+ *
+ * @param entering - the view being switched TO (mutated)
+ * @param worldPxW - entering view's world width px
+ * @param worldPxH - entering view's world height px
+ */
+export function settleEnteringView(entering: CameraView, worldPxW: number, worldPxH: number): void {
+  cancelZoomLerp(entering);
+  clampCameraView(entering, worldPxW, worldPxH);
+}
+
+/**
+ * Minimap-nav target (PLAN §A6). The minimap is a SURFACE map; a click sets the SURFACE
+ * view's center to the clicked world point, and — when underground is the active view —
+ * the underground view's center X is linked to it while its DEPTH (centerY) is preserved
+ * (NOT "centerOn whichever camera is active", which would jump the underground depth).
+ *
+ * This helper computes the new centers without committing them, so the caller can clamp
+ * each view with its own world dimensions. Mutates neither input view.
+ *
+ * @param surface - current surface CameraView (read)
+ * @param underground - current underground CameraView (read)
+ * @param worldX - clicked world-pixel X
+ * @param worldY - clicked world-pixel Y (surface depth)
+ */
+export function minimapNavTargets(
+  surface: CameraView,
+  underground: CameraView,
+  worldX: number,
+  worldY: number,
+): {
+  surfaceCenterX: number;
+  surfaceCenterY: number;
+  undergroundCenterX: number;
+  undergroundCenterY: number;
+} {
+  return {
+    surfaceCenterX: worldX,
+    surfaceCenterY: worldY,
+    undergroundCenterX: worldX, // X-link
+    undergroundCenterY: underground.centerY, // preserve underground depth
+  };
+}

--- a/src/render/camera-controller.test.ts
+++ b/src/render/camera-controller.test.ts
@@ -1,0 +1,189 @@
+// camera-controller.test.ts — Vitest tests for the stateful CameraController glue.
+//
+// camera-adapter.test.ts covers the pure math; this file covers the controller's
+// state-machine — the in-flight `anchor` lifecycle and the order in which it drives the
+// adapter — which is exercised by no other test. Focus areas (PLAN-stage2.md §E18):
+//   - apply() pushes zoom THEN center onto the Phaser camera
+//   - beginZoom records the anchor; tickZoomLerp holds it under the cursor each frame
+//   - the zoom-at-limit early-return that DISCARDS an anchor (zoom === targetZoom)
+//   - the final-step ordering: applyZoomAnchor is applied at the final zoom, THEN the
+//     anchor is nulled (a reversed order would drift the cursor point by one frame)
+//   - cancel() drops the anchor (e.g. across a view toggle)
+//
+// The Phaser camera is faked: the controller's only camera touch-points are
+// setRoundPixels / setZoom / centerOn, so a recording stub cast through the camera type
+// is sufficient (no Phaser runtime, matching the Node + Vitest constraint).
+
+import { describe, it, expect } from 'vitest';
+import type * as Phaser from 'phaser';
+import { CameraController } from './camera-controller.js';
+import {
+  MIN_ZOOM,
+  MAX_ZOOM,
+  applyZoomAnchor,
+  screenToWorld,
+  type CameraView,
+} from './camera-adapter.js';
+
+// World-pixel dimensions (PLAN grounding facts: 128×128 surface tiles × 16).
+const SURFACE_PX = 2048;
+
+function view(centerX: number, centerY: number, zoom: number): CameraView {
+  return { centerX, centerY, zoom, targetZoom: zoom };
+}
+
+/**
+ * Recording stand-in for the Phaser camera. Captures the controller's only camera
+ * touch-points; lastZoom/lastCenter reflect the most recent apply() so projection-order
+ * and final-frame state can be asserted without a Phaser runtime.
+ */
+class FakeCamera {
+  roundPixels = true;
+  lastZoom: number | null = null;
+  lastCenter: { x: number; y: number } | null = null;
+  setRoundPixels(value: boolean): this {
+    this.roundPixels = value;
+    return this;
+  }
+  setZoom(value: number): this {
+    this.lastZoom = value;
+    return this;
+  }
+  centerOn(x: number, y: number): this {
+    this.lastCenter = { x, y };
+    return this;
+  }
+}
+
+function makeController(): { ctrl: CameraController; cam: FakeCamera } {
+  const cam = new FakeCamera();
+  const ctrl = new CameraController(cam as unknown as Phaser.Cameras.Scene2D.Camera);
+  return { ctrl, cam };
+}
+
+describe('CameraController', () => {
+  it('constructor disables pixel rounding (continuous sub-pixel pan)', () => {
+    const { cam } = makeController();
+    expect(cam.roundPixels).toBe(false);
+  });
+
+  it('apply() pushes zoom and center from the view onto the camera', () => {
+    const { ctrl, cam } = makeController();
+    ctrl.apply(view(1000, 500, 1.5));
+    expect(cam.lastZoom).toBe(1.5);
+    expect(cam.lastCenter).toEqual({ x: 1000, y: 500 });
+  });
+
+  it('beginZoom sets targetZoom and records the anchor under the cursor', () => {
+    const { ctrl } = makeController();
+    const v = view(1000, 500, 1);
+    ctrl.beginZoom(v, 1.15, 600, 400);
+    expect(v.targetZoom).toBeCloseTo(1.15, 6);
+    expect(v.zoom).toBe(1); // zoom itself moves only via tickZoomLerp
+  });
+
+  it('tickZoomLerp is a no-op (and discards the anchor) when zoom === targetZoom', () => {
+    const { ctrl } = makeController();
+    const v = view(1000, 500, 1); // zoom === targetZoom: no lerp in flight
+    // Plant an anchor as if a wheel notch had been clamped to a no-op at the limit.
+    ctrl.beginZoom(v, 1, 600, 400); // factor 1 → targetZoom unchanged → still no lerp
+    const before = { centerX: v.centerX, centerY: v.centerY };
+    ctrl.tickZoomLerp(v, SURFACE_PX, SURFACE_PX);
+    // Center must NOT move (a stale anchor applied here would drift it).
+    expect(v.centerX).toBe(before.centerX);
+    expect(v.centerY).toBe(before.centerY);
+  });
+
+  it('zoom-at-limit notch DISCARDS its anchor so a later lerp cannot re-apply it', () => {
+    const { ctrl } = makeController();
+    const v = view(1000, 500, MAX_ZOOM);
+    // A wheel notch at the zoom-in limit: targetZoom clamps back to the current zoom, so
+    // no lerp runs — but beginZoom recorded an off-center anchor that MUST be discarded.
+    ctrl.beginZoom(v, 4, 612, 333);
+    expect(v.targetZoom).toBe(MAX_ZOOM);
+
+    // The early-return tick fires (zoom === targetZoom) and must null that stale anchor.
+    const before = { centerX: v.centerX, centerY: v.centerY };
+    ctrl.tickZoomLerp(v, SURFACE_PX, SURFACE_PX);
+    expect(v.centerX).toBe(before.centerX);
+    expect(v.centerY).toBe(before.centerY);
+
+    // Now a genuine lerp begins WITHOUT a fresh anchor (e.g. a non-wheel zoom path):
+    // arm targetZoom directly. If the at-limit anchor was not discarded, this step would
+    // re-center on the OLD (612,333) cursor point and the center would jump.
+    v.targetZoom = MIN_ZOOM;
+    ctrl.tickZoomLerp(v, SURFACE_PX, SURFACE_PX);
+    expect(v.zoom).not.toBe(MAX_ZOOM); // lerp advanced
+    expect(v.centerX).toBe(before.centerX); // anchor was discarded → no re-center
+    expect(v.centerY).toBe(before.centerY);
+  });
+
+  it('tickZoomLerp holds the cursor world point fixed across every frame', () => {
+    const { ctrl } = makeController();
+    const v = view(1000, 500, 1);
+    ctrl.beginZoom(v, 1.8, 612, 333);
+    const anchorWorld = screenToWorld(612, 333, v);
+    for (let i = 0; i < 40; i++) {
+      ctrl.tickZoomLerp(v, SURFACE_PX, SURFACE_PX);
+      // Center well inside bounds → clamp is a no-op; the cursor's world point must
+      // still project back under the cursor screen point.
+      const back = screenToWorld(612, 333, v);
+      expect(back.worldX).toBeCloseTo(anchorWorld.worldX, 4);
+      expect(back.worldY).toBeCloseTo(anchorWorld.worldY, 4);
+    }
+    expect(v.zoom).toBe(v.targetZoom); // converged
+  });
+
+  it('final lerp step applies the anchor AT the final zoom BEFORE nulling it (no 1-frame drift)', () => {
+    const { ctrl } = makeController();
+    const v = view(1000, 500, 1);
+    // The anchor is private; we assert its lifecycle purely through observable center.
+    const wheelAnchor = screenToWorld(612, 333, v);
+    ctrl.beginZoom(v, 1.6, 612, 333);
+    // Run to convergence.
+    let prevZoom = v.zoom;
+    for (let i = 0; i < 100; i++) {
+      ctrl.tickZoomLerp(v, SURFACE_PX, SURFACE_PX);
+      if (v.zoom === v.targetZoom && v.zoom === prevZoom) break;
+      prevZoom = v.zoom;
+    }
+    expect(v.zoom).toBe(v.targetZoom);
+    // The center on the final frame must equal applyZoomAnchor evaluated at the FINAL
+    // zoom — i.e. the anchor was applied before being dropped. Reconstruct the expected
+    // center independently from the adapter.
+    const expected: CameraView = { ...v };
+    applyZoomAnchor(expected, {
+      screenX: 612,
+      screenY: 333,
+      worldX: wheelAnchor.worldX,
+      worldY: wheelAnchor.worldY,
+    });
+    expect(v.centerX).toBeCloseTo(expected.centerX, 6);
+    expect(v.centerY).toBeCloseTo(expected.centerY, 6);
+
+    // And the anchor is now dropped: a further tick (zoom === targetZoom) is inert.
+    const after = { centerX: v.centerX, centerY: v.centerY };
+    ctrl.tickZoomLerp(v, SURFACE_PX, SURFACE_PX);
+    expect(v.centerX).toBe(after.centerX);
+    expect(v.centerY).toBe(after.centerY);
+  });
+
+  it('cancel() drops the in-flight anchor so a later lerp does not re-apply it', () => {
+    const { ctrl } = makeController();
+    const v = view(1000, 500, 1);
+    ctrl.beginZoom(v, 1.6, 612, 333); // anchor recorded, lerp armed
+    ctrl.tickZoomLerp(v, SURFACE_PX, SURFACE_PX); // one step in
+    ctrl.cancel(v); // e.g. across a view toggle
+    expect(v.targetZoom).toBe(v.zoom); // lerp cancelled (adapter behavior)
+    // Re-arm a lerp WITHOUT a new anchor by nudging targetZoom directly; the dropped
+    // anchor must NOT resurface — center moves only by the clamp, not by re-anchoring.
+    const beforeCenter = { centerX: v.centerX, centerY: v.centerY };
+    const beforeZoom = v.zoom;
+    v.targetZoom = MIN_ZOOM; // lerp now in flight again, anchor still null
+    ctrl.tickZoomLerp(v, SURFACE_PX, SURFACE_PX);
+    // Zoom advanced, but the cleared anchor did not re-center toward the old cursor point.
+    expect(v.zoom).not.toBe(beforeZoom);
+    expect(v.centerX).toBe(beforeCenter.centerX); // no re-anchor (well inside bounds)
+    expect(v.centerY).toBe(beforeCenter.centerY);
+  });
+});

--- a/src/render/camera-controller.ts
+++ b/src/render/camera-controller.ts
@@ -1,0 +1,100 @@
+// camera-controller.ts — Stage 2 controls rework (issue #18): the thin Phaser-bound
+// driver for the continuous-zoom camera. This is the ONLY place in the codebase that
+// calls cameras.main.setZoom / centerOn. All math is delegated to the pure
+// camera-adapter (the single screen↔world authority); this class just pushes the
+// adapter's authoritative CameraView state onto the live Phaser camera and runs the
+// per-frame zoom-lerp.
+//
+// Why centerOn + setZoom is sufficient (no manual scrollX): Phaser centers the view on
+// the camera midpoint = scrollX + width/2 and expands the worldView around it by
+// 1/zoom, so a world→screen point maps to `(worldX − centerX)·zoom + width/2`. That is
+// exactly the adapter's worldToScreen formula, so driving the camera with
+// centerOn(centerX, centerY) + setZoom(zoom) keeps Phaser's projection in lockstep with
+// the adapter's pure formula at every zoom — no Phaser matrix is ever read for input.
+//
+// No setBounds: useBounds is a single flag that can't clamp per-axis and PINS (not
+// centers) an undersized world (fatal underground). The adapter's custom center-aware
+// clampCameraView handles bounds instead.
+
+import type * as Phaser from 'phaser';
+import {
+  type CameraView,
+  type ZoomAnchor,
+  beginWheelZoom,
+  stepZoomLerp,
+  applyZoomAnchor,
+  clampCameraView,
+  cancelZoomLerp,
+} from './camera-adapter.js';
+
+/** Per-wheel-notch zoom multiplier (a notch zooms in by ×1.15, out by ÷1.15). */
+export const WHEEL_ZOOM_STEP = 1.15;
+
+/**
+ * Per-frame interpolation factor toward targetZoom. A fixed factor gives an
+ * exponential ease (~snappy in ~150 ms at 60 fps); zoom smoothing is cosmetic, so —
+ * unlike pan/WASD — it is not frame-rate normalized (the adapter snaps to the target
+ * within ZOOM_LERP_EPSILON, so it always terminates).
+ */
+const ZOOM_LERP_RATE = 0.18;
+
+/**
+ * CameraController — binds a Phaser camera to a pure CameraView. Construct once per
+ * GameScene with cameras.main; the active view's CameraView is passed into each method
+ * (the controller is stateless except for the in-flight wheel anchor).
+ */
+export class CameraController {
+  private readonly camera: Phaser.Cameras.Scene2D.Camera;
+  /** The fixed screen point + world point under it for the in-flight wheel zoom. */
+  private anchor: ZoomAnchor | null = null;
+
+  constructor(camera: Phaser.Cameras.Scene2D.Camera) {
+    this.camera = camera;
+    // Crisp + smooth pan: the camera must NOT round pixels (continuous sub-pixel pan;
+    // the snapping PR6 removed must not return), and we never enable bounds.
+    this.camera.setRoundPixels(false);
+  }
+
+  /**
+   * Push the authoritative CameraView onto the Phaser camera (zoom THEN center — order
+   * is irrelevant since centerOn is zoom-independent, but zoom first keeps worldView
+   * consistent for any same-frame reads). Call once per frame after all mutations.
+   */
+  apply(view: CameraView): void {
+    this.camera.setZoom(view.zoom);
+    this.camera.centerOn(view.centerX, view.centerY);
+  }
+
+  /**
+   * Begin a cursor-anchored wheel zoom: sets the view's targetZoom and records the
+   * anchor (the world point under the cursor) for the lerp to hold fixed. The actual
+   * zoom moves over subsequent frames via tickZoomLerp.
+   */
+  beginZoom(view: CameraView, factor: number, screenX: number, screenY: number): void {
+    this.anchor = beginWheelZoom(view, factor, screenX, screenY);
+  }
+
+  /**
+   * Advance an in-flight zoom-lerp by one frame: step zoom toward targetZoom, re-anchor
+   * the center so the cursor's world point stays fixed (recomputed EVERY frame — not
+   * once on the wheel event — so it doesn't drift), then custom-clamp. No-op when no
+   * lerp is active (zoom === targetZoom). Does NOT call apply(); the caller applies once
+   * per frame after pan + lerp.
+   */
+  tickZoomLerp(view: CameraView, worldPxW: number, worldPxH: number): void {
+    if (view.zoom === view.targetZoom) {
+      this.anchor = null;
+      return;
+    }
+    const done = stepZoomLerp(view, ZOOM_LERP_RATE);
+    if (this.anchor !== null) applyZoomAnchor(view, this.anchor);
+    clampCameraView(view, worldPxW, worldPxH);
+    if (done) this.anchor = null;
+  }
+
+  /** Cancel any in-flight zoom-lerp (e.g. across a view toggle) and drop the anchor. */
+  cancel(view: CameraView): void {
+    cancelZoomLerp(view);
+    this.anchor = null;
+  }
+}

--- a/src/render/camera-controller.ts
+++ b/src/render/camera-controller.ts
@@ -27,8 +27,17 @@ import {
   cancelZoomLerp,
 } from './camera-adapter.js';
 
-/** Per-wheel-notch zoom multiplier (a notch zooms in by ×1.15, out by ÷1.15). */
+/** Per-wheel-notch zoom multiplier (one full ~WHEEL_NOTCH_PX notch zooms ×1.15 / ÷1.15). */
 export const WHEEL_ZOOM_STEP = 1.15;
+
+/**
+ * Wheel deltaY (px) treated as one full zoom notch. A standard mouse-wheel notch is
+ * ~100px; trackpads and high-resolution wheels emit MANY small deltas per gesture, so the
+ * zoom factor is scaled by deltaY/WHEEL_NOTCH_PX (WHEEL_ZOOM_STEP ** (−dy/WHEEL_NOTCH_PX))
+ * — one notch = ×1.15, while small trackpad deltas zoom proportionally instead of slamming
+ * targetZoom to the min/max on every event.
+ */
+export const WHEEL_NOTCH_PX = 100;
 
 /**
  * Per-frame interpolation factor toward targetZoom. A fixed factor gives an

--- a/src/render/camera.test.ts
+++ b/src/render/camera.test.ts
@@ -1,66 +1,60 @@
-// camera.test.ts — Vitest tests for src/render/camera.ts
+// camera.test.ts — Vitest tests for src/render/camera.ts (Stage 2 world-px model).
 //
-// Tests cover:
-//   - createViewState: correct initial positions, independence of camera objects
-//   - toggleView (VIEW-02, §7c): X-sync, first-visit Y-center, surface Y preservation, repeat-visit
-//   - clampCamera: minimum/maximum clamp on both axes, degenerate guard
-//   - screenToTile: center-canvas round-trip, top-left corner, tile round-trip
+// Tests cover the two-view lifecycle on the new world-pixel CameraView model:
+//   - createViewState / resetViewState: world-px centers, default zoom, in-place reset
+//   - toggleView: X-link (world px), first-underground-visit centering, surface-Y/underground-Y
+//     preservation, and the atomic-toggle §A5 behavior (per-view ZOOM save/restore,
+//     in-flight zoom-lerp cancelled, clamp at the restored zoom)
+//   - toggleUndergroundColony: binary colony flip
+//
+// The pure projection / clamp / screen↔tile math (formerly clampCamera/screenToTile here)
+// now lives in camera-adapter.ts and is covered by camera-adapter.test.ts.
 
 import { describe, it, expect } from 'vitest';
 import {
-  VIEWPORT_WIDTH_TILES,
-  VIEWPORT_HEIGHT_TILES,
-  UNDERGROUND_INITIAL_CAMERA_Y,
+  UNDERGROUND_INITIAL_CENTER_Y_PX,
+  UNDERGROUND_WORLD_PX_H,
   createViewState,
   resetViewState,
   toggleView,
   toggleUndergroundColony,
-  clampCamera,
-  screenToTile,
 } from './camera.js';
-import { TILE_SIZE_PX } from './sprites.js';
+import { DEFAULT_ZOOM, viewWorldHeight } from './camera-adapter.js';
+import { TILE_SIZE_PX, CANVAS_H } from './sprites.js';
 import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
 
-// Convenience: default viewport camera
-function makeCamera(x: number, y: number) {
-  return {
-    x,
-    y,
-    viewportWidth: VIEWPORT_WIDTH_TILES,
-    viewportHeight: VIEWPORT_HEIGHT_TILES,
-  };
-}
+// Center (world px) of a tile — mirrors camera.ts's framing of the start tile.
+const tileCenterPx = (tile: number): number => (tile + 0.5) * TILE_SIZE_PX;
 
 // ---------------------------------------------------------------------------
 // createViewState
 // ---------------------------------------------------------------------------
 
 describe('createViewState', () => {
-  it('surfaceCamera starts at (startTileX, startTileY)', () => {
+  it('surfaceCamera is centered (world px) on the start tile at default zoom', () => {
     const vs = createViewState(24, 64);
-    expect(vs.surfaceCamera.x).toBe(24);
-    expect(vs.surfaceCamera.y).toBe(64);
+    expect(vs.surfaceCamera.centerX).toBe(tileCenterPx(24)); // 392
+    expect(vs.surfaceCamera.centerY).toBe(tileCenterPx(64)); // 1032
+    expect(vs.surfaceCamera.zoom).toBe(DEFAULT_ZOOM);
+    expect(vs.surfaceCamera.targetZoom).toBe(DEFAULT_ZOOM);
   });
 
-  it('undergroundCamera starts at (startTileX, UNDERGROUND_INITIAL_CAMERA_Y) — starter shaft near top', () => {
-    // UNDERGROUND_INITIAL_CAMERA_Y = VIEWPORT_HEIGHT_TILES / 2 = 18.5 (the clamp
-    // minimum Y), which places underground tile row 0 at the very top of the
-    // viewport. The starter entrance / shaft row is visible on first view,
-    // giving the player an immediate surface→underground connection.
+  it('undergroundCamera starts X-aligned with the start tile and Y at the shaft-top anchor', () => {
+    // UNDERGROUND_INITIAL_CENTER_Y_PX = CANVAS_H/2 places world y=0 (the ceiling /
+    // surface-entrance row) at the very top of the viewport at zoom 1.
     const vs = createViewState(24, 64);
-    expect(vs.undergroundCamera.x).toBe(24);
-    expect(vs.undergroundCamera.y).toBe(UNDERGROUND_INITIAL_CAMERA_Y);
-    expect(UNDERGROUND_INITIAL_CAMERA_Y).toBe(VIEWPORT_HEIGHT_TILES / 2);
+    expect(vs.undergroundCamera.centerX).toBe(tileCenterPx(24));
+    expect(vs.undergroundCamera.centerY).toBe(UNDERGROUND_INITIAL_CENTER_Y_PX);
+    expect(UNDERGROUND_INITIAL_CENTER_Y_PX).toBe(CANVAS_H / 2); // 296
+    expect(vs.undergroundCamera.zoom).toBe(DEFAULT_ZOOM);
   });
 
   it('undergroundVisited is false initially', () => {
-    const vs = createViewState(24, 64);
-    expect(vs.undergroundVisited).toBe(false);
+    expect(createViewState(24, 64).undergroundVisited).toBe(false);
   });
 
   it('activeView is "surface" initially', () => {
-    const vs = createViewState(24, 64);
-    expect(vs.activeView).toBe('surface');
+    expect(createViewState(24, 64).activeView).toBe('surface');
   });
 
   it('surfaceCamera and undergroundCamera are distinct object references', () => {
@@ -68,20 +62,9 @@ describe('createViewState', () => {
     expect(vs.surfaceCamera).not.toBe(vs.undergroundCamera);
   });
 
-  it('cameras have correct viewport dimensions', () => {
-    const vs = createViewState(10, 20);
-    expect(vs.surfaceCamera.viewportWidth).toBe(VIEWPORT_WIDTH_TILES);
-    expect(vs.surfaceCamera.viewportHeight).toBe(VIEWPORT_HEIGHT_TILES);
-    expect(vs.undergroundCamera.viewportWidth).toBe(VIEWPORT_WIDTH_TILES);
-    expect(vs.undergroundCamera.viewportHeight).toBe(VIEWPORT_HEIGHT_TILES);
-  });
-
   it('issue #114 — showPheromoneOverlay defaults to true (matches DEFAULT_SETTINGS)', () => {
-    // jsdom has localStorage available but the suite clears between tests,
-    // so loadSettings falls back to DEFAULT_SETTINGS.pheromoneOverlay = true.
     localStorage.removeItem('subterrans:settings:v1');
-    const vs = createViewState(10, 20);
-    expect(vs.showPheromoneOverlay).toBe(true);
+    expect(createViewState(10, 20).showPheromoneOverlay).toBe(true);
   });
 
   it('issue #114 — showPheromoneOverlay hydrates from persisted settings', () => {
@@ -89,14 +72,13 @@ describe('createViewState', () => {
       'subterrans:settings:v1',
       JSON.stringify({ version: 1, settings: { pheromoneOverlay: false } }),
     );
-    const vs = createViewState(10, 20);
-    expect(vs.showPheromoneOverlay).toBe(false);
+    expect(createViewState(10, 20).showPheromoneOverlay).toBe(false);
     localStorage.removeItem('subterrans:settings:v1');
   });
 });
 
 // ---------------------------------------------------------------------------
-// resetViewState — Phase 9 session reset
+// resetViewState — session reset (in place)
 // ---------------------------------------------------------------------------
 
 describe('resetViewState', () => {
@@ -107,22 +89,28 @@ describe('resetViewState', () => {
     expect(vs.activeView).toBe('surface');
   });
 
-  it('rebinds surfaceCamera center to the given start tile', () => {
+  it('rebinds the surface camera center (world px) to the given start tile and resets zoom', () => {
     const vs = createViewState(10, 10);
-    vs.surfaceCamera.x = 999;
-    vs.surfaceCamera.y = 999;
+    vs.surfaceCamera.centerX = 999;
+    vs.surfaceCamera.centerY = 999;
+    vs.surfaceCamera.zoom = 1.7;
+    vs.surfaceCamera.targetZoom = 1.7;
     resetViewState(vs, 24, 64);
-    expect(vs.surfaceCamera.x).toBe(24);
-    expect(vs.surfaceCamera.y).toBe(64);
+    expect(vs.surfaceCamera.centerX).toBe(tileCenterPx(24));
+    expect(vs.surfaceCamera.centerY).toBe(tileCenterPx(64));
+    expect(vs.surfaceCamera.zoom).toBe(DEFAULT_ZOOM);
+    expect(vs.surfaceCamera.targetZoom).toBe(DEFAULT_ZOOM);
   });
 
-  it('rebinds undergroundCamera to (start, UNDERGROUND_INITIAL_CAMERA_Y) — starter shaft near top', () => {
+  it('rebinds the underground camera to (start-X, shaft-top anchor) at default zoom', () => {
     const vs = createViewState(10, 10);
-    vs.undergroundCamera.x = 999;
-    vs.undergroundCamera.y = 999;
+    vs.undergroundCamera.centerX = 999;
+    vs.undergroundCamera.centerY = 999;
+    vs.undergroundCamera.zoom = 0.4;
     resetViewState(vs, 24, 64);
-    expect(vs.undergroundCamera.x).toBe(24);
-    expect(vs.undergroundCamera.y).toBe(UNDERGROUND_INITIAL_CAMERA_Y);
+    expect(vs.undergroundCamera.centerX).toBe(tileCenterPx(24));
+    expect(vs.undergroundCamera.centerY).toBe(UNDERGROUND_INITIAL_CENTER_Y_PX);
+    expect(vs.undergroundCamera.zoom).toBe(DEFAULT_ZOOM);
   });
 
   it('clears undergroundVisited so the next toggle re-anchors the shaft near the top', () => {
@@ -132,15 +120,12 @@ describe('resetViewState', () => {
     expect(vs.undergroundVisited).toBe(true);
     resetViewState(vs, 24, 64);
     expect(vs.undergroundVisited).toBe(false);
-    // Next underground toggle should restore the first-visit top anchor.
-    vs.undergroundCamera.y = 5;
+    vs.undergroundCamera.centerY = 5;
     toggleView(vs);
-    expect(vs.undergroundCamera.y).toBe(UNDERGROUND_INITIAL_CAMERA_Y);
+    expect(vs.undergroundCamera.centerY).toBe(UNDERGROUND_INITIAL_CENTER_Y_PX);
   });
 
-  it('preserves the ViewState object identity (mutates in place)', () => {
-    // Critical invariant: UIScene + input handlers capture this reference in
-    // create(). A reassigned object would strand those references on the old.
+  it('preserves the ViewState + camera object identities (mutates in place)', () => {
     const vs = createViewState(10, 10);
     const surfaceCamRef = vs.surfaceCamera;
     const undergroundCamRef = vs.undergroundCamera;
@@ -149,22 +134,7 @@ describe('resetViewState', () => {
     expect(vs.undergroundCamera).toBe(undergroundCamRef);
   });
 
-  it('restores viewport dimensions to canonical defaults', () => {
-    const vs = createViewState(10, 10);
-    vs.surfaceCamera.viewportWidth = 99;
-    vs.surfaceCamera.viewportHeight = 99;
-    vs.undergroundCamera.viewportWidth = 99;
-    vs.undergroundCamera.viewportHeight = 99;
-    resetViewState(vs, 24, 64);
-    expect(vs.surfaceCamera.viewportWidth).toBe(VIEWPORT_WIDTH_TILES);
-    expect(vs.surfaceCamera.viewportHeight).toBe(VIEWPORT_HEIGHT_TILES);
-    expect(vs.undergroundCamera.viewportWidth).toBe(VIEWPORT_WIDTH_TILES);
-    expect(vs.undergroundCamera.viewportHeight).toBe(VIEWPORT_HEIGHT_TILES);
-  });
-
   it('issue #114 — re-reads pheromoneOverlay setting from localStorage on reset', () => {
-    // Settings are cosmetic preferences, not session state — a restart should
-    // honor the player's current toggle, not snap back to the boot-time value.
     const vs = createViewState(10, 10);
     expect(vs.showPheromoneOverlay).toBe(true);
     localStorage.setItem(
@@ -175,259 +145,137 @@ describe('resetViewState', () => {
     expect(vs.showPheromoneOverlay).toBe(false);
     localStorage.removeItem('subterrans:settings:v1');
   });
-
-  it('restart simulation: mid-game underground pan does not leak into fresh session', () => {
-    const vs = createViewState(24, 64);
-    toggleView(vs); // underground
-    vs.undergroundCamera.x = 100;
-    vs.undergroundCamera.y = 40;
-    vs.surfaceCamera.x = 80;
-    resetViewState(vs, 24, 64);
-    expect(vs.activeView).toBe('surface');
-    expect(vs.surfaceCamera.x).toBe(24);
-    expect(vs.surfaceCamera.y).toBe(64);
-    expect(vs.undergroundCamera.x).toBe(24);
-    expect(vs.undergroundCamera.y).toBe(UNDERGROUND_INITIAL_CAMERA_Y);
-    expect(vs.undergroundVisited).toBe(false);
-  });
 });
 
 // ---------------------------------------------------------------------------
-// toggleView — VIEW-02, §7c
+// toggleView — atomic toggle (PLAN-stage2 §A5)
 // ---------------------------------------------------------------------------
 
 describe('toggleView', () => {
-  describe('first toggle: surface → underground (first visit)', () => {
-    it('undergroundCamera.x becomes surfaceCamera.x', () => {
+  describe('surface → underground (first visit)', () => {
+    it('X-links the underground center to the surface center (world px)', () => {
       const vs = createViewState(24, 64);
-      vs.surfaceCamera.x = 50; // change surface X to test sync
+      vs.surfaceCamera.centerX = 800; // in-bounds world px
       toggleView(vs);
-      expect(vs.undergroundCamera.x).toBe(50);
+      expect(vs.undergroundCamera.centerX).toBe(800);
     });
 
-    it('undergroundCamera.y is anchored at UNDERGROUND_INITIAL_CAMERA_Y (starter shaft near top) on first visit', () => {
+    it('anchors underground centerY at the shaft-top on first visit (overriding any prior value)', () => {
       const vs = createViewState(24, 64);
-      vs.undergroundCamera.y = 99; // override a prior value to verify the first-visit anchor wins
+      vs.undergroundCamera.centerY = 900; // a stale value the first-visit anchor must win over
       toggleView(vs);
-      expect(vs.undergroundCamera.y).toBe(UNDERGROUND_INITIAL_CAMERA_Y);
+      expect(vs.undergroundCamera.centerY).toBe(UNDERGROUND_INITIAL_CENTER_Y_PX);
     });
 
-    it('undergroundVisited becomes true', () => {
+    it('marks undergroundVisited and sets activeView=underground', () => {
       const vs = createViewState(24, 64);
       toggleView(vs);
       expect(vs.undergroundVisited).toBe(true);
-    });
-
-    it('activeView becomes "underground"', () => {
-      const vs = createViewState(24, 64);
-      toggleView(vs);
       expect(vs.activeView).toBe('underground');
     });
   });
 
-  describe('second toggle: underground → surface (VIEW-03: surface Y preserved)', () => {
-    it('surfaceCamera.x becomes undergroundCamera.x', () => {
+  describe('underground → surface (surface Y preserved)', () => {
+    it('X-links the surface center to the underground center (world px)', () => {
       const vs = createViewState(24, 64);
       toggleView(vs); // → underground
-      vs.undergroundCamera.x = 77;
+      vs.undergroundCamera.centerX = 700;
       toggleView(vs); // → surface
-      expect(vs.surfaceCamera.x).toBe(77);
+      expect(vs.surfaceCamera.centerX).toBe(700);
     });
 
-    it('activeView becomes "surface"', () => {
+    it('does NOT change surface centerY across the round trip', () => {
       const vs = createViewState(24, 64);
+      vs.surfaceCamera.centerY = 1000; // in-bounds
+      const before = vs.surfaceCamera.centerY;
       toggleView(vs); // → underground
       toggleView(vs); // → surface
-      expect(vs.activeView).toBe('surface');
-    });
-
-    it('surfaceCamera.y is NOT changed (VIEW-03: surface Y preserved across toggles)', () => {
-      const vs = createViewState(24, 64);
-      const originalSurfaceY = vs.surfaceCamera.y;
-      toggleView(vs); // → underground
-      toggleView(vs); // → surface
-      expect(vs.surfaceCamera.y).toBe(originalSurfaceY);
+      expect(vs.surfaceCamera.centerY).toBe(before);
     });
   });
 
-  describe('third toggle: surface → underground (already visited)', () => {
-    it('undergroundCamera.y is NOT re-anchored (preserves user-panned underground.y)', () => {
+  describe('surface → underground (already visited)', () => {
+    it('preserves the user-panned underground centerY (no re-anchor)', () => {
       const vs = createViewState(24, 64);
-      toggleView(vs); // first visit → y set to UNDERGROUND_INITIAL_CAMERA_Y, visited=true
-      vs.undergroundCamera.y = 55; // simulate a user pan after first visit
+      toggleView(vs); // first visit
+      vs.undergroundCamera.centerY = 600; // in-bounds user pan (1024-tall world, half-view 296 → [296,728])
       toggleView(vs); // → surface
-      toggleView(vs); // second visit → must preserve 55, NOT snap back to the top anchor
-      expect(vs.undergroundCamera.y).toBe(55);
+      toggleView(vs); // → underground (2nd visit): keep 600
+      expect(vs.undergroundCamera.centerY).toBe(600);
     });
 
-    it('undergroundCamera.x still syncs from surfaceCamera.x on repeated toggle', () => {
+    it('still X-links underground centerX from surface on repeat toggle', () => {
       const vs = createViewState(24, 64);
       toggleView(vs); // → underground (first visit)
       toggleView(vs); // → surface
-      vs.surfaceCamera.x = 88;
-      toggleView(vs); // → underground (second visit)
-      expect(vs.undergroundCamera.x).toBe(88);
+      vs.surfaceCamera.centerX = 900;
+      toggleView(vs); // → underground (2nd visit)
+      expect(vs.undergroundCamera.centerX).toBe(900);
     });
   });
-});
 
-// ---------------------------------------------------------------------------
-// clampCamera
-// ---------------------------------------------------------------------------
+  describe('atomic-toggle behavior (§A5)', () => {
+    it('PER-VIEW ZOOM is saved and restored across toggles', () => {
+      const vs = createViewState(64, 64);
+      vs.surfaceCamera.zoom = 1.5;
+      vs.surfaceCamera.targetZoom = 1.5;
+      vs.undergroundCamera.zoom = 0.5;
+      vs.undergroundCamera.targetZoom = 0.5;
 
-describe('clampCamera', () => {
-  it('clamps camera too far left/up to half-viewport boundary', () => {
-    const cam = makeCamera(0, 0);
-    clampCamera(cam, 128, 128);
-    // half-viewport: 50/2 = 25, 37/2 = 18.5
-    expect(cam.x).toBe(VIEWPORT_WIDTH_TILES / 2); // 25
-    expect(cam.y).toBe(VIEWPORT_HEIGHT_TILES / 2); // 18.5
+      toggleView(vs); // → underground; each view keeps its own zoom
+      expect(vs.undergroundCamera.zoom).toBe(0.5);
+      expect(vs.surfaceCamera.zoom).toBe(1.5); // leaving view's zoom snapshotted
+
+      toggleView(vs); // → surface; surface zoom still 1.5
+      expect(vs.surfaceCamera.zoom).toBe(1.5);
+      expect(vs.undergroundCamera.zoom).toBe(0.5);
+    });
+
+    it('cancels an in-flight zoom-lerp on both the leaving and entering views', () => {
+      const vs = createViewState(64, 64);
+      vs.surfaceCamera.targetZoom = 1.8; // surface mid-lerp (zoom 1 → 1.8)
+      vs.undergroundCamera.targetZoom = 0.3; // underground had a pending lerp too
+      toggleView(vs); // leaving surface, entering underground
+      expect(vs.surfaceCamera.targetZoom).toBe(vs.surfaceCamera.zoom); // leaving cancelled
+      expect(vs.undergroundCamera.targetZoom).toBe(vs.undergroundCamera.zoom); // entering settled
+    });
+
+    it('clamps the entering view at its restored zoom (out-of-bounds center pulled in)', () => {
+      const vs = createViewState(24, 64);
+      toggleView(vs); // first visit underground (zoom 1)
+      vs.undergroundCamera.centerY = 99999; // force out of bounds
+      toggleView(vs); // → surface
+      toggleView(vs); // → underground (2nd visit) → settle clamps
+      // zoom 1, underground world 1024 tall, half-view = viewWorldHeight(1)/2 = 296 → max 728.
+      const maxCenterY = UNDERGROUND_WORLD_PX_H - viewWorldHeight(1) / 2;
+      expect(vs.undergroundCamera.centerY).toBeCloseTo(maxCenterY, 6); // 728
+    });
   });
 
-  it('clamps camera too far right/down to worldSize - half-viewport boundary', () => {
-    const cam = makeCamera(200, 200);
-    clampCamera(cam, 128, 128);
-    // max: 128 - 25 = 103, 128 - 18.5 = 109.5
-    expect(cam.x).toBe(128 - VIEWPORT_WIDTH_TILES / 2); // 103
-    expect(cam.y).toBe(128 - VIEWPORT_HEIGHT_TILES / 2); // 109.5
-  });
-
-  it('leaves camera unchanged when within valid bounds', () => {
-    const cam = makeCamera(64, 64);
-    clampCamera(cam, 128, 128);
-    expect(cam.x).toBe(64);
-    expect(cam.y).toBe(64);
-  });
-
-  it('handles degenerate case where worldW < viewportWidth (centers X)', () => {
-    const cam = makeCamera(0, 32);
-    clampCamera(cam, 10, 128); // world width 10 < viewport 50
-    expect(cam.x).toBe(10 / 2); // 5 = worldW/2
-  });
-
-  it('handles degenerate case where worldH < viewportHeight (centers Y)', () => {
-    const cam = makeCamera(64, 0);
-    clampCamera(cam, 128, 10); // world height 10 < viewport 37
-    expect(cam.y).toBe(10 / 2); // 5 = worldH/2
-  });
-});
-
-// ---------------------------------------------------------------------------
-// screenToTile
-// ---------------------------------------------------------------------------
-
-describe('screenToTile', () => {
-  it('pointer at canvas center (400, 296) with camera at world center (64, 64) returns the tile the renderer drew there', () => {
-    // Camera center at tile (64, 64), viewport 50×37.
-    //   Horizontal: cam.x=64, vw/2=25 (integer) → left = 64-25 = 39
-    //     tileX = floor(400/16) + 39 = 25 + 39 = 64
-    //   Vertical:   cam.y=64, vh/2=18.5 (fractional) → top = floor(45.5) = 45
-    //     tileY = floor(296/16) + 45 = 18 + 45 = 63
-    // The odd viewport height means the renderer draws tile 63 at screen
-    // y=288..303, so a click at y=296 hits tile 63 — not 64.
-    const cam = makeCamera(64, 64);
-    const result = screenToTile(400, 296, cam);
-    expect(result.tileX).toBe(64);
-    expect(result.tileY).toBe(63);
-  });
-
-  it('pointer at (0, 0) with camera clamped to minimum (25, 18.5) returns tile (0, 0)', () => {
-    // Camera center at (25, 18.5) = half-viewport clamp
-    // cameraPixelX = (25 - 25) * 16 = 0
-    // tileX = Math.floor((0 + 0) / 16) = 0
-    // cameraPixelY = (18.5 - 18.5) * 16 = 0
-    // tileY = Math.floor((0 + 0) / 16) = 0
-    const cam = makeCamera(VIEWPORT_WIDTH_TILES / 2, VIEWPORT_HEIGHT_TILES / 2);
-    const result = screenToTile(0, 0, cam);
-    expect(result.tileX).toBe(0);
-    expect(result.tileY).toBe(0);
-  });
-
-  it('round-trip: tile pixel coordinates through screenToTile return same tile', () => {
-    // For tile (tx, ty), the top-left pixel the renderer draws it at is:
-    //   screenX = (tx - camLeft) * TILE_SIZE_PX
-    // where camLeft = Math.floor(cam.x - cam.viewportWidth/2) — the
-    // integer-tile snap the renderer applies. screenToTile mirrors that
-    // floor, so any pixel inside the drawn tile must round-trip to (tx, ty).
-    const cam = makeCamera(64, 64);
-    const camLeft = Math.floor(cam.x - cam.viewportWidth / 2);
-    const camTop = Math.floor(cam.y - cam.viewportHeight / 2);
-
-    // Test a specific tile inside the viewport: tile (70, 70)
-    const tx = 70;
-    const ty = 70;
-    const screenX = (tx - camLeft) * TILE_SIZE_PX;
-    const screenY = (ty - camTop) * TILE_SIZE_PX;
-    const result = screenToTile(screenX, screenY, cam);
-    expect(result.tileX).toBe(tx);
-    expect(result.tileY).toBe(ty);
-  });
-
-  it('fractional camera: clicks anywhere in a rendered tile resolve to that tile', () => {
-    // Regression: drag-pan and the 0.5-tile keyboard scroll leave cam.x
-    // fractional. The renderer snaps its tile offset with Math.floor(cam.x -
-    // viewportWidth/2), so visible tiles are integer-aligned. If screenToTile
-    // used the raw fractional camera instead, the tile it reports drifts up
-    // to a full tile away from what the player sees — which is why food-pile
-    // clicks only worked near the center of the drawn mark.
-    const cam = makeCamera(64.3, 64.7); // mid-pan / mid-scroll
-    const left = Math.floor(cam.x - cam.viewportWidth / 2); // renderer's floor
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
-
-    // Tile (70, 70) is drawn spanning screen px [(70-left)*16, (70-left+1)*16)
-    // horizontally — every click inside that span must resolve to tileX=70.
-    const tx = 70;
-    const ty = 70;
-    const tileLeftPx = (tx - left) * TILE_SIZE_PX;
-    const tileTopPx = (ty - top) * TILE_SIZE_PX;
-
-    // Four corners + center of the drawn tile all map to (70, 70)
-    for (const [dx, dy] of [
-      [0, 0],
-      [15, 0],
-      [0, 15],
-      [15, 15],
-      [8, 8],
-    ]) {
-      const r = screenToTile(tileLeftPx + dx!, tileTopPx + dy!, cam);
-      expect(r.tileX).toBe(tx);
-      expect(r.tileY).toBe(ty);
-    }
+  it('resets the active tool to the entering view default on toggle', () => {
+    const vs = createViewState(24, 64);
+    expect(vs.activeTool).toBe('command');
+    toggleView(vs); // → underground
+    expect(vs.activeTool).toBe('dig');
+    toggleView(vs); // → surface
+    expect(vs.activeTool).toBe('command');
   });
 });
 
 // ---------------------------------------------------------------------------
-// toggleUndergroundColony — Phase 09.1 Chunk 2 (enemy underground view)
+// toggleUndergroundColony — 09.1 Chunk 2 (enemy underground view)
 // ---------------------------------------------------------------------------
-//
-// Binary toggle that flips ViewState.activeUndergroundColonyId between
-// PLAYER_COLONY_ID and ENEMY_COLONY_ID so the player can inspect the enemy
-// nest before invasion (09.1 CONTEXT §Chunk 2). Mutates in place — same
-// in-place contract as toggleView and resetViewState so UIScene and input
-// handlers that hold a captured ViewState reference keep seeing the update.
-// The reducer is pure with respect to the toggle itself; the caller (the X
-// keybind handler in GameScene) is responsible for gating the dispatch on
-// activeView==='underground' so the surface view never flips colony id.
 
 describe('toggleUndergroundColony', () => {
   it('initial createViewState sets activeUndergroundColonyId to PLAYER_COLONY_ID', () => {
-    // Fresh boot must start looking at the player's own underground — there
-    // is no session where we want the first underground Tab to surface the
-    // enemy grid. This also makes the `Your Colony` HUD label the default.
-    const vs = createViewState(24, 64);
-    expect(vs.activeUndergroundColonyId).toBe(PLAYER_COLONY_ID);
+    expect(createViewState(24, 64).activeUndergroundColonyId).toBe(PLAYER_COLONY_ID);
   });
 
-  it('flips PLAYER_COLONY_ID → ENEMY_COLONY_ID on first call', () => {
+  it('flips PLAYER → ENEMY then ENEMY → PLAYER', () => {
     const vs = createViewState(24, 64);
     toggleUndergroundColony(vs);
     expect(vs.activeUndergroundColonyId).toBe(ENEMY_COLONY_ID);
-  });
-
-  it('flips ENEMY_COLONY_ID → PLAYER_COLONY_ID on second call (idempotence)', () => {
-    const vs = createViewState(24, 64);
-    toggleUndergroundColony(vs); // → ENEMY
-    toggleUndergroundColony(vs); // → PLAYER
+    toggleUndergroundColony(vs);
     expect(vs.activeUndergroundColonyId).toBe(PLAYER_COLONY_ID);
   });
 
@@ -440,41 +288,34 @@ describe('toggleUndergroundColony', () => {
   });
 
   it('leaves activeView unchanged (reducer is pure w.r.t. other fields)', () => {
-    // Gating on activeView is the caller's responsibility. The reducer only
-    // touches activeUndergroundColonyId so a stray dispatch cannot silently
-    // flip the player out of the surface view.
     const vs = createViewState(24, 64);
-    expect(vs.activeView).toBe('surface');
     toggleUndergroundColony(vs);
     expect(vs.activeView).toBe('surface');
   });
 
-  it('leaves surfaceCamera and undergroundCamera positions unchanged', () => {
+  it('leaves both camera centers unchanged', () => {
     const vs = createViewState(24, 64);
-    const sx = vs.surfaceCamera.x;
-    const sy = vs.surfaceCamera.y;
-    const ux = vs.undergroundCamera.x;
-    const uy = vs.undergroundCamera.y;
+    const sx = vs.surfaceCamera.centerX;
+    const sy = vs.surfaceCamera.centerY;
+    const ux = vs.undergroundCamera.centerX;
+    const uy = vs.undergroundCamera.centerY;
     toggleUndergroundColony(vs);
-    expect(vs.surfaceCamera.x).toBe(sx);
-    expect(vs.surfaceCamera.y).toBe(sy);
-    expect(vs.undergroundCamera.x).toBe(ux);
-    expect(vs.undergroundCamera.y).toBe(uy);
+    expect(vs.surfaceCamera.centerX).toBe(sx);
+    expect(vs.surfaceCamera.centerY).toBe(sy);
+    expect(vs.undergroundCamera.centerX).toBe(ux);
+    expect(vs.undergroundCamera.centerY).toBe(uy);
   });
 
-  it('leaves undergroundVisited flag unchanged', () => {
+  it('leaves undergroundVisited unchanged', () => {
     const vs = createViewState(24, 64);
-    toggleView(vs); // → underground, visited=true
-    toggleView(vs); // → surface
+    toggleView(vs);
+    toggleView(vs);
     expect(vs.undergroundVisited).toBe(true);
     toggleUndergroundColony(vs);
     expect(vs.undergroundVisited).toBe(true);
   });
 
-  it('mutates the ViewState in place — preserves object identity for captured refs', () => {
-    // UIScene and input handlers capture a reference to the ViewState in
-    // create(). Reassigning a fresh object would strand those references
-    // (same failure class as the stale-world bug documented in camera.ts).
+  it('mutates in place — preserves camera object identity for captured refs', () => {
     const vs = createViewState(24, 64);
     const surfaceCamRef = vs.surfaceCamera;
     const undergroundCamRef = vs.undergroundCamera;
@@ -484,8 +325,6 @@ describe('toggleUndergroundColony', () => {
   });
 
   it('resetViewState restores activeUndergroundColonyId to PLAYER_COLONY_ID', () => {
-    // Session reset must clear the enemy-view state — a fresh game starts
-    // with `Your Colony` regardless of what the prior session was viewing.
     const vs = createViewState(24, 64);
     toggleUndergroundColony(vs);
     expect(vs.activeUndergroundColonyId).toBe(ENEMY_COLONY_ID);

--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -1,78 +1,64 @@
-// camera.ts — Phase 8 render-layer camera state, view state, and camera utilities.
+// camera.ts — render-layer two-view state (surface + underground) for the
+// continuous-zoom camera (Stage 2 controls rework, issue #18).
 //
-// Source: PRD §7a/§7b/§7c (03-PRD-world-interaction.md)
+// Stage 2 replaced the fixed 50×37-tile viewport with a continuous Phaser-camera
+// zoom. The per-view camera is now a world-pixel `CameraView` ({centerX, centerY,
+// zoom, targetZoom}) owned by the pure adapter (camera-adapter.ts) — the SINGLE
+// screen↔world authority. This file keeps only the two-view lifecycle: create /
+// reset / toggle / colony-flip, plus the tool palette. All projection / clamp /
+// pan / zoom math lives in camera-adapter.ts.
 //
-// This file is in src/render/ — no Phaser imports, no DOM globals.
-// Only imports: src/sim/constants.js (world dimensions) and src/render/sprites.js (TILE_SIZE_PX).
-// Pure TypeScript functions, fully testable under Node + Vitest.
+// This file is in src/render/ — no Phaser imports, no DOM globals. It imports the
+// pure adapter, sim world dimensions, and persisted settings only. Fully testable
+// under Node + Vitest.
 
-import { TILE_SIZE_PX } from './sprites.js';
-import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
+import { CANVAS_H, TILE_SIZE_PX } from './sprites.js';
+import {
+  type CameraView,
+  makeCameraView,
+  DEFAULT_ZOOM,
+  cancelZoomLerp,
+  settleEnteringView,
+} from './camera-adapter.js';
+import {
+  PLAYER_COLONY_ID,
+  ENEMY_COLONY_ID,
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
+  UNDERGROUND_GRID_WIDTH,
+  UNDERGROUND_GRID_HEIGHT,
+} from '../sim/constants.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
 import { loadSettings } from '../platform/settings.js';
 
-// Suppress unused import warning — TILE_SIZE_PX is used in screenToTile below.
-void TILE_SIZE_PX;
+// ---------------------------------------------------------------------------
+// World-pixel dimensions per view (tiles × TILE_SIZE_PX)
+// ---------------------------------------------------------------------------
 
-// ---------------------------------------------------------------------------
-// CameraState
-// ---------------------------------------------------------------------------
+/** Surface world width in pixels (128 tiles × 16 = 2048). */
+export const SURFACE_WORLD_PX_W = SURFACE_GRID_WIDTH * TILE_SIZE_PX;
+/** Surface world height in pixels (2048). */
+export const SURFACE_WORLD_PX_H = SURFACE_GRID_HEIGHT * TILE_SIZE_PX;
+/** Underground world width in pixels (128 tiles × 16 = 2048). */
+export const UNDERGROUND_WORLD_PX_W = UNDERGROUND_GRID_WIDTH * TILE_SIZE_PX;
+/** Underground world height in pixels (64 tiles × 16 = 1024). */
+export const UNDERGROUND_WORLD_PX_H = UNDERGROUND_GRID_HEIGHT * TILE_SIZE_PX;
 
 /**
- * CameraState — pure TypeScript render-layer camera position.
- *
- * All values are in tile units. x/y are the CENTER of the viewport (not top-left).
- * This is distinct from Phaser's camera `scrollX`/`scrollY` which are top-left pixel offsets.
- *
- * To convert for Phaser: `scrollX = (cam.x - cam.viewportWidth / 2) * TILE_SIZE_PX`
+ * Initial underground-camera CENTER Y (world px) on fresh boot / reset / first
+ * view toggle. CANVAS_H/2 places world y=0 (the ceiling / surface-entrance row)
+ * at the very top of the viewport at zoom 1 — the same "shaft anchored to the
+ * top" framing as before Stage 2. It is also the clamp minimum for the 1024-px-
+ * tall underground world at zoom 1, so the shaft stays anchored as zoom changes.
  */
-export interface CameraState {
-  /** Tile-unit X coordinate of the viewport center. */
-  x: number;
-  /** Tile-unit Y coordinate of the viewport center. */
-  y: number;
-  /** Viewport width in tiles. */
-  viewportWidth: number;
-  /** Viewport height in tiles. */
-  viewportHeight: number;
+export const UNDERGROUND_INITIAL_CENTER_Y_PX = CANVAS_H / 2;
+
+/** World-pixel [width, height] for a view. */
+export function worldPxDimensions(view: 'surface' | 'underground'): [number, number] {
+  return view === 'surface'
+    ? [SURFACE_WORLD_PX_W, SURFACE_WORLD_PX_H]
+    : [UNDERGROUND_WORLD_PX_W, UNDERGROUND_WORLD_PX_H];
 }
-
-// ---------------------------------------------------------------------------
-// Camera constants (PRD §7a)
-// ---------------------------------------------------------------------------
-
-/** Number of tiles visible horizontally at the default 800×592 canvas / 16px tiles. PRD §7a. */
-export const VIEWPORT_WIDTH_TILES = 50;
-
-/** Number of tiles visible vertically at the default 800×592 canvas / 16px tiles. PRD §7a. */
-export const VIEWPORT_HEIGHT_TILES = 37;
-
-/**
- * Camera pan speed in tiles per render frame.
- * Applied each frame arrow/WASD key is held. PRD §7a.
- */
-export const CAMERA_SCROLL_SPEED = 0.5;
-
-/**
- * Distance from canvas edge (in pixels) that triggers mouse edge-pan. PRD §7a.
- */
-export const EDGE_PAN_THRESHOLD_PX = 32;
-
-/**
- * Initial underground-camera Y on fresh boot / session reset / first view
- * toggle. Set to half the viewport so tile y=0 sits at the very top of the
- * visible region — this places the surface entrance / starter shaft row
- * near the top-center of the underground view, giving the player an
- * immediate spatial connection between the surface hole they just dug and
- * the tunnel they're about to excavate.
- *
- * Derived from VIEWPORT_HEIGHT_TILES rather than UNDERGROUND_GRID_HEIGHT —
- * the old mid-depth start (UNDERGROUND_GRID_HEIGHT/2) left the shaft
- * entirely off-screen and made the first underground visit disorienting.
- * Using the viewport half puts this value exactly at clampCamera's minimum
- * Y, so if viewport dimensions change the shaft stays anchored to the top.
- */
-export const UNDERGROUND_INITIAL_CAMERA_Y = VIEWPORT_HEIGHT_TILES / 2;
 
 // ---------------------------------------------------------------------------
 // Tool palette (Stage 1 controls rework — issue #18)
@@ -102,21 +88,22 @@ export function defaultToolForView(view: 'surface' | 'underground'): ToolId {
 /**
  * ViewState — render-layer state for the two-view system (surface + underground).
  *
- * Not part of WorldState — this is render-layer state only (PRD §7c).
- * Surface and underground cameras maintain independent Y positions.
- * X positions are linked on toggle (PRD §7c algorithm: Pattern 9).
+ * Not part of WorldState — this is render-layer state only (PRD §7c). Each view
+ * owns an independent world-pixel CameraView; X positions are linked on toggle
+ * (PRD §7c Pattern 9), and each view's zoom is preserved across toggles
+ * (PLAN-stage2 §A5).
  */
 export interface ViewState {
   /** Which view is currently displayed. */
   activeView: 'surface' | 'underground';
-  /** Camera state for the surface top-down view. */
-  surfaceCamera: CameraState;
-  /** Camera state for the underground side-view cross-section. */
-  undergroundCamera: CameraState;
+  /** World-pixel camera for the surface top-down view. */
+  surfaceCamera: CameraView;
+  /** World-pixel camera for the underground side-view cross-section. */
+  undergroundCamera: CameraView;
   /**
    * Whether the underground view has been visited at least once.
-   * Used for first-visit Y-centering (PRD §7c): undergroundCamera.y is set to
-   * UNDERGROUND_INITIAL_CAMERA_Y (shaft row near the top) on the FIRST
+   * Used for first-visit Y-centering (PRD §7c): undergroundCamera.centerY is set
+   * to UNDERGROUND_INITIAL_CENTER_Y_PX (shaft row near the top) on the FIRST
    * toggle to underground only.
    */
   undergroundVisited: boolean;
@@ -124,30 +111,25 @@ export interface ViewState {
    * 09.1 Chunk 2 — which colony's underground grid the player is currently
    * viewing. Defaults to PLAYER_COLONY_ID on fresh boot and after
    * resetViewState. Toggled between PLAYER and ENEMY by the X keybind (via
-   * toggleUndergroundColony) while activeView === 'underground'. 09.1 has
-   * exactly two colonies, so a binary flip is sufficient; future N-colony
-   * expansion is out of scope per 09.1-CONTEXT.
-   *
-   * draw-underground.ts reads this field for all four grid-keyed lookups
-   * (grid, entrances, chambers, ant filter). Ant filter also consults
-   * ants.currentGridColonyId so player Fighters inside the enemy grid
-   * still render (Research Risk D, Chunk 0 dependency).
+   * toggleUndergroundColony) while activeView === 'underground'.
    */
   activeUndergroundColonyId: ColonyId;
   /**
    * Issue #114 — render-only flag controlling whether the player's pheromone
-   * overlay is drawn. Hydrated from persisted settings (subterrans:settings:v1)
-   * on createViewState / resetViewState; toggled by the P key and by the pause
-   * menu Settings sub-screen, both of which write back through saveSettings.
-   * Skipped at draw time in game-scene.ts; never round-trips through save.ts.
+   * overlay is drawn. Hydrated from persisted settings on create/reset; toggled
+   * by the P key and the pause-menu Settings sub-screen.
    */
   showPheromoneOverlay: boolean;
   /**
    * Stage 1 controls rework (issue #18) — the active input tool. Resets to the
-   * view default on every `toggleView`; persists within a view. `chamber` is
-   * underground-only (selecting it on the surface is a no-op upstream).
+   * view default on every `toggleView`; persists within a view.
    */
   activeTool: ToolId;
+}
+
+/** Center (world px) of a tile, used to frame the camera on a tile coordinate. */
+function tileCenterPx(tile: number): number {
+  return (tile + 0.5) * TILE_SIZE_PX;
 }
 
 // ---------------------------------------------------------------------------
@@ -157,13 +139,11 @@ export interface ViewState {
 /**
  * createViewState — construct initial ViewState for a new game session.
  *
- * surfaceCamera is centered at (startTileX, startTileY).
- * undergroundCamera is centered horizontally on the starter entrance column
- * (startTileX) and vertically at UNDERGROUND_INITIAL_CAMERA_Y so the shaft /
- * surface-entrance row sits near the top of the viewport.
- * undergroundVisited is false; activeView is 'surface'.
- *
- * Each camera is an independent object instance (no shared references).
+ * surfaceCamera is centered (world px) on the start tile. undergroundCamera is
+ * centered horizontally on the starter entrance column and vertically at
+ * UNDERGROUND_INITIAL_CENTER_Y_PX so the shaft / surface-entrance row sits near
+ * the top of the viewport. Both start at DEFAULT_ZOOM. undergroundVisited is
+ * false; activeView is 'surface'. Each camera is an independent object instance.
  *
  * @param startTileX - Starting tile X (typically PLAYER_START_X from constants.ts)
  * @param startTileY - Starting tile Y (typically PLAYER_START_Y from constants.ts)
@@ -172,26 +152,17 @@ export function createViewState(startTileX: number, startTileY: number): ViewSta
   return {
     activeView: 'surface',
     activeTool: 'command',
-    surfaceCamera: {
-      x: startTileX,
-      y: startTileY,
-      viewportWidth: VIEWPORT_WIDTH_TILES,
-      viewportHeight: VIEWPORT_HEIGHT_TILES,
-    },
-    undergroundCamera: {
-      x: startTileX,
-      y: UNDERGROUND_INITIAL_CAMERA_Y,
-      viewportWidth: VIEWPORT_WIDTH_TILES,
-      viewportHeight: VIEWPORT_HEIGHT_TILES,
-    },
+    surfaceCamera: makeCameraView(tileCenterPx(startTileX), tileCenterPx(startTileY), DEFAULT_ZOOM),
+    undergroundCamera: makeCameraView(
+      tileCenterPx(startTileX),
+      UNDERGROUND_INITIAL_CENTER_Y_PX,
+      DEFAULT_ZOOM,
+    ),
     undergroundVisited: false,
     // 09.1 Chunk 2 — fresh boot always starts looking at the player's own
     // underground so the first Tab to underground shows "Your Colony".
     activeUndergroundColonyId: PLAYER_COLONY_ID,
     // Issue #114 — hydrate the pheromone overlay flag from persisted settings.
-    // localStorage may be unavailable (Node test runs); loadSettings falls back
-    // to DEFAULT_SETTINGS, which keeps the overlay ON to match the prior
-    // always-visible behavior.
     showPheromoneOverlay: loadSettings().pheromoneOverlay,
   };
 }
@@ -201,71 +172,73 @@ export function createViewState(startTileX: number, startTileY: number): ViewSta
 // ---------------------------------------------------------------------------
 
 /**
- * Reset an existing ViewState back to the same defaults as createViewState,
- * but MUTATING IN PLACE so references captured by UIScene / input handlers
- * remain valid. Reassigning to a fresh object would strand those references
- * on the pre-restart ViewState (same failure class as the stale-world bug).
+ * Reset an existing ViewState back to createViewState defaults, MUTATING IN PLACE
+ * so references captured by UIScene / input handlers remain valid (reassigning to
+ * a fresh object would strand those references — same failure class as the
+ * stale-world bug). CameraView fields are written individually for the same reason.
  *
- * Used by bootFresh / bootFromSave / restartGame: a new session must not
- * inherit the prior session's activeView, camera position, drag state, or
- * first-visit flag. Save files do not persist camera state, so continue-from-
- * save also starts the player back at the default surface view.
+ * Used by bootFresh / bootFromSave / restartGame. Save files do not persist camera
+ * state, so continue-from-save also starts back at the default surface view/zoom.
  */
 export function resetViewState(viewState: ViewState, startTileX: number, startTileY: number): void {
   viewState.activeView = 'surface';
   viewState.activeTool = 'command';
-  viewState.surfaceCamera.x = startTileX;
-  viewState.surfaceCamera.y = startTileY;
-  viewState.surfaceCamera.viewportWidth = VIEWPORT_WIDTH_TILES;
-  viewState.surfaceCamera.viewportHeight = VIEWPORT_HEIGHT_TILES;
-  viewState.undergroundCamera.x = startTileX;
-  viewState.undergroundCamera.y = UNDERGROUND_INITIAL_CAMERA_Y;
-  viewState.undergroundCamera.viewportWidth = VIEWPORT_WIDTH_TILES;
-  viewState.undergroundCamera.viewportHeight = VIEWPORT_HEIGHT_TILES;
+
+  viewState.surfaceCamera.centerX = tileCenterPx(startTileX);
+  viewState.surfaceCamera.centerY = tileCenterPx(startTileY);
+  viewState.surfaceCamera.zoom = DEFAULT_ZOOM;
+  viewState.surfaceCamera.targetZoom = DEFAULT_ZOOM;
+
+  viewState.undergroundCamera.centerX = tileCenterPx(startTileX);
+  viewState.undergroundCamera.centerY = UNDERGROUND_INITIAL_CENTER_Y_PX;
+  viewState.undergroundCamera.zoom = DEFAULT_ZOOM;
+  viewState.undergroundCamera.targetZoom = DEFAULT_ZOOM;
+
   viewState.undergroundVisited = false;
   // 09.1 Chunk 2 — restart always re-anchors the underground view on the
-  // player's own grid. Save files do not persist which enemy nest was being
-  // inspected, so continue-from-save also defaults to "Your Colony".
+  // player's own grid. Save files do not persist which enemy nest was inspected.
   viewState.activeUndergroundColonyId = PLAYER_COLONY_ID;
-  // Issue #114 — re-read the persisted overlay preference. The setting is a
-  // cosmetic preference, not session state, so a restart should respect the
-  // current localStorage value rather than snap back to ON unconditionally.
+  // Issue #114 — re-read the persisted overlay preference.
   viewState.showPheromoneOverlay = loadSettings().pheromoneOverlay;
 }
 
 // ---------------------------------------------------------------------------
-// toggleView
+// toggleView — atomic toggle algorithm (PLAN-stage2 §A5)
 // ---------------------------------------------------------------------------
 
 /**
- * toggleView — PRD §7c algorithm (Pattern 9) for instant view switching.
+ * toggleView — instant view switch with per-view zoom/center preserved.
  *
- * Surface → Underground:
- *   - Copies surfaceCamera.x → undergroundCamera.x (X-link sync)
- *   - If first visit: sets undergroundCamera.y = UNDERGROUND_INITIAL_CAMERA_Y
- *     (shaft/starter-hole row near the top) and marks visited
- *   - Sets activeView = 'underground'
- *
- * Underground → Surface:
- *   - Copies undergroundCamera.x → surfaceCamera.x (X-link sync)
- *   - Surface Y is NOT changed (PRD §7c: "Surface Y is preserved across toggles")
- *   - Sets activeView = 'surface'
+ * Algorithm (PLAN-stage2 §A5), order matters:
+ *   1. Snapshot the LEAVING view — automatic: its CameraView persists in place; we
+ *      only cancel any in-flight zoom-lerp so a later return doesn't resume a stale
+ *      target.
+ *   2. For the ENTERING view: its stored zoom is already restored (it persists on
+ *      the CameraView). Apply the first-underground-visit centering BEFORE the
+ *      X-link, then the X-link (centerX), then settle = cancel-lerp + custom clamp
+ *      at the restored zoom (clamp depends on the zoomed viewport size, so zoom is
+ *      restored before clamping).
+ *   3. Reset the active tool to the entering view's default.
  *
  * Mutates viewState in-place. No animation — instant switch (VIEW-02).
- *
- * @param viewState - The current ViewState to toggle
  */
 export function toggleView(viewState: ViewState): void {
   if (viewState.activeView === 'surface') {
-    viewState.undergroundCamera.x = viewState.surfaceCamera.x;
+    cancelZoomLerp(viewState.surfaceCamera); // freeze the leaving view's snapshot
+    // First-underground-visit centering BEFORE the X-link (independent axes, but
+    // spec order): set the shaft-at-top Y on the first visit only.
     if (!viewState.undergroundVisited) {
-      viewState.undergroundCamera.y = UNDERGROUND_INITIAL_CAMERA_Y;
+      viewState.undergroundCamera.centerY = UNDERGROUND_INITIAL_CENTER_Y_PX;
       viewState.undergroundVisited = true;
     }
+    viewState.undergroundCamera.centerX = viewState.surfaceCamera.centerX; // X-link (world px)
+    settleEnteringView(viewState.undergroundCamera, UNDERGROUND_WORLD_PX_W, UNDERGROUND_WORLD_PX_H);
     viewState.activeView = 'underground';
     viewState.activeTool = defaultToolForView('underground');
   } else {
-    viewState.surfaceCamera.x = viewState.undergroundCamera.x;
+    cancelZoomLerp(viewState.undergroundCamera); // freeze the leaving view's snapshot
+    viewState.surfaceCamera.centerX = viewState.undergroundCamera.centerX; // X-link (world px)
+    settleEnteringView(viewState.surfaceCamera, SURFACE_WORLD_PX_W, SURFACE_WORLD_PX_H);
     viewState.activeView = 'surface';
     viewState.activeTool = defaultToolForView('surface');
   }
@@ -276,98 +249,14 @@ export function toggleView(viewState: ViewState): void {
 // ---------------------------------------------------------------------------
 
 /**
- * toggleUndergroundColony — flip `activeUndergroundColonyId` between the
- * player's colony and the enemy's colony.
- *
- * Binary toggle: 09.1 has exactly 2 colonies, so flipping between
- * PLAYER_COLONY_ID and ENEMY_COLONY_ID is sufficient. Any future N-colony
- * expansion should replace this helper with a parameterized version (cycle
- * forward / set explicit).
+ * toggleUndergroundColony — flip `activeUndergroundColonyId` between the player's
+ * colony and the enemy's colony. Binary toggle (09.1 has exactly 2 colonies).
  *
  * The caller (game-scene.ts X-keybind handler) must gate dispatch on
- * `activeView === 'underground'`. The reducer itself is pure with respect
- * to other fields — it only touches `activeUndergroundColonyId`, so a stray
- * dispatch while on the surface view cannot flip the player out of surface
- * mode. Mutates in place so UIScene and input handlers that captured a
- * reference to the ViewState in create() keep seeing the update (same
- * in-place contract as toggleView / resetViewState).
- *
- * @param viewState - The current ViewState to toggle
+ * `activeView === 'underground'`. Mutates in place so UIScene / input handlers
+ * that captured a ViewState reference keep seeing the update.
  */
 export function toggleUndergroundColony(viewState: ViewState): void {
   viewState.activeUndergroundColonyId =
     viewState.activeUndergroundColonyId === PLAYER_COLONY_ID ? ENEMY_COLONY_ID : PLAYER_COLONY_ID;
-}
-
-// ---------------------------------------------------------------------------
-// clampCamera
-// ---------------------------------------------------------------------------
-
-/**
- * clampCamera — constrain camera center position to valid world bounds.
- *
- * Enforces that the camera center stays at least half a viewport from each world edge,
- * so the visible window never shows outside the world bounds (VIEW-04).
- *
- * Mutates cam in-place.
- *
- * Degenerate guard: if worldW < viewportWidth, cam.x = worldW/2 (centers on the world).
- *
- * @param cam - The CameraState to clamp (mutated in-place)
- * @param worldW - World width in tiles
- * @param worldH - World height in tiles
- */
-export function clampCamera(cam: CameraState, worldW: number, worldH: number): void {
-  const hw = cam.viewportWidth / 2;
-  const hh = cam.viewportHeight / 2;
-
-  // X axis
-  if (worldW < cam.viewportWidth) {
-    cam.x = worldW / 2;
-  } else {
-    cam.x = Math.max(hw, Math.min(worldW - hw, cam.x));
-  }
-
-  // Y axis
-  if (worldH < cam.viewportHeight) {
-    cam.y = worldH / 2;
-  } else {
-    cam.y = Math.max(hh, Math.min(worldH - hh, cam.y));
-  }
-}
-
-// ---------------------------------------------------------------------------
-// screenToTile
-// ---------------------------------------------------------------------------
-
-/**
- * screenToTile — convert screen pixel coordinates to tile coordinates.
- *
- * Converts a screen pixel position (e.g., mouse cursor) to the tile coordinates
- * it corresponds to, given the current camera state.
- *
- * Mirrors the renderer's integer-tile snap: draw-surface / draw-underground /
- * draw-pheromone all compute `left = Math.floor(cam.x - viewportWidth/2)` so
- * world tiles are drawn at integer-aligned pixel offsets. We apply the same
- * floor here so a click lands on the tile the player sees. Using the raw
- * fractional camera caused up to a ~15px drift between the rendered food
- * pile and the tile `findFoodPileAt` resolved to, making clicks miss unless
- * they struck near the tile center.
- *
- * @param screenX - Screen X in pixels (0 = left edge of canvas)
- * @param screenY - Screen Y in pixels (0 = top edge of canvas)
- * @param cam - The active CameraState
- * @returns Tile coordinates { tileX, tileY }
- */
-export function screenToTile(
-  screenX: number,
-  screenY: number,
-  cam: CameraState,
-): { tileX: number; tileY: number } {
-  const left = Math.floor(cam.x - cam.viewportWidth / 2);
-  const top = Math.floor(cam.y - cam.viewportHeight / 2);
-  return {
-    tileX: Math.floor(screenX / TILE_SIZE_PX) + left,
-    tileY: Math.floor(screenY / TILE_SIZE_PX) + top,
-  };
 }

--- a/src/render/draw-pheromone.test.ts
+++ b/src/render/draw-pheromone.test.ts
@@ -19,8 +19,12 @@ import { createWorldState } from '../sim/types.js';
 import { createPheromoneGrid, phSet, pheromoneGridKey } from '../sim/pheromone/pheromone-store.js';
 import { PheromoneType } from '../sim/enums.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
-import { COLOR_PHEROMONE_FOOD_FAINT, COLOR_PHEROMONE_FOOD_STRONG } from './sprites.js';
-import type { CameraState } from './camera.js';
+import {
+  TILE_SIZE_PX,
+  COLOR_PHEROMONE_FOOD_FAINT,
+  COLOR_PHEROMONE_FOOD_STRONG,
+} from './sprites.js';
+import { makeCameraView, type CameraView } from './camera-adapter.js';
 
 // ---------------------------------------------------------------------------
 // MockGfx — spy recorder implementing GfxLike
@@ -76,8 +80,15 @@ class MockGfx implements GfxLike {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeCamera(cx: number, cy: number, vpW: number, vpH: number): CameraState {
-  return { x: cx, y: cy, viewportWidth: vpW, viewportHeight: vpH };
+// Stage 2 world-space camera: the per-view camera is now a world-pixel
+// CameraView. To frame on tile (cx, cy) we center on (cx × TILE_SIZE_PX,
+// cy × TILE_SIZE_PX) at zoom 1, where the visible window is CANVAS_W/zoom ×
+// CANVAS_H/zoom = 800 × 592 world px. The old viewport-in-tiles args (vpW/vpH)
+// are gone — every fixture grid in this file is small enough to sit entirely
+// inside that window, so the visible-tile counts these tests assert (non-zero
+// tiles only, clamped to grid bounds) are unchanged by the wider window.
+function makeCamera(cx: number, cy: number): CameraView {
+  return makeCameraView(cx * TILE_SIZE_PX, cy * TILE_SIZE_PX);
 }
 
 /**
@@ -163,14 +174,14 @@ describe('drawPheromoneOverlay — FoodTrail grid', () => {
   });
 
   it('produces exactly 3 fillRect calls (skips the zero tile)', () => {
-    const cam = makeCamera(2, 0.5, 4, 1);
+    const cam = makeCamera(2, 0.5);
     drawPheromoneOverlay(gfx, world, cam, 'surface');
     const rects = gfx.callsOf('fillRect');
     expect(rects.length).toBe(3);
   });
 
   it('alpha increases from first to last non-zero tile (ramp behavior)', () => {
-    const cam = makeCamera(2, 0.5, 4, 1);
+    const cam = makeCamera(2, 0.5);
     drawPheromoneOverlay(gfx, world, cam, 'surface');
     const styles = gfx.callsOf('fillStyle');
     // fillStyle is called once per non-zero tile, in order tx=1,2,3
@@ -182,7 +193,7 @@ describe('drawPheromoneOverlay — FoodTrail grid', () => {
   });
 
   it('color at ¼-scale value (PHEROMONE_VISUAL_MAX >> 2) is between faint and strong (not equal to either endpoint)', () => {
-    const cam = makeCamera(2, 0.5, 4, 1);
+    const cam = makeCamera(2, 0.5);
     drawPheromoneOverlay(gfx, world, cam, 'surface');
     const styles = gfx.callsOf('fillStyle');
     // First non-zero tile (tx=1, value = PHEROMONE_VISUAL_MAX >> 2 = 128) → normalized=0.25
@@ -200,7 +211,7 @@ describe('drawPheromoneOverlay — missing grid', () => {
   it('produces no fillRect calls and does not throw when grid key is absent', () => {
     const gfx = new MockGfx();
     const world = createWorldState(1); // no pheromoneGrids installed
-    const cam = makeCamera(5, 5, 10, 10);
+    const cam = makeCamera(5, 5);
     expect(() => drawPheromoneOverlay(gfx, world, cam, 'surface')).not.toThrow();
     expect(gfx.callsOf('fillRect').length).toBe(0);
   });
@@ -227,7 +238,7 @@ describe('drawPheromoneOverlay — both pheromone types', () => {
     phSet(dangerGrid, 1, 1, PHEROMONE_VISUAL_MAX);
     world.pheromoneGrids[dangerKey] = dangerGrid;
 
-    const cam = makeCamera(2, 2, 4, 4);
+    const cam = makeCamera(2, 2);
     drawPheromoneOverlay(gfx, world, cam, 'surface');
 
     expect(gfx.callsOf('fillRect').length).toBe(2);
@@ -249,7 +260,7 @@ describe('drawPheromoneOverlay — both pheromone types', () => {
     phSet(dangerGrid, 0, 0, PHEROMONE_VISUAL_MAX);
     world.pheromoneGrids[dangerKey] = dangerGrid;
 
-    const cam = makeCamera(2, 2, 4, 4);
+    const cam = makeCamera(2, 2);
     drawPheromoneOverlay(gfx, world, cam, 'surface');
 
     const styles = gfx.callsOf('fillStyle');
@@ -281,7 +292,7 @@ describe('drawPheromoneOverlay — underground zone', () => {
     // Surface key should NOT be read
     // (no surface grid installed)
 
-    const cam = makeCamera(2, 2, 4, 4);
+    const cam = makeCamera(2, 2);
     drawPheromoneOverlay(gfx, world, cam, 'underground');
 
     expect(gfx.callsOf('fillRect').length).toBe(1); // one non-zero underground tile
@@ -304,7 +315,7 @@ describe('drawPheromoneOverlay — enemy colony pheromones excluded', () => {
     phSet(enemyGrid, 2, 2, PHEROMONE_VISUAL_MAX);
     world.pheromoneGrids[enemyKey] = enemyGrid;
 
-    const cam = makeCamera(2, 2, 4, 4);
+    const cam = makeCamera(2, 2);
     drawPheromoneOverlay(gfx, world, cam, 'surface');
 
     // No player grids → no draws; enemy grid is never accessed
@@ -330,7 +341,7 @@ describe('drawPheromoneOverlay — viewport clipping', () => {
     world.pheromoneGrids[key] = smallGrid;
 
     // Huge viewport — should still produce only 4 fillRect calls (2×2 grid)
-    const cam = makeCamera(0, 0, 100, 100);
+    const cam = makeCamera(0, 0);
     drawPheromoneOverlay(gfx, world, cam, 'surface');
 
     // Only 4 tiles exist; DangerTrail grid is absent (no calls from it)

--- a/src/render/draw-pheromone.ts
+++ b/src/render/draw-pheromone.ts
@@ -1,4 +1,5 @@
-// draw-pheromone.ts — Phase 8 pheromone heatmap overlay drawing module.
+// draw-pheromone.ts — Phase 8 pheromone heatmap overlay drawing module
+// (Stage 2 world-space migration, Phase A).
 //
 // Pure functions: take a GfxLike + WorldState, issue Graphics API calls.
 // No scene management, no input handling, no state mutation.
@@ -8,6 +9,12 @@
 //
 // Uses ONLY Graphics primitives: fillRect, fillStyle — NO Image, NO Sprite,
 // NO texture loading (HUD-05).
+//
+// Stage 2 (issue #18): tiles are drawn in WORLD pixels (worldX = tileX ×
+// TILE_SIZE_PX); the Phaser main camera (camera adapter: setZoom + centerOn)
+// projects world → screen, so this no longer subtracts a camera offset. The
+// visible tile range comes from the zoom-aware visibleTileRange helper (shared
+// with draw-surface), not a fixed viewport in tiles.
 //
 // Draw order: called by GameScene between terrain and entities.
 
@@ -27,7 +34,8 @@ import {
   COLOR_PHEROMONE_DANGER_STRONG,
   lerpColor,
 } from './sprites.js';
-import type { CameraState } from './camera.js';
+import { type CameraView } from './camera-adapter.js';
+import { visibleTileRange } from './draw-surface.js';
 
 // ---------------------------------------------------------------------------
 // Constants — PRD §7f
@@ -96,19 +104,15 @@ export function pheromoneRenderParams(
  *
  * @param gfx   - GfxLike graphics recorder / Phaser Graphics object.
  * @param world - Current WorldState (read-only; not mutated).
- * @param cam   - Camera position and viewport dimensions (in tiles).
+ * @param cam   - Zoom-aware CameraView (world pixels); drives the visible tile range.
  * @param zone  - 'surface' or 'underground' — selects which pheromone grids to draw.
  */
 export function drawPheromoneOverlay(
   gfx: GfxLike,
   world: WorldState,
-  cam: CameraState,
+  cam: CameraView,
   zone: 'surface' | 'underground',
 ): void {
-  // Compute visible tile range
-  const left = Math.floor(cam.x - cam.viewportWidth / 2);
-  const top = Math.floor(cam.y - cam.viewportHeight / 2);
-
   const pheromoneTypes = [PheromoneType.FoodTrail, PheromoneType.DangerTrail] as const;
 
   for (const pheromoneType of pheromoneTypes) {
@@ -116,9 +120,8 @@ export function drawPheromoneOverlay(
     const grid = world.pheromoneGrids[key];
     if (grid === undefined) continue;
 
-    // Clamp right/bottom to grid bounds
-    const right = Math.min(left + cam.viewportWidth + 1, grid.width);
-    const bottom = Math.min(top + cam.viewportHeight + 1, grid.height);
+    // Visible tile range (zoom-aware), clamped to this grid's bounds.
+    const { left, top, right, bottom } = visibleTileRange(cam, grid.width, grid.height);
 
     // Choose faint/strong palette by pheromone type
     const faintColor =
@@ -137,12 +140,7 @@ export function drawPheromoneOverlay(
 
         const params = pheromoneRenderParams(val, faintColor, strongColor);
         gfx.fillStyle(params.color, params.alpha);
-        gfx.fillRect(
-          (tx - left) * TILE_SIZE_PX,
-          (ty - top) * TILE_SIZE_PX,
-          TILE_SIZE_PX,
-          TILE_SIZE_PX,
-        );
+        gfx.fillRect(tx * TILE_SIZE_PX, ty * TILE_SIZE_PX, TILE_SIZE_PX, TILE_SIZE_PX);
       }
     }
   }

--- a/src/render/draw-surface.test.ts
+++ b/src/render/draw-surface.test.ts
@@ -8,7 +8,12 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
-import { drawSurfaceTerrain, drawSurfaceEntities, drawSurface } from './draw-surface.js';
+import {
+  drawSurfaceTerrain,
+  drawSurfaceEntities,
+  drawSurface,
+  visibleTileRange,
+} from './draw-surface.js';
 import type { GfxLike } from './draw-surface.js';
 import type {
   AntSpriteDrawOptions,
@@ -37,7 +42,7 @@ import {
   COLOR_RALLY_POINT,
 } from './sprites.js';
 import { COLOR_BARREN_EARTH } from './terrain-atlas.js';
-import type { CameraState } from './camera.js';
+import { makeCameraView, type CameraView } from './camera-adapter.js';
 
 // ---------------------------------------------------------------------------
 // MockGfx — spy recorder implementing GfxLike
@@ -128,9 +133,17 @@ class MockAntSprites implements AntSpriteLayer {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Build a minimal camera centered at (cx, cy) with given viewport. */
-function makeCamera(cx: number, cy: number, vpW: number, vpH: number): CameraState {
-  return { x: cx, y: cy, viewportWidth: vpW, viewportHeight: vpH };
+// Stage 2 world-space camera: the per-view camera is now a world-pixel
+// CameraView. To frame on tile (cx, cy) we center on (cx × TILE_SIZE_PX,
+// cy × TILE_SIZE_PX) at zoom 1, where the visible window is CANVAS_W/zoom ×
+// CANVAS_H/zoom = 800 × 592 world px (50 × 37 tiles — the same window the old
+// fixed viewport gave). The old viewport-in-tiles args (vpW/vpH) are gone:
+// drawing is now in world px (tile (tx,ty) → tx × TILE_SIZE_PX), so the entity
+// fixtures here are positioned the same on screen regardless of the removed
+// per-call viewport size, and entity-count assertions are unaffected because
+// their tiles sit well within the 800 × 592 window.
+function makeCamera(cx: number, cy: number): CameraView {
+  return makeCameraView(cx * TILE_SIZE_PX, cy * TILE_SIZE_PX);
 }
 
 /** Build a WorldState with a small surface grid seeded with alternating Grass/Dirt. */
@@ -143,21 +156,22 @@ function makeWorld4x4(): WorldState {
   return w;
 }
 
-/** Collect every fillRect that falls within a single tile's screen window.
- *  Used by the panning-stability test below — proves the same tile produces
- *  the same draws regardless of where the camera centers it on screen. */
-function textureRectsInsideTile(gfx: MockGfx, screenX: number, screenY: number): Rect[] {
+/** Collect every fillRect that falls within a single tile's WORLD-px window
+ *  (top-left at worldX, worldY). Used by the panning-stability test below —
+ *  proves the same tile produces the same draws regardless of where the camera
+ *  centers it (drawing is in world px, so a tile's coords are camera-independent). */
+function textureRectsInsideTile(gfx: MockGfx, worldX: number, worldY: number): Rect[] {
   const rects: Rect[] = [];
   for (const call of gfx.calls) {
     if (call.method !== 'fillRect') continue;
     const [x, y, w, h] = call.args as [number, number, number, number];
     if (
-      x >= screenX &&
-      y >= screenY &&
-      x + w <= screenX + TILE_SIZE_PX &&
-      y + h <= screenY + TILE_SIZE_PX
+      x >= worldX &&
+      y >= worldY &&
+      x + w <= worldX + TILE_SIZE_PX &&
+      y + h <= worldY + TILE_SIZE_PX
     ) {
-      rects.push({ x: x - screenX, y: y - screenY, w, h });
+      rects.push({ x: x - worldX, y: y - worldY, w, h });
     }
   }
   return rects;
@@ -176,14 +190,25 @@ describe('drawSurfaceTerrain', () => {
 
   it('renders every visible tile with the barren-earth substrate (issue #40)', () => {
     // Issue #40: surface is universally barren-earth substrate (with motifs
-    // scattered on top per tile hash). Every visible tile should produce at
-    // least one barren-earth fillStyle.
+    // scattered on top per tile hash). Every visible tile should produce
+    // exactly one barren-earth fillStyle.
+    //
+    // Stage 2: the camera no longer carries a tile viewport; the visible window
+    // is the zoom-1 800×592-world-px frame. drawSurfaceTerrain culls to
+    // visibleTileRange(cam, gridW, gridH) and applies the barren-earth fill once
+    // per visible tile, so the expected count is the area of that clamped tile
+    // range (computed from the camera, NOT copied from the draw output).
     const world = makeWorld4x4();
-    const cam = makeCamera(1.5, 1.5, 3, 3);
+    const cam = makeCamera(1.5, 1.5);
     drawSurfaceTerrain(gfx, world, cam);
     const earthStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_BARREN_EARTH);
-    // 4×4 visible tiles = 16; each tile applies the barren-earth fill once.
-    expect(earthStyles.length).toBe(16);
+    const { left, top, right, bottom } = visibleTileRange(
+      cam,
+      world.surface.width,
+      world.surface.height,
+    );
+    const expectedTiles = (right - Math.max(left, 0)) * (bottom - Math.max(top, 0));
+    expect(earthStyles.length).toBe(expectedTiles);
   });
 
   it('keeps texture placement stable for the same world tile as the camera pans', () => {
@@ -191,39 +216,34 @@ describe('drawSurfaceTerrain', () => {
     const tileX = 20;
     const tileY = 20;
 
-    const camA = makeCamera(20, 20, 20, 20);
+    // Stage 2: drawing is in world px, so tile (20,20) draws at the SAME world
+    // coordinate (tileX × TILE_SIZE_PX, tileY × TILE_SIZE_PX) no matter where the
+    // camera centers it — the main camera does the screen projection. Panning the
+    // camera one tile (center 20 → 21) must not change the tile's own draws.
+    const camA = makeCamera(20, 20);
     drawSurfaceTerrain(gfx, world, camA);
-    const leftA = Math.floor(camA.x - camA.viewportWidth / 2);
-    const topA = Math.floor(camA.y - camA.viewportHeight / 2);
-    const rectsA = textureRectsInsideTile(
-      gfx,
-      (tileX - leftA) * TILE_SIZE_PX,
-      (tileY - topA) * TILE_SIZE_PX,
-    );
+    const rectsA = textureRectsInsideTile(gfx, tileX * TILE_SIZE_PX, tileY * TILE_SIZE_PX);
 
     gfx.reset();
-    const camB = makeCamera(21, 20, 20, 20);
+    const camB = makeCamera(21, 20);
     drawSurfaceTerrain(gfx, world, camB);
-    const leftB = Math.floor(camB.x - camB.viewportWidth / 2);
-    const topB = Math.floor(camB.y - camB.viewportHeight / 2);
-    const rectsB = textureRectsInsideTile(
-      gfx,
-      (tileX - leftB) * TILE_SIZE_PX,
-      (tileY - topB) * TILE_SIZE_PX,
-    );
+    const rectsB = textureRectsInsideTile(gfx, tileX * TILE_SIZE_PX, tileY * TILE_SIZE_PX);
 
     expect(rectsA.length).toBeGreaterThan(0);
     expect(rectsA).toEqual(rectsB);
   });
 
   it('clips viewport to grid bounds — no fillRect with negative tx or ty offset', () => {
+    // Camera centered on the world's left edge (tile X=0). visibleTileRange
+    // clamps the tile loop at 0, so the leftmost drawn tile is tx=0 → worldX=0;
+    // no tile draws at a negative world X.
     const world = createWorldState(1);
-    const cam = makeCamera(0, 64, 50, 37);
+    const cam = makeCamera(0, 64);
     drawSurfaceTerrain(gfx, world, cam);
     const rects = gfx.callsOf('fillRect');
     for (const r of rects) {
-      const screenX = r.args[0] as number;
-      expect(screenX).toBeGreaterThanOrEqual(0);
+      const worldX = r.args[0] as number;
+      expect(worldX).toBeGreaterThanOrEqual(0);
     }
   });
 
@@ -234,7 +254,7 @@ describe('drawSurfaceTerrain', () => {
         sgSet(world.surface, x, y, SurfaceTileState.Dirt);
       }
     }
-    const cam = makeCamera(0, 0, 200, 200);
+    const cam = makeCamera(0, 0);
     drawSurfaceTerrain(gfx, world, cam);
     // Per-tile fillRect budget — explicit ceiling, bumped intentionally as
     // each kind of large feature has scaled up:
@@ -258,8 +278,8 @@ describe('drawSurfaceTerrain', () => {
     const world = makeWorld4x4();
     const a = new MockGfx();
     const b = new MockGfx();
-    drawSurfaceTerrain(a, world, makeCamera(1.5, 1.5, 3, 3));
-    drawSurfaceTerrain(b, world, makeCamera(1.5, 1.5, 3, 3));
+    drawSurfaceTerrain(a, world, makeCamera(1.5, 1.5));
+    drawSurfaceTerrain(b, world, makeCamera(1.5, 1.5));
     expect(a.calls).toEqual(b.calls);
   });
 });
@@ -300,7 +320,7 @@ describe('drawSurfaceEntities', () => {
       pickupsRemaining: 50,
       pickupsInitial: 50,
     });
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     const circles = gfx.callsOf('fillCircle');
     expect(circles.length).toBe(2);
@@ -327,7 +347,7 @@ describe('drawSurfaceEntities', () => {
       pickupsRemaining: 50,
       pickupsInitial: 50,
     });
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     const markedStyles = gfx
       .callsOf('fillStyle')
@@ -360,7 +380,7 @@ describe('drawSurfaceEntities', () => {
       pickupsRemaining: 50,
       pickupsInitial: 50,
     });
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     const markedStyles = gfx
       .callsOf('fillStyle')
@@ -371,8 +391,9 @@ describe('drawSurfaceEntities', () => {
   it('preserves sub-tile fixed-point precision when projecting ant position to pixels', () => {
     // Regression: previous code did `(posX >> FP_SHIFT) * TILE_SIZE_PX`, which
     // truncated sub-tile precision before multiplying by tile size. The sprite
-    // layer now receives screen-space pixels directly, so the same assertion
-    // applies: an ant at tile 10.5 must land at pixel 10.5 * TILE_SIZE_PX.
+    // layer now receives WORLD-space pixels directly (Stage 2), so the same
+    // assertion applies: an ant at tile 10.5 must land at world px
+    // 10.5 * TILE_SIZE_PX.
     const prev = createWorldState(1);
     const curr = createWorldState(1);
     const workerId = 0;
@@ -398,18 +419,18 @@ describe('drawSurfaceEntities', () => {
       zone: 0,
     });
 
-    const cam = makeCamera(10, 5, 20, 20);
+    const cam = makeCamera(10, 5);
     drawSurfaceEntities(gfx, sprites, prev, curr, 0, cam);
 
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
-    const expectedScreenX = 10.5 * TILE_SIZE_PX - left * TILE_SIZE_PX;
-    const expectedScreenY = 5.5 * TILE_SIZE_PX - top * TILE_SIZE_PX;
+    // World px (Stage 2): an ant at tile 10.5 / 5.5 draws at 10.5 × TILE_SIZE_PX
+    // / 5.5 × TILE_SIZE_PX, no camera offset (the main camera projects it).
+    const expectedWorldX = 10.5 * TILE_SIZE_PX;
+    const expectedWorldY = 5.5 * TILE_SIZE_PX;
     const antCall = sprites.calls.find(
       (c) =>
         c.kind === 'worker' &&
-        Math.abs(c.x - expectedScreenX) < 0.01 &&
-        Math.abs(c.y - expectedScreenY) < 0.01,
+        Math.abs(c.x - expectedWorldX) < 0.01 &&
+        Math.abs(c.y - expectedWorldY) < 0.01,
     );
     expect(antCall).toBeDefined();
   });
@@ -431,13 +452,14 @@ describe('drawSurfaceEntities', () => {
     initAnt(prev.ants, workerId, { colonyId, posX: 10 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 0 });
     initAnt(curr.ants, workerId, { colonyId, posX: 20 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 0 });
 
-    const cam = makeCamera(15, 5, 50, 37);
+    const cam = makeCamera(15, 5);
     drawSurfaceEntities(gfx, sprites, prev, curr, 0.5, cam);
 
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const expectedScreenX = 10 * 16 + (20 * 16 - 10 * 16) * 0.5 - left * TILE_SIZE_PX;
+    // World px (Stage 2): halfway between prev tile 10 and curr tile 20 at
+    // alpha 0.5 → (10×16 + 20×16) / 2 = 240, no camera offset.
+    const expectedWorldX = 10 * 16 + (20 * 16 - 10 * 16) * 0.5;
     const antCall = sprites.calls.find(
-      (c) => c.kind === 'worker' && Math.abs(c.x - expectedScreenX) < 0.5,
+      (c) => c.kind === 'worker' && Math.abs(c.x - expectedWorldX) < 0.5,
     );
     expect(antCall).toBeDefined();
   });
@@ -453,7 +475,7 @@ describe('drawSurfaceEntities', () => {
     world.colonies[colonyId] = colony;
 
     initAnt(world.ants, antId, { colonyId, posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 0 });
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
 
     expect(sprites.calls.length).toBe(1);
@@ -472,7 +494,7 @@ describe('drawSurfaceEntities', () => {
     world.colonies[colonyId] = colony;
 
     initAnt(world.ants, antId, { colonyId, posX: 5 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 0 });
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
 
     expect(sprites.calls.length).toBe(1);
@@ -508,7 +530,7 @@ describe('drawSurfaceEntities', () => {
       zone: 0,
     });
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
 
     const playerTints = sprites.calls.filter((c) => c.tint === COLOR_PLAYER_COLONY);
@@ -531,7 +553,7 @@ describe('drawSurfaceEntities', () => {
       posY: 5 << FP_SHIFT,
       zone: 1,
     });
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     expect(sprites.calls.length).toBe(0);
     expect(gfx.callsOf('fillCircle').length).toBe(0);
@@ -569,7 +591,7 @@ describe('drawSurfaceEntities — ant facing direction', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
     const { world } = makeWorldWithSurfaceAnt();
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     expect(sprites.calls.length).toBe(1);
     expect(sprites.calls[0]!.rotation).toBe(0);
@@ -583,7 +605,7 @@ describe('drawSurfaceEntities — ant facing direction', () => {
     // Shift curr ant one full tile to the right relative to prev.
     curr.ants.posX[antId] = 6 << FP_SHIFT;
     curr.ants.posY[antId] = 5 << FP_SHIFT;
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, prev, curr, 1, cam);
     expect(sprites.calls.length).toBe(1);
     // atan2(-0, -1) returns -π in JS; +π and -π both rotate the sprite to face right.
@@ -597,7 +619,7 @@ describe('drawSurfaceEntities — ant facing direction', () => {
     const { world: curr } = makeWorldWithSurfaceAnt();
     curr.ants.posX[antId] = 5 << FP_SHIFT;
     curr.ants.posY[antId] = 6 << FP_SHIFT;
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, prev, curr, 1, cam);
     expect(sprites.calls[0]!.rotation).toBeCloseTo(-Math.PI / 2, 5);
   });
@@ -609,7 +631,7 @@ describe('drawSurfaceEntities — ant facing direction', () => {
     const { world: curr } = makeWorldWithSurfaceAnt();
     curr.ants.posX[antId] = 5 << FP_SHIFT;
     curr.ants.posY[antId] = 4 << FP_SHIFT;
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, prev, curr, 1, cam);
     expect(sprites.calls[0]!.rotation).toBeCloseTo(Math.PI / 2, 5);
   });
@@ -621,7 +643,7 @@ describe('drawSurfaceEntities — ant facing direction', () => {
     const { world: curr } = makeWorldWithSurfaceAnt();
     curr.ants.posX[antId] = 4 << FP_SHIFT;
     curr.ants.posY[antId] = 5 << FP_SHIFT;
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, prev, curr, 1, cam);
     // Sprite's native head is at -x so zero rotation already points left.
     expect(sprites.calls[0]!.rotation).toBeCloseTo(0, 5);
@@ -661,7 +683,7 @@ describe('drawSurfaceEntities — facing cache smoothing', () => {
   it('alternating right/down movement settles toward a diagonal rotation (not axis-aligned)', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
-    const cam = makeCamera(10, 10, 30, 30);
+    const cam = makeCamera(10, 10);
     const facing = new AntFacingCache();
 
     // Walk an 8-step southeast zig-zag: (5,5)→(6,5)→(6,6)→(7,6)→(7,7)…
@@ -701,7 +723,7 @@ describe('drawSurfaceEntities — facing cache smoothing', () => {
   it('spawn frame does not inherit a stale heading from a recycled ant id', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
-    const cam = makeCamera(10, 10, 30, 30);
+    const cam = makeCamera(10, 10);
     const facing = new AntFacingCache();
 
     // First ant (id=0) builds up a rightward heading over a couple frames.
@@ -737,7 +759,7 @@ describe('drawSurfaceEntities — facing cache smoothing', () => {
   it('stationary ant keeps its prior smoothed heading across idle frames', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
-    const cam = makeCamera(10, 10, 30, 30);
+    const cam = makeCamera(10, 10);
     const facing = new AntFacingCache();
 
     // Frame 1: establish a rightward heading. (Cardinal move seeds raw atan2.)
@@ -786,12 +808,12 @@ describe('drawSurfaceEntities — wrong-plane flicker guard', () => {
     initAnt(prev.ants, antId, { colonyId, posX: 10 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 1 });
     initAnt(curr.ants, antId, { colonyId, posX: 20 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 0 });
 
-    const cam = makeCamera(15, 5, 50, 37);
+    const cam = makeCamera(15, 5);
     drawSurfaceEntities(gfx, sprites, prev, curr, 0.5, cam);
 
     expect(sprites.calls.length).toBe(1);
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const expectedCurrX = 20 * TILE_SIZE_PX - left * TILE_SIZE_PX;
+    // World px (Stage 2): snap-to-curr at tile 20 → 20 × TILE_SIZE_PX, no offset.
+    const expectedCurrX = 20 * TILE_SIZE_PX;
     expect(sprites.calls[0]!.x).toBeCloseTo(expectedCurrX, 5);
     expect(sprites.calls[0]!.rotation).toBe(0);
   });
@@ -813,12 +835,12 @@ describe('drawSurfaceEntities — wrong-plane flicker guard', () => {
     // prev deliberately not initialized — slot is !isAlive with default posX=0.
     initAnt(curr.ants, antId, { colonyId, posX: 20 << FP_SHIFT, posY: 5 << FP_SHIFT, zone: 0 });
 
-    const cam = makeCamera(20, 5, 50, 37);
+    const cam = makeCamera(20, 5);
     drawSurfaceEntities(gfx, sprites, prev, curr, 0.5, cam);
 
     expect(sprites.calls.length).toBe(1);
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const expectedCurrX = 20 * TILE_SIZE_PX - left * TILE_SIZE_PX;
+    // World px (Stage 2): snap-to-curr at tile 20 → 20 × TILE_SIZE_PX, no offset.
+    const expectedCurrX = 20 * TILE_SIZE_PX;
     expect(sprites.calls[0]!.x).toBeCloseTo(expectedCurrX, 5);
     expect(sprites.calls[0]!.rotation).toBe(0);
   });
@@ -864,28 +886,28 @@ describe('drawSurfaceEntities — rally-point marker', () => {
 
   it('renders a rally marker when the player colony has a rally point', () => {
     addPlayerColony({ tileX: 5, tileY: 5 });
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     expect(rallyRects(gfx).length).toBeGreaterThan(0);
   });
 
   it('renders no rally marker when rallyPoint is null', () => {
     addPlayerColony(null);
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     expect(rallyRects(gfx).length).toBe(0);
   });
 
   it('rally marker moves with the rally point tile (camera-relative position)', () => {
     addPlayerColony({ tileX: 10, tileY: 4 });
-    const cam = makeCamera(10, 4, 20, 20);
+    const cam = makeCamera(10, 4);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     const rects = rallyRects(gfx);
     expect(rects.length).toBeGreaterThan(0);
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
-    const sx = (10 - left) * TILE_SIZE_PX;
-    const sy = (4 - top) * TILE_SIZE_PX;
+    // World px (Stage 2): rally tile (10,4) draws at world (10×16, 4×16); the
+    // crosshair rects all fall inside that one tile box.
+    const sx = 10 * TILE_SIZE_PX;
+    const sy = 4 * TILE_SIZE_PX;
     for (const r of rects) {
       const rx = r.args[0] as number;
       const ry = r.args[1] as number;
@@ -898,7 +920,7 @@ describe('drawSurfaceEntities — rally-point marker', () => {
 
   it('rally marker disappears after rallyPoint is cleared', () => {
     addPlayerColony({ tileX: 5, tileY: 5 });
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
 
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     expect(rallyRects(gfx).length).toBeGreaterThan(0);
@@ -920,7 +942,7 @@ describe('drawSurfaceEntities — rally-point marker', () => {
     enemy.priorityFoodPileId = null;
     world.colonies[enemyId] = enemy;
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     expect(rallyRects(gfx).length).toBe(0);
   });
@@ -936,16 +958,15 @@ describe('drawSurfaceEntities — rally-point marker', () => {
   // any reduction below three COLOR_RALLY_POINT rects fails loudly.
   it('renders the full crosshair composition: exactly 3 white rally rects (H-bar + V-bar + center accent)', () => {
     addPlayerColony({ tileX: 5, tileY: 5 });
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
     const rects = rallyRects(gfx);
     expect(rects.length).toBe(3);
 
-    // Derive expected pixel coords for the marker's tile.
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
-    const sx = (5 - left) * TILE_SIZE_PX;
-    const sy = (5 - top) * TILE_SIZE_PX;
+    // Derive expected world-px coords for the marker's tile (Stage 2: tile
+    // (5,5) draws at world (5×16, 5×16), no camera offset).
+    const sx = 5 * TILE_SIZE_PX;
+    const sy = 5 * TILE_SIZE_PX;
 
     // Horizontal bar: full-tile-width minus edges, 2-px thick, centered vertically.
     const hBar = rects.find(
@@ -1046,7 +1067,7 @@ describe('drawSurfaceEntities — spider health bar (issue #148)', () => {
   it('hides the bar at full health', () => {
     const gfx = new MockGfx();
     const world = makeWorldWithSpider(SPIDER_HP_FULL);
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, new MockAntSprites(), world, world, 0, cam);
     expect(findHealthBar(gfx)).toBeNull();
   });
@@ -1054,7 +1075,7 @@ describe('drawSurfaceEntities — spider health bar (issue #148)', () => {
   it('shows a 24×4 bar once damaged, with fill width proportional to hp ratio', () => {
     const gfx = new MockGfx();
     const world = makeWorldWithSpider(SPIDER_HP_FULL / 2);
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, new MockAntSprites(), world, world, 0, cam);
     const bar = findHealthBar(gfx);
     expect(bar).not.toBeNull();
@@ -1069,16 +1090,17 @@ describe('drawSurfaceEntities — spider health bar (issue #148)', () => {
   it('floats above the sprite top edge', () => {
     const gfx = new MockGfx();
     const world = makeWorldWithSpider(10);
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, new MockAntSprites(), world, world, 0, cam);
     const bar = findHealthBar(gfx)!;
-    // Sprite center screen-y is tile 5 → 80px (camera left/top = -5 tiles).
-    const spriteCenterY = 80 - -5 * TILE_SIZE_PX;
+    // World px (Stage 2): the spider at tile 5 has world-y center 5 × TILE_SIZE_PX
+    // = 80 (no camera offset). The bar floats above the sprite's top edge.
+    const spriteCenterY = 5 * TILE_SIZE_PX;
     expect(bar.track.y).toBeLessThan(spriteCenterY - SPIDER_SPRITE_HEIGHT / 2);
   });
 
   it('fill colour skews green at high hp and red at low hp', () => {
-    const camY = makeCamera(5, 5, 20, 20);
+    const camY = makeCamera(5, 5);
     const highGfx = new MockGfx();
     drawSurfaceEntities(
       highGfx,
@@ -1109,7 +1131,7 @@ describe('drawSurfaceEntities — spider health bar (issue #148)', () => {
   it('clamps a negative hp ratio without drawing a negative-width fill', () => {
     const gfx = new MockGfx();
     const world = makeWorldWithSpider(-5);
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, new MockAntSprites(), world, world, 0, cam);
     const bar = findHealthBar(gfx)!;
     expect(bar.fill.w).toBe(0);
@@ -1122,7 +1144,7 @@ describe('drawSurfaceEntities — spider health bar (issue #148)', () => {
     const base = new MockGfx();
     const overlay = new MockGfx();
     const world = makeWorldWithSpider(SPIDER_HP_FULL / 2);
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(
       base,
       new MockAntSprites(),
@@ -1146,7 +1168,7 @@ describe('drawSurfaceEntities — spider health bar (issue #148)', () => {
     // spider indistinguishable from a full-health one (whose bar is hidden).
     const gfx = new MockGfx();
     const world = makeWorldWithSpider(SPIDER_HP_FULL - 1);
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, new MockAntSprites(), world, world, 0, cam);
     const bar = findHealthBar(gfx)!;
     expect(bar.fill.w).toBe(23);
@@ -1158,7 +1180,7 @@ describe('drawSurfaceEntities — spider health bar (issue #148)', () => {
     // dead. A positive hp must always show at least 1px.
     const gfx = new MockGfx();
     const world = makeWorldWithSpider(1);
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawSurfaceEntities(gfx, new MockAntSprites(), world, world, 0, cam);
     const bar = findHealthBar(gfx)!;
     expect(bar.fill.w).toBeGreaterThanOrEqual(1);
@@ -1194,7 +1216,7 @@ describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
     const tileX = 10;
     const tileY = 0;
     const world = makeWorldWithEnemyEntrance(tileX, tileY);
-    const cam = makeCamera(tileX, tileY, 10, 4);
+    const cam = makeCamera(tileX, tileY);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
 
     // Issue #117 replaced the four-rect perimeter with a single strokeCircle
@@ -1210,11 +1232,10 @@ describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
     }
     expect(enemyStrokes.length).toBe(1);
 
-    // Center on tile center, radius = mound outer radius (TILE_SIZE_PX/2 + 2).
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
-    const expectedCx = (tileX - left) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
-    const expectedCy = (tileY - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    // Center on tile center (world px, Stage 2: tileX×16 + 8, tileY×16 + 8),
+    // radius = mound outer radius (TILE_SIZE_PX/2 + 2).
+    const expectedCx = tileX * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    const expectedCy = tileY * TILE_SIZE_PX + TILE_SIZE_PX / 2;
     const expectedR = TILE_SIZE_PX / 2 + 2;
     expect(enemyStrokes[0]).toEqual([expectedCx, expectedCy, expectedR]);
 
@@ -1239,7 +1260,7 @@ describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
     player.digFlowFieldDirty = false;
     player.priorityFoodPileId = null;
     w.colonies[PLAYER_COLONY_ID] = player;
-    const cam = makeCamera(0, 0, 10, 4);
+    const cam = makeCamera(0, 0);
     drawSurfaceEntities(gfx, sprites, w, w, 0, cam);
 
     // No enemy-colored stroke should be present (lineStyle never sets COLOR_ENEMY_COLONY).
@@ -1260,7 +1281,7 @@ describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
     const world = makeWorldWithEnemyEntrance(tileX, tileY);
     // Drop the player entrance so the only entrance under inspection is the enemy's.
     world.colonies[PLAYER_COLONY_ID]!.entrances = [];
-    const cam = makeCamera(tileX, tileY, 10, 10);
+    const cam = makeCamera(tileX, tileY);
     drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
 
     // Walk fillStyle/fillCircle pairs and group by color.
@@ -1280,11 +1301,10 @@ describe('drawSurfaceEntities — enemy entrance border (issue #14)', () => {
     expect(circlesByColor.get(0x5a4a30)?.length).toBe(1); // COLOR_BARREN_EARTH_DAMP
     expect(circlesByColor.get(0x1a0f00)?.length).toBe(1); // COLOR_SURFACE_ENTRANCE_HOLE
 
-    // Concentric and centered on the tile center; radii match mound > body > hole.
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
-    const cx = (tileX - left) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
-    const cy = (tileY - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    // Concentric and centered on the tile center (world px, Stage 2: tileX×16 +
+    // 8, tileY×16 + 8); radii match mound > body > hole.
+    const cx = tileX * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    const cy = tileY * TILE_SIZE_PX + TILE_SIZE_PX / 2;
     expect(circlesByColor.get(0x6d563a)![0]).toEqual([cx, cy, TILE_SIZE_PX / 2 + 2]);
     expect(circlesByColor.get(0x5a4a30)![0]).toEqual([cx, cy, TILE_SIZE_PX / 2 + 1]);
     expect(circlesByColor.get(0x1a0f00)![0]).toEqual([cx, cy, TILE_SIZE_PX / 2 - 2]);
@@ -1307,7 +1327,7 @@ describe('drawSurface', () => {
       pickupsRemaining: 50,
       pickupsInitial: 50,
     });
-    const cam = makeCamera(5, 5, 10, 10);
+    const cam = makeCamera(5, 5);
     drawSurface(gfx, sprites, world, world, 0, cam);
     expect(gfx.callsOf('fillRect').length).toBeGreaterThan(0);
     expect(gfx.callsOf('fillCircle').length).toBe(1);

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -1,17 +1,19 @@
-// draw-surface.ts — Phase 8 surface view drawing module.
+// draw-surface.ts — Phase 8 surface view drawing module (Stage 2 world-space migration).
 //
-// Pure functions: take a GfxLike + AntSpriteLayer + WorldState snapshots,
-// issue Graphics API calls and AntSpriteLayer.drawAnt calls. No scene
-// management, no input handling, no state mutation.
+// Pure functions: take a GfxLike + AntSpriteLayer + WorldState snapshots, issue
+// Graphics API calls and AntSpriteLayer.drawAnt calls. No scene management, no input
+// handling, no state mutation.
 //
-// Non-ant primitives use ONLY Graphics: fillRect, fillCircle, strokeCircle,
-// fillTriangle, lineStyle, fillStyle. Ants go through the AntSpriteLayer —
-// GameScene plugs in a Phaser-backed sprite pool; tests plug in a recording
-// mock. draw-surface.ts itself remains Phaser-free.
+// Stage 2 (issue #18): all drawing is now in WORLD pixels (worldX = tileX × TILE_SIZE_PX).
+// The Phaser main camera (driven by the camera adapter: setZoom + centerOn) projects
+// world → screen, so these modules no longer subtract a camera offset. Culling is
+// against the adapter's visibleWorldRect (zoom-aware), not a fixed canvas rectangle.
+// Low-level per-tile/per-sprite helpers are unchanged — they draw at the given px,
+// which are now world px.
 //
 // Draw order: drawSurface calls drawSurfaceTerrain then drawSurfaceEntities.
 // Pheromone overlay is NOT called from here — GameScene calls drawPheromoneOverlay
-// between terrain and entities per RESEARCH §Architecture draw-order diagram.
+// between terrain and entities.
 
 import { sgGet } from '../sim/terrain.js';
 import { AntTask } from '../sim/enums.js';
@@ -41,7 +43,12 @@ import {
   COLOR_BARREN_EARTH_MOUND,
 } from './terrain-atlas.js';
 export type { AntSpriteLayer } from './ant-sprite-layer.js';
-import type { CameraState } from './camera.js';
+import {
+  type CameraView,
+  visibleWorldRect,
+  type WorldRect,
+  ANT_DOT_SCREEN_PX,
+} from './camera-adapter.js';
 import { SPIDER_SPRITE_HEIGHT, SPIDER_SPRITE_WIDTH } from './ant-sprite-layer.js';
 import { SPIDER_HUNGER_MAX_TICKS, SPIDER_HP_FULL } from '../sim/constants.js';
 import { tierIndex } from '../sim/ai-state.js';
@@ -67,17 +74,38 @@ export interface GfxLike {
 // Viewport helpers (shared by all draw modules)
 // ---------------------------------------------------------------------------
 
-/** Compute visible tile range from camera state. Returns { left, top, right, bottom }. */
-function visibleRange(
-  cam: CameraState,
+/**
+ * Compute the visible TILE range from the camera (zoom-aware), clamped to the grid.
+ * Derived from the adapter's world rect; the +1 margin covers tiles straddling the
+ * visible edge. Returns { left, top, right, bottom } in tile coordinates.
+ */
+export function visibleTileRange(
+  cam: CameraView,
   gridWidth: number,
   gridHeight: number,
 ): { left: number; top: number; right: number; bottom: number } {
-  const left = Math.floor(cam.x - cam.viewportWidth / 2);
-  const top = Math.floor(cam.y - cam.viewportHeight / 2);
-  const right = Math.min(left + cam.viewportWidth + 1, gridWidth);
-  const bottom = Math.min(top + cam.viewportHeight + 1, gridHeight);
+  const rect = visibleWorldRect(cam);
+  const left = Math.floor(rect.left / TILE_SIZE_PX);
+  const top = Math.floor(rect.top / TILE_SIZE_PX);
+  const right = Math.min(Math.ceil(rect.right / TILE_SIZE_PX) + 1, gridWidth);
+  const bottom = Math.min(Math.ceil(rect.bottom / TILE_SIZE_PX) + 1, gridHeight);
   return { left, top, right, bottom };
+}
+
+/**
+ * World-space cull test for a tile-anchored primitive whose top-left is at world
+ * (worldX, worldY). Mirrors the prior screen cull (one-tile left/top margin, right/
+ * bottom at the visible edge), now in world px so it is correct under any zoom.
+ * `margin` widens the box for primitives that spill past their tile (entrance mounds,
+ * spider sprite).
+ */
+function tileInView(worldX: number, worldY: number, rect: WorldRect, margin: number): boolean {
+  return (
+    worldX >= rect.left - margin &&
+    worldX <= rect.right + margin &&
+    worldY >= rect.top - margin &&
+    worldY <= rect.bottom + margin
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -85,29 +113,34 @@ function visibleRange(
 // ---------------------------------------------------------------------------
 
 /**
- * Draw the surface terrain tiles visible through the camera.
+ * Draw the surface terrain tiles visible through the camera, in WORLD pixels.
  *
- * Issue #40 reframe: surface is barren-earth-default with grass tufts /
- * pebbles / twigs / dead leaves / stones scattered as deterministic
- * decoration. The sim-layer SurfaceTileState (Dirt vs. Grass) no longer maps
- * to dramatically different colors — we render the same earthy substrate
- * everywhere and let the per-tile motif scattering create variety. Grass
- * tiles still bias slightly toward live-grass tufts (vs. dry-grass on dirt
- * tiles), but the dominant readout is "ant-scale ground", not "lawn vs.
- * dirt patch". This puts the visual focus on the ants where it belongs.
+ * Issue #40 reframe: surface is barren-earth-default with grass tufts / pebbles /
+ * twigs scattered as deterministic decoration. The per-tile motif scattering creates
+ * variety; the dominant readout is "ant-scale ground".
+ *
+ * Stage 2: this draws at world px and culls to the visible tile range, immediate-mode
+ * every frame (it draws tiles at world px into whatever GfxLike target it is given).
  */
-export function drawSurfaceTerrain(gfx: GfxLike, world: WorldState, cam: CameraState): void {
-  const { left, top, right, bottom } = visibleRange(cam, world.surface.width, world.surface.height);
+export function drawSurfaceTerrain(
+  gfx: GfxLike,
+  world: WorldState,
+  cam: CameraView,
+  // Stage 2 §B: when true, draw the WHOLE grid (off-screen RenderTexture bake) instead of
+  // culling to the camera's visible window. (Surface is static → baked once.)
+  bakeAll: boolean = false,
+): void {
+  const { left, top, right, bottom } = bakeAll
+    ? { left: 0, top: 0, right: world.surface.width, bottom: world.surface.height }
+    : visibleTileRange(cam, world.surface.width, world.surface.height);
 
   for (let ty = Math.max(top, 0); ty < bottom; ty++) {
     for (let tx = Math.max(left, 0); tx < right; tx++) {
-      // sgGet is read for future SurfaceTileState-aware decoration biasing
-      // (live-grass density on grass tiles, etc.). Right now barren-earth is
-      // the universal substrate.
+      // sgGet is read for future SurfaceTileState-aware decoration biasing.
       void sgGet(world.surface, tx, ty);
-      const screenX = (tx - left) * TILE_SIZE_PX;
-      const screenY = (ty - top) * TILE_SIZE_PX;
-      drawBarrenEarthTile(gfx, world, screenX, screenY, tx, ty);
+      const worldX = tx * TILE_SIZE_PX;
+      const worldY = ty * TILE_SIZE_PX;
+      drawBarrenEarthTile(gfx, world, worldX, worldY, tx, ty);
     }
   }
 }
@@ -117,17 +150,16 @@ export function drawSurfaceTerrain(gfx: GfxLike, world: WorldState, cam: CameraS
 // ---------------------------------------------------------------------------
 
 /**
- * Draw food piles, entrance holes, and ants (workers + queens) on the surface.
+ * Draw food piles, entrance holes, and ants (workers + queens) on the surface, in
+ * WORLD pixels (the main camera projects them).
  *
  * Moving entities (ants) are interpolated between prev and curr state at alpha.
  * Static entities (food piles, entrances) read directly from curr. (VIEW-03)
  *
- * `entranceHover` is the Stage 1 controls-rework hover outline (issue #18):
- * when non-null, a 2-px frame is drawn on the tile under the pointer while the
- * Dig tool is active on the surface — GREEN when `valid` (DesignateEntrance
- * would accept) or RED when not. GameScene recomputes both the tile and its
- * validity from the live camera every frame, so the outline tracks the pointer
- * even when keyboard/drag pan moves the camera beneath a stationary cursor.
+ * `entranceHover` is the Stage 1 controls-rework hover outline (issue #18): when
+ * non-null, a 2-px frame is drawn on the tile under the pointer while the Dig tool is
+ * active on the surface — GREEN when valid, RED otherwise. GameScene recomputes the
+ * tile + validity from the live camera every frame.
  */
 export function drawSurfaceEntities(
   gfx: GfxLike,
@@ -135,65 +167,44 @@ export function drawSurfaceEntities(
   prev: WorldState,
   curr: WorldState,
   alpha: number,
-  cam: CameraState,
+  cam: CameraView,
   entranceHover: { tileX: number; tileY: number; valid: boolean } | null = null,
   facing?: AntFacingCache,
   frameTimeMs: number = 0,
   contestedGlowFrames?: Map<number, number>,
   currentFrame: number = 0,
   // Overlay layer for primitives that must render ABOVE the sprite pool
-  // (SPIDER_SPRITE_DEPTH = 52). GameScene supplies a Graphics object set to a
-  // higher depth; callers that omit it (orchestrator + tests) fall back to the
-  // base gfx, preserving the previous single-layer behaviour.
+  // (SPIDER_SPRITE_DEPTH = 52). GameScene supplies a higher-depth Graphics; callers
+  // that omit it fall back to the base gfx.
   overlayGfx: GfxLike = gfx,
+  // Stage 2 §C13: strategic LOD — when true, ants render as screen-constant dots and the
+  // ant-derived contested-glow pass is skipped (allocation-free strategic frame).
+  dotMode: boolean = false,
 ): void {
-  const left = Math.floor(cam.x - cam.viewportWidth / 2);
-  const top = Math.floor(cam.y - cam.viewportHeight / 2);
-
-  const canvasW = cam.viewportWidth * TILE_SIZE_PX;
-  const canvasH = cam.viewportHeight * TILE_SIZE_PX;
+  const rect = visibleWorldRect(cam);
 
   // --- Food piles ---
-  // Phase 8.5 readability: add a 1-px dark outline to separate the green pile
-  // circle from the green grass tile underneath.
-  //
-  // Per Phase 9 food-mark fix: the "marked" flag was moved off the shared
-  // FoodPile entity (which is not per-colony) onto ColonyRecord. The HUD
-  // renders the PLAYER colony's perspective only — enemy priority targets
-  // stay invisible so the player can't read the enemy AI's intent.
-  //
   // Issue #112 shrink buckets: each pile renders one of 4 sizes based on
-  // `pickupsRemaining / pickupsInitial`. Bucketing against `pickupsInitial`
-  // (per-pile starting size) ensures small ephemeral piles and large strategic
-  // anchors both visibly shrink across their lifetime — a 30-pickup pile and
-  // a 150-pickup pile both go full → ¾ → ½ → ¼ as they drain.
+  // pickupsRemaining / pickupsInitial.
   const playerColony = curr.colonies[PLAYER_COLONY_ID];
   const playerPriorityPileId = playerColony ? playerColony.priorityFoodPileId : null;
   const baseRadius = TILE_SIZE_PX / 2 - 2;
   for (const pile of curr.foodPiles) {
-    const sx = (pile.tileX - left) * TILE_SIZE_PX;
-    const sy = (pile.tileY - top) * TILE_SIZE_PX;
-    // Trivial viewport cull
-    if (sx < -TILE_SIZE_PX || sx > canvasW || sy < -TILE_SIZE_PX || sy > canvasH) continue;
+    const wx = pile.tileX * TILE_SIZE_PX;
+    const wy = pile.tileY * TILE_SIZE_PX;
+    if (!tileInView(wx, wy, rect, TILE_SIZE_PX)) continue;
     const isPlayerMarked =
       playerPriorityPileId !== null && pile.foodPileId === playerPriorityPileId;
     const color = isPlayerMarked ? COLOR_FOOD_PILE_MARKED : COLOR_FOOD_PILE_NORMAL;
-    const cx = sx + TILE_SIZE_PX / 2;
-    const cy = sy + TILE_SIZE_PX / 2;
+    const cx = wx + TILE_SIZE_PX / 2;
+    const cy = wy + TILE_SIZE_PX / 2;
     // Shrink-bucket radius: percent-remaining buckets in [>75%, >50%, >25%, >0%].
-    // pickupsInitial > 0 by validator + scenario contract, so the divide is safe.
-    // Reads as floats are fine here — render layer is float-permitted (the sim
-    // float-ban only applies to src/sim/).
     const pct = pile.pickupsRemaining / pile.pickupsInitial;
     let r = baseRadius;
     if (pct <= 0.75) r = baseRadius - 2;
     if (pct <= 0.5) r = baseRadius - 4;
     if (pct <= 0.25) r = baseRadius - 6;
-    // Floor at 1: with TILE_SIZE_PX = 16, baseRadius = 6, so the smallest
-    // bucket would compute to r = 0 — invisible. Snap to 1px so a not-yet-
-    // vanished pile is always visible. Once the pile drains to 0 charges,
-    // the sim splices it out of foodPiles (food-system.ts) and this loop
-    // never sees it again, so there's no "ghost 1px circle" risk.
+    // Floor at 1 so a not-yet-vanished pile is always visible.
     if (r < 1) r = 1;
     gfx.fillStyle(color, 1);
     gfx.fillCircle(cx, cy, r);
@@ -202,57 +213,33 @@ export function drawSurfaceEntities(
   }
 
   // --- Entrance holes on surface (issue #117) ---
-  // Round hole in a piled-dirt mound. Three concentric circles (mound rim →
-  // mound body → hole interior) plus, for enemy entrances, a thin
-  // enemy-colored ring traced just outside the mound.
-  //
-  // Footprint spills 2 px onto each adjacent tile so the entrance reads as a
-  // 3-D bump on the surface, not a flat painted disc. The viewport cull
-  // margin below is widened from `TILE_SIZE_PX` to `TILE_SIZE_PX + MOUND_SPILL_PX + 1`
-  // so a tile whose mound spills onto a visible neighbor is still drawn even
-  // when its own center sits slightly off-screen.
-  //
-  // Diameters / radii at TILE_SIZE_PX = 16:
-  //   mound (outer)   = 10 px → spills 2 px onto each neighbor
-  //   mound (body)    = 9 px  → 1 px lighter rim around the body for shading
-  //   hole (interior) = 6 px  → matches food-pile baseRadius for visual weight
-  //
-  // Issue #14 cue: enemy entrances get a 1-px enemy-colony stroke around the
-  // mound so the player reads them as "rally here to invade" targets.
+  // Round hole in a piled-dirt mound. Three concentric circles plus, for enemy
+  // entrances, a thin enemy-colored ring just outside the mound. The footprint spills
+  // MOUND_SPILL_PX onto each adjacent tile, so the cull margin is widened.
   const MOUND_SPILL_PX = 2;
   const MOUND_OUTER_R = TILE_SIZE_PX / 2 + MOUND_SPILL_PX; // 10
-  const MOUND_BODY_R = TILE_SIZE_PX / 2 + 1; // 9 — 1px lighter rim shows around the body
-  const HOLE_R = TILE_SIZE_PX / 2 - 2; // 6 — matches food pile baseRadius
+  const MOUND_BODY_R = TILE_SIZE_PX / 2 + 1; // 9
+  const HOLE_R = TILE_SIZE_PX / 2 - 2; // 6
   for (const colony of Object.values(curr.colonies)) {
     if (!colony.entrances) continue;
     const isEnemy = colony.colonyId !== PLAYER_COLONY_ID;
     for (const entrance of colony.entrances) {
-      const sx = (entrance.surfaceTileX - left) * TILE_SIZE_PX;
-      const sy = (entrance.surfaceTileY - top) * TILE_SIZE_PX;
-      const cullMargin = TILE_SIZE_PX + MOUND_SPILL_PX + 1;
-      if (
-        sx < -cullMargin ||
-        sx > canvasW + MOUND_SPILL_PX ||
-        sy < -cullMargin ||
-        sy > canvasH + MOUND_SPILL_PX
-      )
-        continue;
-      const cx = sx + TILE_SIZE_PX / 2;
-      const cy = sy + TILE_SIZE_PX / 2;
-      // Outer mound rim: lighter spoil tone — reads as "raised dirt edge."
+      const wx = entrance.surfaceTileX * TILE_SIZE_PX;
+      const wy = entrance.surfaceTileY * TILE_SIZE_PX;
+      if (!tileInView(wx, wy, rect, TILE_SIZE_PX + MOUND_SPILL_PX + 1)) continue;
+      const cx = wx + TILE_SIZE_PX / 2;
+      const cy = wy + TILE_SIZE_PX / 2;
+      // Outer mound rim: lighter spoil tone.
       gfx.fillStyle(COLOR_BARREN_EARTH_MOUND, 1);
       gfx.fillCircle(cx, cy, MOUND_OUTER_R);
-      // Mound body: darker damp earth — reads as the "shadowed inside" of the mound.
+      // Mound body: darker damp earth.
       gfx.fillStyle(COLOR_BARREN_EARTH_DAMP, 1);
       gfx.fillCircle(cx, cy, MOUND_BODY_R);
       // Hole interior — round dark cavity.
       gfx.fillStyle(COLOR_SURFACE_ENTRANCE_HOLE, 1);
       gfx.fillCircle(cx, cy, HOLE_R);
       if (isEnemy) {
-        // 1-px enemy-colony ring traced just outside the mound. Replaces the
-        // four-rect rectangle with a stroke that follows the mound's circular
-        // silhouette so the cue reads as "this is an enemy entrance" without
-        // visually fighting the round shape.
+        // 1-px enemy-colony ring just outside the mound.
         gfx.lineStyle(1, COLOR_ENEMY_COLONY, 1);
         gfx.strokeCircle(cx, cy, MOUND_OUTER_R);
       }
@@ -260,9 +247,10 @@ export function drawSurfaceEntities(
   }
 
   // --- Surface contested tile glow (S1 → S6 polished) ---
-  // S6: surface combat uses COLOR_NEUTRAL_CONTESTED_GLOW (yellow) instead of
-  // the raw orange. A 5-frame fade-out is tracked via contestedGlowFrames.
-  {
+  // S6: surface combat uses COLOR_NEUTRAL_CONTESTED_GLOW (yellow). A 5-frame fade-out
+  // is tracked via contestedGlowFrames. Skipped in strategic dot mode (allocation-free
+  // pass — no per-entity Map/Set scan; §C13/R3-2).
+  if (!dotMode) {
     const tileColony = new Map<number, number>(); // tileKey → first colonyId
     const contested = new Set<number>();
     const n = curr.ants.alive.length;
@@ -283,7 +271,7 @@ export function drawSurfaceEntities(
         contestedGlowFrames.set(key, currentFrame);
       }
     }
-    // Draw glows for all tiles that were contested within the last 5 frames.
+    // Draw glows for all tiles contested within the last 5 frames.
     const GLOW_FADE_FRAMES = 5;
     const tilesToDraw = contestedGlowFrames ? contestedGlowFrames : null;
     const drawKeys = tilesToDraw
@@ -294,22 +282,21 @@ export function drawSurfaceEntities(
     for (const key of drawKeys) {
       const tx = key & 0xffff;
       const ty = (key >> 16) & 0xffff;
-      const sx = (tx - left) * TILE_SIZE_PX;
-      const sy = (ty - top) * TILE_SIZE_PX;
-      if (sx < -TILE_SIZE_PX || sx > canvasW || sy < -TILE_SIZE_PX || sy > canvasH) continue;
+      const wx = tx * TILE_SIZE_PX;
+      const wy = ty * TILE_SIZE_PX;
+      if (!tileInView(wx, wy, rect, TILE_SIZE_PX)) continue;
       // Fade alpha based on frames since last seen.
       const framesAgo = tilesToDraw ? currentFrame - (tilesToDraw.get(key) ?? currentFrame) : 0;
       const alpha_g = 0.15 * (1 - framesAgo / GLOW_FADE_FRAMES);
       if (alpha_g <= 0) continue;
-      // Soft edge: draw the center tile at full alpha, then draw 1px-thin
-      // border rects at half alpha to create a soft halo effect.
+      // Soft edge: center tile at full alpha, then 1px-thin border rects at half alpha.
       gfx.fillStyle(COLOR_NEUTRAL_CONTESTED_GLOW, alpha_g);
-      gfx.fillRect(sx + 2, sy + 2, TILE_SIZE_PX - 4, TILE_SIZE_PX - 4);
+      gfx.fillRect(wx + 2, wy + 2, TILE_SIZE_PX - 4, TILE_SIZE_PX - 4);
       gfx.fillStyle(COLOR_NEUTRAL_CONTESTED_GLOW, alpha_g * 0.5);
-      gfx.fillRect(sx, sy, TILE_SIZE_PX, 2);
-      gfx.fillRect(sx, sy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2);
-      gfx.fillRect(sx, sy + 2, 2, TILE_SIZE_PX - 4);
-      gfx.fillRect(sx + TILE_SIZE_PX - 2, sy + 2, 2, TILE_SIZE_PX - 4);
+      gfx.fillRect(wx, wy, TILE_SIZE_PX, 2);
+      gfx.fillRect(wx, wy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2);
+      gfx.fillRect(wx, wy + 2, 2, TILE_SIZE_PX - 4);
+      gfx.fillRect(wx + TILE_SIZE_PX - 2, wy + 2, 2, TILE_SIZE_PX - 4);
     }
     // Prune stale entries so the map doesn't grow without bound.
     if (tilesToDraw) {
@@ -320,12 +307,11 @@ export function drawSurfaceEntities(
   }
 
   // --- Hunt reticle (S3 → S6 polished) ---
-  // S6: deep red border with animated alpha pulse; subtle fill at 0.3 alpha.
   if (curr.scatterReticleTile !== null) {
     const { x: rtx, y: rty } = curr.scatterReticleTile;
-    const rsx = (rtx - left) * TILE_SIZE_PX;
-    const rsy = (rty - top) * TILE_SIZE_PX;
-    if (rsx > -TILE_SIZE_PX && rsx < canvasW && rsy > -TILE_SIZE_PX && rsy < canvasH) {
+    const rwx = rtx * TILE_SIZE_PX;
+    const rwy = rty * TILE_SIZE_PX;
+    if (tileInView(rwx, rwy, rect, TILE_SIZE_PX)) {
       // Pulse: alpha oscillates between 0.4 and 0.7 at 1 Hz.
       const pulse = 0.55 + 0.15 * Math.sin((2 * Math.PI * frameTimeMs) / 1000);
       // Scale: 1.0–1.05× on pulse (shift origin to tile center).
@@ -334,16 +320,16 @@ export function drawSurfaceEntities(
       // Tile fill at 0.3 alpha.
       gfx.fillStyle(0xcc1010, 0.3);
       gfx.fillRect(
-        rsx - sizeOffset,
-        rsy - sizeOffset,
+        rwx - sizeOffset,
+        rwy - sizeOffset,
         TILE_SIZE_PX * scalePulse,
         TILE_SIZE_PX * scalePulse,
       );
-      // Border at pulsed alpha: draw as 2-px edge strips.
+      // Border at pulsed alpha: 2-px edge strips.
       const bw = TILE_SIZE_PX * scalePulse;
       const bh = TILE_SIZE_PX * scalePulse;
-      const bx = rsx - sizeOffset;
-      const by = rsy - sizeOffset;
+      const bx = rwx - sizeOffset;
+      const by = rwy - sizeOffset;
       gfx.fillStyle(0xcc1010, pulse);
       gfx.fillRect(bx, by, bw, 2);
       gfx.fillRect(bx, by + bh - 2, bw, 2);
@@ -353,11 +339,9 @@ export function drawSurfaceEntities(
   }
 
   // --- Ants on surface (zone === 0) ---
-  // Wrong-plane flicker guard (09 render polish): when an ant's zone flipped
-  // between prev and curr (e.g. queen descending through an entrance), OR when
-  // the slot wasn't alive in prev (a freshly-spawned ant whose prev.posX/Y is
-  // a stale default like 0), interpolating prev→curr briefly draws the ant
-  // somewhere it never actually was. Snap to the curr position in those cases.
+  // Wrong-plane flicker guard: when an ant's zone flipped between prev and curr, OR
+  // the slot wasn't alive in prev, snap to curr (interpolating would draw it somewhere
+  // it never was).
   const maxId = curr.ants.alive.length;
   for (let id = 0; id < maxId; id++) {
     if (!isAlive(curr.ants, id)) continue;
@@ -365,28 +349,30 @@ export function drawSurfaceEntities(
 
     const useInterp = isAlive(prev.ants, id) && prev.ants.zone[id] === curr.ants.zone[id];
 
-    // Interpolate position: fixed-point → pixel. Multiply BEFORE dividing so
-    // sub-tile precision survives — truncating with `>> FP_SHIFT` first would
-    // snap the ant to its tile's upper-left corner and it would appear
-    // pinned to tile origins instead of moving smoothly within a tile.
+    // Interpolate position: fixed-point → world px. Multiply BEFORE dividing so
+    // sub-tile precision survives.
     const prevPxX = (prev.ants.posX[id]! * TILE_SIZE_PX) / FP_ONE;
     const currPxX = (curr.ants.posX[id]! * TILE_SIZE_PX) / FP_ONE;
     const prevPxY = (prev.ants.posY[id]! * TILE_SIZE_PX) / FP_ONE;
     const currPxY = (curr.ants.posY[id]! * TILE_SIZE_PX) / FP_ONE;
 
-    const baseX = useInterp ? prevPxX + (currPxX - prevPxX) * alpha : currPxX;
-    const baseY = useInterp ? prevPxY + (currPxY - prevPxY) * alpha : currPxY;
-    const screenX = baseX - left * TILE_SIZE_PX;
-    const screenY = baseY - top * TILE_SIZE_PX;
+    const worldX = useInterp ? prevPxX + (currPxX - prevPxX) * alpha : currPxX;
+    const worldY = useInterp ? prevPxY + (currPxY - prevPxY) * alpha : currPxY;
 
-    // Trivial viewport cull
-    if (
-      screenX < -TILE_SIZE_PX ||
-      screenX > canvasW ||
-      screenY < -TILE_SIZE_PX ||
-      screenY > canvasH
-    )
+    // Trivial world-rect cull.
+    if (!tileInView(worldX, worldY, rect, TILE_SIZE_PX)) continue;
+
+    // Strategic LOD (§C13): a screen-constant colony-colored dot instead of the detailed
+    // sprite — allocation-free (no facing/containment/sprite-pool work). ANT_DOT_SCREEN_PX
+    // / zoom keeps it ~constant on screen as the camera zooms out.
+    if (dotMode) {
+      const dotColor =
+        curr.ants.colonyId[id]! === PLAYER_COLONY_ID ? COLOR_PLAYER_COLONY : COLOR_ENEMY_COLONY;
+      const ds = ANT_DOT_SCREEN_PX / cam.zoom;
+      gfx.fillStyle(dotColor, 1);
+      gfx.fillRect(worldX - ds / 2, worldY - ds / 2, ds, ds);
       continue;
+    }
 
     const colonyId = curr.ants.colonyId[id]!;
     const colony = curr.colonies[colonyId];
@@ -394,17 +380,8 @@ export function drawSurfaceEntities(
 
     const color = colonyId === PLAYER_COLONY_ID ? COLOR_PLAYER_COLONY : COLOR_ENEMY_COLONY;
 
-    // Facing: rotate the SVG (head on -x natively) so the head points along
-    // the motion vector. Smoothing is applied by the AntFacingCache when one
-    // is supplied (GameScene owns the instance and hands it to every frame)
-    // — blends recent deltas so cardinal zig-zag movement reads as a diagonal
-    // facing instead of flipping axis every tick. Stationary ants reuse the
-    // prior smoothed rotation so the sprite holds its pose instead of
-    // snapping back to the default. When useInterp is false (zone flip or
-    // spawn frame) the delta is meaningless and the cache evicts stale state;
-    // rotation falls back to the sprite's default pose. See
-    // AntSpriteDrawOptions.rotation for the math and ant-facing-cache.ts for
-    // the blending contract.
+    // Facing: rotate the SVG so the head points along the motion vector; smoothing via
+    // AntFacingCache when supplied. Stationary ants reuse the prior smoothed rotation.
     const dx = currPxX - prevPxX;
     const dy = currPxY - prevPxY;
     const rotation = computeAntRotation(facing, id, curr.ants.zone[id]!, dx, dy, useInterp);
@@ -412,38 +389,34 @@ export function drawSurfaceEntities(
     const isFighter = curr.ants.task[id] === AntTask.Fighting;
     sprites.drawAnt({
       kind: isQueen ? 'queen' : 'worker',
-      x: screenX,
-      y: screenY,
+      x: worldX,
+      y: worldY,
       // S1: fighters get a red tint blended over their colony color.
       tint: isFighter && !isQueen ? lerpColor(color, COLOR_FIGHTER_TINT, 0.45) : color,
       rotation,
-      // S1: fighters render slightly larger (+1px equivalent at TILE_SIZE_PX=16).
+      // S1: fighters render slightly larger.
       scale: isFighter && !isQueen ? 1.25 : 1.0,
     });
   }
 
   // --- Spider sprite + hunger ring (S3) ---
-  // Drawn above ants (SPIDER_SPRITE_DEPTH = 52 > ANT_SPRITE_DEPTH = 50).
-  // Spider is always on the surface regardless of behavior state.
+  // Drawn above ants (SPIDER_SPRITE_DEPTH = 52 > ANT_SPRITE_DEPTH = 50). Spider is
+  // always on the surface regardless of behavior state.
   if (curr.spider !== null) {
     const spiderPrev = prev.spider;
     const currPxX = (curr.spider.posX * TILE_SIZE_PX) / FP_ONE;
     const currPxY = (curr.spider.posY * TILE_SIZE_PX) / FP_ONE;
     const prevPxX = spiderPrev !== null ? (spiderPrev.posX * TILE_SIZE_PX) / FP_ONE : currPxX;
     const prevPxY = spiderPrev !== null ? (spiderPrev.posY * TILE_SIZE_PX) / FP_ONE : currPxY;
-    // Spider has no zone field (surface-only) and never teleports between ticks,
-    // so a null-check on prev.spider suffices as the interp guard.
     const useSpiderInterp = spiderPrev !== null;
-    const baseSX = useSpiderInterp ? prevPxX + (currPxX - prevPxX) * alpha : currPxX;
-    const baseSY = useSpiderInterp ? prevPxY + (currPxY - prevPxY) * alpha : currPxY;
-    const spiderScreenX = baseSX - left * TILE_SIZE_PX;
-    const spiderScreenY = baseSY - top * TILE_SIZE_PX;
+    const spiderWorldX = useSpiderInterp ? prevPxX + (currPxX - prevPxX) * alpha : currPxX;
+    const spiderWorldY = useSpiderInterp ? prevPxY + (currPxY - prevPxY) * alpha : currPxY;
 
     if (
-      spiderScreenX > -SPIDER_SPRITE_WIDTH &&
-      spiderScreenX < canvasW + SPIDER_SPRITE_WIDTH &&
-      spiderScreenY > -SPIDER_SPRITE_HEIGHT &&
-      spiderScreenY < canvasH + SPIDER_SPRITE_HEIGHT
+      spiderWorldX > rect.left - SPIDER_SPRITE_WIDTH &&
+      spiderWorldX < rect.right + SPIDER_SPRITE_WIDTH &&
+      spiderWorldY > rect.top - SPIDER_SPRITE_HEIGHT &&
+      spiderWorldY < rect.bottom + SPIDER_SPRITE_HEIGHT
     ) {
       const hungerFraction = Math.min(
         curr.spider.hungerTicks / SPIDER_HUNGER_MAX_TICKS[tierIndex(curr.difficulty)],
@@ -452,22 +425,18 @@ export function drawSurfaceEntities(
       // S6: linear tint gradient pale (#ffeecc) → deep red (#cc2020) by hungerFraction.
       const tint = lerpColor(0xffeecc, 0xcc2020, hungerFraction);
 
-      sprites.drawSpider({ x: spiderScreenX, y: spiderScreenY, tint });
+      sprites.drawSpider({ x: spiderWorldX, y: spiderWorldY, tint });
 
-      // Hunger ring (S3 → S6 polished):
-      // Appears at 70% hunger, fades in to full alpha at 100%.
-      // At ≥80%, an additional faster pulse (0.5 Hz) signals rampage warning.
+      // Hunger ring (S3 → S6 polished): appears at 70% hunger, fades to full at 100%.
       if (hungerFraction > 0.7) {
         const baseRingAlpha = ((hungerFraction - 0.7) / 0.3) * 0.85;
-        // S6: rampage warning pulse at ≥80% hunger.
         const rampagePulse =
           hungerFraction >= 0.8 ? 0.1 * Math.sin((2 * Math.PI * frameTimeMs) / 2000) : 0;
         const ringAlpha = Math.min(1, baseRingAlpha + rampagePulse);
-        const rl = Math.round(spiderScreenX - SPIDER_SPRITE_WIDTH / 2);
-        const rt = Math.round(spiderScreenY - SPIDER_SPRITE_HEIGHT / 2);
+        const rl = Math.round(spiderWorldX - SPIDER_SPRITE_WIDTH / 2);
+        const rt = Math.round(spiderWorldY - SPIDER_SPRITE_HEIGHT / 2);
         const rw = SPIDER_SPRITE_WIDTH;
         const rh = SPIDER_SPRITE_HEIGHT;
-        // S6: smooth gradient by color-lerping the ring toward deep red.
         const ringColor = lerpColor(0xffeecc, 0xcc2020, hungerFraction);
         gfx.fillStyle(ringColor, ringAlpha);
         gfx.fillRect(rl, rt, rw, 2);
@@ -477,11 +446,9 @@ export function drawSurfaceEntities(
       }
 
       // S7/D1: spider priority indicator — white border when player has set priority.
-      // Drawn 2px outside the sprite bounding box so it remains visible alongside
-      // the hunger ring (which occupies the same edge pixels as the sprite boundary).
       if (curr.spiderPriorityColonyId === PLAYER_COLONY_ID) {
-        const pl = Math.round(spiderScreenX - SPIDER_SPRITE_WIDTH / 2) - 2;
-        const pt = Math.round(spiderScreenY - SPIDER_SPRITE_HEIGHT / 2) - 2;
+        const pl = Math.round(spiderWorldX - SPIDER_SPRITE_WIDTH / 2) - 2;
+        const pt = Math.round(spiderWorldY - SPIDER_SPRITE_HEIGHT / 2) - 2;
         const pw = SPIDER_SPRITE_WIDTH + 4;
         const ph = SPIDER_SPRITE_HEIGHT + 4;
         gfx.fillStyle(0xffffff, 1);
@@ -491,32 +458,20 @@ export function drawSurfaceEntities(
         gfx.fillRect(pl + pw - 2, pt + 2, 2, ph - 4);
       }
 
-      // Health bar (issue #148): render-only HP indicator floating just above
-      // the sprite. maxHp is the regen cap SPIDER_HP_FULL — SpiderState stores
-      // only hp (clamped to that constant), so no sim field is needed. Hidden
-      // at full health; appears once the spider has taken damage. Drawn on
-      // overlayGfx so it renders above the spider sprite (SPIDER_SPRITE_DEPTH).
+      // Health bar (issue #148): render-only HP indicator above the sprite, drawn on
+      // overlayGfx so it renders above the spider sprite.
       const hpRatio = Math.max(0, Math.min(1, curr.spider.hp / SPIDER_HP_FULL));
       if (hpRatio < 1) {
         const barW = 24;
         const barH = 4;
-        const barX = Math.round(spiderScreenX - barW / 2);
-        // Sit above the sprite top edge (and clear of the priority border,
-        // which sits 2px outside the box).
-        const barY = Math.round(spiderScreenY - SPIDER_SPRITE_HEIGHT / 2 - barH - 4);
-        // green (full) → yellow (half) → red (empty).
+        const barX = Math.round(spiderWorldX - barW / 2);
+        const barY = Math.round(spiderWorldY - SPIDER_SPRITE_HEIGHT / 2 - barH - 4);
         const fillColor =
           hpRatio > 0.5
             ? lerpColor(0xffcc00, 0x33cc33, (hpRatio - 0.5) / 0.5)
             : lerpColor(0xcc2020, 0xffcc00, hpRatio / 0.5);
-        // Quantize the fill so a damaged spider never reads as full and a
-        // barely-alive one never reads as empty: any 0 < ratio < 1 paints
-        // between 1px and barW-1px. hp == 0 paints an empty track. Without
-        // this, hp=79/80 rounds to the full 24px (looks undamaged) and hp=1/80
-        // rounds to 0px (looks dead).
         const fillW =
           hpRatio <= 0 ? 0 : Math.max(1, Math.min(barW - 1, Math.round(barW * hpRatio)));
-        // Dark outline + track so a near-empty bar still reads against terrain.
         overlayGfx.fillStyle(0x000000, 0.7);
         overlayGfx.fillRect(barX - 1, barY - 1, barW + 2, barH + 2);
         overlayGfx.fillStyle(0x333333, 0.85);
@@ -528,48 +483,39 @@ export function drawSurfaceEntities(
   }
 
   // --- Rally-point marker (Phase 9 usability fix) ---
-  // Player-colony only: a crosshair on the rally tile so the fight-control loop
-  // is visible and discoverable. Distinct from every other surface symbol:
-  //   - food piles         → filled green circle w/ dark outline
-  //   - marked food pile   → filled gold circle
-  //   - entrance           → dark hole w/ dirt rim (filled rects)
-  //   - queen              → gold strokeCircle around a filled body
-  //   - pending entrance   → gold 2-px tile frame
-  //   - rally point        → white crosshair: + bars across the tile, center dot
-  // Enemy colonies' rally points are never drawn (leaks AI intent).
+  // Player-colony only: a white crosshair on the rally tile. Enemy rally points are
+  // never drawn (leaks AI intent).
   if (playerColony && playerColony.rallyPoint !== null) {
     const rp = playerColony.rallyPoint;
-    const sx = (rp.tileX - left) * TILE_SIZE_PX;
-    const sy = (rp.tileY - top) * TILE_SIZE_PX;
-    if (sx > -TILE_SIZE_PX && sx < canvasW && sy > -TILE_SIZE_PX && sy < canvasH) {
+    const wx = rp.tileX * TILE_SIZE_PX;
+    const wy = rp.tileY * TILE_SIZE_PX;
+    if (tileInView(wx, wy, rect, TILE_SIZE_PX)) {
       gfx.fillStyle(COLOR_RALLY_POINT, 1);
-      // Horizontal bar across the tile (leave 1-px edges so adjacent tiles don't fuse)
-      gfx.fillRect(sx + 1, sy + 7, TILE_SIZE_PX - 2, 2);
-      // Vertical bar across the tile
-      gfx.fillRect(sx + 7, sy + 1, 2, TILE_SIZE_PX - 2);
-      // Center square accent — makes the crosshair pop against busy backgrounds
-      gfx.fillRect(sx + 6, sy + 6, 4, 4);
+      // Horizontal bar across the tile (leave 1-px edges so adjacent tiles don't fuse).
+      gfx.fillRect(wx + 1, wy + 7, TILE_SIZE_PX - 2, 2);
+      // Vertical bar across the tile.
+      gfx.fillRect(wx + 7, wy + 1, 2, TILE_SIZE_PX - 2);
+      // Center square accent.
+      gfx.fillRect(wx + 6, wy + 6, 4, 4);
     }
   }
 
   // --- Entrance hover outline (Stage 1 controls rework, issue #18) ---
-  // A 2-px frame on the tile under the pointer while the Dig tool is active on
-  // the surface: GREEN when DesignateEntrance would accept the tile, RED when
-  // not. GameScene re-resolves the tile + validity from the live camera every
-  // frame (Codex R1-9/R2-9/R3-4), so the outline never goes stale and tracks the
-  // pointer even when the camera pans beneath a stationary cursor.
+  // A 2-px frame on the tile under the pointer while the Dig tool is active: GREEN when
+  // DesignateEntrance would accept, RED otherwise. GameScene re-resolves tile + validity
+  // from the live camera every frame.
   if (entranceHover !== null) {
-    const sx = (entranceHover.tileX - left) * TILE_SIZE_PX;
-    const sy = (entranceHover.tileY - top) * TILE_SIZE_PX;
-    if (sx > -TILE_SIZE_PX && sx < canvasW && sy > -TILE_SIZE_PX && sy < canvasH) {
+    const wx = entranceHover.tileX * TILE_SIZE_PX;
+    const wy = entranceHover.tileY * TILE_SIZE_PX;
+    if (tileInView(wx, wy, rect, TILE_SIZE_PX)) {
       gfx.fillStyle(
         entranceHover.valid ? COLOR_ENTRANCE_HOVER_VALID : COLOR_ENTRANCE_HOVER_INVALID,
         0.8,
       );
-      gfx.fillRect(sx, sy, TILE_SIZE_PX, 2); // top
-      gfx.fillRect(sx, sy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2); // bottom
-      gfx.fillRect(sx, sy, 2, TILE_SIZE_PX); // left
-      gfx.fillRect(sx + TILE_SIZE_PX - 2, sy, 2, TILE_SIZE_PX); // right
+      gfx.fillRect(wx, wy, TILE_SIZE_PX, 2); // top
+      gfx.fillRect(wx, wy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2); // bottom
+      gfx.fillRect(wx, wy, 2, TILE_SIZE_PX); // left
+      gfx.fillRect(wx + TILE_SIZE_PX - 2, wy, 2, TILE_SIZE_PX); // right
     }
   }
 }
@@ -581,11 +527,8 @@ export function drawSurfaceEntities(
 /**
  * Orchestrator: draw terrain then entities for the surface view.
  *
- * Note: pheromone overlay is drawn by GameScene between terrain and entities;
- * it is NOT called from here.
- *
- * `entranceHover` (Stage 1 controls rework) is forwarded to drawSurfaceEntities
- * so the Dig-tool hover outline renders on top of all other surface layers.
+ * Note: pheromone overlay is drawn by GameScene between terrain and entities; it is
+ * NOT called from here.
  */
 export function drawSurface(
   gfx: GfxLike,
@@ -593,7 +536,7 @@ export function drawSurface(
   prev: WorldState,
   curr: WorldState,
   alpha: number,
-  cam: CameraState,
+  cam: CameraView,
   entranceHover: { tileX: number; tileY: number; valid: boolean } | null = null,
   facing?: AntFacingCache,
 ): void {

--- a/src/render/draw-underground.test.ts
+++ b/src/render/draw-underground.test.ts
@@ -44,7 +44,7 @@ import {
 } from './sprites.js';
 import { COLOR_ROCK_BASE, COLOR_FLOOR_BASE, COLOR_BARREN_EARTH } from './terrain-atlas.js';
 import { FOOD_CHAMBER_CAPACITY } from '../sim/constants.js';
-import type { CameraState } from './camera.js';
+import { makeCameraView, type CameraView } from './camera-adapter.js';
 import { AntFacingCache } from './ant-facing-cache.js';
 
 // ---------------------------------------------------------------------------
@@ -136,8 +136,16 @@ class MockAntSprites implements AntSpriteLayer {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeCamera(cx: number, cy: number, vpW: number, vpH: number): CameraState {
-  return { x: cx, y: cy, viewportWidth: vpW, viewportHeight: vpH };
+// Stage 2 world-space camera: the per-view camera is now a world-pixel
+// CameraView. To frame on tile (cx, cy) we center on (cx × TILE_SIZE_PX,
+// cy × TILE_SIZE_PX) at zoom 1, where the visible window is CANVAS_W/zoom ×
+// CANVAS_H/zoom = 800 × 592 world px. The old viewport-in-tiles args (vpW/vpH)
+// are gone — every fixture grid here (10×10) sits entirely inside that window,
+// so the visible-tile counts these tests assert are unchanged by the wider
+// window (ceiling-strip tints still count one per non-entrance ty=0 column,
+// since only the ceiling row gets that color).
+function makeCamera(cx: number, cy: number): CameraView {
+  return makeCameraView(cx * TILE_SIZE_PX, cy * TILE_SIZE_PX);
 }
 
 /** Build a WorldState with a player colony and a 10×10 underground grid. */
@@ -167,7 +175,7 @@ describe('drawUndergroundTerrain', () => {
 
   it('returns immediately (no draws) when player underground grid is absent', () => {
     const w = createWorldState(1);
-    const cam = makeCamera(5, 5, 10, 10);
+    const cam = makeCamera(5, 5);
     drawUndergroundTerrain(gfx, w, cam);
     expect(gfx.calls.length).toBe(0);
   });
@@ -178,7 +186,7 @@ describe('drawUndergroundTerrain', () => {
     // vocabulary) with a ceiling-strip tint overlay. The tint color survives
     // as evidence that ceiling tiles are visually distinct from interior
     // floor tiles.
-    const cam = makeCamera(5, 0.5, 10, 1);
+    const cam = makeCamera(5, 0.5);
     drawUndergroundTerrain(gfx, world, cam);
     const ceilingTintStyles = gfx
       .callsOf('fillStyle')
@@ -190,7 +198,7 @@ describe('drawUndergroundTerrain', () => {
     world.colonies[PLAYER_COLONY_ID]!.entrances = [
       { entranceId: 1, surfaceTileX: 3, surfaceTileY: 64, isOpen: true },
     ];
-    const cam = makeCamera(5, 0.5, 10, 1);
+    const cam = makeCamera(5, 0.5);
     drawUndergroundTerrain(gfx, world, cam);
 
     const ceilingTintStyles = gfx
@@ -201,7 +209,7 @@ describe('drawUndergroundTerrain', () => {
   });
 
   it('renders Solid tiles with the rock substrate (issue #40 — procedural rock palette)', () => {
-    const cam = makeCamera(5, 5, 4, 4);
+    const cam = makeCamera(5, 5);
     drawUndergroundTerrain(gfx, world, cam);
     const rockBaseStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_ROCK_BASE);
     expect(rockBaseStyles.length).toBeGreaterThan(0);
@@ -209,7 +217,7 @@ describe('drawUndergroundTerrain', () => {
 
   it('renders Open tiles with the floor substrate', () => {
     ugSet(world.undergroundGrids[PLAYER_COLONY_ID]!, 5, 5, UndergroundTileState.Open);
-    const cam = makeCamera(5, 5, 2, 2);
+    const cam = makeCamera(5, 5);
     drawUndergroundTerrain(gfx, world, cam);
     const floorStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_FLOOR_BASE);
     expect(floorStyles.length).toBeGreaterThan(0);
@@ -217,7 +225,7 @@ describe('drawUndergroundTerrain', () => {
 
   it('renders Marked tiles: open floor base + COLOR_MARKED_TILE_OVERLAY tint', () => {
     ugSet(world.undergroundGrids[PLAYER_COLONY_ID]!, 5, 5, UndergroundTileState.Marked);
-    const cam = makeCamera(5.5, 5.5, 2, 2);
+    const cam = makeCamera(5.5, 5.5);
     drawUndergroundTerrain(gfx, world, cam);
     const floorStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_FLOOR_BASE);
     const markedStyles = gfx
@@ -229,7 +237,7 @@ describe('drawUndergroundTerrain', () => {
 
   it('renders BeingDug tiles: open floor base + COLOR_BEING_DUG_OVERLAY tint', () => {
     ugSet(world.undergroundGrids[PLAYER_COLONY_ID]!, 5, 5, UndergroundTileState.BeingDug);
-    const cam = makeCamera(5.5, 5.5, 2, 2);
+    const cam = makeCamera(5.5, 5.5);
     drawUndergroundTerrain(gfx, world, cam);
     const floorStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_FLOOR_BASE);
     const beingDugStyles = gfx
@@ -244,7 +252,7 @@ describe('drawUndergroundTerrain', () => {
       { entranceId: 1, surfaceTileX: 2, surfaceTileY: 64, isOpen: true },
       { entranceId: 2, surfaceTileX: 7, surfaceTileY: 64, isOpen: true },
     ];
-    const cam = makeCamera(5, 0.5, 10, 1);
+    const cam = makeCamera(5, 0.5);
     drawUndergroundTerrain(gfx, world, cam);
     const ceilingTintStyles = gfx
       .callsOf('fillStyle')
@@ -260,7 +268,7 @@ describe('drawUndergroundTerrain', () => {
     world.colonies[PLAYER_COLONY_ID]!.entrances = [
       { entranceId: 1, surfaceTileX: 3, surfaceTileY: 64, isOpen: true },
     ];
-    const cam = makeCamera(5, 0.5, 10, 1);
+    const cam = makeCamera(5, 0.5);
     drawUndergroundTerrain(gfx, world, cam);
     const earthStyles = gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_BARREN_EARTH);
     expect(earthStyles.length).toBeGreaterThan(0);
@@ -279,7 +287,7 @@ describe('drawUndergroundTerrain', () => {
         ugSet(grid, x, y, UndergroundTileState.Marked);
       }
     }
-    const cam = makeCamera(0, 0, 200, 200);
+    const cam = makeCamera(0, 0);
     drawUndergroundTerrain(gfx, world, cam);
     expect(gfx.callsOf('fillRect').length).toBeLessThanOrEqual(grid.width * grid.height * 80);
   });
@@ -287,8 +295,8 @@ describe('drawUndergroundTerrain', () => {
   it('produces deterministic terrain renders for the same seed (issue #40 — replay-stable visuals)', () => {
     const a = new MockGfx();
     const b = new MockGfx();
-    drawUndergroundTerrain(a, world, makeCamera(5, 5, 4, 4));
-    drawUndergroundTerrain(b, world, makeCamera(5, 5, 4, 4));
+    drawUndergroundTerrain(a, world, makeCamera(5, 5));
+    drawUndergroundTerrain(b, world, makeCamera(5, 5));
     expect(a.calls).toEqual(b.calls);
   });
 });
@@ -320,13 +328,13 @@ describe('drawUndergroundEntities', () => {
       zone: 1,
     });
 
-    const cam = makeCamera(5, 3, 20, 20);
+    const cam = makeCamera(5, 3);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
-    const expectedX = 5.5 * TILE_SIZE_PX - left * TILE_SIZE_PX;
-    const expectedY = 3.5 * TILE_SIZE_PX - top * TILE_SIZE_PX;
+    // World px (Stage 2): the ant at tile 5.5 / 3.5 draws at 5.5 × TILE_SIZE_PX
+    // / 3.5 × TILE_SIZE_PX with no camera offset (the main camera projects it).
+    const expectedX = 5.5 * TILE_SIZE_PX;
+    const expectedY = 3.5 * TILE_SIZE_PX;
     const antCall = sprites.calls.find(
       (c) =>
         c.kind === 'worker' && Math.abs(c.x - expectedX) < 0.01 && Math.abs(c.y - expectedY) < 0.01,
@@ -353,13 +361,12 @@ describe('drawUndergroundEntities', () => {
       zone: 1,
     });
 
-    const cam = makeCamera(5, 3, 20, 20);
+    const cam = makeCamera(5, 3);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
-    const expectedX = (5 - left) * TILE_SIZE_PX;
-    const expectedY = (3 - top) * TILE_SIZE_PX;
+    // World px (Stage 2): tile 5 / 3 draws at 5 × TILE_SIZE_PX / 3 × TILE_SIZE_PX.
+    const expectedX = 5 * TILE_SIZE_PX;
+    const expectedY = 3 * TILE_SIZE_PX;
     const antCall = sprites.calls.find(
       (c) =>
         c.kind === 'worker' && Math.abs(c.x - expectedX) < 0.5 && Math.abs(c.y - expectedY) < 0.5,
@@ -376,7 +383,7 @@ describe('drawUndergroundEntities', () => {
       zone: 0,
     });
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     expect(sprites.calls.length).toBe(0);
@@ -392,7 +399,7 @@ describe('drawUndergroundEntities', () => {
       zone: 1,
     });
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     expect(sprites.calls.length).toBe(1);
@@ -418,7 +425,7 @@ describe('drawUndergroundEntities', () => {
     };
     world.colonies[PLAYER_COLONY_ID]!.chambers = [chamber];
 
-    const cam = makeCamera(5, 10, 20, 20);
+    const cam = makeCamera(5, 10);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     // Chamber color is applied at least once before the shape is drawn.
@@ -462,7 +469,7 @@ describe('drawUndergroundEntities', () => {
     };
     world.colonies[PLAYER_COLONY_ID]!.chambers = [chamber];
 
-    const cam = makeCamera(5, 10, 20, 20);
+    const cam = makeCamera(5, 10);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     // Outline pass switches fillStyle to COLOR_QUEEN_OUTLINE exactly once.
@@ -517,7 +524,7 @@ describe('drawUndergroundEntities', () => {
     };
     world.colonies[PLAYER_COLONY_ID]!.chambers = [chamber];
 
-    const cam = makeCamera(5, 10, 20, 20);
+    const cam = makeCamera(5, 10);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     // No fillStyle call with COLOR_QUEEN_OUTLINE → no gold outline emitted.
@@ -540,7 +547,7 @@ describe('drawUndergroundEntities', () => {
     };
     world.colonies[PLAYER_COLONY_ID]!.chambers = [chamber];
 
-    const cam = makeCamera(5, 10, 20, 20);
+    const cam = makeCamera(5, 10);
 
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
     const trianglesA = gfx
@@ -573,7 +580,7 @@ describe('drawUndergroundEntities', () => {
     });
     world.colonies[PLAYER_COLONY_ID]!.eggs = [eggId];
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     // SVG-backed render path: egg goes through the sprite layer, NOT fillCircle.
@@ -584,11 +591,11 @@ describe('drawUndergroundEntities', () => {
     // it only asserted the egg sprite was emitted, not that no ant sprite was.
     expect(sprites.calls.length).toBe(0);
     // Sprite is positioned at the tile center.
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
+    // World px (Stage 2): tile (4,5) center is at 4 × TILE_SIZE_PX + TILE_SIZE_PX/2
+    // / 5 × TILE_SIZE_PX + TILE_SIZE_PX/2.
     const eggCall = sprites.staticOfKind('egg')[0]!;
-    expect(eggCall.x).toBe((4 - left) * TILE_SIZE_PX + TILE_SIZE_PX / 2);
-    expect(eggCall.y).toBe((5 - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2);
+    expect(eggCall.x).toBe(4 * TILE_SIZE_PX + TILE_SIZE_PX / 2);
+    expect(eggCall.y).toBe(5 * TILE_SIZE_PX + TILE_SIZE_PX / 2);
   });
 
   // Issue #17 Phase 1.6 — visible carry render offset.
@@ -611,15 +618,14 @@ describe('drawUndergroundEntities', () => {
     world.ants.carriedBy[eggId] = carrierId;
     world.colonies[PLAYER_COLONY_ID]!.eggs = [eggId];
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
+    // World px (Stage 2): tile (4,5) center, no camera offset.
     const eggCall = sprites.staticOfKind('egg')[0]!;
-    expect(eggCall.x).toBe((4 - left) * TILE_SIZE_PX + TILE_SIZE_PX / 2);
+    expect(eggCall.x).toBe(4 * TILE_SIZE_PX + TILE_SIZE_PX / 2);
     // y is shifted upward (smaller value) by ~1/4 tile vs. the un-carried baseline.
-    const baseline = (5 - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    const baseline = 5 * TILE_SIZE_PX + TILE_SIZE_PX / 2;
     expect(eggCall.y).toBeLessThan(baseline);
     expect(baseline - eggCall.y).toBe(Math.round(TILE_SIZE_PX / 4));
   });
@@ -647,13 +653,12 @@ describe('drawUndergroundEntities', () => {
     world.ants.carriedBy[eggId] = carrierId;
     world.colonies[PLAYER_COLONY_ID]!.eggs = [eggId];
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
     const eggCall = sprites.staticOfKind('egg')[0]!;
-    // No offset — sits at tile center exactly.
-    expect(eggCall.y).toBe((5 - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2);
+    // No offset — sits at tile center exactly (world px, Stage 2).
+    expect(eggCall.y).toBe(5 * TILE_SIZE_PX + TILE_SIZE_PX / 2);
   });
 
   it('does NOT draw enemy-colony ants even when underground in view (PRD §7b)', () => {
@@ -671,7 +676,7 @@ describe('drawUndergroundEntities', () => {
       zone: 1,
     });
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     expect(sprites.calls.length).toBe(0);
@@ -692,7 +697,7 @@ describe('drawUndergroundEntities', () => {
       },
     ];
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     expect(sprites.staticOfKind('food-cache').length).toBe(0);
@@ -719,7 +724,7 @@ describe('drawUndergroundEntities', () => {
       },
     ];
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     const caches = sprites.staticOfKind('food-cache');
@@ -744,7 +749,7 @@ describe('drawUndergroundEntities', () => {
       },
     ];
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     const caches = sprites.staticOfKind('food-cache');
@@ -754,14 +759,14 @@ describe('drawUndergroundEntities', () => {
     for (const c of caches) {
       expect(c.tint).toBe(COLOR_CHAMBER_FOOD_STORAGE_FILL);
     }
-    // At least one cache sits on the chamber floor row (bottom tiles).
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
-    const bottomRowY =
-      (5 - top) * TILE_SIZE_PX + (foodDims.height - 1) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    // At least one cache sits on the chamber floor row (bottom tiles). World px
+    // (Stage 2): chamber posY tile 5, bottom row at row (height-1), each cache
+    // centered in its tile.
+    const bottomRowY = 5 * TILE_SIZE_PX + (foodDims.height - 1) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
     const bottomCaches = caches.filter((c) => Math.abs(c.y - bottomRowY) < 0.01);
     expect(bottomCaches.length).toBe(foodDims.width);
     // And at least one sits on the top row — chamber is fully packed.
-    const topRowY = (5 - top) * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+    const topRowY = 5 * TILE_SIZE_PX + TILE_SIZE_PX / 2;
     expect(caches.some((c) => Math.abs(c.y - topRowY) < 0.01)).toBe(true);
     // Chamber floor is still drawn as COLOR_CHAMBER_FOOD_STORAGE (unchanged
     // baseline). Just make sure the legacy amber fillRect path isn't emitted.
@@ -791,7 +796,7 @@ describe('drawUndergroundEntities', () => {
       },
     ];
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     expect(sprites.staticOfKind('food-cache').length).toBe(totalTiles);
@@ -853,7 +858,7 @@ describe('drawUndergroundEntities', () => {
     });
     world.colonies[PLAYER_COLONY_ID]!.larvae = [larvaId];
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     expect(sprites.staticOfKind('larva').length).toBe(1);
@@ -887,7 +892,7 @@ describe('drawUndergroundEntities', () => {
     world.colonies[PLAYER_COLONY_ID]!.eggs = [eggId];
     world.colonies[PLAYER_COLONY_ID]!.larvae = [larvaId];
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     // Brood gets static sprites at the right kind…
@@ -926,7 +931,7 @@ describe('drawUndergroundEntities', () => {
     world.colonies[PLAYER_COLONY_ID]!.eggs = [eggId];
     world.colonies[PLAYER_COLONY_ID]!.larvae = [larvaId];
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
 
     // Exactly one worker ant sprite (the nurse), and the two brood static sprites.
@@ -957,7 +962,7 @@ describe('drawUndergroundEntities — ant facing direction', () => {
     const world = makeWorldWithUnderground();
     world.colonies[PLAYER_COLONY_ID]!.queenEntityId = 999;
     setupAnt(world, 0, 5, 5);
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, world, world, 0, cam);
     expect(sprites.calls[0]!.rotation).toBe(0);
   });
@@ -971,7 +976,7 @@ describe('drawUndergroundEntities — ant facing direction', () => {
     curr.colonies[PLAYER_COLONY_ID]!.queenEntityId = 999;
     setupAnt(prev, 0, 5, 5);
     setupAnt(curr, 0, 6, 5);
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, prev, curr, 1, cam);
     expect(Math.abs(sprites.calls[0]!.rotation!)).toBeCloseTo(Math.PI, 5);
   });
@@ -985,7 +990,7 @@ describe('drawUndergroundEntities — ant facing direction', () => {
     curr.colonies[PLAYER_COLONY_ID]!.queenEntityId = 999;
     setupAnt(prev, 0, 5, 5);
     setupAnt(curr, 0, 5, 6);
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, prev, curr, 1, cam);
     expect(sprites.calls[0]!.rotation).toBeCloseTo(-Math.PI / 2, 5);
   });
@@ -1017,7 +1022,7 @@ describe('drawUndergroundEntities — facing cache smoothing', () => {
   it('alternating right/down movement settles toward a diagonal rotation (not axis-aligned)', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
-    const cam = makeCamera(5, 5, 30, 30);
+    const cam = makeCamera(5, 5);
     const facing = new AntFacingCache();
 
     let x = 3,
@@ -1050,7 +1055,7 @@ describe('drawUndergroundEntities — facing cache smoothing', () => {
   it('stationary ant keeps its prior smoothed heading across idle frames', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
-    const cam = makeCamera(5, 5, 30, 30);
+    const cam = makeCamera(5, 5);
     const facing = new AntFacingCache();
 
     const prev1 = makeUndergroundAntWorld(3, 3);
@@ -1070,7 +1075,7 @@ describe('drawUndergroundEntities — facing cache smoothing', () => {
   it('spawn frame does not inherit a stale heading from a recycled ant id', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
-    const cam = makeCamera(5, 5, 30, 30);
+    const cam = makeCamera(5, 5);
     const facing = new AntFacingCache();
 
     // Build up a heading for id=0.
@@ -1139,14 +1144,14 @@ describe('drawUndergroundEntities — wrong-plane flicker guard', () => {
       zone: 1,
     });
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, prev, curr, 0.5, cam);
 
     expect(sprites.calls.length).toBe(1);
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
-    const expectedCurrX = 6 * TILE_SIZE_PX - left * TILE_SIZE_PX;
-    const expectedCurrY = 7 * TILE_SIZE_PX - top * TILE_SIZE_PX;
+    // World px (Stage 2): snap-to-curr position is tile (6,7) → 6 × TILE_SIZE_PX
+    // / 7 × TILE_SIZE_PX with no camera offset.
+    const expectedCurrX = 6 * TILE_SIZE_PX;
+    const expectedCurrY = 7 * TILE_SIZE_PX;
     expect(sprites.calls[0]!.x).toBeCloseTo(expectedCurrX, 5);
     expect(sprites.calls[0]!.y).toBeCloseTo(expectedCurrY, 5);
     expect(sprites.calls[0]!.rotation).toBe(0);
@@ -1176,14 +1181,14 @@ describe('drawUndergroundEntities — wrong-plane flicker guard', () => {
       zone: 1,
     });
 
-    const cam = makeCamera(5, 5, 20, 20);
+    const cam = makeCamera(5, 5);
     drawUndergroundEntities(gfx, sprites, prev, curr, 0.5, cam);
 
     expect(sprites.calls.length).toBe(1);
-    const left = Math.floor(cam.x - cam.viewportWidth / 2);
-    const top = Math.floor(cam.y - cam.viewportHeight / 2);
-    const expectedCurrX = 6 * TILE_SIZE_PX - left * TILE_SIZE_PX;
-    const expectedCurrY = 7 * TILE_SIZE_PX - top * TILE_SIZE_PX;
+    // World px (Stage 2): snap-to-curr position is tile (6,7) → 6 × TILE_SIZE_PX
+    // / 7 × TILE_SIZE_PX with no camera offset.
+    const expectedCurrX = 6 * TILE_SIZE_PX;
+    const expectedCurrY = 7 * TILE_SIZE_PX;
     expect(sprites.calls[0]!.x).toBeCloseTo(expectedCurrX, 5);
     expect(sprites.calls[0]!.y).toBeCloseTo(expectedCurrY, 5);
     expect(sprites.calls[0]!.rotation).toBe(0);
@@ -1199,7 +1204,7 @@ describe('drawUnderground', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
     const w = createWorldState(1);
-    const cam = makeCamera(5, 5, 10, 10);
+    const cam = makeCamera(5, 5);
     expect(() => drawUnderground(gfx, sprites, w, w, 0, cam)).not.toThrow();
     expect(gfx.callsOf('fillRect').length).toBe(0);
   });
@@ -1208,7 +1213,7 @@ describe('drawUnderground', () => {
     const gfx = new MockGfx();
     const sprites = new MockAntSprites();
     const world = makeWorldWithUnderground();
-    const cam = makeCamera(5, 5, 10, 10);
+    const cam = makeCamera(5, 5);
     expect(() => drawUnderground(gfx, sprites, world, world, 0, cam)).not.toThrow();
     expect(gfx.callsOf('fillRect').length).toBeGreaterThan(0);
   });

--- a/src/render/draw-underground.ts
+++ b/src/render/draw-underground.ts
@@ -27,7 +27,7 @@ import {
 } from './ant-sprite-layer.js';
 import { containSpritePlacement } from './sprite-containment.js';
 import { computeAntRotation, type AntFacingCache } from './ant-facing-cache.js';
-import { ugGet, UndergroundTileState } from '../sim/terrain.js';
+import { ugGet, UndergroundTileState, type UndergroundGrid } from '../sim/terrain.js';
 import { isAlive } from '../sim/ant/ant-store.js';
 import { FP_SHIFT, FP_ONE } from '../sim/fixed.js';
 import { PLAYER_COLONY_ID, FOOD_CHAMBER_CAPACITY } from '../sim/constants.js';
@@ -42,6 +42,7 @@ import {
   COLOR_MARKED_TILE_OVERLAY,
   COLOR_BEING_DUG_OVERLAY,
   COLOR_UNDERGROUND_CEILING_STRIP,
+  COLOR_UNDERGROUND_SOLID,
   COLOR_CHAMBER_QUEEN,
   COLOR_CHAMBER_NURSERY,
   COLOR_CHAMBER_FOOD_STORAGE,
@@ -57,7 +58,13 @@ import { drawBarrenEarthSubstrate, drawOpenFloorTile } from './terrain-atlas.js'
 import { drawAutotiledUndergroundTile, drawUndergroundRim } from './underground-autotile.js';
 import { gatherUnderground3x3Neighbors, type Neighbors3x3 } from './underground-neighbors.js';
 import { chamberSeed, chamberPerimeterPoints } from './chamber-shape.js';
-import type { CameraState } from './camera.js';
+import {
+  type CameraView,
+  visibleWorldRect,
+  type WorldRect,
+  ANT_DOT_SCREEN_PX,
+} from './camera-adapter.js';
+import { visibleTileRange } from './draw-surface.js';
 
 // ---------------------------------------------------------------------------
 // Chamber color map
@@ -153,16 +160,18 @@ export function projectFoodStorageFill(colony: ColonyRecord, chamberId: number):
 export function drawUndergroundTerrain(
   gfx: GfxLike,
   world: WorldState,
-  cam: CameraState,
+  cam: CameraView,
   activeUndergroundColonyId: ColonyId = PLAYER_COLONY_ID,
+  // Stage 2 §B: when true, draw the WHOLE grid (off-screen RenderTexture bake) instead of
+  // culling to the camera's visible window.
+  bakeAll: boolean = false,
 ): void {
   const grid = world.undergroundGrids[activeUndergroundColonyId];
   if (grid === undefined) return;
 
-  const left = Math.floor(cam.x - cam.viewportWidth / 2);
-  const top = Math.floor(cam.y - cam.viewportHeight / 2);
-  const right = Math.min(left + cam.viewportWidth + 1, grid.width);
-  const bottom = Math.min(top + cam.viewportHeight + 1, grid.height);
+  const { left, top, right, bottom } = bakeAll
+    ? { left: 0, top: 0, right: grid.width, bottom: grid.height }
+    : visibleTileRange(cam, grid.width, grid.height);
 
   // Collect entrance X positions for ceiling gap rendering — uses the viewed
   // colony's entrances so the player sees enemy entrances when inspecting the
@@ -193,61 +202,117 @@ export function drawUndergroundTerrain(
 
   for (let ty = Math.max(top, 0); ty < bottom; ty++) {
     for (let tx = Math.max(left, 0); tx < right; tx++) {
-      const screenX = (tx - left) * TILE_SIZE_PX;
-      const screenY = (ty - top) * TILE_SIZE_PX;
-
-      if (ty === 0) {
-        // Ceiling strip: open gap at entrance columns, surface earth elsewhere.
-        // The ceiling reads as the underside of the surface — same barren
-        // earth substrate the player sees on the surface view (issue #40
-        // reframe), so the two views feel like the same continuous world.
-        if (entranceXSet.has(tx)) {
-          // Open shaft top — render as Open floor + gold tint highlight.
-          drawOpenFloorTile(gfx, screenX, screenY, tx, ty);
-          // Phase 8.5 usability (PRD §7c.1): translucent gold tint marks
-          // the "way in" so the entrance reads even on a near-full Solid
-          // grid (first-visit state).
-          gfx.fillStyle(COLOR_QUEEN_OUTLINE, 0.28);
-          gfx.fillRect(screenX, screenY, TILE_SIZE_PX, TILE_SIZE_PX);
-        } else {
-          // Plain ceiling — surface-style barren-earth SUBSTRATE only
-          // (codex P2 follow-up: drawBarrenEarthTile would intermittently
-          // paint multi-tile boulders / bushes into the ceiling strip,
-          // which is supposed to be a consistent texture row).
-          drawBarrenEarthSubstrate(gfx, screenX, screenY, tx, ty);
-          // Subtle ceiling-strip tint to differentiate from a real surface
-          // tile. Half-transparent so the underlying texture still shows.
-          gfx.fillStyle(COLOR_UNDERGROUND_CEILING_STRIP, 0.35);
-          gfx.fillRect(screenX, screenY, TILE_SIZE_PX, TILE_SIZE_PX);
-        }
-      } else {
-        // Issue #43 — quarter-tile autotiling. The classifier treats Solid
-        // (and OOB / non-entrance ceiling) as wall, and Open / Marked /
-        // BeingDug as open. The tile's substrate plus opposite-kind
-        // chamfer/inner-corner masks together resolve stair-step diagonals
-        // into smooth silhouettes across tile boundaries.
-        gatherUnderground3x3Neighbors(grid, tx, ty, entranceXSet, neighbors);
-        drawAutotiledUndergroundTile(gfx, screenX, screenY, tx, ty, neighbors.c, neighbors);
-        // Rim pass — subtle 2-pixel darker band on the open side of each
-        // wall boundary. The shape is correct without it but the corridor
-        // reads as flat black; the rim is what gives it the "carved out
-        // of packed earth" feel.
-        drawUndergroundRim(gfx, screenX, screenY, tx, ty, neighbors.c, neighbors);
-
-        // Marked / BeingDug tint overlay — applied AFTER autotile so the
-        // tint reads through the dug silhouette. Ensures the player sees
-        // what's queued / in progress without losing the smooth shape.
-        const state = ugGet(grid, tx, ty);
-        if (state === UndergroundTileState.Marked) {
-          gfx.fillStyle(COLOR_MARKED_TILE_OVERLAY, 0.55);
-          gfx.fillRect(screenX, screenY, TILE_SIZE_PX, TILE_SIZE_PX);
-        } else if (state === UndergroundTileState.BeingDug) {
-          gfx.fillStyle(COLOR_BEING_DUG_OVERLAY, 0.65);
-          gfx.fillRect(screenX, screenY, TILE_SIZE_PX, TILE_SIZE_PX);
-        }
-      }
+      drawOneUndergroundTile(gfx, grid, entranceXSet, tx, ty, neighbors);
     }
   }
+}
+
+/**
+ * Draw ONE underground terrain tile (ceiling row or autotiled interior + Marked/BeingDug
+ * tints) at world px. Shared by the per-frame/full-bake loop and the incremental dirty
+ * re-stamp (§B). `neighbors` is a reused scratch buffer so the caller can avoid
+ * per-tile allocation.
+ */
+function drawOneUndergroundTile(
+  gfx: GfxLike,
+  grid: UndergroundGrid,
+  entranceXSet: ReadonlySet<number>,
+  tx: number,
+  ty: number,
+  neighbors: Neighbors3x3,
+): void {
+  const worldX = tx * TILE_SIZE_PX;
+  const worldY = ty * TILE_SIZE_PX;
+
+  if (ty === 0) {
+    // Ceiling strip: open gap at entrance columns, surface earth elsewhere.
+    if (entranceXSet.has(tx)) {
+      // Open shaft top — render as Open floor + gold tint highlight.
+      drawOpenFloorTile(gfx, worldX, worldY, tx, ty);
+      gfx.fillStyle(COLOR_QUEEN_OUTLINE, 0.28);
+      gfx.fillRect(worldX, worldY, TILE_SIZE_PX, TILE_SIZE_PX);
+    } else {
+      // Plain ceiling — surface-style barren-earth SUBSTRATE only.
+      drawBarrenEarthSubstrate(gfx, worldX, worldY, tx, ty);
+      gfx.fillStyle(COLOR_UNDERGROUND_CEILING_STRIP, 0.35);
+      gfx.fillRect(worldX, worldY, TILE_SIZE_PX, TILE_SIZE_PX);
+    }
+  } else {
+    // Issue #43 — quarter-tile autotiling resolves stair-step diagonals into smooth
+    // silhouettes across tile boundaries.
+    gatherUnderground3x3Neighbors(grid, tx, ty, entranceXSet, neighbors);
+    drawAutotiledUndergroundTile(gfx, worldX, worldY, tx, ty, neighbors.c, neighbors);
+    // Rim pass — subtle darker band on the open side of each wall boundary.
+    drawUndergroundRim(gfx, worldX, worldY, tx, ty, neighbors.c, neighbors);
+
+    // Marked / BeingDug tint overlay — AFTER autotile so the tint reads through the shape.
+    const state = ugGet(grid, tx, ty);
+    if (state === UndergroundTileState.Marked) {
+      gfx.fillStyle(COLOR_MARKED_TILE_OVERLAY, 0.55);
+      gfx.fillRect(worldX, worldY, TILE_SIZE_PX, TILE_SIZE_PX);
+    } else if (state === UndergroundTileState.BeingDug) {
+      gfx.fillStyle(COLOR_BEING_DUG_OVERLAY, 0.65);
+      gfx.fillRect(worldX, worldY, TILE_SIZE_PX, TILE_SIZE_PX);
+    }
+  }
+}
+
+/**
+ * Incrementally re-stamp specific dirty tiles into a bake target (§B10). Each tile is
+ * first painted with an opaque Solid base so re-stamping fully OVERWRITES the prior RT
+ * pixels (autotile chamfers don't cover every corner — without the opaque base, stale
+ * pixels would bleed through on a state change). `dirtyKeys` are ty*width+tx indices
+ * (from diffTerrainShadow). The caller draws the returned Graphics into the RenderTexture.
+ */
+export function restampUndergroundTiles(
+  gfx: GfxLike,
+  world: WorldState,
+  colonyId: ColonyId,
+  dirtyKeys: Iterable<number>,
+): void {
+  const grid = world.undergroundGrids[colonyId];
+  if (grid === undefined) return;
+  const colony = world.colonies[colonyId];
+  const entranceXSet = new Set<number>();
+  if (colony?.entrances) {
+    for (const entrance of colony.entrances) entranceXSet.add(entrance.surfaceTileX);
+  }
+  const neighbors: Neighbors3x3 = {
+    nw: 'wall',
+    n: 'wall',
+    ne: 'wall',
+    w: 'wall',
+    c: 'wall',
+    e: 'wall',
+    sw: 'wall',
+    s: 'wall',
+    se: 'wall',
+  };
+  for (const key of dirtyKeys) {
+    const tx = key % grid.width;
+    const ty = (key / grid.width) | 0;
+    // Opaque base so the re-stamp cleanly overwrites the prior RT pixels.
+    gfx.fillStyle(COLOR_UNDERGROUND_SOLID, 1);
+    gfx.fillRect(tx * TILE_SIZE_PX, ty * TILE_SIZE_PX, TILE_SIZE_PX, TILE_SIZE_PX);
+    drawOneUndergroundTile(gfx, grid, entranceXSet, tx, ty, neighbors);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// tileInView — world-space cull (copied verbatim from draw-surface.ts, where it
+// is a private helper and not exported). A tile-anchored primitive whose top-left
+// is at world (worldX, worldY) is kept when it lies within the visible world rect
+// expanded by `margin`. `margin` widens the box for primitives that spill past
+// their tile.
+// ---------------------------------------------------------------------------
+
+function tileInView(worldX: number, worldY: number, rect: WorldRect, margin: number): boolean {
+  return (
+    worldX >= rect.left - margin &&
+    worldX <= rect.right + margin &&
+    worldY >= rect.top - margin &&
+    worldY <= rect.bottom + margin
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -278,22 +343,21 @@ export function drawUndergroundEntities(
   prev: WorldState,
   curr: WorldState,
   alpha: number,
-  cam: CameraState,
+  cam: CameraView,
   activeUndergroundColonyId: ColonyId = PLAYER_COLONY_ID,
   facing?: AntFacingCache,
   undergoundGlowFrames?: Map<number, number>,
   currentFrame: number = 0,
+  // Stage 2 §C13: strategic LOD — ants render as screen-constant dots; the ant-derived
+  // contested-glow + brood detail are skipped (allocation-free strategic frame).
+  dotMode: boolean = false,
 ): void {
   const colony = curr.colonies[activeUndergroundColonyId];
   if (colony === undefined) return;
   // PR 6-render (#128 class-iii) — the grid for sprite-containment scale clamping.
   const ugGrid = curr.undergroundGrids[activeUndergroundColonyId];
 
-  const left = Math.floor(cam.x - cam.viewportWidth / 2);
-  const top = Math.floor(cam.y - cam.viewportHeight / 2);
-
-  const canvasW = cam.viewportWidth * TILE_SIZE_PX;
-  const canvasH = cam.viewportHeight * TILE_SIZE_PX;
+  const rect = visibleWorldRect(cam);
 
   // --- Chambers ---
   // Phase 8.5 usability (PRD §7c.1): after drawing the chamber fill, queen
@@ -314,15 +378,15 @@ export function drawUndergroundEntities(
     if (dims === undefined) continue;
     const tileX = chamber.posX >> FP_SHIFT;
     const tileY = chamber.posY >> FP_SHIFT;
-    const screenX = (tileX - left) * TILE_SIZE_PX;
-    const screenY = (tileY - top) * TILE_SIZE_PX;
+    const worldX = tileX * TILE_SIZE_PX;
+    const worldY = tileY * TILE_SIZE_PX;
     const color = CHAMBER_COLORS[chamber.chamberType] ?? COLOR_CHAMBER_QUEEN;
     const w = dims.width * TILE_SIZE_PX;
     const h = dims.height * TILE_SIZE_PX;
     const seed = chamberSeed(colony.colonyId, chamber.chamberId, chamber.chamberType);
-    const points = chamberPerimeterPoints(seed, screenX, screenY, w, h);
-    const cx = screenX + w / 2;
-    const cy = screenY + h / 2;
+    const points = chamberPerimeterPoints(seed, worldX, worldY, w, h);
+    const cx = worldX + w / 2;
+    const cy = worldY + h / 2;
 
     // Fill via fan triangulation from chamber center. The polygon is nearly
     // convex (small jitter on a rectangle), so any "bowtie" overdraw from
@@ -381,8 +445,8 @@ export function drawUndergroundEntities(
         let placed = 0;
         for (let row = dims.height - 1; row >= 0 && placed < filledTiles; row--) {
           for (let col = 0; col < dims.width && placed < filledTiles; col++) {
-            const cx = screenX + col * TILE_SIZE_PX + TILE_SIZE_PX / 2;
-            const cy = screenY + row * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+            const cx = worldX + col * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+            const cy = worldY + row * TILE_SIZE_PX + TILE_SIZE_PX / 2;
             sprites.drawStatic({
               kind: 'food-cache',
               x: cx,
@@ -432,8 +496,9 @@ export function drawUndergroundEntities(
   // entity IDs are world-globally unique (no collision risk).
   // --- Underground home-ground combat tile glow (S6) ---
   // Per-grid color: blue for player grid, orange for enemy grid.
-  // Fade-out over 5 frames once combat ants leave a tile.
-  {
+  // Fade-out over 5 frames once combat ants leave a tile. Skipped in strategic dot mode
+  // (allocation-free pass — no per-entity Map/Set scan; §C13/R3-2).
+  if (!dotMode) {
     const glowColor =
       activeUndergroundColonyId === PLAYER_COLONY_ID
         ? COLOR_PLAYER_HOME_GLOW
@@ -477,9 +542,9 @@ export function drawUndergroundEntities(
     for (const key of drawKeys) {
       const tx = key & 0xff; // bits 0-7; tx max = 127
       const ty = (key >> 16) & 0xff; // bits 16-23; top byte (24+) holds colony ID
-      const sx = (tx - left) * TILE_SIZE_PX;
-      const sy = (ty - top) * TILE_SIZE_PX;
-      if (sx < -TILE_SIZE_PX || sx > canvasW || sy < -TILE_SIZE_PX || sy > canvasH) continue;
+      const worldX = tx * TILE_SIZE_PX;
+      const worldY = ty * TILE_SIZE_PX;
+      if (!tileInView(worldX, worldY, rect, TILE_SIZE_PX)) continue;
       const framesAgo = undergoundGlowFrames
         ? currentFrame - (undergoundGlowFrames.get(key) ?? currentFrame)
         : 0;
@@ -487,12 +552,12 @@ export function drawUndergroundEntities(
       if (alpha_g <= 0) continue;
       // Soft edge.
       gfx.fillStyle(glowColor, alpha_g);
-      gfx.fillRect(sx + 2, sy + 2, TILE_SIZE_PX - 4, TILE_SIZE_PX - 4);
+      gfx.fillRect(worldX + 2, worldY + 2, TILE_SIZE_PX - 4, TILE_SIZE_PX - 4);
       gfx.fillStyle(glowColor, alpha_g * 0.5);
-      gfx.fillRect(sx, sy, TILE_SIZE_PX, 2);
-      gfx.fillRect(sx, sy + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2);
-      gfx.fillRect(sx, sy + 2, 2, TILE_SIZE_PX - 4);
-      gfx.fillRect(sx + TILE_SIZE_PX - 2, sy + 2, 2, TILE_SIZE_PX - 4);
+      gfx.fillRect(worldX, worldY, TILE_SIZE_PX, 2);
+      gfx.fillRect(worldX, worldY + TILE_SIZE_PX - 2, TILE_SIZE_PX, 2);
+      gfx.fillRect(worldX, worldY + 2, 2, TILE_SIZE_PX - 4);
+      gfx.fillRect(worldX + TILE_SIZE_PX - 2, worldY + 2, 2, TILE_SIZE_PX - 4);
     }
     // Prune stale entries.
     if (undergoundGlowFrames) {
@@ -526,19 +591,24 @@ export function drawUndergroundEntities(
     const prevPxY = (prev.ants.posY[id]! * TILE_SIZE_PX) / FP_ONE;
     const currPxY = (curr.ants.posY[id]! * TILE_SIZE_PX) / FP_ONE;
 
+    // baseX/baseY are already world px (posX/posY → px), so they double as the
+    // draw position; the main camera projects them to screen.
     const baseX = useInterp ? prevPxX + (currPxX - prevPxX) * alpha : currPxX;
     const baseY = useInterp ? prevPxY + (currPxY - prevPxY) * alpha : currPxY;
-    const screenX = baseX - left * TILE_SIZE_PX;
-    const screenY = baseY - top * TILE_SIZE_PX;
 
-    // Trivial viewport cull
-    if (
-      screenX < -TILE_SIZE_PX ||
-      screenX > canvasW ||
-      screenY < -TILE_SIZE_PX ||
-      screenY > canvasH
-    )
+    // Trivial world-rect cull.
+    if (!tileInView(baseX, baseY, rect, TILE_SIZE_PX)) continue;
+
+    // Strategic LOD (§C13): a screen-constant colony-colored dot instead of the detailed
+    // sprite — allocation-free (no facing/containment/sprite-pool work).
+    if (dotMode) {
+      const dotColor =
+        curr.ants.colonyId[id]! === PLAYER_COLONY_ID ? COLOR_PLAYER_COLONY : COLOR_ENEMY_COLONY;
+      const ds = ANT_DOT_SCREEN_PX / cam.zoom;
+      gfx.fillStyle(dotColor, 1);
+      gfx.fillRect(baseX - ds / 2, baseY - ds / 2, ds, ds);
       continue;
+    }
 
     // Facing: rotate the SVG (head on -x natively) toward the motion vector.
     // Smoothing is applied by the AntFacingCache when one is supplied — the
@@ -572,19 +642,23 @@ export function drawUndergroundEntities(
     const isFighter2 = curr.ants.task[id] === AntTask.Fighting;
     // PR 6-render (#128 class-iii) — contain the sprite's rotated footprint so
     // it never paints over a Solid/off-grid neighbour. baseX/baseY are the
-    // interpolated grid-space pixel center (pre-camera-offset), which is what
-    // the containment math is in terms of. Containment nudges POSITION before
-    // scale (containSpritePlacement): the sim pins shaft/descent ants to exact
+    // interpolated world-pixel center, which is what the containment math is in
+    // terms of. Containment nudges POSITION before scale
+    // (containSpritePlacement): the sim pins shaft/descent ants to exact
     // tile-edge coordinates, where a pure scale clamp against the Solid shaft
     // wall would collapse them to scale 0 (invisible). Workers at natural size
     // already fit a tile, so they adjust only when rotation enlarges their AABB
     // near dirt or they sit on a tile edge beside it.
+    //
+    // Continuity (issue #18): the containment input/output stays a continuous
+    // float — the world px are NOT rounded — so the main camera's zoom
+    // projection keeps the sub-tile precision PR6 introduced.
     const desiredScale = isFighter2 && !isQueen ? 1.25 : 1.0;
     const nativeW = isQueen ? QUEEN_SPRITE_WIDTH : WORKER_SPRITE_WIDTH;
     const nativeH = isQueen ? QUEEN_SPRITE_HEIGHT : WORKER_SPRITE_HEIGHT;
     let scale = desiredScale;
-    let drawX = screenX;
-    let drawY = screenY;
+    let drawX = baseX;
+    let drawY = baseY;
     if (ugGrid !== undefined) {
       const placed = containSpritePlacement(
         ugGrid,
@@ -596,8 +670,8 @@ export function drawUndergroundEntities(
         desiredScale,
       );
       scale = placed.scale;
-      drawX = placed.cxPx - left * TILE_SIZE_PX;
-      drawY = placed.cyPx - top * TILE_SIZE_PX;
+      drawX = placed.cxPx;
+      drawY = placed.cyPx;
     }
     sprites.drawAnt({
       kind: isQueen ? 'queen' : 'worker',
@@ -614,28 +688,11 @@ export function drawUndergroundEntities(
   // from the brood entity positions exactly — the sim's nurses have already
   // moved them into the nursery footprint, so rendering at the entity's
   // current tile is what places them inside the chamber visually.
-  drawBrood(
-    sprites,
-    curr,
-    colony.eggs,
-    'egg',
-    left,
-    top,
-    canvasW,
-    canvasH,
-    activeUndergroundColonyId,
-  );
-  drawBrood(
-    sprites,
-    curr,
-    colony.larvae,
-    'larva',
-    left,
-    top,
-    canvasW,
-    canvasH,
-    activeUndergroundColonyId,
-  );
+  // Brood detail is skipped in strategic dot mode (§C13).
+  if (!dotMode) {
+    drawBrood(sprites, curr, colony.eggs, 'egg', rect, activeUndergroundColonyId);
+    drawBrood(sprites, curr, colony.larvae, 'larva', rect, activeUndergroundColonyId);
+  }
 }
 
 /**
@@ -654,10 +711,7 @@ function drawBrood(
   curr: WorldState,
   entityIds: readonly number[],
   kind: 'egg' | 'larva',
-  left: number,
-  top: number,
-  canvasW: number,
-  canvasH: number,
+  rect: WorldRect,
   activeUndergroundColonyId: ColonyId,
 ): void {
   const ants = curr.ants;
@@ -671,15 +725,9 @@ function drawBrood(
     if (ants.currentGridColonyId[id] !== activeUndergroundColonyId) continue;
     const tileX = ants.posX[id]! >> FP_SHIFT;
     const tileY = ants.posY[id]! >> FP_SHIFT;
-    const screenX = (tileX - left) * TILE_SIZE_PX;
-    const screenY = (tileY - top) * TILE_SIZE_PX;
-    if (
-      screenX < -TILE_SIZE_PX ||
-      screenX > canvasW ||
-      screenY < -TILE_SIZE_PX ||
-      screenY > canvasH
-    )
-      continue;
+    const worldX = tileX * TILE_SIZE_PX;
+    const worldY = tileY * TILE_SIZE_PX;
+    if (!tileInView(worldX, worldY, rect, TILE_SIZE_PX)) continue;
     // Visible-carry offset: when this brood is on a carrier's tile and
     // the carrier is alive, lift it ~1/4 tile so it visually sits
     // above the carrier instead of being hidden under the ant sprite.
@@ -687,8 +735,8 @@ function drawBrood(
     const carryDy = carrierId !== -1 && isAlive(ants, carrierId) ? CARRY_RENDER_DY_PX : 0;
     sprites.drawStatic({
       kind,
-      x: screenX + TILE_SIZE_PX / 2,
-      y: screenY + TILE_SIZE_PX / 2 + carryDy,
+      x: worldX + TILE_SIZE_PX / 2,
+      y: worldY + TILE_SIZE_PX / 2 + carryDy,
     });
   }
 }
@@ -713,7 +761,7 @@ export function drawUnderground(
   prev: WorldState,
   curr: WorldState,
   alpha: number,
-  cam: CameraState,
+  cam: CameraView,
   activeUndergroundColonyId: ColonyId = PLAYER_COLONY_ID,
   facing?: AntFacingCache,
 ): void {

--- a/src/render/game-scene.test.ts
+++ b/src/render/game-scene.test.ts
@@ -26,7 +26,7 @@ import {
   createViewState,
   resetViewState,
   toggleView,
-  UNDERGROUND_INITIAL_CAMERA_Y,
+  UNDERGROUND_INITIAL_CENTER_Y_PX,
 } from './camera.js';
 import { resetPaintStrokeState, type PaintStrokeState } from '../input/underground-input.js';
 import {
@@ -38,6 +38,7 @@ import {
 import { clearAllPauseReasons, type PauseReasonState } from './pause-reasons.js';
 import { contextMenuState, hideContextMenu } from './context-menu-state.js';
 import { PLAYER_START_X, PLAYER_START_Y } from '../sim/constants.js';
+import { TILE_SIZE_PX } from './sprites.js';
 import type { WorldState } from '../sim/types.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
 import type { SimCommand } from '../sim/commands.js';
@@ -419,9 +420,10 @@ describe('session reset orchestration (bootFresh / bootFromSave precondition)', 
     ];
     const viewState = createViewState(PLAYER_START_X, PLAYER_START_Y);
     toggleView(viewState); // → underground, visited
-    viewState.undergroundCamera.x = 100;
-    viewState.undergroundCamera.y = 40;
-    viewState.surfaceCamera.x = 90;
+    // Dirty world-px camera centers (Stage 2 CameraView model).
+    viewState.undergroundCamera.centerX = 100;
+    viewState.undergroundCamera.centerY = 40;
+    viewState.surfaceCamera.centerX = 90;
     viewState.activeTool = 'chamber'; // non-default tool
     const paintStroke: PaintStrokeState = {
       active: true,
@@ -465,10 +467,13 @@ describe('session reset orchestration (bootFresh / bootFromSave precondition)', 
     expect(s.inputLog).toHaveLength(0);
     expect(s.viewState.activeView).toBe('surface');
     expect(s.viewState.activeTool).toBe('command'); // surface default
-    expect(s.viewState.surfaceCamera.x).toBe(PLAYER_START_X);
-    expect(s.viewState.surfaceCamera.y).toBe(PLAYER_START_Y);
-    expect(s.viewState.undergroundCamera.x).toBe(PLAYER_START_X);
-    expect(s.viewState.undergroundCamera.y).toBe(UNDERGROUND_INITIAL_CAMERA_Y);
+    // resetViewState frames the surface camera on the start tile CENTER (world px):
+    // centerX/Y = (tile + 0.5) × TILE_SIZE_PX. Underground X-links to the same
+    // start column; its centerY resets to the shaft-at-top initial depth.
+    expect(s.viewState.surfaceCamera.centerX).toBe((PLAYER_START_X + 0.5) * TILE_SIZE_PX);
+    expect(s.viewState.surfaceCamera.centerY).toBe((PLAYER_START_Y + 0.5) * TILE_SIZE_PX);
+    expect(s.viewState.undergroundCamera.centerX).toBe((PLAYER_START_X + 0.5) * TILE_SIZE_PX);
+    expect(s.viewState.undergroundCamera.centerY).toBe(UNDERGROUND_INITIAL_CENTER_Y_PX);
     expect(s.viewState.undergroundVisited).toBe(false);
     expect(s.paintStroke.active).toBe(false);
     expect(s.paintStroke.lastMarkedTileX).toBe(-1);
@@ -544,7 +549,7 @@ describe('session reset orchestration (bootFresh / bootFromSave precondition)', 
     const s = makeDirtySession();
     runSessionReset(s);
     appendInputLog(s.inputLog, [{ type: 'NoOp', issuedAtTick: 5 }]);
-    s.viewState.surfaceCamera.x = 70;
+    s.viewState.surfaceCamera.centerX = 70;
     s.paintStroke.active = true;
     s.pauseReasons.user = true;
     s.speedMultiplier = 2;
@@ -552,7 +557,7 @@ describe('session reset orchestration (bootFresh / bootFromSave precondition)', 
     runSessionReset(s);
 
     expect(s.inputLog).toHaveLength(0);
-    expect(s.viewState.surfaceCamera.x).toBe(PLAYER_START_X);
+    expect(s.viewState.surfaceCamera.centerX).toBe((PLAYER_START_X + 0.5) * TILE_SIZE_PX);
     expect(s.paintStroke.active).toBe(false);
     expect(s.pauseReasons.user).toBe(false);
     expect(s.speedMultiplier).toBe(1);

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -281,7 +281,13 @@ export class GameScene extends Phaser.Scene {
   private terrainBaker!: Phaser.GameObjects.Graphics;
   // Stage 2 §C13: strategic ant-dot LOD mode, resolved each frame from the smoothed zoom
   // via the hysteresis resolver (held across frames so the 0.55/0.65 band doesn't thrash).
-  private dotMode = false;
+  // PER VIEW (Codex P2): surface + underground keep independent zooms, so their LOD modes
+  // must be tracked separately — a single shared flag carries the leaving view's mode onto
+  // the entering view and strands it in the wrong mode inside the hysteresis band on toggle.
+  private readonly dotModeByView: { surface: boolean; underground: boolean } = {
+    surface: false,
+    underground: false,
+  };
   // Render-only ant-facing smoothing (see ant-facing-cache.ts). One instance
   // per scene, threaded into drawSurface + drawUnderground each frame so
   // cardinal zig-zag movement settles into a diagonal heading instead of
@@ -1836,9 +1842,13 @@ export class GameScene extends Phaser.Scene {
     this.cameraController.apply(cam);
 
     // Stage 2 §C13: resolve the strategic dot-LOD mode from the smoothed zoom (stateful
-    // hysteresis — the 0.55/0.65 band holds the prior mode), threaded into the entity
-    // draw so strategic zoom-out renders ants as batched dots instead of full sprites.
-    this.dotMode = resolveDotMode(cam.zoom, this.dotMode);
+    // hysteresis — the 0.55/0.65 band holds the prior mode) for the ACTIVE view, using
+    // that view's own prior mode so a toggle never carries the other view's LOD state
+    // across (Codex P2). Threaded into the entity draw so strategic zoom-out renders ants
+    // as batched dots instead of full sprites.
+    const activeViewKey = this.viewState.activeView;
+    this.dotModeByView[activeViewKey] = resolveDotMode(cam.zoom, this.dotModeByView[activeViewKey]);
+    const dotMode = this.dotModeByView[activeViewKey];
 
     // Stage 1 controls rework (issue #18): set the per-tool canvas cursor. Reset
     // to the default cursor over any HUD zone / the context menu / any modal so
@@ -1906,7 +1916,7 @@ export class GameScene extends Phaser.Scene {
         this.contestedGlowFrames, // S6: surface glow fade map
         this.renderFrame, // S6: current render frame
         overlayGfx, // #148: health bar renders above sprites
-        this.dotMode, // §C13: strategic dot-LOD
+        dotMode, // §C13: strategic dot-LOD
       );
     } else {
       this.recordDrawLayer('terrain');
@@ -1926,7 +1936,7 @@ export class GameScene extends Phaser.Scene {
         this.antFacingCache,
         this.undergroundGlowFrames, // S6: underground glow fade map
         this.renderFrame, // S6: current render frame
-        this.dotMode, // §C13: strategic dot-LOD
+        dotMode, // §C13: strategic dot-LOD
       );
     }
     this.antSprites.endFrame();

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -76,7 +76,7 @@ import {
   screenToTileZoom,
   resolveDotMode,
 } from './camera-adapter.js';
-import { CameraController, WHEEL_ZOOM_STEP } from './camera-controller.js';
+import { CameraController, WHEEL_ZOOM_STEP, WHEEL_NOTCH_PX } from './camera-controller.js';
 import {
   TerrainCache,
   surfaceCacheKey,
@@ -560,7 +560,11 @@ export class GameScene extends Phaser.Scene {
           this.viewState.activeView === 'surface'
             ? this.viewState.surfaceCamera
             : this.viewState.undergroundCamera;
-        const factor = dy < 0 ? WHEEL_ZOOM_STEP : 1 / WHEEL_ZOOM_STEP;
+        // Scale by deltaY magnitude so continuous trackpad / high-res-wheel scrolling
+        // (many small events per gesture) zooms smoothly instead of jumping a full step
+        // every event and slamming to the zoom limit (Codex P1). One ~WHEEL_NOTCH_PX notch
+        // = one ×WHEEL_ZOOM_STEP; dy<0 (scroll up) zooms in.
+        const factor = Math.pow(WHEEL_ZOOM_STEP, -dy / WHEEL_NOTCH_PX);
         this.cameraController.beginZoom(cam, factor, pointer.x, pointer.y);
       },
     );
@@ -1750,6 +1754,11 @@ export class GameScene extends Phaser.Scene {
         }
       }
     }
+    // Free the off-screen baker's command buffer now — a full bake holds the entire
+    // 128×128 procedural-terrain Graphics (hundreds of thousands of primitives) and would
+    // otherwise be retained until the next bake, which may never happen in a surface-only
+    // session (Codex P2).
+    this.terrainBaker.clear();
 
     // Show only the active view's RT.
     for (const k of this.terrainCache.allocatedKeys()) {

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -5,18 +5,18 @@
 //       AI controller wiring (onBeforeTick → runAIController per AI colony),
 //       outcome handling (gameLoop.pause() + UIScene overlay), autosave.
 //
-// Coordinate model (Phase 8.5 stabilization):
-//   The project owns the camera. `CameraState` is in tile units; the draw modules
-//   project world tiles into screen pixels manually by subtracting `left/top` in
-//   visibleRange(). Phaser's own camera (`this.cameras.main`) is left at
-//   scroll=0 and bounds=default — it is NOT synced to CameraState. Previously we
-//   also set `cameras.main.scrollX/scrollY` from CameraState, which double-
-//   translated the Graphics object and pushed the world offscreen (this was the
-//   "surface appears all black" + "underground click Y-offset" bug). The fix is
-//   a single transform: manual projection in the draw modules.
+// Coordinate model (Stage 2 continuous-zoom rework, issue #18):
+//   The render layer draws everything in WORLD pixels (worldX = tileX × TILE_SIZE_PX).
+//   The Phaser main camera IS the projection: CameraController drives
+//   cameras.main.setZoom + centerOn from the active view's world-pixel CameraView
+//   (camera-adapter.ts is the single screen↔world authority). Input never reads a
+//   Phaser matrix — it uses the adapter's pure formula. No setBounds (custom
+//   center-aware clamp instead). Pre-Stage-2 this used manual screen-space projection
+//   in the draw modules with cameras.main left at scroll=0; that is gone.
 //
-// Pitfall 1: Do not sync `cameras.main.scrollX/scrollY` from CameraState. The
-//            draw modules already project to screen space.
+// Pitfall 1: All world drawing is in world px; the camera projects. Do NOT re-introduce
+//            manual screen offsets in the draw modules, and do NOT setScrollFactor(0) on
+//            world objects (that cancels scroll but NOT zoom — see screen-effects).
 // Pitfall 2: Keyboard registration is GameScene-only — UIScene must NOT call createCursorKeys().
 // Pitfall 3: scale.mode = NONE, fixed 800x592 — no DPR scaling.
 // Pitfall 4: NEVER use .keys()/.entries()/.get() on world.colonies — it is a PLAIN OBJECT (ADR-0006).
@@ -64,22 +64,39 @@ import {
   resetViewState,
   toggleView,
   toggleUndergroundColony,
-  clampCamera,
-  screenToTile,
+  worldPxDimensions,
+  SURFACE_WORLD_PX_W,
+  SURFACE_WORLD_PX_H,
+  UNDERGROUND_WORLD_PX_W,
+  UNDERGROUND_WORLD_PX_H,
 } from './camera.js';
+import {
+  type CameraView,
+  clampCameraView,
+  screenToTileZoom,
+  resolveDotMode,
+} from './camera-adapter.js';
+import { CameraController, WHEEL_ZOOM_STEP } from './camera-controller.js';
+import {
+  TerrainCache,
+  surfaceCacheKey,
+  undergroundCacheKey,
+  createTerrainShadow,
+  diffTerrainShadow,
+} from './terrain-bake.js';
 import {
   PLAYER_COLONY_ID,
   PLAYER_START_X,
   PLAYER_START_Y,
-  SURFACE_GRID_WIDTH,
-  SURFACE_GRID_HEIGHT,
-  UNDERGROUND_GRID_WIDTH,
-  UNDERGROUND_GRID_HEIGHT,
   STARVATION_GRACE_TICKS,
 } from '../sim/constants.js';
 import { GameOutcome } from '../sim/game-over.js';
 import { drawSurfaceTerrain, drawSurfaceEntities, type GfxLike } from './draw-surface.js';
-import { drawUndergroundTerrain, drawUndergroundEntities } from './draw-underground.js';
+import {
+  drawUndergroundTerrain,
+  drawUndergroundEntities,
+  restampUndergroundTiles,
+} from './draw-underground.js';
 import { drawPheromoneOverlay } from './draw-pheromone.js';
 import { publishSpeedMultiplier } from './ui-scene.js';
 import { AntFacingCache } from './ant-facing-cache.js';
@@ -127,6 +144,7 @@ import {
   resetDragState,
   resetPanInputState,
   isPointerOverHUD,
+  panInputState,
 } from '../input/camera-input.js';
 import { isValidEntranceTarget } from '../input/surface-input.js';
 import { registerGestureArbiter, type GestureArbiter } from '../input/gesture-arbiter.js';
@@ -145,10 +163,10 @@ import { antActivityPanelState } from './ant-activity-panel-state.js';
 import { buildPlaytraceSummary, type GameOutcomeLabel } from './summary-builder.js';
 import { captionForEvent, checkAndTrigger, resetCaptions } from './onboarding-captions.js';
 import {
-  triggerScreenEdgeFlash,
   triggerQueenDamagePulse,
   inferFlashDirection,
   QUEEN_DAMAGE_SUPPRESS_TICKS,
+  type FlashDirection,
 } from './screen-effects.js';
 import { ChamberType } from '../sim/enums.js';
 import { CANVAS_W, CANVAS_H } from './sprites.js';
@@ -205,6 +223,10 @@ interface UIScenePhase9 {
   hideDifficultySelectOverlay(): void;
   // S6 — first-occurrence caption overlay (light onboarding).
   showCaption(text: string, screenX: number, screenY: number): void;
+  // Stage 2 controls rework (issue #18) — the invasion screen-edge flash renders
+  // on UIScene (non-zooming camera), NOT GameScene (zoom-driven main camera), so
+  // setScrollFactor(0)'s scroll-but-not-zoom gap can't miscale the edge strips.
+  triggerScreenEdgeFlash(direction: FlashDirection): void;
   // Stage 1 controls rework (issue #18) — surface the queue-full hint when
   // enqueueCommand drops a command at the cap. `paused` selects the message:
   // paused → "resume to continue"; running → "try again" (transient burst).
@@ -248,6 +270,18 @@ export class GameScene extends Phaser.Scene {
   // SPIDER_SPRITE_DEPTH so it clears every in-world sprite.
   private overlayGfx!: Phaser.GameObjects.Graphics;
   private antSprites!: AntSpritePool;
+  // Stage 2 (issue #18): the Phaser-bound camera driver. Wraps cameras.main and is
+  // driven from the active view's world-pixel CameraView every frame (setZoom +
+  // centerOn); the only place that touches cameras.main's transform.
+  private cameraController!: CameraController;
+  // Stage 2 §B: baked-terrain RenderTexture cache (one RT per view, lazy enemy) + a
+  // reusable off-screen Graphics used to stamp terrain into the RTs (full bake / dirty
+  // re-stamp). The RTs are world-space GOs at origin (0,0) that cameras.main projects.
+  private terrainCache!: TerrainCache<Phaser.GameObjects.RenderTexture>;
+  private terrainBaker!: Phaser.GameObjects.Graphics;
+  // Stage 2 §C13: strategic ant-dot LOD mode, resolved each frame from the smoothed zoom
+  // via the hysteresis resolver (held across frames so the 0.55/0.65 band doesn't thrash).
+  private dotMode = false;
   // Render-only ant-facing smoothing (see ant-facing-cache.ts). One instance
   // per scene, threaded into drawSurface + drawUnderground each frame so
   // cardinal zig-zag movement settles into a diagonal heading instead of
@@ -428,6 +462,42 @@ export class GameScene extends Phaser.Scene {
     this.overlayGfx = this.add.graphics();
     this.overlayGfx.setDepth(SPIDER_SPRITE_DEPTH + 1);
     this.antSprites = new AntSpritePool(this);
+    // Stage 2 (issue #18): bind the continuous-zoom camera. cameras.main is now the
+    // world→screen projection (driven from the CameraView each frame); roundPixels is
+    // disabled inside the controller for smooth sub-pixel pan.
+    this.cameraController = new CameraController(this.cameras.main);
+
+    // Stage 2 §B: baked-terrain RenderTextures (one RT per view, origin (0,0); surface
+    // 2048², underground 2048×1024 per colony, enemy lazily on first X-toggle). NEAREST
+    // filtering for crisp scaling; depth below all dynamic layers; hidden until shown.
+    // cameras.main projects/zooms the RT each frame.
+    this.terrainCache = new TerrainCache<Phaser.GameObjects.RenderTexture>((key) => {
+      const [w, h] =
+        key === surfaceCacheKey()
+          ? [SURFACE_WORLD_PX_W, SURFACE_WORLD_PX_H]
+          : [UNDERGROUND_WORLD_PX_W, UNDERGROUND_WORLD_PX_H];
+      const rt = this.add.renderTexture(0, 0, w, h);
+      rt.setOrigin(0, 0);
+      rt.setDepth(-10); // below the dynamic gfx (depth 0) + ant pool (50)
+      rt.setVisible(false);
+      rt.texture.setFilter(Phaser.Textures.FilterMode.NEAREST);
+      return rt;
+    });
+    // Off-screen reusable Graphics for stamping terrain into the RTs (not on the display list).
+    this.terrainBaker = this.make.graphics({}, false);
+
+    // Stage 2 §B (R2-11/R4-6): a WebGL context restore leaves RT framebuffers blank — flag
+    // every allocated cache for a full rebake. The WebGLRenderer (game.renderer) emits
+    // 'restorewebgl' (game.events does NOT). Unsubscribe + destroy the RTs on shutdown.
+    const renderer = this.game.renderer as unknown as Phaser.Events.EventEmitter;
+    renderer.on('restorewebgl', this.onWebglRestore);
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      renderer.off('restorewebgl', this.onWebglRestore);
+      this.terrainCache.destroyAll((rt) => rt.destroy());
+      // terrainBaker is off the display list (make.graphics addToScene=false), so Phaser
+      // won't auto-destroy it on shutdown — free its WebGL batch explicitly.
+      this.terrainBaker.destroy();
+    });
 
     // Issue #122 — pull the playtrace endpoint out of the registry (set by
     // main.ts in callbacks.preBoot). Treat any non-string value as "feature
@@ -466,6 +536,28 @@ export class GameScene extends Phaser.Scene {
     // Resume (Codex P2). A bare user-pause (Space) is NOT modal, so middle-pan
     // still works while paused — intended.
     this.dragState = registerDragPan(this, this.viewState, () => this.isModalOpen());
+
+    // Stage 2 (issue #18): mouse-wheel zoom. Gated exactly like world pan — ignored
+    // over HUD zones and whenever a modal / menu / game-over owns input
+    // (canAcceptWorldHotkey). ctrl/cmd-wheel is ignored so the OS/browser pinch-zoom
+    // gesture is never hijacked for game zoom. Wheel-up (deltaY < 0) zooms IN; the
+    // controller runs the cursor-anchored zoom-lerp from here.
+    this.input.on(
+      'wheel',
+      (pointer: Phaser.Input.Pointer, _over: unknown, _dx: number, dy: number) => {
+        if (!this.canAcceptWorldHotkey()) return;
+        if (isPointerOverHUD(pointer.x, pointer.y, this.viewState)) return;
+        const native = pointer.event as WheelEvent | undefined;
+        if (native?.ctrlKey || native?.metaKey) return;
+        if (dy === 0) return;
+        const cam =
+          this.viewState.activeView === 'surface'
+            ? this.viewState.surfaceCamera
+            : this.viewState.undergroundCamera;
+        const factor = dy < 0 ? WHEEL_ZOOM_STEP : 1 / WHEEL_ZOOM_STEP;
+        this.cameraController.beginZoom(cam, factor, pointer.x, pointer.y);
+      },
+    );
 
     // Issue #116 — Esc opens the pause menu overlay (which also pauses the
     // sim). The Esc keybinding itself lives in UIScene (which already owned
@@ -552,6 +644,14 @@ export class GameScene extends Phaser.Scene {
       if (!this.canAcceptWorldHotkey()) return;
       if (this.viewState.activeView !== 'underground') return;
       toggleUndergroundColony(this.viewState);
+      // Toggling the active colony retargets where a Dig/Command lands, so it
+      // must abort any pending gesture eagerly — same as selectTool on a tool
+      // change. Otherwise a same-frame keydown-X batched before a queued
+      // pointerup would dispatch the tap onto the now-live colony's grid at a
+      // tile picked while inspecting the OTHER colony (the down-time snapshot's
+      // colony is bypassed in dispatchTap; reconcileContext only covers the
+      // cross-frame case).
+      this.arbiter.cancelGesture();
       // Clear stale glow entries from the previous colony grid — tile keys are
       // not scoped to a colony, so entries from one grid must not bleed into
       // the other when the view switches.
@@ -599,6 +699,17 @@ export class GameScene extends Phaser.Scene {
           // 1×/2×/4× set the multiplier WITHOUT changing pause reasons (Codex R2-11).
           this.setSpeedMultiplier(control);
         }
+      },
+      // A minimap click-to-nav has just recentered the active camera. Cancel any
+      // in-flight wheel zoom-lerp/anchor on it so the next tickZoomLerp doesn't
+      // re-anchor centerX/Y from the fixed cursor point and overwrite the nav —
+      // same cancel the keyboard/drag-pan path does below in update().
+      onMinimapNav: () => {
+        const cam =
+          this.viewState.activeView === 'surface'
+            ? this.viewState.surfaceCamera
+            : this.viewState.undergroundCamera;
+        this.cameraController.cancel(cam);
       },
       isPaused: () => isPausedByAny(this.pauseReasons),
       getSpeedMultiplier: () => this.speedMultiplier,
@@ -849,9 +960,9 @@ export class GameScene extends Phaser.Scene {
             ev.payload.rallyTile?.x ?? queenTileX,
             ev.payload.rallyTile?.y ?? queenTileY,
           );
-          triggerScreenEdgeFlash(this, direction, CANVAS_W, CANVAS_H);
+          uiScene?.triggerScreenEdgeFlash(direction);
         } else {
-          triggerScreenEdgeFlash(this, 'right', CANVAS_W, CANVAS_H);
+          uiScene?.triggerScreenEdgeFlash('right');
         }
         // Caption #7: AI invasion (one-shot, via the event→caption policy).
         const captionText = captionForEvent(ev.type);
@@ -879,7 +990,7 @@ export class GameScene extends Phaser.Scene {
         // is null and neither flash nor caption fires again here.
         const captionText = checkAndTrigger('aiInvading');
         if (captionText) {
-          triggerScreenEdgeFlash(this, 'right', CANVAS_W, CANVAS_H);
+          uiScene?.triggerScreenEdgeFlash('right');
           if (uiScene) uiScene.showCaption(captionText, CANVAS_W / 2, 60);
         }
       }
@@ -1073,6 +1184,11 @@ export class GameScene extends Phaser.Scene {
   }
 
   private finishBoot(): void {
+    // Stage 2 §B: a fresh/loaded world must rebake every allocated terrain RT (the prior
+    // session's RTs are stale). Optional chaining — finishBoot can run before create() has
+    // instantiated the cache in some boot orderings; the first frame then lazily bakes.
+    this.terrainCache?.invalidateAll();
+
     this.prevState = createScenario(this.currentSeed, this.currentDifficulty);
     copyWorldState(this.world, this.prevState);
 
@@ -1577,6 +1693,71 @@ export class GameScene extends Phaser.Scene {
   // Update loop
   // ---------------------------------------------------------------------------
 
+  /**
+   * Stage 2 §B: (re)bake the active view's terrain into its RenderTexture, then show only
+   * that RT (hide the others). Surface is static → baked once on first visit; underground
+   * full-bakes on first visit / WebGL-restore / restart, then incrementally re-stamps only
+   * the tiles the render-owned shadow-diff reports dirty (AI digging). The RT is a
+   * world-space GO the main camera projects, so this replaces the per-frame immediate-mode
+   * terrain draw. Pixels are validated in UAT (no GPU here).
+   */
+  private bakeAndShowTerrain(cam: CameraView): void {
+    if (this.world === undefined) return;
+    const isSurface = this.viewState.activeView === 'surface';
+    const colonyId = this.viewState.activeUndergroundColonyId;
+    const key = isSurface ? surfaceCacheKey() : undergroundCacheKey(colonyId);
+    const entry = this.terrainCache.ensure(key);
+    const baker = this.terrainBaker as unknown as GfxLike;
+
+    // Entrance ceiling-gap columns for the viewed underground colony (used by the
+    // shadow-diff + autotile ceiling row).
+    const entranceCols = (): Set<number> => {
+      const set = new Set<number>();
+      const colony = this.world?.colonies[colonyId];
+      if (colony?.entrances) {
+        for (const e of colony.entrances) set.add(e.surfaceTileX);
+      }
+      return set;
+    };
+
+    if (entry.needsRebake) {
+      this.terrainBaker.clear();
+      entry.rt.clear();
+      if (isSurface) {
+        drawSurfaceTerrain(baker, this.world, cam, true);
+        entry.rt.draw(this.terrainBaker);
+        this.terrainCache.markBaked(key); // surface is static → no shadow
+      } else {
+        drawUndergroundTerrain(baker, this.world, cam, colonyId, true);
+        entry.rt.draw(this.terrainBaker);
+        const grid = this.world.undergroundGrids[colonyId];
+        this.terrainCache.markBaked(key, grid ? createTerrainShadow(grid, entranceCols()) : null);
+      }
+    } else if (!isSurface && entry.shadow !== null) {
+      const grid = this.world.undergroundGrids[colonyId];
+      if (grid !== undefined) {
+        const dirty = diffTerrainShadow(entry.shadow, grid, entranceCols());
+        if (dirty.size > 0) {
+          this.terrainBaker.clear();
+          restampUndergroundTiles(baker, this.world, colonyId, dirty);
+          entry.rt.draw(this.terrainBaker);
+        }
+      }
+    }
+
+    // Show only the active view's RT.
+    for (const k of this.terrainCache.allocatedKeys()) {
+      const e = this.terrainCache.get(k);
+      if (e !== undefined) e.rt.setVisible(k === key);
+    }
+  }
+
+  /** Stage 2 §B: WebGL context restored → RT framebuffers are blank → flag for rebake.
+   *  Arrow field so the reference is stably bound (lint-safe + same ref for on/off). */
+  private readonly onWebglRestore = (): void => {
+    this.terrainCache.invalidateAll();
+  };
+
   update(time: number, delta: number) {
     // SavePrompt phase: overlay handles input; no tick updates expected.
     if (this.gamePhase === GamePhase.SavePrompt) return;
@@ -1620,23 +1801,44 @@ export class GameScene extends Phaser.Scene {
 
     // Apply keyboard-pan + final clamp. Blocked behind any modal (menu /
     // SavePrompt / GameOver); still active during a bare user-pause (Fix 3).
+    let keyboardPanned = false;
     if (keyboardPanActive) {
-      processCameraInput(this.viewState, {
-        cursors: this.cursors,
-        wasd: this.wasd,
-        dragState: this.dragState,
-      });
+      keyboardPanned = processCameraInput(
+        this.viewState,
+        {
+          cursors: this.cursors,
+          wasd: this.wasd,
+          dragState: this.dragState,
+        },
+        delta / 1000, // time-based keyboard pan: screen-px/sec × dt ÷ zoom
+      );
     }
 
     const cam =
       this.viewState.activeView === 'surface'
         ? this.viewState.surfaceCamera
         : this.viewState.undergroundCamera;
-    const worldW =
-      this.viewState.activeView === 'surface' ? SURFACE_GRID_WIDTH : UNDERGROUND_GRID_WIDTH;
-    const worldH =
-      this.viewState.activeView === 'surface' ? SURFACE_GRID_HEIGHT : UNDERGROUND_GRID_HEIGHT;
-    clampCamera(cam, worldW, worldH);
+    const [worldPxW, worldPxH] = worldPxDimensions(this.viewState.activeView);
+    // Controls rework (issue #18): if the user moved the camera by ANY other input
+    // this frame — keyboard pan above, or a left/middle drag-pan (panInputState.isPanning,
+    // set async by the arbiter / registerDragPan) — drop the in-flight wheel-zoom anchor.
+    // Otherwise the next tickZoomLerp re-anchors centerX/Y purely from the fixed cursor
+    // point and overwrites the pan on the same frame, stuttering/freezing pan for ~0.5s
+    // per notch while a zoom lerps.
+    if (keyboardPanned || panInputState.isPanning) {
+      this.cameraController.cancel(cam);
+    }
+    // Advance any in-flight cursor-anchored wheel zoom (it re-anchors + clamps as it
+    // lerps), keep the active camera valid, then push zoom + center onto Phaser's
+    // camera for this frame. cameras.main IS the projection now.
+    this.cameraController.tickZoomLerp(cam, worldPxW, worldPxH);
+    clampCameraView(cam, worldPxW, worldPxH);
+    this.cameraController.apply(cam);
+
+    // Stage 2 §C13: resolve the strategic dot-LOD mode from the smoothed zoom (stateful
+    // hysteresis — the 0.55/0.65 band holds the prior mode), threaded into the entity
+    // draw so strategic zoom-out renders ants as batched dots instead of full sprites.
+    this.dotMode = resolveDotMode(cam.zoom, this.dotMode);
 
     // Stage 1 controls rework (issue #18): set the per-tool canvas cursor. Reset
     // to the default cursor over any HUD zone / the context menu / any modal so
@@ -1674,9 +1876,12 @@ export class GameScene extends Phaser.Scene {
     // Player colony only — enemy pheromones stay hidden regardless of toggle
     // state (PRD §7b / T-08-05).
     this.beginDrawTrace();
+    // Stage 2 §B: (re)bake the active view's terrain into its RenderTexture and show it
+    // (cameras.main projects/zooms the RT). Replaces the per-frame immediate-mode terrain
+    // draw — the dynamic layers (pheromone, entities, chambers, dots) still draw into gfx.
+    this.bakeAndShowTerrain(cam);
     if (this.viewState.activeView === 'surface') {
       this.recordDrawLayer('terrain');
-      drawSurfaceTerrain(gfx, this.world, cam);
       if (this.viewState.showPheromoneOverlay) {
         this.recordDrawLayer('pheromone');
         drawPheromoneOverlay(gfx, this.world, cam, 'surface');
@@ -1701,10 +1906,10 @@ export class GameScene extends Phaser.Scene {
         this.contestedGlowFrames, // S6: surface glow fade map
         this.renderFrame, // S6: current render frame
         overlayGfx, // #148: health bar renders above sprites
+        this.dotMode, // §C13: strategic dot-LOD
       );
     } else {
       this.recordDrawLayer('terrain');
-      drawUndergroundTerrain(gfx, this.world, cam, this.viewState.activeUndergroundColonyId);
       if (this.viewState.showPheromoneOverlay) {
         this.recordDrawLayer('pheromone');
         drawPheromoneOverlay(gfx, this.world, cam, 'underground');
@@ -1721,6 +1926,7 @@ export class GameScene extends Phaser.Scene {
         this.antFacingCache,
         this.undergroundGlowFrames, // S6: underground glow fade map
         this.renderFrame, // S6: current render frame
+        this.dotMode, // §C13: strategic dot-LOD
       );
     }
     this.antSprites.endFrame();
@@ -1747,15 +1953,21 @@ export class GameScene extends Phaser.Scene {
    * the LIVE camera so the outline tracks the pointer even under a moving camera.
    */
   private computeEntranceHover(
-    cam: import('./camera.js').CameraState,
+    cam: CameraView,
   ): { tileX: number; tileY: number; valid: boolean } | null {
     if (this.viewState.activeView !== 'surface') return null;
     if (this.viewState.activeTool !== 'dig') return null;
     if (this.hoverScreenX === null || this.hoverScreenY === null) return null;
     if (isPointerOverHUD(this.hoverScreenX, this.hoverScreenY, this.viewState)) return null;
     if (this.world === undefined) return null;
-    const { tileX, tileY } = screenToTile(this.hoverScreenX, this.hoverScreenY, cam);
+    const { tileX, tileY } = screenToTileZoom(this.hoverScreenX, this.hoverScreenY, cam);
+    // Reject off-grid tiles on BOTH axes. Zoomed out, the visible world rect can extend
+    // past the grid edge (clampCameraView centers an undersized-vs-viewport world), so a
+    // cursor in that margin maps to an out-of-bounds tile; without the upper-bound guard a
+    // spurious red (invalid) hover frame paints over the empty margin past the right/bottom
+    // edge (a Stage-2 zoom regression — the pre-zoom fixed viewport never exposed margins).
     if (tileX < 0 || tileY < 0) return null;
+    if (tileX >= this.world.surface.width || tileY >= this.world.surface.height) return null;
     const valid = isValidEntranceTarget(this.world, tileX, tileY);
     return { tileX, tileY, valid };
   }

--- a/src/render/minimap.test.ts
+++ b/src/render/minimap.test.ts
@@ -4,7 +4,7 @@
 // Runs under Node with no Phaser.
 
 import { describe, it, expect } from 'vitest';
-import { HUD } from './sprites.js';
+import { HUD, TILE_SIZE_PX } from './sprites.js';
 import { COLOR_BARREN_EARTH, COLOR_BARREN_EARTH_DARK } from './terrain-atlas.js';
 import { createViewState } from './camera.js';
 import {
@@ -16,7 +16,13 @@ import {
 } from './minimap.js';
 import type { GfxLike } from './draw-surface.js';
 import type { WorldState } from '../sim/types.js';
-import { PLAYER_COLONY_ID, PLAYER_START_X, PLAYER_START_Y } from '../sim/constants.js';
+import {
+  PLAYER_COLONY_ID,
+  PLAYER_START_X,
+  PLAYER_START_Y,
+  SURFACE_GRID_WIDTH,
+  SURFACE_GRID_HEIGHT,
+} from '../sim/constants.js';
 import { SurfaceTileState, sgSet } from '../sim/terrain.js';
 
 // ---------------------------------------------------------------------------
@@ -148,48 +154,56 @@ describe('minimapClickToTile', () => {
 // ---------------------------------------------------------------------------
 
 describe('applyMinimapClick', () => {
-  it('click at center sets surfaceCamera to (64, 64) and returns true', () => {
+  it('click at center sets surfaceCamera center to world px (1024, 1024) and returns true', () => {
     const vs = createViewState(PLAYER_START_X, PLAYER_START_Y);
     const cx = HUD.MINIMAP.x + HUD.MINIMAP.w / 2;
     const cy = HUD.MINIMAP.y + HUD.MINIMAP.h / 2;
     const result = applyMinimapClick(vs, cx, cy);
     expect(result).toBe(true);
-    expect(vs.surfaceCamera.x).toBeCloseTo(64, 0);
-    expect(vs.surfaceCamera.y).toBeCloseTo(64, 0);
+    // Minimap center → tile (64, 64) → world px (64×16, 64×16) = (1024, 1024).
+    // At zoom 1 the surface clamp ([400,1648]×[296,1752]) leaves both untouched.
+    const clickedTileX = SURFACE_GRID_WIDTH / 2; // 64
+    const clickedTileY = SURFACE_GRID_HEIGHT / 2; // 64
+    expect(vs.surfaceCamera.centerX).toBeCloseTo(clickedTileX * TILE_SIZE_PX, 0);
+    expect(vs.surfaceCamera.centerY).toBeCloseTo(clickedTileY * TILE_SIZE_PX, 0);
     expect(vs.activeView).toBe('surface'); // unchanged
   });
 
   it('click outside minimap returns false and does not mutate', () => {
     const vs = createViewState(PLAYER_START_X, PLAYER_START_Y);
-    const origX = vs.surfaceCamera.x;
-    const origY = vs.surfaceCamera.y;
+    const origX = vs.surfaceCamera.centerX;
+    const origY = vs.surfaceCamera.centerY;
     const result = applyMinimapClick(vs, 0, 0);
     expect(result).toBe(false);
-    expect(vs.surfaceCamera.x).toBe(origX);
-    expect(vs.surfaceCamera.y).toBe(origY);
+    expect(vs.surfaceCamera.centerX).toBe(origX);
+    expect(vs.surfaceCamera.centerY).toBe(origY);
   });
 
-  it('when activeView=underground, click syncs undergroundCamera.x but not y', () => {
+  it('when activeView=underground, click syncs undergroundCamera.centerX but PRESERVES centerY (depth)', () => {
     const vs = createViewState(PLAYER_START_X, PLAYER_START_Y);
     vs.activeView = 'underground';
-    vs.undergroundCamera.y = 20; // some depth
+    // Pick a depth (world px) that survives the underground clamp at zoom 1
+    // (centerY range [296, 728] for the 1024-px-tall underground world), so the
+    // depth-preservation assertion tests preservation, not the clamp. §A6.
+    const depthY = 500;
+    vs.undergroundCamera.centerY = depthY;
     const cx = HUD.MINIMAP.x + HUD.MINIMAP.w / 2;
     const cy = HUD.MINIMAP.y + HUD.MINIMAP.h / 2;
     applyMinimapClick(vs, cx, cy);
-    // X should be synced to surface camera's clamped X
-    expect(vs.undergroundCamera.x).toBe(vs.surfaceCamera.x);
-    // Y should NOT be changed (underground depth is independent)
-    expect(vs.undergroundCamera.y).toBe(20);
+    // X should be X-linked to the surface camera's clamped center X.
+    expect(vs.undergroundCamera.centerX).toBe(vs.surfaceCamera.centerX);
+    // centerY (depth) must be UNCHANGED — underground depth is independent (§A6).
+    expect(vs.undergroundCamera.centerY).toBe(depthY);
   });
 
-  it('when activeView=surface, click does NOT touch undergroundCamera.x', () => {
+  it('when activeView=surface, click does NOT touch undergroundCamera.centerX', () => {
     const vs = createViewState(PLAYER_START_X, PLAYER_START_Y);
-    const origUnderX = vs.undergroundCamera.x;
+    const origUnderX = vs.undergroundCamera.centerX;
     const cx = HUD.MINIMAP.x + HUD.MINIMAP.w / 2;
     const cy = HUD.MINIMAP.y + HUD.MINIMAP.h / 2;
     applyMinimapClick(vs, cx, cy);
-    // undergroundCamera.x should NOT change when in surface view
-    expect(vs.undergroundCamera.x).toBe(origUnderX);
+    // undergroundCamera.centerX should NOT change when in surface view
+    expect(vs.undergroundCamera.centerX).toBe(origUnderX);
   });
 });
 

--- a/src/render/minimap.ts
+++ b/src/render/minimap.ts
@@ -9,13 +9,17 @@
 //   applyMinimapClick(viewState, px, py) — pan surface camera + X-link underground camera
 //   MINIMAP_SCALE_X, MINIMAP_SCALE_Y — pixel-to-tile scale factors
 
-import { HUD, COLOR_PLAYER_COLONY, COLOR_ENEMY_COLONY, COLOR_FOOD_PILE_NORMAL } from './sprites.js';
+import {
+  HUD,
+  TILE_SIZE_PX,
+  COLOR_PLAYER_COLONY,
+  COLOR_ENEMY_COLONY,
+  COLOR_FOOD_PILE_NORMAL,
+} from './sprites.js';
 import { COLOR_BARREN_EARTH, COLOR_BARREN_EARTH_DARK } from './terrain-atlas.js';
 import {
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
-  UNDERGROUND_GRID_WIDTH,
-  UNDERGROUND_GRID_HEIGHT,
   PLAYER_COLONY_ID,
   ENEMY_COLONY_ID,
 } from '../sim/constants.js';
@@ -25,7 +29,13 @@ import { sgGet } from '../sim/terrain.js';
 import { spatialHash } from './terrain-noise.js';
 import type { WorldState } from '../sim/types.js';
 import type { ViewState } from './camera.js';
-import { clampCamera } from './camera.js';
+import {
+  SURFACE_WORLD_PX_W,
+  SURFACE_WORLD_PX_H,
+  UNDERGROUND_WORLD_PX_W,
+  UNDERGROUND_WORLD_PX_H,
+} from './camera.js';
+import { clampCameraView, minimapNavTargets, visibleWorldRect } from './camera-adapter.js';
 import type { GfxLike } from './draw-surface.js';
 
 export const MINIMAP_SCALE_X = HUD.MINIMAP.w / SURFACE_GRID_WIDTH; // 160 / 128 = 1.25
@@ -37,6 +47,11 @@ export const MINIMAP_SCALE_Y = HUD.MINIMAP.h / SURFACE_GRID_HEIGHT; // 1.25
 // than the live 4×4 marker — subtler, conveys 'remains' rather than
 // active colony.
 const COLOR_DEAD_COLONY_MEMORIAL = 0x444444 as const;
+
+/** Clamp a scalar to [lo, hi] (render-side float math, ARCHITECTURE.md Principle 6). */
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
 
 export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewState): void {
   // Surface terrain (issue #40 reframe — barren-earth-default). Base layer
@@ -150,12 +165,25 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
     gfx.fillRect(px - halfOffset, py - halfOffset, size, size);
   }
 
-  // Viewport rect — always tracks surfaceCamera (minimap shows surface always per PRD §7a)
-  const cam = viewState.surfaceCamera;
-  const rx = HUD.MINIMAP.x + (cam.x - cam.viewportWidth / 2) * MINIMAP_SCALE_X;
-  const ry = HUD.MINIMAP.y + (cam.y - cam.viewportHeight / 2) * MINIMAP_SCALE_Y;
-  const rw = cam.viewportWidth * MINIMAP_SCALE_X;
-  const rh = cam.viewportHeight * MINIMAP_SCALE_Y;
+  // Viewport rect — always tracks surfaceCamera (minimap shows surface always per
+  // PRD §7a). Stage 2: the visible window is zoom-dependent, so derive it from the
+  // adapter's world rect (world px → tiles → minimap px).
+  const rect = visibleWorldRect(viewState.surfaceCamera);
+  // Clamp the rect to the minimap frame before drawing. Under zoom the visible
+  // world window can exceed the world/minimap extent (e.g. at MIN_ZOOM the rect
+  // is ~312px wide vs the 160px minimap, and a centered camera pushes its left
+  // edge negative), so the unclamped outline would spill outside the 160×160 box
+  // onto neighboring HUD. Clamp each edge to [HUD.MINIMAP.x .. x+w] / [.y .. y+h].
+  const minX = HUD.MINIMAP.x;
+  const maxX = HUD.MINIMAP.x + HUD.MINIMAP.w;
+  const minY = HUD.MINIMAP.y;
+  const maxY = HUD.MINIMAP.y + HUD.MINIMAP.h;
+  const rx = clamp(HUD.MINIMAP.x + (rect.left / TILE_SIZE_PX) * MINIMAP_SCALE_X, minX, maxX);
+  const ry = clamp(HUD.MINIMAP.y + (rect.top / TILE_SIZE_PX) * MINIMAP_SCALE_Y, minY, maxY);
+  const rRight = clamp(HUD.MINIMAP.x + (rect.right / TILE_SIZE_PX) * MINIMAP_SCALE_X, minX, maxX);
+  const rBottom = clamp(HUD.MINIMAP.y + (rect.bottom / TILE_SIZE_PX) * MINIMAP_SCALE_Y, minY, maxY);
+  const rw = rRight - rx;
+  const rh = rBottom - ry;
 
   // Four one-pixel fillRects form the viewport outline (GfxLike has no strokeRect)
   gfx.fillStyle(0xffffff, 0.8);
@@ -180,18 +208,26 @@ export function minimapClickToTile(
 export function applyMinimapClick(viewState: ViewState, px: number, py: number): boolean {
   const tile = minimapClickToTile(px, py);
   if (!tile) return false;
-  viewState.surfaceCamera.x = tile.tileX;
-  viewState.surfaceCamera.y = tile.tileY;
-  clampCamera(viewState.surfaceCamera, SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT);
-  // X-link per PRD §7c: minimap pans surface; underground X follows surface X.
-  // Issue #86 — defensive clamp the underground camera with its own dimensions
-  // after the X-link. Today SURFACE_GRID_WIDTH === UNDERGROUND_GRID_WIDTH so
-  // this is a no-op, but the constants are independent and a future width
-  // change to either side would silently let the underground camera fall
-  // outside its grid without this clamp.
+  // Click tile (fractional) → world px. minimapNavTargets sets the SURFACE center to
+  // the click and X-links the underground center while PRESERVING its depth (PLAN
+  // §A6) — not "centerOn whichever camera is active".
+  const worldX = tile.tileX * TILE_SIZE_PX;
+  const worldY = tile.tileY * TILE_SIZE_PX;
+  const targets = minimapNavTargets(
+    viewState.surfaceCamera,
+    viewState.undergroundCamera,
+    worldX,
+    worldY,
+  );
+  viewState.surfaceCamera.centerX = targets.surfaceCenterX;
+  viewState.surfaceCamera.centerY = targets.surfaceCenterY;
+  clampCameraView(viewState.surfaceCamera, SURFACE_WORLD_PX_W, SURFACE_WORLD_PX_H);
+  // Issue #86 — clamp the underground camera with its OWN dimensions after the
+  // X-link (independent constants; underground is shorter, so a different clamp).
   if (viewState.activeView === 'underground') {
-    viewState.undergroundCamera.x = viewState.surfaceCamera.x;
-    clampCamera(viewState.undergroundCamera, UNDERGROUND_GRID_WIDTH, UNDERGROUND_GRID_HEIGHT);
+    viewState.undergroundCamera.centerX = targets.undergroundCenterX;
+    viewState.undergroundCamera.centerY = targets.undergroundCenterY;
+    clampCameraView(viewState.undergroundCamera, UNDERGROUND_WORLD_PX_W, UNDERGROUND_WORLD_PX_H);
   }
   return true;
 }

--- a/src/render/terrain-bake.test.ts
+++ b/src/render/terrain-bake.test.ts
@@ -1,0 +1,291 @@
+// terrain-bake.test.ts — Vitest tests for the terrain bake subsystem (PLAN-stage2 §B):
+//   - render-owned shadow-diff dirty set (§E18 "shadow-diff dirty set, grid+entrance,
+//     chambers excluded")
+//   - RT lifecycle manager (§E18 "RT lifecycle: origin, lazy enemy, rebake on restart +
+//     RESTORE_WEBGL")
+// Pure logic — no Phaser (the RT is a stub).
+
+import { describe, it, expect } from 'vitest';
+import {
+  createUndergroundGrid,
+  ugSet,
+  UndergroundTileState,
+  type UndergroundGrid,
+} from '../sim/terrain.js';
+import {
+  createTerrainShadow,
+  diffTerrainShadow,
+  tileKey,
+  TerrainCache,
+  surfaceCacheKey,
+  undergroundCacheKey,
+  type TerrainShadow,
+  type TerrainCacheKey,
+} from './terrain-bake.js';
+
+const W = 5;
+const H = 5;
+const sorted = (s: Set<number>): number[] => [...s].sort((a, b) => a - b);
+const keys = (grid: UndergroundGrid, coords: Array<[number, number]>): number[] =>
+  coords.map(([x, y]) => tileKey(x, y, grid.width)).sort((a, b) => a - b);
+
+function freshGrid(): UndergroundGrid {
+  return createUndergroundGrid(W, H); // all Solid (0)
+}
+
+// ---------------------------------------------------------------------------
+// Shadow-diff dirty tracking
+// ---------------------------------------------------------------------------
+
+describe('createTerrainShadow', () => {
+  it('snapshots every tile state and the entrance columns', () => {
+    const grid = freshGrid();
+    ugSet(grid, 2, 2, UndergroundTileState.Open);
+    ugSet(grid, 1, 3, UndergroundTileState.Marked);
+    const shadow = createTerrainShadow(grid, new Set([2, 4]));
+    expect(shadow.width).toBe(W);
+    expect(shadow.height).toBe(H);
+    expect(shadow.tiles[tileKey(2, 2, W)]).toBe(UndergroundTileState.Open);
+    expect(shadow.tiles[tileKey(1, 3, W)]).toBe(UndergroundTileState.Marked);
+    expect(shadow.tiles[tileKey(0, 0, W)]).toBe(UndergroundTileState.Solid);
+    expect([...shadow.entranceCols]).toEqual([0, 0, 1, 0, 1]);
+  });
+});
+
+describe('diffTerrainShadow — grid tile changes dirty a clipped 3×3', () => {
+  it('returns an empty set when nothing changed', () => {
+    const grid = freshGrid();
+    const shadow = createTerrainShadow(grid, new Set());
+    expect(diffTerrainShadow(shadow, grid, new Set()).size).toBe(0);
+  });
+
+  it('an interior tile change dirties all 9 tiles of its 3×3', () => {
+    const grid = freshGrid();
+    const shadow = createTerrainShadow(grid, new Set());
+    ugSet(grid, 2, 2, UndergroundTileState.Open);
+    const dirty = diffTerrainShadow(shadow, grid, new Set());
+    expect(sorted(dirty)).toEqual(
+      keys(grid, [
+        [1, 1],
+        [2, 1],
+        [3, 1],
+        [1, 2],
+        [2, 2],
+        [3, 2],
+        [1, 3],
+        [2, 3],
+        [3, 3],
+      ]),
+    );
+  });
+
+  it('a corner tile change dirties only the in-bounds 2×2', () => {
+    const grid = freshGrid();
+    const shadow = createTerrainShadow(grid, new Set());
+    ugSet(grid, 0, 0, UndergroundTileState.Open);
+    const dirty = diffTerrainShadow(shadow, grid, new Set());
+    expect(sorted(dirty)).toEqual(
+      keys(grid, [
+        [0, 0],
+        [1, 0],
+        [0, 1],
+        [1, 1],
+      ]),
+    );
+  });
+
+  it('a left-edge tile change clips the off-grid column', () => {
+    const grid = freshGrid();
+    const shadow = createTerrainShadow(grid, new Set());
+    ugSet(grid, 0, 2, UndergroundTileState.BeingDug);
+    const dirty = diffTerrainShadow(shadow, grid, new Set());
+    expect(sorted(dirty)).toEqual(
+      keys(grid, [
+        [0, 1],
+        [1, 1],
+        [0, 2],
+        [1, 2],
+        [0, 3],
+        [1, 3],
+      ]),
+    );
+  });
+
+  it('refreshes the shadow in place — a second diff with no further change is empty', () => {
+    const grid = freshGrid();
+    const shadow = createTerrainShadow(grid, new Set());
+    ugSet(grid, 2, 2, UndergroundTileState.Open);
+    expect(diffTerrainShadow(shadow, grid, new Set()).size).toBe(9);
+    expect(diffTerrainShadow(shadow, grid, new Set()).size).toBe(0); // shadow updated
+  });
+
+  it('Marked → BeingDug is a state change (baked tints update with the diff)', () => {
+    const grid = freshGrid();
+    ugSet(grid, 2, 2, UndergroundTileState.Marked);
+    const shadow = createTerrainShadow(grid, new Set());
+    ugSet(grid, 2, 2, UndergroundTileState.BeingDug);
+    expect(diffTerrainShadow(shadow, grid, new Set()).size).toBe(9);
+  });
+});
+
+describe('diffTerrainShadow — entrance column changes dirty (x,0)+(x±1,1),(x,1)', () => {
+  it('an interior entrance column added dirties exactly the clipped set', () => {
+    const grid = freshGrid();
+    const shadow = createTerrainShadow(grid, new Set());
+    const dirty = diffTerrainShadow(shadow, grid, new Set([2]));
+    expect(sorted(dirty)).toEqual(
+      keys(grid, [
+        [2, 0],
+        [1, 1],
+        [2, 1],
+        [3, 1],
+      ]),
+    );
+  });
+
+  it('a column-0 entrance clips the off-grid x−1 neighbour', () => {
+    const grid = freshGrid();
+    const shadow = createTerrainShadow(grid, new Set());
+    const dirty = diffTerrainShadow(shadow, grid, new Set([0]));
+    expect(sorted(dirty)).toEqual(
+      keys(grid, [
+        [0, 0],
+        [0, 1],
+        [1, 1],
+      ]),
+    );
+  });
+
+  it('removing an entrance column is also a change', () => {
+    const grid = freshGrid();
+    const shadow = createTerrainShadow(grid, new Set([2]));
+    const dirty = diffTerrainShadow(shadow, grid, new Set()); // entrance gone
+    expect(sorted(dirty)).toEqual(
+      keys(grid, [
+        [2, 0],
+        [1, 1],
+        [2, 1],
+        [3, 1],
+      ]),
+    );
+  });
+});
+
+describe('chambers are excluded from the bake invalidation', () => {
+  it('the diff has no chamber input — only grid tile-state + entrance changes dirty tiles', () => {
+    // A pre-existing excavated region (e.g. a chamber floor already Open in the shadow)
+    // produces NO dirty tiles while unchanged: chamber SHAPES are a dynamic overlay, not
+    // baked. Only when the underlying grid tiles or entrance columns change does the bake
+    // need re-stamping — which the tile scan handles.
+    const grid = freshGrid();
+    ugSet(grid, 1, 1, UndergroundTileState.Open);
+    ugSet(grid, 2, 1, UndergroundTileState.Open);
+    ugSet(grid, 1, 2, UndergroundTileState.Open);
+    const shadow = createTerrainShadow(grid, new Set());
+    expect(diffTerrainShadow(shadow, grid, new Set()).size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RT lifecycle manager (§E18 — origin, lazy enemy, rebake on restart + RESTORE_WEBGL)
+// ---------------------------------------------------------------------------
+
+interface StubRt {
+  id: TerrainCacheKey;
+}
+
+/** A TerrainCache over a stub RT, with a spy counter for factory calls. */
+function makeCache(): { cache: TerrainCache<StubRt>; created: TerrainCacheKey[] } {
+  const created: TerrainCacheKey[] = [];
+  const cache = new TerrainCache<StubRt>((key) => {
+    created.push(key);
+    return { id: key };
+  });
+  return { cache, created };
+}
+
+function shadowOf(width = 4, height = 2): TerrainShadow {
+  return {
+    width,
+    height,
+    tiles: new Uint8Array(width * height),
+    entranceCols: new Uint8Array(width),
+  };
+}
+
+describe('TerrainCache lifecycle', () => {
+  it('ensure() allocates a NEW entry at origin (0,0), needsRebake, no shadow, factory once', () => {
+    const { cache, created } = makeCache();
+    const e = cache.ensure(surfaceCacheKey());
+    expect(e.originX).toBe(0);
+    expect(e.originY).toBe(0);
+    expect(e.needsRebake).toBe(true);
+    expect(e.shadow).toBeNull();
+    expect(e.rt.id).toBe('surface');
+    expect(created).toEqual(['surface']);
+  });
+
+  it('ensure() is memoized — second call returns the SAME entry, factory not re-run', () => {
+    const { cache, created } = makeCache();
+    const a = cache.ensure(surfaceCacheKey());
+    const b = cache.ensure(surfaceCacheKey());
+    expect(b).toBe(a);
+    expect(created).toEqual(['surface']); // exactly once
+  });
+
+  it('enemy underground is allocated LAZILY (only on first ensure)', () => {
+    const { cache, created } = makeCache();
+    // "boot": allocate surface + player underground only.
+    cache.ensure(surfaceCacheKey());
+    cache.ensure(undergroundCacheKey(0)); // player colony 0
+    expect(cache.has(undergroundCacheKey(1))).toBe(false); // enemy NOT allocated
+    expect(sorted2(cache.allocatedKeys())).toEqual(['surface', 'ug:0']);
+    // First X-toggle to the enemy grid allocates it now.
+    const enemy = cache.ensure(undergroundCacheKey(1));
+    expect(enemy.rt.id).toBe('ug:1');
+    expect(created).toEqual(['surface', 'ug:0', 'ug:1']);
+    expect(sorted2(cache.allocatedKeys())).toEqual(['surface', 'ug:0', 'ug:1']);
+  });
+
+  it('markBaked() clears needsRebake and stores the shadow', () => {
+    const { cache } = makeCache();
+    cache.ensure(surfaceCacheKey());
+    const sh = shadowOf();
+    cache.markBaked(surfaceCacheKey(), sh);
+    const e = cache.get(surfaceCacheKey())!;
+    expect(e.needsRebake).toBe(false);
+    expect(e.shadow).toBe(sh);
+  });
+
+  it('invalidateAll() flags EVERY allocated cache for rebake and drops shadows (restart / RESTORE_WEBGL)', () => {
+    const { cache } = makeCache();
+    cache.ensure(surfaceCacheKey());
+    cache.ensure(undergroundCacheKey(0));
+    cache.markBaked(surfaceCacheKey(), shadowOf());
+    cache.markBaked(undergroundCacheKey(0), shadowOf());
+    // both baked + clean now
+    expect(cache.get(surfaceCacheKey())!.needsRebake).toBe(false);
+
+    cache.invalidateAll(); // restart/load OR webgl context restore
+
+    for (const k of cache.allocatedKeys()) {
+      const e = cache.get(k)!;
+      expect(e.needsRebake).toBe(true);
+      expect(e.shadow).toBeNull();
+    }
+    // It does NOT allocate the never-opened enemy cache.
+    expect(cache.has(undergroundCacheKey(1))).toBe(false);
+  });
+
+  it('destroyAll() disposes every RT and clears the cache', () => {
+    const { cache } = makeCache();
+    cache.ensure(surfaceCacheKey());
+    cache.ensure(undergroundCacheKey(0));
+    const destroyed: TerrainCacheKey[] = [];
+    cache.destroyAll((rt) => destroyed.push(rt.id));
+    expect(sorted2(destroyed)).toEqual(['surface', 'ug:0']);
+    expect(cache.allocatedKeys()).toEqual([]);
+  });
+});
+
+const sorted2 = (a: string[]): string[] => [...a].sort();

--- a/src/render/terrain-bake.ts
+++ b/src/render/terrain-bake.ts
@@ -1,0 +1,241 @@
+// terrain-bake.ts — Stage 2 controls rework (issue #18) §B: the render-owned terrain
+// bake subsystem for the baked-terrain RenderTexture path.
+//
+// PURE core (no Phaser, no DOM) — fully unit-testable. Two pieces:
+//   1. Shadow-diff dirty tracking (§B10): a render-owned snapshot of the underground
+//      grid + entrance columns; each tick, diff the live grid → the set of tiles whose
+//      baked appearance must be re-stamped into the RT (instead of redrawing ~2–3k tiles
+//      every frame).
+//   2. RT lifecycle manager (§B7/8/11): tracks which view RenderTextures are allocated
+//      (surface + player-underground up front, enemy-underground LAZILY on first
+//      X-toggle), all at world origin (0,0), with a needsRebake flag flipped on
+//      restart/load and on WebGL context restore. Generic over the RT type so the
+//      lifecycle is testable with a stub; GameScene injects a real Phaser
+//      RenderTexture factory and drives the actual blits from this state.
+//
+// Render-only: imports sim terrain read accessors only (no mutation, no simVersion bump).
+
+import { ugGet, type UndergroundGrid } from '../sim/terrain.js';
+
+// ===========================================================================
+// Shadow-diff dirty tracking (§B10)
+// ===========================================================================
+
+/** Dirty-set tile key for (tx, ty) in a grid of the given width: ty * width + tx. */
+export function tileKey(tx: number, ty: number, width: number): number {
+  return ty * width + tx;
+}
+
+/**
+ * Render-owned snapshot of the underground terrain's baked-relevant state: every tile's
+ * UndergroundTileState plus which columns are entrance ceiling-gaps. One per allocated
+ * underground cache (player + enemy). The ACTIVE view's shadow is diffed each frame; an
+ * inactive grid's shadow persists from its last active frame, and diffTerrainShadow
+ * full-reconciles everything the AI dug while it was inactive on the first frame after it
+ * is reactivated (R4-2's "mark inactive stale + reconcile-on-activate" option — NOT a
+ * per-tick diff of every allocated cache).
+ */
+export interface TerrainShadow {
+  width: number;
+  height: number;
+  /** Snapshot of ugGet(grid, tx, ty) for every tile, indexed ty*width + tx. */
+  tiles: Uint8Array;
+  /** Per-column flag (length = width): 1 if the column is an entrance ceiling-gap. */
+  entranceCols: Uint8Array;
+}
+
+/** Build a fresh shadow snapshot from the current grid + entrance columns. */
+export function createTerrainShadow(
+  grid: UndergroundGrid,
+  entranceXSet: ReadonlySet<number>,
+): TerrainShadow {
+  const { width, height } = grid;
+  const tiles = new Uint8Array(width * height);
+  for (let ty = 0; ty < height; ty++) {
+    for (let tx = 0; tx < width; tx++) {
+      tiles[ty * width + tx] = ugGet(grid, tx, ty);
+    }
+  }
+  const entranceCols = new Uint8Array(width);
+  for (let x = 0; x < width; x++) {
+    entranceCols[x] = entranceXSet.has(x) ? 1 : 0;
+  }
+  return { width, height, tiles, entranceCols };
+}
+
+/** Add a tile's clipped 3×3 block to the dirty set. */
+function addClipped3x3(
+  dirty: Set<number>,
+  tx: number,
+  ty: number,
+  width: number,
+  height: number,
+): void {
+  for (let dy = -1; dy <= 1; dy++) {
+    for (let dx = -1; dx <= 1; dx++) {
+      const nx = tx + dx;
+      const ny = ty + dy;
+      if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+      dirty.add(ny * width + nx);
+    }
+  }
+}
+
+/**
+ * Add an entrance column's clipped dirty set: (x,0) plus the row-1 neighbours
+ * (x−1,1),(x,1),(x+1,1) — the exact set whose autotile reads row-0 column x (R3-5).
+ */
+function addEntranceDirty(dirty: Set<number>, x: number, width: number, height: number): void {
+  if (x >= 0 && x < width) dirty.add(x); // (x, 0)
+  if (height > 1) {
+    for (const nx of [x - 1, x, x + 1]) {
+      if (nx >= 0 && nx < width) dirty.add(width + nx); // (nx, 1)
+    }
+  }
+}
+
+/**
+ * Diff the live grid + entrance columns against the shadow, returning the set of tile
+ * keys whose baked appearance must be re-stamped, and refreshing the shadow IN PLACE so
+ * the next tick diffs against the new state.
+ *
+ * Dirty rules (PLAN §B10, grilled R1-5/6, R2-7, R3-5):
+ *   - a changed grid tile dirties its FULL clipped 3×3 (autotile is neighbour-dependent);
+ *   - a changed entrance column x dirties (x,0)+(x−1,1),(x,1),(x+1,1);
+ *   - chambers are NOT tracked here (dynamic overlay layer §C — no chamber input); the
+ *     grid tiles under a chamber are baked terrain and update via the tile scan.
+ *
+ * O(width × height) per call — cheap at 128×64. Called for the ACTIVE view's cache each
+ * frame; an inactive (toggled-away) grid the AI keeps excavating is reconciled in full on
+ * its first frame back, since the diff compares the live grid to the shadow last refreshed
+ * while it was active (R4-2 reconcile-on-activate).
+ */
+export function diffTerrainShadow(
+  shadow: TerrainShadow,
+  grid: UndergroundGrid,
+  entranceXSet: ReadonlySet<number>,
+): Set<number> {
+  const dirty = new Set<number>();
+  const { width, height } = shadow;
+
+  for (let ty = 0; ty < height; ty++) {
+    for (let tx = 0; tx < width; tx++) {
+      const idx = ty * width + tx;
+      const cur = ugGet(grid, tx, ty);
+      if (shadow.tiles[idx] !== cur) {
+        addClipped3x3(dirty, tx, ty, width, height);
+        shadow.tiles[idx] = cur;
+      }
+    }
+  }
+
+  for (let x = 0; x < width; x++) {
+    const cur = entranceXSet.has(x) ? 1 : 0;
+    if (shadow.entranceCols[x] !== cur) {
+      addEntranceDirty(dirty, x, width, height);
+      shadow.entranceCols[x] = cur;
+    }
+  }
+
+  return dirty;
+}
+
+// ===========================================================================
+// RT lifecycle manager (§B7/8/11)
+// ===========================================================================
+
+/** Cache key identifying a view's RenderTexture: 'surface' or 'ug:<colonyId>'. */
+export type TerrainCacheKey = string;
+
+export function surfaceCacheKey(): TerrainCacheKey {
+  return 'surface';
+}
+export function undergroundCacheKey(colonyId: number): TerrainCacheKey {
+  return `ug:${colonyId}`;
+}
+
+/**
+ * One cached view RenderTexture + its bake bookkeeping. RTs are always created at world
+ * origin (0,0) so a world-px draw lands at the matching texel; the main camera then
+ * scrolls/zooms the whole RT.
+ */
+export interface TerrainCacheEntry<RT> {
+  key: TerrainCacheKey;
+  rt: RT;
+  readonly originX: 0;
+  readonly originY: 0;
+  /** True until the RT has been (re)stamped with the current terrain (full bake). */
+  needsRebake: boolean;
+  /** Render-owned shadow for incremental dirty-diff; null until the first full bake. */
+  shadow: TerrainShadow | null;
+}
+
+/**
+ * Pure RT lifecycle manager. Generic over the RT type so the lifecycle is unit-testable
+ * with a stub; GameScene injects a real Phaser RenderTexture factory.
+ *   - surface + player-underground are allocated up front (ensure at boot);
+ *   - enemy-underground is allocated LAZILY on first ensure (first X-toggle) (R1-13);
+ *   - every NEW entry starts at origin (0,0), needsRebake=true, shadow=null;
+ *   - invalidateAll() (restart/load + RESTORE_WEBGL) flags every ALLOCATED cache for a
+ *     full rebake and drops its shadow (R2-11/R4-6) — it never allocates the lazy enemy
+ *     cache that was never opened.
+ */
+export class TerrainCache<RT> {
+  private readonly entries = new Map<TerrainCacheKey, TerrainCacheEntry<RT>>();
+  constructor(private readonly createRt: (key: TerrainCacheKey) => RT) {}
+
+  has(key: TerrainCacheKey): boolean {
+    return this.entries.has(key);
+  }
+
+  get(key: TerrainCacheKey): TerrainCacheEntry<RT> | undefined {
+    return this.entries.get(key);
+  }
+
+  /** All currently-allocated keys (excludes a lazy enemy cache never opened). */
+  allocatedKeys(): TerrainCacheKey[] {
+    return [...this.entries.keys()];
+  }
+
+  /**
+   * Fetch (or lazily allocate) the entry for a key. A new entry is created at origin
+   * (0,0) with needsRebake=true and no shadow; the RT factory runs exactly once per key.
+   */
+  ensure(key: TerrainCacheKey): TerrainCacheEntry<RT> {
+    let e = this.entries.get(key);
+    if (e === undefined) {
+      e = { key, rt: this.createRt(key), originX: 0, originY: 0, needsRebake: true, shadow: null };
+      this.entries.set(key, e);
+    }
+    return e;
+  }
+
+  /**
+   * Mark an entry baked: clear needsRebake and store the fresh shadow. Surface terrain is
+   * static (never diffed) so it bakes with a null shadow; underground passes its shadow.
+   */
+  markBaked(key: TerrainCacheKey, shadow: TerrainShadow | null = null): void {
+    const e = this.entries.get(key);
+    if (e !== undefined) {
+      e.needsRebake = false;
+      e.shadow = shadow;
+    }
+  }
+
+  /**
+   * Restart/load OR WebGL-context restore: every ALLOCATED cache must fully rebake.
+   * Drops shadows so the next bake re-snapshots from scratch.
+   */
+  invalidateAll(): void {
+    for (const e of this.entries.values()) {
+      e.needsRebake = true;
+      e.shadow = null;
+    }
+  }
+
+  /** Destroy every RT (scene shutdown), calling the provided disposer, then clear. */
+  destroyAll(destroy: (rt: RT) => void): void {
+    for (const e of this.entries.values()) destroy(e.rt);
+    this.entries.clear();
+  }
+}

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -33,6 +33,11 @@ import {
   type QueenDeathCause,
 } from './ui-scene-logic.js';
 import { PLAYER_COLONY_ID as _PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
+import {
+  triggerScreenEdgeFlash as drawScreenEdgeFlash,
+  type FlashDirection,
+} from './screen-effects.js';
+import { CANVAS_W, CANVAS_H } from './sprites.js';
 
 // Re-export pure helpers for Plan 07 and external consumers
 export { formatOutcomeTitle, formatKillStatsSubtitle, formatCauseSubtitle, type QueenDeathCause };
@@ -356,6 +361,11 @@ export class UIScene extends Phaser.Scene {
   // enqueueCommand cap on chamber/behavior commands.
   private onSelectTool: ((tool: ToolId) => void) | null = null;
   private onSpeedControl: ((control: SpeedControl) => void) | null = null;
+  // Fires after a successful minimap click-to-nav so GameScene can cancel any
+  // in-flight wheel zoom-lerp/anchor on the active camera; otherwise the next
+  // tickZoomLerp re-anchors centerX/Y from the fixed cursor point and throws the
+  // minimap recenter away (mirrors the keyboard/drag-pan cancel in game-scene.ts).
+  private onMinimapNav: (() => void) | null = null;
   private isPausedFn: (() => boolean) | null = null;
   private getSpeedMultiplierFn: (() => 1 | 2 | 4) | null = null;
   // Tool palette button labels (3) and the hint strip text + speed widget labels.
@@ -443,6 +453,7 @@ export class UIScene extends Phaser.Scene {
     // the HUD palette/speed widget route through the same gates as the hotkeys.
     onSelectTool?: (tool: ToolId) => void;
     onSpeedControl?: (control: SpeedControl) => void;
+    onMinimapNav?: () => void;
     isPaused?: () => boolean;
     getSpeedMultiplier?: () => 1 | 2 | 4;
   }) {
@@ -451,6 +462,7 @@ export class UIScene extends Phaser.Scene {
     this.onEscape = data.onEscape ?? null;
     this.onSelectTool = data.onSelectTool ?? null;
     this.onSpeedControl = data.onSpeedControl ?? null;
+    this.onMinimapNav = data.onMinimapNav ?? null;
     this.isPausedFn = data.isPaused ?? null;
     this.getSpeedMultiplierFn = data.getSpeedMultiplier ?? null;
   }
@@ -831,8 +843,14 @@ export class UIScene extends Phaser.Scene {
         this.onSpeedControl?.(speedHit);
         return;
       }
-      // Minimap click
-      if (applyMinimapClick(this.viewState, pointer.x, pointer.y)) return;
+      // Minimap click. On a successful recenter, notify GameScene so it can drop
+      // any in-flight wheel zoom-lerp/anchor on the active camera — otherwise the
+      // next tickZoomLerp re-anchors from the fixed cursor point and overrides the
+      // minimap nav (same class of bug the keyboard/drag-pan cancel prevents).
+      if (applyMinimapClick(this.viewState, pointer.x, pointer.y)) {
+        this.onMinimapNav?.();
+        return;
+      }
       // Behavior slider drag start (Phase 10 / D-01 — 1-D Forage↔Fight axis)
       if (isInsideSlider(pointer.x, pointer.y)) {
         this.dragState.isDragging = true;
@@ -1224,6 +1242,17 @@ export class UIScene extends Phaser.Scene {
         });
       },
     });
+  }
+
+  // Stage 2 controls rework (issue #18) — the invasion screen-edge flash MUST
+  // render on UIScene, NOT GameScene. GameScene's main camera is zoom-driven
+  // (CameraController.apply → setZoom + centerOn), and setScrollFactor(0)
+  // cancels scroll but NOT zoom, so a flash drawn there is scaled/offset at any
+  // zoom != 1 (see game-scene.ts Pitfall 1). UIScene's camera never zooms or
+  // scrolls, so the fixed-canvas edge strips land correctly. Delegates the draw
+  // to the pure screen-effects helper with `this` = UIScene.
+  public triggerScreenEdgeFlash(direction: FlashDirection): void {
+    drawScreenEdgeFlash(this, direction, CANVAS_W, CANVAS_H);
   }
 
   public hideGameOverOverlay(): void {


### PR DESCRIPTION
## Stage 2 of the controls rework (#18) — continuous zoom + smooth pan

Continuous Google-Maps-style **zoom + smooth pan** in both views via Phaser's main camera over **baked terrain `RenderTexture`s**, with a **batched ant-dot LOD** for strategic whole-nest zoom-out (~0.2×–2×) and crisp/NEAREST filtering.

**Strictly render-only** — no `src/sim` edits, no `simVersion` bump, no `SimCommand` changes, no determinism/replay impact (`git diff main -- src/sim` is empty). Stage 1 (input model) shipped in #210; Stage 3 (teaching) is next.

### What changed
- **`camera-adapter.ts` (new)** — the single, pure `screen↔world` authority: projection, custom center-aware **per-axis clamp** (no `setBounds`), **cursor-anchored zoom** re-anchored every lerp frame, pan & **time-based WASD** (both ÷zoom), LOD hysteresis, minimap-nav. Fully unit-tested (no Phaser).
- **`camera-controller.ts` (new)** — thin Phaser driver (`setZoom` + `centerOn`; `roundPixels` off for smooth sub-pixel pan).
- **ViewState → world-pixel `CameraView`** with atomic per-view zoom/center **save-restore on toggle**. Every draw + input module migrated to **world space**; `cameras.main` is now the projection (previously manual screen-space).
- **`terrain-bake.ts` (new)** — render-owned **shadow-diff dirty tracking** (grid + entrance only; chambers excluded) + **RT lifecycle cache** (origin (0,0); lazy enemy-underground RT; rebake on restart + `RESTORE_WEBGL`). Wired into `GameScene`: terrain baked into per-view RenderTextures; underground incrementally re-stamped from the dirty set; RTs freed on shutdown.
- **Batched ant-dot LOD** at strategic zoom (0.55/0.65 hysteresis), inverse-zoom cues.
- **Screen-edge flash moved to the UIScene** (unzoomed camera — `setScrollFactor(0)` ≠ unzoomed under a zoom camera).
- **Mouse-wheel zoom**, gated like world pan (HUD/modal aware; ctrl/cmd-wheel ignored).

### Tests
New unit suites: `camera-adapter` (projection / clamp / cursor-anchor / pan / WASD / LOD hysteresis / minimap-nav), `terrain-bake` (shadow-diff dirty set + RT lifecycle), `camera-controller`; all draw/input suites migrated to the world-px model. `npm run verify` green on a clean runner.

### Plan & review
Locked + Codex-grilled plan: `plan/controls-rework/PLAN-stage2.md` (private repo). Internal `ship-review` passed.

### UAT focus (pixel/feel — not verifiable in CI)
Terrain renders via the baked RT at all zooms; first-underground-visit bake; dot-LOD swap ≤0.55×; incremental dig re-stamps; edge-flash on the UI camera; zoom/pan feel at 60fps.
