### PR TITLE
feat(controls): Stage 3b — navigation teaching (glyphs, hint strip, first-use hints, tooltips) (#18)

### DIFF
--- a/src/input/camera-input.test.ts
+++ b/src/input/camera-input.test.ts
@@ -14,7 +14,7 @@
 //     new drags)
 //   - reset helpers
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   isPointerOverHUD,
   processCameraInput,
@@ -36,6 +36,13 @@ import { SURFACE_WORLD_PX_W } from '../render/camera.js';
 import { makeCameraView, KEYBOARD_PAN_SPEED_PX_PER_SEC } from '../render/camera-adapter.js';
 import { HUD, CANVAS_W } from '../render/sprites.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
+import { hintStripState, resetHintStripState } from '../render/hint-strip-state.js';
+
+// Stage 3b: the hint-strip visibility singleton gates HUD.HINTS masking. Reset
+// it after each test so a hidden-legend case doesn't leak into its neighbors.
+afterEach(() => {
+  resetHintStripState();
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -126,6 +133,19 @@ describe('isPointerOverHUD', () => {
   it('masks the Stage 1 interactive zones: TOOLS, HINTS, and SPEED', () => {
     const vs = makeViewState('surface');
     for (const rect of [HUD.TOOLS, HUD.HINTS, HUD.SPEED]) {
+      const [x, y] = center(rect);
+      expect(isPointerOverHUD(x, y, vs)).toBe(true);
+    }
+  });
+
+  it('Stage 3b: drops HUD.HINTS from the mask when the legend is hidden, keeps TOOLS/SPEED', () => {
+    const vs = makeViewState('surface');
+    hintStripState.visible = false;
+    const [hx, hy] = center(HUD.HINTS);
+    // The freed legend band is no longer a dead input zone…
+    expect(isPointerOverHUD(hx, hy, vs)).toBe(false);
+    // …but the other interactive widgets stay masked.
+    for (const rect of [HUD.TOOLS, HUD.SPEED]) {
       const [x, y] = center(rect);
       expect(isPointerOverHUD(x, y, vs)).toBe(true);
     }

--- a/src/input/camera-input.ts
+++ b/src/input/camera-input.ts
@@ -26,6 +26,7 @@
 import type * as Phaser from 'phaser';
 import { HUD } from '../render/sprites.js';
 import { antActivityPanelState } from '../render/ant-activity-panel-state.js';
+import { hintStripState } from '../render/hint-strip-state.js';
 import { type ViewState, worldPxDimensions } from '../render/camera.js';
 import {
   type CameraView,
@@ -102,10 +103,16 @@ export function isPointerOverHUD(px: number, py: number, viewState?: ViewState):
     HUD.TRIANGLE,
     HUD.SPEED,
     HUD.TOOLS,
-    HUD.HINTS,
     HUD.MINIMAP,
     HUD.VIEW_TOGGLE,
   ];
+  // Stage 3b (issue #18, Codex R1#2) — the hint strip masks world input ONLY
+  // while its legend is visible. When the player hides the legend (settings
+  // toggle → hintStripState.visible=false), drop HUD.HINTS so the freed band is
+  // not a dead input zone. Default visible → the band stays masked as before.
+  if (hintStripState.visible) {
+    zones.push(HUD.HINTS);
+  }
   // Issue #14 — colony toggle is rendered ONLY on the underground view. Mask the
   // click zone only when it's actually visible. Callers without a ViewState
   // (legacy/test) pass undefined and the toggle stays unmasked.

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -185,6 +185,16 @@ export interface GestureArbiterDeps {
    * on the next move); one-shot taps call it on ANY drop (no re-emit) (Codex P2).
    */
   onPausedQueueFull?: (paused: boolean) => void;
+  // Stage 3b (issue #18, #3) — thin teaching seams. Fired on the EFFECT, not the
+  // raw input (Codex R1#10), so first-use hints react to what actually happened.
+  // Optional: tests and any non-teaching caller simply omit them.
+  /** The camera actually moved on a left-drag pan ("Drag to look around"). */
+  onPanEffect?: () => void;
+  /** A dig-paint drag actually enqueued ≥1 mark ("Drag to paint tunnels"). */
+  onPaintEffect?: () => void;
+  /** A world gesture began (a left press that armed a snapshot) — the signal
+   *  GameScene uses to evaluate the proactive [Tab] nudge on first world input. */
+  onWorldInput?: () => void;
 }
 
 /** Return the active CameraView for the current view. */
@@ -376,6 +386,12 @@ export class GestureArbiter {
     this.panLastX = ev.x;
     this.panLastY = ev.y;
 
+    // Stage 3b (#3): a world gesture has begun. Signal it so GameScene can
+    // evaluate the proactive [Tab] first-use nudge on the player's first world
+    // input of the session (the nudge gate reads view/undergroundVisited, which
+    // a pan/dig press does not change, so firing at press-time is safe).
+    this.deps.onWorldInput?.();
+
     // Eagerly begin a paint stroke for underground-Dig so the down-tile mark
     // fires immediately (matching the prior click-then-drag behavior). The
     // stroke only PAINTS once the threshold is crossed; a release before then
@@ -407,6 +423,7 @@ export class GestureArbiter {
         if (world) {
           // Begin the stroke at the SNAPSHOTTED down-tile so the first painted
           // segment interpolates from there, then extend to the current tile.
+          const queuedBefore = world.commandQueue.length;
           const dropped = beginPaintStroke(
             this.paintStroke,
             world,
@@ -415,6 +432,9 @@ export class GestureArbiter {
             snap.tileY,
             this.deps.isPaused(),
           );
+          // Stage 3b (#3): fire the paint hint only if a mark actually enqueued
+          // (queue grew) — not on a no-op drag over already-open tiles.
+          if (world.commandQueue.length > queuedBefore) this.deps.onPaintEffect?.();
           this.notifyCapHit(dropped);
         }
       } else {
@@ -604,6 +624,7 @@ export class GestureArbiter {
     // Accepted residual: a single coalesced >64-tile move + immediate release
     // (no later move) loses the tail past the cap — see continuePaintStroke and
     // the file header.
+    const queuedBefore = world.commandQueue.length;
     const capHit = continuePaintStroke(
       this.paintStroke,
       world,
@@ -612,6 +633,7 @@ export class GestureArbiter {
       tileY,
       this.deps.isPaused(),
     );
+    if (world.commandQueue.length > queuedBefore) this.deps.onPaintEffect?.();
     this.notifyCapHit(capHit);
   }
 
@@ -625,11 +647,21 @@ export class GestureArbiter {
       return;
     }
     const cam = activeCamera(vs);
+    // Snapshot the camera CENTER before the move so the first-use hint fires on
+    // the actual EFFECT, not the raw pointer delta (ship-review R1#2): at a
+    // clamped world edge the pointer can move while the camera stays put. Mirrors
+    // the zoom seam (targetZoom before/after) and the paint seam (queue length).
+    const beforeCenterX = cam.centerX;
+    const beforeCenterY = cam.centerY;
     panByScreenDelta(cam, ev.x - this.panLastX, ev.y - this.panLastY);
     const [worldW, worldH] = worldDimensions(vs);
     clampCameraView(cam, worldW, worldH);
     this.panLastX = ev.x;
     this.panLastY = ev.y;
+    // Stage 3b (#3): the camera ACTUALLY moved → first-use "Drag to look around".
+    if (cam.centerX !== beforeCenterX || cam.centerY !== beforeCenterY) {
+      this.deps.onPanEffect?.();
+    }
   }
 
   private handleRightClick(ev: ArbiterPointerEvent): void {

--- a/src/platform/settings.test.ts
+++ b/src/platform/settings.test.ts
@@ -14,6 +14,12 @@ beforeEach(() => {
   localStorage.removeItem(SETTINGS_KEY);
 });
 
+// Build a full Settings object from a partial, so individual tests only state
+// the field(s) they care about (Stage 3b added hintStripVisible + firstUseHints).
+function mk(overrides: Partial<Settings> = {}): Settings {
+  return { ...DEFAULT_SETTINGS, ...overrides };
+}
+
 describe('loadSettings', () => {
   it('returns DEFAULT_SETTINGS when localStorage is empty', () => {
     expect(loadSettings()).toEqual(DEFAULT_SETTINGS);
@@ -27,7 +33,11 @@ describe('loadSettings', () => {
   });
 
   it('round-trips a saved Settings object losslessly', () => {
-    const next: Settings = { pheromoneOverlay: false };
+    const next: Settings = mk({
+      pheromoneOverlay: false,
+      hintStripVisible: false,
+      firstUseHints: { pan: true, zoom: true },
+    });
     saveSettings(next);
     expect(loadSettings()).toEqual(next);
   });
@@ -53,18 +63,54 @@ describe('loadSettings', () => {
     expect(loadSettings()).toEqual(DEFAULT_SETTINGS);
   });
 
-  it('replaces a wrong-typed pheromoneOverlay with the default but keeps siblings intact', () => {
+  it('migrates an old blob missing the Stage-3b keys by filling defaults (no version bump)', () => {
+    // A settings file written before Stage 3b has only pheromoneOverlay. The
+    // permissive loader must fill hintStripVisible + firstUseHints from defaults
+    // without invalidating the file (Codex: backward-compatible add).
+    localStorage.setItem(
+      SETTINGS_KEY,
+      JSON.stringify({ version: SETTINGS_VERSION, settings: { pheromoneOverlay: false } }),
+    );
+    expect(loadSettings()).toEqual(mk({ pheromoneOverlay: false }));
+  });
+
+  it('replaces a wrong-typed field with its default but keeps valid siblings intact', () => {
     // Permissive merge: a single corrupt field shouldn't wipe valid neighbors.
-    // Today we only have one boolean field; this guards the merge logic so a
-    // future field is safe to add.
     localStorage.setItem(
       SETTINGS_KEY,
       JSON.stringify({
         version: SETTINGS_VERSION,
-        settings: { pheromoneOverlay: 'not-a-bool' },
+        settings: { pheromoneOverlay: 'not-a-bool', hintStripVisible: false },
       }),
     );
-    expect(loadSettings()).toEqual({ pheromoneOverlay: DEFAULT_SETTINGS.pheromoneOverlay });
+    expect(loadSettings()).toEqual(
+      mk({ pheromoneOverlay: DEFAULT_SETTINGS.pheromoneOverlay, hintStripVisible: false }),
+    );
+  });
+
+  it('sanitizes firstUseHints: keeps boolean entries, drops non-boolean ones', () => {
+    localStorage.setItem(
+      SETTINGS_KEY,
+      JSON.stringify({
+        version: SETTINGS_VERSION,
+        settings: { firstUseHints: { pan: true, zoom: 'yes', paint: false, view: 1 } },
+      }),
+    );
+    expect(loadSettings().firstUseHints).toEqual({ pan: true, paint: false });
+  });
+
+  it('coerces a non-object firstUseHints (e.g. a stringified Set) to an empty record', () => {
+    // A pre-fix build that stored a Set serializes to `{}`/array/etc.; either way
+    // we must not crash and must yield a clean record (Codex R1#4).
+    localStorage.setItem(
+      SETTINGS_KEY,
+      JSON.stringify({
+        version: SETTINGS_VERSION,
+        settings: { firstUseHints: ['pan', 'zoom'] },
+      }),
+    );
+    // Arrays are objects; only string-keyed boolean entries survive → {}.
+    expect(loadSettings().firstUseHints).toEqual({});
   });
 
   it('ignores unknown extra keys in the settings object', () => {
@@ -75,25 +121,23 @@ describe('loadSettings', () => {
         settings: { pheromoneOverlay: false, futureKey: 'whatever' },
       }),
     );
-    expect(loadSettings()).toEqual({ pheromoneOverlay: false });
+    expect(loadSettings()).toEqual(mk({ pheromoneOverlay: false }));
   });
 });
 
 describe('saveSettings', () => {
   it('writes a versioned envelope under SETTINGS_KEY', () => {
-    saveSettings({ pheromoneOverlay: false });
+    const s = mk({ pheromoneOverlay: false, firstUseHints: { pan: true } });
+    saveSettings(s);
     const raw = localStorage.getItem(SETTINGS_KEY);
     expect(raw).not.toBeNull();
     const parsed = JSON.parse(raw!);
-    expect(parsed).toEqual({
-      version: SETTINGS_VERSION,
-      settings: { pheromoneOverlay: false },
-    });
+    expect(parsed).toEqual({ version: SETTINGS_VERSION, settings: s });
   });
 
   it('overwrites an earlier saved state', () => {
-    saveSettings({ pheromoneOverlay: true });
-    saveSettings({ pheromoneOverlay: false });
-    expect(loadSettings()).toEqual({ pheromoneOverlay: false });
+    saveSettings(mk({ pheromoneOverlay: true }));
+    saveSettings(mk({ pheromoneOverlay: false }));
+    expect(loadSettings()).toEqual(mk({ pheromoneOverlay: false }));
   });
 });

--- a/src/platform/settings.ts
+++ b/src/platform/settings.ts
@@ -21,10 +21,21 @@ export interface Settings {
   /** Pheromone trail overlay visibility (issue #114). When false, the player's
    *  pheromone overlay is not drawn. Render-only; does not affect simulation. */
   pheromoneOverlay: boolean;
+  /** Stage 3b (issue #18) — visibility of the static per-tool hint-strip legend.
+   *  When false, only the legend is hidden; the paused-queue-full warning and
+   *  caption-yield still render. Default true. Render-only. */
+  hintStripVisible: boolean;
+  /** Stage 3b (issue #18) — cross-session "already shown" flags for the one-time
+   *  first-use navigation hints, keyed by HintFirstUseId. A JSON-safe Record
+   *  (NOT a Set, which JSON.stringify flattens to `{}` — Codex R1#4). A hint is
+   *  marked here only once it actually begins displaying (Codex R1#9). Render-only. */
+  firstUseHints: Record<string, boolean>;
 }
 
 export const DEFAULT_SETTINGS: Readonly<Settings> = {
   pheromoneOverlay: true,
+  hintStripVisible: true,
+  firstUseHints: {},
 };
 
 interface SettingsEnvelope {
@@ -32,30 +43,38 @@ interface SettingsEnvelope {
   settings: Settings;
 }
 
+/** A fresh defaults object. NEVER return `{ ...DEFAULT_SETTINGS }` directly: the
+ *  shallow spread copies primitives but SHARES the nested `firstUseHints` object,
+ *  so a caller that mutates it (markFirstUseHintShown) would poison the module-
+ *  level default for every later load. This deep-copies the mutable field. */
+function freshDefaults(): Settings {
+  return { ...DEFAULT_SETTINGS, firstUseHints: { ...DEFAULT_SETTINGS.firstUseHints } };
+}
+
 /** Load settings from localStorage. Returns DEFAULT_SETTINGS if missing,
  *  malformed, or for any version beyond SETTINGS_VERSION. Never throws. */
 export function loadSettings(): Settings {
-  if (typeof localStorage === 'undefined') return { ...DEFAULT_SETTINGS };
+  if (typeof localStorage === 'undefined') return freshDefaults();
   let raw: string | null;
   try {
     raw = localStorage.getItem(SETTINGS_KEY);
   } catch {
-    return { ...DEFAULT_SETTINGS };
+    return freshDefaults();
   }
-  if (raw === null) return { ...DEFAULT_SETTINGS };
+  if (raw === null) return freshDefaults();
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    return { ...DEFAULT_SETTINGS };
+    return freshDefaults();
   }
-  if (parsed === null || typeof parsed !== 'object') return { ...DEFAULT_SETTINGS };
+  if (parsed === null || typeof parsed !== 'object') return freshDefaults();
   const env = parsed as Partial<SettingsEnvelope>;
   if (typeof env.version !== 'number' || env.version > SETTINGS_VERSION) {
-    return { ...DEFAULT_SETTINGS };
+    return freshDefaults();
   }
   if (env.settings === null || typeof env.settings !== 'object') {
-    return { ...DEFAULT_SETTINGS };
+    return freshDefaults();
   }
   // Permissive merge: unknown keys ignored, missing keys filled from defaults.
   // Type-check each known field; reject the value (fall back to default) if
@@ -67,7 +86,25 @@ export function loadSettings(): Settings {
       typeof s.pheromoneOverlay === 'boolean'
         ? s.pheromoneOverlay
         : DEFAULT_SETTINGS.pheromoneOverlay,
+    hintStripVisible:
+      typeof s.hintStripVisible === 'boolean'
+        ? s.hintStripVisible
+        : DEFAULT_SETTINGS.hintStripVisible,
+    firstUseHints: sanitizeFirstUseHints(s.firstUseHints),
   };
+}
+
+/** Coerce an unknown blob into a clean Record<string, boolean>: keep only own
+ *  string keys whose value is a boolean, drop everything else. A non-object
+ *  (missing / corrupt / a stringified Set's `{}` from an older build) yields an
+ *  empty record. Keeps a single corrupt entry from poisoning the whole field. */
+function sanitizeFirstUseHints(raw: unknown): Record<string, boolean> {
+  if (raw === null || typeof raw !== 'object') return {};
+  const out: Record<string, boolean> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof v === 'boolean') out[k] = v;
+  }
+  return out;
 }
 
 /** Persist settings to localStorage. Silent on quota / availability errors —

--- a/src/render/caption-queue.test.ts
+++ b/src/render/caption-queue.test.ts
@@ -1,0 +1,127 @@
+// caption-queue.test.ts — Stage 3b (#3): the caption-admission policy
+// (priority / coalesce / drop / promote).
+
+import { describe, it, expect } from 'vitest';
+import {
+  admitCaption,
+  completeCaption,
+  clearPending,
+  createCaptionQueueState,
+  type CaptionRequest,
+} from './caption-queue.js';
+
+const evt = (text: string): CaptionRequest => ({ text, x: 0, y: 0, source: 'event' });
+const fu = (hintId: string): CaptionRequest => ({
+  text: hintId,
+  x: 0,
+  y: 0,
+  source: 'first-use',
+  hintId,
+});
+
+describe('admitCaption', () => {
+  it('displays immediately when nothing is active', () => {
+    const s = createCaptionQueueState();
+    const r = admitCaption(s, evt('a'));
+    expect(r.begin?.text).toBe('a');
+    expect(s.active?.text).toBe('a');
+    expect(s.pending).toBeNull();
+  });
+
+  it('never preempts the active caption — second goes to pending', () => {
+    const s = createCaptionQueueState();
+    admitCaption(s, evt('a'));
+    const r = admitCaption(s, evt('b'));
+    expect(r.begin).toBeUndefined();
+    expect(r.queued?.text).toBe('b');
+    expect(s.active?.text).toBe('a');
+    expect(s.pending?.text).toBe('b');
+  });
+
+  it('coalesces a duplicate first-use against the ACTIVE one', () => {
+    const s = createCaptionQueueState();
+    admitCaption(s, fu('pan'));
+    const r = admitCaption(s, fu('pan'));
+    expect(r.coalesced).toBe(true);
+    expect(s.pending).toBeNull();
+  });
+
+  it('coalesces a duplicate first-use against the PENDING one', () => {
+    const s = createCaptionQueueState();
+    admitCaption(s, evt('a')); // active
+    admitCaption(s, fu('zoom')); // pending
+    const r = admitCaption(s, fu('zoom'));
+    expect(r.coalesced).toBe(true);
+    expect(s.pending?.hintId).toBe('zoom');
+  });
+
+  it('an incoming EVENT evicts a pending FIRST-USE (event outranks)', () => {
+    const s = createCaptionQueueState();
+    admitCaption(s, evt('a')); // active
+    admitCaption(s, fu('pan')); // pending first-use
+    const r = admitCaption(s, evt('b'));
+    expect(r.queued?.text).toBe('b');
+    expect(r.droppedFirstUse?.hintId).toBe('pan');
+    expect(s.pending?.text).toBe('b');
+  });
+
+  it('an incoming FIRST-USE is dropped when the slot is occupied (overflow)', () => {
+    const s = createCaptionQueueState();
+    admitCaption(s, evt('a')); // active
+    admitCaption(s, evt('b')); // pending event
+    const r = admitCaption(s, fu('paint'));
+    expect(r.dropped?.hintId).toBe('paint');
+    expect(s.pending?.text).toBe('b'); // unchanged
+  });
+
+  it('a second EVENT loses to the first queued event (order preserved)', () => {
+    const s = createCaptionQueueState();
+    admitCaption(s, evt('a'));
+    admitCaption(s, evt('b'));
+    const r = admitCaption(s, evt('c'));
+    expect(r.dropped?.text).toBe('c');
+    expect(s.pending?.text).toBe('b');
+  });
+
+  it('a dropped one-shot event carries its captionKey so UIScene can un-mark it', () => {
+    // Regression guard: a one-shot caption is marked-triggered before it reaches
+    // the queue; if overflow drops it the key must travel back so UIScene un-marks
+    // it (otherwise the first-occurrence caption is lost for the session).
+    const s = createCaptionQueueState();
+    admitCaption(s, evt('a')); // active
+    admitCaption(s, evt('b')); // pending
+    const r = admitCaption(s, { ...evt('c'), captionKey: 'dig' });
+    expect(r.dropped?.captionKey).toBe('dig');
+  });
+});
+
+describe('completeCaption', () => {
+  it('promotes pending to active and signals begin', () => {
+    const s = createCaptionQueueState();
+    admitCaption(s, evt('a'));
+    admitCaption(s, evt('b'));
+    const r = completeCaption(s);
+    expect(r.begin?.text).toBe('b');
+    expect(s.active?.text).toBe('b');
+    expect(s.pending).toBeNull();
+  });
+
+  it('goes idle when nothing is pending', () => {
+    const s = createCaptionQueueState();
+    admitCaption(s, evt('a'));
+    const r = completeCaption(s);
+    expect(r.begin).toBeUndefined();
+    expect(s.active).toBeNull();
+  });
+});
+
+describe('clearPending', () => {
+  it('drops the pending entry but leaves the active one mid-fade', () => {
+    const s = createCaptionQueueState();
+    admitCaption(s, evt('a'));
+    admitCaption(s, fu('pan'));
+    clearPending(s);
+    expect(s.pending).toBeNull();
+    expect(s.active?.text).toBe('a');
+  });
+});

--- a/src/render/caption-queue.test.ts
+++ b/src/render/caption-queue.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect } from 'vitest';
 import {
   admitCaption,
   completeCaption,
-  clearPending,
+  clearPendingFirstUse,
   createCaptionQueueState,
   type CaptionRequest,
 } from './caption-queue.js';
@@ -115,13 +115,21 @@ describe('completeCaption', () => {
   });
 });
 
-describe('clearPending', () => {
-  it('drops the pending entry but leaves the active one mid-fade', () => {
+describe('clearPendingFirstUse', () => {
+  it('drops a pending FIRST-USE entry but leaves the active one mid-fade', () => {
     const s = createCaptionQueueState();
     admitCaption(s, evt('a'));
     admitCaption(s, fu('pan'));
-    clearPending(s);
+    clearPendingFirstUse(s);
     expect(s.pending).toBeNull();
     expect(s.active?.text).toBe('a');
+  });
+
+  it('LEAVES a pending EVENT caption intact (Codex PR #218 — do not drop unrelated events)', () => {
+    const s = createCaptionQueueState();
+    admitCaption(s, evt('a')); // active
+    admitCaption(s, evt('queen-damage')); // pending EVENT caption
+    clearPendingFirstUse(s);
+    expect(s.pending?.text).toBe('queen-damage'); // survives the first-use reset
   });
 });

--- a/src/render/caption-queue.ts
+++ b/src/render/caption-queue.ts
@@ -126,9 +126,12 @@ export function completeCaption(state: CaptionQueueState): { begin?: CaptionRequ
   return state.active ? { begin: state.active } : {};
 }
 
-/** Drop any pending entry (used by "Reset hints" so a queued first-use does not
- *  surface after its persisted flag was cleared). Does not touch the active
- *  caption, which is mid-fade and allowed to finish. */
-export function clearPending(state: CaptionQueueState): void {
-  state.pending = null;
+/** Drop a pending FIRST-USE entry (used by "Reset first-use hints" so a queued
+ *  first-use does not surface after its persisted flag was cleared). A pending
+ *  EVENT caption is left intact: event captions are marked-triggered BEFORE they
+ *  reach the queue and this path does not untrigger them, so dropping one would
+ *  suppress it for the rest of the round (Codex PR #218). Does not touch the
+ *  active caption, which is mid-fade and allowed to finish. */
+export function clearPendingFirstUse(state: CaptionQueueState): void {
+  if (state.pending?.source === 'first-use') state.pending = null;
 }

--- a/src/render/caption-queue.ts
+++ b/src/render/caption-queue.ts
@@ -1,0 +1,134 @@
+// caption-queue.ts — Stage 3b controls rework (issue #18, component #3).
+//
+// The ONE caption-admission policy that ALL callers route through (existing
+// event captions, onboarding-captions, and the new first-use hints) so two
+// captions can never paint on top of each other (Codex R1#8/R2). Pure + Phaser-
+// free: UIScene owns the Phaser Text/tween + the timing; this module owns only
+// the "what happens to this request" decision, so the policy is unit-testable.
+//
+// Policy (locked in the grill):
+//   - The currently-displaying caption is NEVER preempted (it finishes its fade).
+//   - Pending capacity = 1.
+//   - Event captions outrank first-use hints.
+//   - A duplicate first-use (same hintId already active OR pending) is coalesced
+//     — never queued twice.
+//   - On overflow the first-use is dropped before an event caption: an incoming
+//     event replaces a pending first-use; an incoming first-use is dropped when
+//     anything is already pending.
+//   - A dropped/coalesced first-use is NOT reported as "begun", so UIScene never
+//     marks it shown and it can re-trigger later (Codex R1#9).
+
+import type { CaptionKey } from './onboarding-captions.js';
+
+export type CaptionSource = 'event' | 'first-use';
+
+export interface CaptionRequest {
+  text: string;
+  /** Screen-pixel center for the caption Text. */
+  x: number;
+  y: number;
+  source: CaptionSource;
+  /** First-use hint id — present iff source === 'first-use'. Drives coalescing
+   *  and the mark-shown-on-display persistence in UIScene. */
+  hintId?: string;
+  /** One-shot caption key — present iff source === 'event' AND the caption was
+   *  produced by a one-shot trigger (checkAndTrigger/captionForEvent), which marks
+   *  the key BEFORE the request reaches this queue. If the request is dropped on
+   *  overflow, UIScene un-marks this key so the caption can re-fire (it never
+   *  displayed). Absent for recurring captions, which don't dedup on `triggered`. */
+  captionKey?: CaptionKey;
+}
+
+export interface CaptionQueueState {
+  /** The request currently displaying (its tween is in flight), or null. */
+  active: CaptionRequest | null;
+  /** The single queued request waiting for `active` to finish, or null. */
+  pending: CaptionRequest | null;
+}
+
+export function createCaptionQueueState(): CaptionQueueState {
+  return { active: null, pending: null };
+}
+
+/**
+ * Outcome of admitting a request. Exactly one of begin/queued/coalesced/dropped
+ * describes the incoming request; `droppedFirstUse`, when set, is a previously-
+ * pending first-use that the incoming event evicted (UIScene clears any
+ * mark/marking for it — though since it never began displaying, nothing was
+ * marked).
+ */
+export interface AdmitResult {
+  /** The request should start displaying NOW (UIScene begins its tween, and —
+   *  if first-use — marks it shown). */
+  begin?: CaptionRequest;
+  /** The request was parked in `pending`. */
+  queued?: CaptionRequest;
+  /** A duplicate first-use was folded into an existing one. */
+  coalesced?: boolean;
+  /** The request was rejected (overflow). */
+  dropped?: CaptionRequest;
+  /** A pending first-use evicted by an incoming higher-priority event. */
+  droppedFirstUse?: CaptionRequest;
+}
+
+function sameFirstUse(a: CaptionRequest | null, b: CaptionRequest): boolean {
+  return (
+    a !== null && a.source === 'first-use' && b.source === 'first-use' && a.hintId === b.hintId
+  );
+}
+
+/**
+ * Admit a request into the queue, mutating `state`. Returns what UIScene should
+ * do with it. Never throws.
+ */
+export function admitCaption(state: CaptionQueueState, req: CaptionRequest): AdmitResult {
+  // Nothing on screen → display immediately.
+  if (state.active === null) {
+    state.active = req;
+    return { begin: req };
+  }
+
+  // Coalesce a duplicate first-use against whatever is active or already pending
+  // (Codex R2): the same hint must never queue twice.
+  if (
+    req.source === 'first-use' &&
+    (sameFirstUse(state.active, req) || sameFirstUse(state.pending, req))
+  ) {
+    return { coalesced: true };
+  }
+
+  // Free pending slot → park it.
+  if (state.pending === null) {
+    state.pending = req;
+    return { queued: req };
+  }
+
+  // Pending is occupied. Event outranks a pending first-use: evict it.
+  if (req.source === 'event' && state.pending.source === 'first-use') {
+    const evicted = state.pending;
+    state.pending = req;
+    return { queued: req, droppedFirstUse: evicted };
+  }
+
+  // Otherwise overflow — drop the incoming request (an incoming first-use loses
+  // to any occupied slot; a second event loses to the first event already
+  // queued, preserving order).
+  return { dropped: req };
+}
+
+/**
+ * Mark the active caption finished and promote the pending one. Returns the
+ * request that should now begin displaying (if any).
+ */
+export function completeCaption(state: CaptionQueueState): { begin?: CaptionRequest } {
+  state.active = state.pending;
+  state.pending = null;
+  return state.active ? { begin: state.active } : {};
+}
+
+/** Drop any pending entry (used by "Reset hints" so a queued first-use does not
+ *  surface after its persisted flag was cleared). Does not touch the active
+ *  caption, which is mid-fade and allowed to finish. */
+export function clearPending(state: CaptionQueueState): void {
+  state.pending = null;
+}

--- a/src/render/first-use-hints.test.ts
+++ b/src/render/first-use-hints.test.ts
@@ -1,0 +1,156 @@
+// first-use-hints.test.ts — Stage 3b (#3): gating, mark-shown persistence,
+// reset, and the proactive [Tab] first-world-input nudge.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SETTINGS_KEY, loadSettings } from '../platform/settings.js';
+import {
+  firstUseHintText,
+  isFirstUseHintShown,
+  markFirstUseHintShown,
+  resetFirstUseHints,
+  resetFirstUseSession,
+  resetFirstUseHintCacheForTests,
+  triggerReactiveHint,
+  tabNudgeGateOpen,
+  notifyFirstWorldInput,
+  type HintFirstUseId,
+  type FirstUseHintSink,
+} from './first-use-hints.js';
+
+// A spy sink that records what the triggers asked to display.
+function makeSink(): FirstUseHintSink & { shown: Array<{ id: HintFirstUseId; text: string }> } {
+  const shown: Array<{ id: HintFirstUseId; text: string }> = [];
+  return {
+    shown,
+    showFirstUseHint(id, text) {
+      shown.push({ id, text });
+    },
+  };
+}
+
+beforeEach(() => {
+  localStorage.removeItem(SETTINGS_KEY);
+  resetFirstUseHintCacheForTests();
+});
+
+describe('firstUseHintText', () => {
+  it('composes copy from the glyph table', () => {
+    expect(firstUseHintText('pan')).toBe('Drag to look around');
+    expect(firstUseHintText('zoom')).toBe('Scroll to zoom');
+    expect(firstUseHintText('paint')).toBe('Drag to paint tunnels');
+    expect(firstUseHintText('view-tab')).toBe('Press [Tab] to view underground');
+  });
+});
+
+describe('persistence: mark-shown + reset', () => {
+  it('a freshly-loaded hint is not shown', () => {
+    expect(isFirstUseHintShown('pan')).toBe(false);
+  });
+
+  it('markFirstUseHintShown persists to settings and survives a cache reload', () => {
+    markFirstUseHintShown('pan');
+    expect(isFirstUseHintShown('pan')).toBe(true);
+    // Persisted, not just in-memory:
+    expect(loadSettings().firstUseHints).toEqual({ pan: true });
+    // A fresh page load (cache cleared) re-reads the flag from settings.
+    resetFirstUseHintCacheForTests();
+    expect(isFirstUseHintShown('pan')).toBe(true);
+  });
+
+  it('resetFirstUseHints clears every flag in memory and persistence', () => {
+    markFirstUseHintShown('pan');
+    markFirstUseHintShown('view-tab');
+    resetFirstUseHints();
+    expect(isFirstUseHintShown('pan')).toBe(false);
+    expect(isFirstUseHintShown('view-tab')).toBe(false);
+    expect(loadSettings().firstUseHints).toEqual({});
+  });
+});
+
+describe('triggerReactiveHint (show-once)', () => {
+  it('shows the hint the first time, then never again until reset', () => {
+    const sink = makeSink();
+    triggerReactiveHint(sink, 'pan');
+    expect(sink.shown).toEqual([{ id: 'pan', text: 'Drag to look around' }]);
+
+    // It is the SINK (UIScene) that marks on display; simulate that here so the
+    // second trigger is correctly suppressed.
+    markFirstUseHintShown('pan');
+    triggerReactiveHint(sink, 'pan');
+    expect(sink.shown).toHaveLength(1);
+
+    // After reset it surfaces again.
+    resetFirstUseHints();
+    triggerReactiveHint(sink, 'pan');
+    expect(sink.shown).toHaveLength(2);
+  });
+});
+
+describe('tabNudgeGateOpen (effect gate)', () => {
+  it('opens only on surface, underground unvisited, with an entrance', () => {
+    expect(tabNudgeGateOpen('surface', false, 1)).toBe(true);
+    expect(tabNudgeGateOpen('underground', false, 1)).toBe(false);
+    expect(tabNudgeGateOpen('surface', true, 1)).toBe(false);
+    expect(tabNudgeGateOpen('surface', false, 0)).toBe(false);
+  });
+});
+
+describe('notifyFirstWorldInput (proactive [Tab] nudge)', () => {
+  it('fires the nudge on the first world input when the gate is open', () => {
+    const sink = makeSink();
+    resetFirstUseSession();
+    notifyFirstWorldInput(sink, {
+      activeView: 'surface',
+      undergroundVisited: false,
+      entranceCount: 2,
+    });
+    expect(sink.shown).toEqual([{ id: 'view-tab', text: 'Press [Tab] to view underground' }]);
+  });
+
+  it('fires at most once per session (only the FIRST input)', () => {
+    const sink = makeSink();
+    resetFirstUseSession();
+    notifyFirstWorldInput(sink, {
+      activeView: 'surface',
+      undergroundVisited: false,
+      entranceCount: 2,
+    });
+    notifyFirstWorldInput(sink, {
+      activeView: 'surface',
+      undergroundVisited: false,
+      entranceCount: 2,
+    });
+    expect(sink.shown).toHaveLength(1);
+  });
+
+  it('self-suppresses when the first input was Tab (undergroundVisited already set)', () => {
+    const sink = makeSink();
+    resetFirstUseSession();
+    // Post-input state after a Tab first-input: underground has been visited.
+    notifyFirstWorldInput(sink, {
+      activeView: 'underground',
+      undergroundVisited: true,
+      entranceCount: 2,
+    });
+    expect(sink.shown).toHaveLength(0);
+    // And the latch is consumed — a later surface input does not revive it.
+    notifyFirstWorldInput(sink, {
+      activeView: 'surface',
+      undergroundVisited: false,
+      entranceCount: 2,
+    });
+    expect(sink.shown).toHaveLength(0);
+  });
+
+  it('does not fire if the [Tab] hint was already shown in a prior session', () => {
+    const sink = makeSink();
+    markFirstUseHintShown('view-tab');
+    resetFirstUseSession();
+    notifyFirstWorldInput(sink, {
+      activeView: 'surface',
+      undergroundVisited: false,
+      entranceCount: 2,
+    });
+    expect(sink.shown).toHaveLength(0);
+  });
+});

--- a/src/render/first-use-hints.ts
+++ b/src/render/first-use-hints.ts
@@ -1,0 +1,156 @@
+// first-use-hints.ts — Stage 3b controls rework (issue #18, component #3).
+//
+// One-time, cross-session nudges for the affordance-less gestures a new player
+// can't see: drag-to-pan, scroll-to-zoom, drag-to-paint-tunnels, and the ONE
+// proactive nudge — [Tab] to view underground (which has no preceding gesture
+// to react to: a fresh game starts on the surface with an open entrance, so the
+// underground is relevant from t=0 — Codex R3).
+//
+// Render-only: reads ViewState + persisted settings, NEVER mutates WorldState.
+// Phaser-free and decoupled from UIScene via the FirstUseHintSink interface, so
+// the gating + persistence are unit-testable. UIScene supplies the sink and is
+// the thing that actually queues the caption AND marks the hint shown — only
+// when it begins displaying (Codex R1#9), not here at trigger time.
+//
+// Triggers fire on the EFFECT, not raw input (Codex R1#10): the seams that call
+// triggerReactiveHint live at the input sites (gesture arbiter / wheel handler)
+// and only fire once the camera actually moved / a mark was actually enqueued.
+
+import { loadSettings, saveSettings } from '../platform/settings.js';
+import { glyphFor } from './input-glyphs.js';
+
+/** The four first-use hints. 'view-tab' is the proactive one; the rest are
+ *  reactive (fired on their gesture's effect). */
+export type HintFirstUseId = 'pan' | 'zoom' | 'paint' | 'view-tab';
+
+/** Caption copy, composed from the glyph table so the symbol has one home.
+ *  Wording is UAT-tuned (Rob). */
+export function firstUseHintText(id: HintFirstUseId): string {
+  switch (id) {
+    case 'pan':
+      return `${glyphFor('PAN', 'mouse')} to look around`;
+    case 'zoom':
+      return `${glyphFor('ZOOM', 'mouse')} to zoom`;
+    case 'paint':
+      return `${glyphFor('DIG_PAINT', 'mouse')} to paint tunnels`;
+    case 'view-tab':
+      return `Press ${glyphFor('VIEW_SWITCH', 'keyboard')} to view underground`;
+  }
+}
+
+/** Sink the triggers route through. UIScene implements it (enqueue + mark-on-
+ *  display); tests pass a spy. */
+export interface FirstUseHintSink {
+  showFirstUseHint(id: HintFirstUseId, text: string): void;
+}
+
+// ---------------------------------------------------------------------------
+// Persistence (cross-session) — in-memory cache write-through to settings.
+// ---------------------------------------------------------------------------
+
+// Lazily loaded once from settings, then kept in lockstep with persisted state
+// by writing through on every mutation. Null until first access so a fresh page
+// load picks up the stored flags.
+let shownCache: Record<string, boolean> | null = null;
+
+function ensureLoaded(): Record<string, boolean> {
+  if (shownCache === null) shownCache = loadSettings().firstUseHints;
+  return shownCache;
+}
+
+export function isFirstUseHintShown(id: HintFirstUseId): boolean {
+  return ensureLoaded()[id] === true;
+}
+
+/** Mark a hint shown and persist. Called by the sink the moment the caption
+ *  BEGINS displaying — never at trigger/enqueue (so a dropped/interrupted queue
+ *  entry isn't lost forever). Best-effort persist (saveSettings is silent on
+ *  quota), but the in-mem cache is authoritative for the session. */
+export function markFirstUseHintShown(id: HintFirstUseId): void {
+  const cache = ensureLoaded();
+  if (cache[id] === true) return;
+  cache[id] = true;
+  const persisted = loadSettings();
+  persisted.firstUseHints = { ...persisted.firstUseHints, [id]: true };
+  saveSettings(persisted);
+}
+
+/** "Reset first-use hints" (pause-menu action): clear every shown flag in memory
+ *  AND persistence so the hints surface again. Also clears the per-session
+ *  first-world-input latch — without this, the proactive [Tab] nudge could never
+ *  re-surface in the current session, because notifyFirstWorldInput early-returns
+ *  on firstWorldInputSeen (already true, since the player has, by definition, made
+ *  a world input before reaching the pause menu) before it consults the
+ *  now-cleared shown flag. Pending queue entries are cleared separately by
+ *  UIScene. */
+export function resetFirstUseHints(): void {
+  shownCache = {};
+  firstWorldInputSeen = false;
+  const persisted = loadSettings();
+  persisted.firstUseHints = {};
+  saveSettings(persisted);
+}
+
+// ---------------------------------------------------------------------------
+// Reactive triggers
+// ---------------------------------------------------------------------------
+
+/** Show a reactive hint if it has not been shown. The EFFECT gate (camera moved
+ *  / mark enqueued) is enforced at the call site; this only guards show-once. */
+export function triggerReactiveHint(sink: FirstUseHintSink, id: 'pan' | 'zoom' | 'paint'): void {
+  if (isFirstUseHintShown(id)) return;
+  sink.showFirstUseHint(id, firstUseHintText(id));
+}
+
+// ---------------------------------------------------------------------------
+// Proactive [Tab] nudge — fired once, on the first world input of a session.
+// ---------------------------------------------------------------------------
+
+/** Pure gate for the proactive nudge: on the surface, underground not yet
+ *  visited this session, and at least one entrance exists to descend through. */
+export function tabNudgeGateOpen(
+  activeView: 'surface' | 'underground',
+  undergroundVisited: boolean,
+  entranceCount: number,
+): boolean {
+  return activeView === 'surface' && !undergroundVisited && entranceCount > 0;
+}
+
+// Per-session: true once the player has made their first world input. Reset on
+// every new round (resetFirstUseSession), alongside onboarding-captions reset.
+let firstWorldInputSeen = false;
+
+/** Reset the per-session first-world-input latch (NOT the cross-session shown
+ *  flags). Called on round start. */
+export function resetFirstUseSession(): void {
+  firstWorldInputSeen = false;
+}
+
+/**
+ * Called AFTER the player's first world input of the session is handled (Codex
+ * R4): on the very first input only, evaluate the proactive [Tab] nudge. Because
+ * it runs post-input, a first input that IS Tab/view-toggle has already set
+ * undergroundVisited, so the gate closes and the nudge self-suppresses. Marks
+ * nothing here — the sink marks on display.
+ */
+export function notifyFirstWorldInput(
+  sink: FirstUseHintSink,
+  ctx: {
+    activeView: 'surface' | 'underground';
+    undergroundVisited: boolean;
+    entranceCount: number;
+  },
+): void {
+  if (firstWorldInputSeen) return;
+  firstWorldInputSeen = true;
+  if (isFirstUseHintShown('view-tab')) return;
+  if (!tabNudgeGateOpen(ctx.activeView, ctx.undergroundVisited, ctx.entranceCount)) return;
+  sink.showFirstUseHint('view-tab', firstUseHintText('view-tab'));
+}
+
+/** Test-only: drop the in-memory persistence cache so the next access re-reads
+ *  settings. */
+export function resetFirstUseHintCacheForTests(): void {
+  shownCache = null;
+  firstWorldInputSeen = false;
+}

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -172,7 +172,20 @@ import { canAcceptWorldHotkey, type HotkeyGamePhase } from '../input/hotkey-poli
 import { contextMenuState, hideContextMenu } from './context-menu-state.js';
 import { antActivityPanelState } from './ant-activity-panel-state.js';
 import { buildPlaytraceSummary, type GameOutcomeLabel } from './summary-builder.js';
-import { captionForEvent, checkAndTrigger, resetCaptions } from './onboarding-captions.js';
+import {
+  captionForEvent,
+  checkAndTrigger,
+  oneShotKeyForEvent,
+  resetCaptions,
+  type CaptionKey,
+} from './onboarding-captions.js';
+// Stage 3b controls rework (issue #18, #3) — first-use navigation hints.
+import {
+  triggerReactiveHint,
+  notifyFirstWorldInput,
+  resetFirstUseSession,
+  type HintFirstUseId,
+} from './first-use-hints.js';
 import {
   triggerQueenDamagePulse,
   inferFlashDirection,
@@ -232,8 +245,16 @@ interface UIScenePhase9 {
     onSelect: (d: 'Easy' | 'Normal' | 'Hard') => void;
   }): void;
   hideDifficultySelectOverlay(): void;
-  // S6 — first-occurrence caption overlay (light onboarding).
-  showCaption(text: string, screenX: number, screenY: number): void;
+  // S6 — first-occurrence caption overlay (light onboarding). Optional captionKey
+  // (Stage 3b #3) lets a dropped one-shot caption un-mark its trigger so it re-fires.
+  showCaption(text: string, screenX: number, screenY: number, captionKey?: CaptionKey): void;
+  // Stage 3b (issue #18, #3) — display a one-time first-use navigation hint via
+  // the shared caption queue. UIScene satisfies first-use-hints' FirstUseHintSink.
+  showFirstUseHint(id: HintFirstUseId, text: string): void;
+  // Stage 3b (ship-review R1#1/#3) — clear the caption queue + any in-flight
+  // caption on round restart (UIScene survives restartGame, so its caption state
+  // must be reset explicitly, like resetCaptions/resetFirstUseSession).
+  resetCaptionsForRound(): void;
   // Stage 2 controls rework (issue #18) — the invasion screen-edge flash renders
   // on UIScene (non-zooming camera), NOT GameScene (zoom-driven main camera), so
   // setScrollFactor(0)'s scroll-but-not-zoom gap can't miscale the edge strips.
@@ -386,6 +407,40 @@ export class GameScene extends Phaser.Scene {
     const idx = order.indexOf(this.speedMultiplier);
     const nextIdx = Math.max(0, Math.min(order.length - 1, idx + dir));
     this.setSpeedMultiplier(order[nextIdx]!);
+  }
+
+  /** Live UIScene handle (null before launch / mid-restart). UIScene satisfies
+   *  the first-use-hints sink + the caption/overlay API. */
+  private getUIScene(): UIScenePhase9 | null {
+    return this.scene.get('UIScene') as unknown as UIScenePhase9 | null;
+  }
+
+  /**
+   * Stage 3b (#3): fire a reactive first-use hint on a gesture's EFFECT. The
+   * effect gate (camera moved / mark enqueued / zoom accepted) is enforced at the
+   * call site; first-use-hints enforces show-once.
+   */
+  private firstUseReactive(id: 'pan' | 'zoom' | 'paint'): void {
+    const ui = this.getUIScene();
+    if (ui) triggerReactiveHint(ui, id);
+  }
+
+  /**
+   * Stage 3b (#3): note a world input and evaluate the proactive [Tab] nudge on
+   * the player's FIRST world input of the session. Called AFTER the input is
+   * handled (Codex R4) — from the arbiter (pointer gestures), the wheel handler,
+   * and the Tab key — so a Tab first-input has already set undergroundVisited and
+   * self-suppresses. notifyFirstWorldInput latches to the first call per session.
+   */
+  private noteWorldInput(): void {
+    const ui = this.getUIScene();
+    if (ui === null) return;
+    const entranceCount = this.world?.colonies[PLAYER_COLONY_ID]?.entrances.length ?? 0;
+    notifyFirstWorldInput(ui, {
+      activeView: this.viewState.activeView,
+      undergroundVisited: this.viewState.undergroundVisited,
+      entranceCount,
+    });
   }
 
   /** DEV/E2E-only render-order trace (issue #193). The draw section of update()
@@ -581,7 +636,13 @@ export class GameScene extends Phaser.Scene {
         // every event and slamming to the zoom limit (Codex P1). One ~WHEEL_NOTCH_PX notch
         // = one ×WHEEL_ZOOM_STEP; dy<0 (scroll up) zooms in.
         const factor = Math.pow(WHEEL_ZOOM_STEP, -dy / WHEEL_NOTCH_PX);
+        // Stage 3b (#3): fire the "Scroll to zoom" hint only on an ACCEPTED zoom
+        // (targetZoom actually changed — not a clamped no-op at the zoom limit).
+        const beforeZoom = cam.targetZoom;
         this.cameraController.beginZoom(cam, factor, pointer.x, pointer.y);
+        if (cam.targetZoom !== beforeZoom) this.firstUseReactive('zoom');
+        // A wheel is a world input → evaluate the proactive [Tab] nudge.
+        this.noteWorldInput();
       },
     );
 
@@ -799,6 +860,12 @@ export class GameScene extends Phaser.Scene {
         const ui = this.scene.get('UIScene') as unknown as UIScenePhase9 | null;
         ui?.flashPausedQueueFull?.(paused);
       },
+      // Stage 3b (#3) — first-use teaching seams. The arbiter fires these on the
+      // EFFECT (camera moved / ≥1 mark enqueued / a world gesture began); the
+      // teaching policy (show-once, queue) lives entirely on the UIScene side.
+      onPanEffect: () => this.firstUseReactive('pan'),
+      onPaintEffect: () => this.firstUseReactive('paint'),
+      onWorldInput: () => this.noteWorldInput(),
     });
 
     // Entrance hover (Dig + surface): track the POINTER screen coords so the
@@ -938,6 +1005,15 @@ export class GameScene extends Phaser.Scene {
     this.contestedGlowFrames.clear();
     this.undergroundGlowFrames.clear();
     resetCaptions();
+    // Stage 3b (#3): reset the per-session first-world-input latch so the
+    // proactive [Tab] nudge can re-evaluate on a fresh round (the cross-session
+    // shown-flags persist in settings and are NOT cleared here).
+    resetFirstUseSession();
+    // Stage 3b (ship-review R1#1/#3): UIScene survives round restarts, so clear
+    // its caption queue + any in-flight caption here too — otherwise a prior
+    // round's queued caption can surface (and falsely mark a hint shown) in the
+    // new game. No-op before UIScene exists (first boot).
+    this.getUIScene()?.resetCaptionsForRound();
     // Issue #122 — rotate the session UUID so each (re)start gets its own
     // telemetry row server-side.
     //
@@ -1005,10 +1081,16 @@ export class GameScene extends Phaser.Scene {
         } else {
           uiScene?.triggerScreenEdgeFlash('right');
         }
-        // Caption #7: AI invasion (one-shot, via the event→caption policy).
+        // Caption #7: AI invasion (one-shot, via the event→caption policy). Pass
+        // the one-shot key so a dropped caption un-marks and re-fires.
         const captionText = captionForEvent(ev.type);
         if (captionText && uiScene) {
-          uiScene.showCaption(captionText, CANVAS_W / 2, 60);
+          uiScene.showCaption(
+            captionText,
+            CANVAS_W / 2,
+            60,
+            oneShotKeyForEvent(ev.type) ?? undefined,
+          );
         }
       }
 
@@ -1016,7 +1098,7 @@ export class GameScene extends Phaser.Scene {
         // Spider rampage caption: fires on EVERY rampage, not just the first.
         // The recurring-vs-one-shot decision lives in captionForEvent; the
         // spider is surface-only now (#146/#176/#177) so the copy no longer
-        // mentions tunnels.
+        // mentions tunnels. No one-shot key — recurring captions never dedup.
         const captionText = captionForEvent(ev.type);
         if (captionText && uiScene) {
           uiScene.showCaption(captionText, CANVAS_W / 2, 60);
@@ -1032,7 +1114,7 @@ export class GameScene extends Phaser.Scene {
         const captionText = checkAndTrigger('aiInvading');
         if (captionText) {
           uiScene?.triggerScreenEdgeFlash('right');
-          if (uiScene) uiScene.showCaption(captionText, CANVAS_W / 2, 60);
+          if (uiScene) uiScene.showCaption(captionText, CANVAS_W / 2, 60, 'aiInvading');
         }
       }
     }
@@ -1065,7 +1147,7 @@ export class GameScene extends Phaser.Scene {
       // Caption #9: first queen damage.
       const captionText = checkAndTrigger('queenDamage');
       if (captionText && uiScene) {
-        uiScene.showCaption(captionText, CANVAS_W / 2, CANVAS_H / 2 - 40);
+        uiScene.showCaption(captionText, CANVAS_W / 2, CANVAS_H / 2 - 40, 'queenDamage');
       }
     }
     this.prevQueenCombinedHp = combinedHp;
@@ -1083,7 +1165,7 @@ export class GameScene extends Phaser.Scene {
       // Caption #10: queen starvation onset.
       const captionText = checkAndTrigger('queenStarvation');
       if (captionText && uiScene) {
-        uiScene.showCaption(captionText, CANVAS_W / 2, CANVAS_H / 2 - 40);
+        uiScene.showCaption(captionText, CANVAS_W / 2, CANVAS_H / 2 - 40, 'queenStarvation');
       }
     }
 
@@ -1094,13 +1176,13 @@ export class GameScene extends Phaser.Scene {
     if (spiderState === 'Hunting' || spiderState === 'Striking') {
       const captionText = checkAndTrigger('spider');
       if (captionText && uiScene) {
-        uiScene.showCaption(captionText, CANVAS_W / 2, 60);
+        uiScene.showCaption(captionText, CANVAS_W / 2, 60, 'spider');
       }
     }
     if (this.world.spiderPriorityColonyId !== null) {
       const captionText = checkAndTrigger('spiderPriority');
       if (captionText && uiScene) {
-        uiScene.showCaption(captionText, CANVAS_W / 2, 60);
+        uiScene.showCaption(captionText, CANVAS_W / 2, 60, 'spiderPriority');
       }
     }
   }
@@ -1257,7 +1339,7 @@ export class GameScene extends Phaser.Scene {
           if ('colonyId' in cmd && cmd.colonyId !== PLAYER_COLONY_ID) continue;
           if (cmd.type === 'MarkDigTile') {
             const text = checkAndTrigger('dig');
-            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);
+            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80, 'dig');
           } else if (cmd.type === 'PlaceChamber') {
             const chamberTypeLabel: Record<number, string> = {
               [ChamberType.Queen]: 'Queen',
@@ -1267,13 +1349,13 @@ export class GameScene extends Phaser.Scene {
             const chamberTypeName =
               chamberTypeLabel[cmd.chamberType] ?? `chamber type ${cmd.chamberType}`;
             const text = checkAndTrigger('chamber', chamberTypeName);
-            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);
+            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80, 'chamber');
           } else if (cmd.type === 'MarkFoodPile') {
             const text = checkAndTrigger('foodMark');
-            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);
+            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80, 'foodMark');
           } else if (cmd.type === 'SetRallyPoint') {
             const text = checkAndTrigger('rally');
-            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80);
+            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80, 'rally');
           }
         }
       },
@@ -1829,6 +1911,9 @@ export class GameScene extends Phaser.Scene {
     // it (Codex R4-4 — previously Tab polled even while Paused).
     if (Phaser.Input.Keyboard.JustDown(this.tabKey) && this.canAcceptWorldHotkey()) {
       toggleView(this.viewState);
+      // Stage 3b (#3): Tab is a world input. Evaluate the [Tab] nudge AFTER the
+      // toggle so a Tab first-input has set undergroundVisited and self-suppresses.
+      this.noteWorldInput();
     }
 
     // Stage 1: detect tool/view/colony transitions (incl. keyboard-driven ones

--- a/src/render/hint-strip-state.ts
+++ b/src/render/hint-strip-state.ts
@@ -1,0 +1,24 @@
+// hint-strip-state.ts — Stage 3b controls rework (issue #18, component #2).
+//
+// Module-level singleton for the hint-strip legend's visibility, mirroring the
+// antActivityPanelState pattern: it is the in-memory authoritative source two
+// layers must agree on without UIScene reaching into camera-input (and vice-
+// versa):
+//   - UIScene.renderHintStrip() gates ONLY the static legend on it (the paused-
+//     queue-full warning + caption-yield stay visible regardless — Codex R1#3).
+//   - isPointerOverHUD() drops HUD.HINTS from the world-input mask when the
+//     legend is hidden, so a hidden strip leaves no dead input zone (Codex R1#2).
+//
+// Authoritative in-memory truth (like ViewState.showPheromoneOverlay): the
+// pause-menu toggle flips this AND best-effort persists `hintStripVisible` to
+// settings. On boot UIScene seeds it from loadSettings(). Default true.
+
+export const hintStripState: { visible: boolean } = {
+  visible: true,
+};
+
+/** Reset to the default (visible). Used by tests so the shared singleton does
+ *  not leak state between cases. */
+export function resetHintStripState(): void {
+  hintStripState.visible = true;
+}

--- a/src/render/hud-controls.ts
+++ b/src/render/hud-controls.ts
@@ -9,6 +9,7 @@
 
 import { HUD } from './sprites.js';
 import type { ToolId } from './camera.js';
+import { glyphFor } from './input-glyphs.js';
 
 // ---------------------------------------------------------------------------
 // Tool palette (HUD.TOOLS) — 3 buttons: Command / Dig / Chamber
@@ -94,26 +95,55 @@ export function speedControlAt(px: number, py: number): SpeedControl | null {
  * surface map has no Chamber entry — callers pass the effective tool.
  */
 export function hintTextFor(tool: ToolId, view: 'surface' | 'underground'): string {
+  // Stage 3b (#2): compose the gesture verbs from the glyph table instead of
+  // hardcoding them, so "Click"/"Drag"/"RMB" have ONE source of truth. All
+  // left-click tool actions share the same glyph, so any one of them yields the
+  // canonical click token; likewise drag/right-click. `?? …` is defensive — the
+  // table always defines these mouse glyphs.
+  const click = glyphFor('DIG_MARK', 'mouse') ?? 'Click';
+  const drag = glyphFor('DIG_PAINT', 'mouse') ?? 'Drag';
+  const rmb = glyphFor('CHAMBER_MENU', 'mouse') ?? 'RMB';
   if (view === 'surface') {
     switch (tool) {
-      case 'command':
-        return 'Cmd: click food to forage, empty ground to rally, the spider to target it';
       case 'dig':
-        return 'Dig: click valid ground to designate an entrance';
+        return `Dig: ${click} valid ground to designate an entrance`;
+      case 'command':
       default:
         // Chamber on the surface is inert; show the Command legend as a fallback.
-        return 'Cmd: click food to forage, empty ground to rally, the spider to target it';
+        return `Cmd: ${click} food to forage, empty ground to rally, the spider to target it`;
     }
   }
   // underground
   switch (tool) {
     case 'command':
-      return 'Cmd: click a marked tile to cancel its dig';
+      return `Cmd: ${click} a marked tile to cancel its dig`;
     case 'dig':
-      return 'Dig: click or drag to mark tunnels; click a marked tile to cancel';
+      return `Dig: ${click} or ${drag} to mark tunnels; ${click} a marked tile to cancel`;
     case 'chamber':
-      return 'Chamber: click dug-out or solid ground to place a chamber';
+      return `Chamber: ${click} dug-out or solid ground to place a chamber (${rmb} anywhere)`;
   }
+}
+
+/**
+ * VISUAL hit-test of the tool palette for tooltips (Stage 3b #5). Unlike
+ * toolButtonAt — which returns null for the inert Chamber-on-surface so a click
+ * is a no-op — this returns every button the player can SEE, with an `enabled`
+ * flag, so the disabled Chamber button still surfaces a tooltip ("underground
+ * only") while its click stays inert (Codex R1#7).
+ */
+export function toolButtonVisualAt(
+  px: number,
+  py: number,
+  view: 'surface' | 'underground',
+): { tool: ToolId; enabled: boolean } | null {
+  for (let i = 0; i < TOOL_ORDER.length; i++) {
+    const tool = TOOL_ORDER[i]!;
+    const r = toolButtonRect(i);
+    if (px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h) {
+      return { tool, enabled: !(tool === 'chamber' && view === 'surface') };
+    }
+  }
+  return null;
 }
 
 /** The queue-full hint surfaced when enqueueCommand drops a one-shot command at

--- a/src/render/input-glyphs.test.ts
+++ b/src/render/input-glyphs.test.ts
@@ -1,0 +1,61 @@
+// input-glyphs.test.ts — Stage 3b (#1). The anti-drift guard: assert the EXACT
+// glyph string for every action (not mere coverage). If a binding changes in
+// game-scene.ts, the matching assertion here must change too — that mismatch is
+// the signal to keep the table in sync (Codex R1#13).
+
+import { describe, it, expect } from 'vitest';
+import { GLYPHS, glyphFor, type ActionId, type Device } from './input-glyphs.js';
+
+describe('glyphFor — exact canonical glyphs', () => {
+  // Every (action, device) that HAS a glyph, asserted exactly. Actions are
+  // keyboard- or mouse-only by design; the absent device is asserted null below.
+  const EXACT: Array<[ActionId, Device, string]> = [
+    ['TOOL_COMMAND', 'keyboard', '[1]'],
+    ['TOOL_DIG', 'keyboard', '[2]'],
+    ['TOOL_CHAMBER', 'keyboard', '[3]'],
+    ['SPEED_STEP_UP', 'keyboard', '[=]'],
+    ['SPEED_STEP_DOWN', 'keyboard', '[-]'],
+    ['SET_SPEED_1', 'mouse', '1×'],
+    ['SET_SPEED_2', 'mouse', '2×'],
+    ['SET_SPEED_4', 'mouse', '4×'],
+    ['PAUSE_TOGGLE', 'keyboard', '[Space]'],
+    ['VIEW_SWITCH', 'keyboard', '[Tab]'],
+    ['COLONY_TOGGLE', 'keyboard', '[X]'],
+    ['PHEROMONE_TOGGLE', 'keyboard', '[P]'],
+    ['PAN', 'mouse', 'Drag'],
+    ['ZOOM', 'mouse', 'Scroll'],
+    ['DIG_MARK', 'mouse', 'Click'],
+    ['DIG_PAINT', 'mouse', 'Drag'],
+    ['CHAMBER_PLACE', 'mouse', 'Click'],
+    ['CHAMBER_MENU', 'mouse', 'RMB'],
+    ['ORDER_RALLY', 'mouse', 'Click'],
+    ['ORDER_FOOD', 'mouse', 'Click'],
+    ['ORDER_SPIDER', 'mouse', 'Click'],
+    ['ENTRANCE_DESIGNATE', 'mouse', 'Click'],
+  ];
+
+  it.each(EXACT)('glyphFor(%s, %s) === "%s"', (action, device, expected) => {
+    expect(glyphFor(action, device)).toBe(expected);
+  });
+
+  it('returns null on the device an action does not bind', () => {
+    // Keyboard-only actions have no mouse glyph, and vice-versa.
+    expect(glyphFor('VIEW_SWITCH', 'mouse')).toBeNull();
+    expect(glyphFor('PAUSE_TOGGLE', 'mouse')).toBeNull();
+    expect(glyphFor('PAN', 'keyboard')).toBeNull();
+    expect(glyphFor('DIG_PAINT', 'keyboard')).toBeNull();
+    expect(glyphFor('SET_SPEED_2', 'keyboard')).toBeNull();
+  });
+
+  it('defines exactly one device glyph for every action (one canonical glyph)', () => {
+    const actions = Object.keys(GLYPHS) as ActionId[];
+    // Every action in the union is present and has at least one glyph; none has
+    // both devices (the "one canonical glyph per action" rule from the grill).
+    for (const a of actions) {
+      const devices = Object.values(GLYPHS[a]).filter((g) => g !== undefined);
+      expect(devices.length, `${a} should have exactly one glyph`).toBe(1);
+    }
+    // Guard the table size so an accidental drop/add trips the test.
+    expect(actions.length).toBe(22);
+  });
+});

--- a/src/render/input-glyphs.ts
+++ b/src/render/input-glyphs.ts
@@ -1,0 +1,116 @@
+// input-glyphs.ts — Stage 3b controls rework (issue #18, component #1): a lean,
+// static device-glyph resolver. Maps an ActionId to ONE canonical on-screen
+// glyph per input device, so the hint strip (#2), first-use hints (#3), and
+// tooltips (#5) all render the SAME symbol for a given action from a single
+// source of truth.
+//
+// Scope: render-only. No Phaser, no DOM, no WorldState — pure data + a lookup,
+// so it is unit-testable and safe under the sim/render boundary guard.
+//
+// Why a static table and not a binding registry: the bindings are stable and
+// NOT rebindable today (Stage 3a). A full binding-constant registry is over-
+// build now (grill + Codex R1#13). Drift is guarded instead by (a) the exact-
+// glyph-string unit test in input-glyphs.test.ts and (b) the cross-reference
+// comment below — keep this table in lockstep with the keydown-* handlers in
+// game-scene.ts. If keys ever become rebindable, replace this with a registry.
+//
+// ─── KEEP IN SYNC WITH game-scene.ts hotkeys (the keydown-* block) ───────────
+//   keydown-ONE   → selectTool('command')   ⇒ TOOL_COMMAND      [1]
+//   keydown-TWO   → selectTool('dig')        ⇒ TOOL_DIG          [2]
+//   keydown-THREE → selectTool('chamber')    ⇒ TOOL_CHAMBER      [3]
+//   keydown-PLUS / NUMPAD_ADD      → stepSpeed(+1) ⇒ SPEED_STEP_UP    [=]
+//   keydown-MINUS / NUMPAD_SUBTRACT→ stepSpeed(-1) ⇒ SPEED_STEP_DOWN  [-]
+//   keydown-SPACE → toggleUserPause()        ⇒ PAUSE_TOGGLE      [Space]
+//   keydown-TAB   → toggleView()             ⇒ VIEW_SWITCH       [Tab]
+//   keydown-X     → toggleUndergroundColony()⇒ COLONY_TOGGLE     [X]
+//   keydown-P     → toggle pheromone overlay ⇒ PHEROMONE_TOGGLE  [P]
+//   speed-widget click (1×/2×/4×)            ⇒ SET_SPEED_1/2/4   1× 2× 4×
+//   left-drag (Command/Dig-surface/Chamber)  ⇒ PAN               Drag
+//   mouse wheel                              ⇒ ZOOM              Scroll
+//   underground Dig tap / drag               ⇒ DIG_MARK / DIG_PAINT  Click / Drag
+//   Chamber-tool tap                         ⇒ CHAMBER_PLACE     Click
+//   right-click (any tool, underground)      ⇒ CHAMBER_MENU      RMB
+//   Command tap (food / ground / spider)     ⇒ ORDER_FOOD/RALLY/SPIDER  Click
+//   Dig tap on the surface                   ⇒ ENTRANCE_DESIGNATE Click
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The two input devices a glyph can describe. Desktop-only in Stage 3b;
+ *  Phase-6 touch will add a third device with its own glyph column. */
+export type Device = 'keyboard' | 'mouse';
+
+/**
+ * Every player action the teaching surfaces can reference. Models the REAL
+ * Stage-3a bindings (Codex R1#12); names group by widget/gesture, not by key.
+ */
+export type ActionId =
+  // Tool selection (number-row hotkeys / palette buttons)
+  | 'TOOL_COMMAND'
+  | 'TOOL_DIG'
+  | 'TOOL_CHAMBER'
+  // Speed — step keys vs widget presets
+  | 'SPEED_STEP_UP'
+  | 'SPEED_STEP_DOWN'
+  | 'SET_SPEED_1'
+  | 'SET_SPEED_2'
+  | 'SET_SPEED_4'
+  // Global toggles
+  | 'PAUSE_TOGGLE'
+  | 'VIEW_SWITCH'
+  | 'COLONY_TOGGLE'
+  | 'PHEROMONE_TOGGLE'
+  // Camera (affordance-less gestures — the #3 first-use hints)
+  | 'PAN'
+  | 'ZOOM'
+  // Tool primary actions
+  | 'DIG_MARK'
+  | 'DIG_PAINT'
+  | 'CHAMBER_PLACE'
+  | 'CHAMBER_MENU'
+  | 'ORDER_RALLY'
+  | 'ORDER_FOOD'
+  | 'ORDER_SPIDER'
+  | 'ENTRANCE_DESIGNATE';
+
+/**
+ * One canonical glyph per (action, device). Keys are bracketed ([1], [Tab]);
+ * mouse gestures are words (Drag, Scroll, Click, RMB); speed presets are their
+ * widget labels (1×). `Partial` because not every action has both devices —
+ * e.g. PAN/ZOOM are mouse-only, VIEW_SWITCH is keyboard-only.
+ *
+ * EXACT strings are asserted in input-glyphs.test.ts; do not edit one without
+ * updating that test (that is the anti-drift guard).
+ */
+export const GLYPHS: Readonly<Record<ActionId, Partial<Record<Device, string>>>> = {
+  TOOL_COMMAND: { keyboard: '[1]' },
+  TOOL_DIG: { keyboard: '[2]' },
+  TOOL_CHAMBER: { keyboard: '[3]' },
+  SPEED_STEP_UP: { keyboard: '[=]' },
+  SPEED_STEP_DOWN: { keyboard: '[-]' },
+  SET_SPEED_1: { mouse: '1×' },
+  SET_SPEED_2: { mouse: '2×' },
+  SET_SPEED_4: { mouse: '4×' },
+  PAUSE_TOGGLE: { keyboard: '[Space]' },
+  VIEW_SWITCH: { keyboard: '[Tab]' },
+  COLONY_TOGGLE: { keyboard: '[X]' },
+  PHEROMONE_TOGGLE: { keyboard: '[P]' },
+  PAN: { mouse: 'Drag' },
+  ZOOM: { mouse: 'Scroll' },
+  DIG_MARK: { mouse: 'Click' },
+  DIG_PAINT: { mouse: 'Drag' },
+  CHAMBER_PLACE: { mouse: 'Click' },
+  CHAMBER_MENU: { mouse: 'RMB' },
+  ORDER_RALLY: { mouse: 'Click' },
+  ORDER_FOOD: { mouse: 'Click' },
+  ORDER_SPIDER: { mouse: 'Click' },
+  ENTRANCE_DESIGNATE: { mouse: 'Click' },
+};
+
+/**
+ * The canonical glyph for an action on a device, or `null` if that action has
+ * no glyph on that device (e.g. glyphFor('PAN','keyboard') → null). Callers
+ * compose UI copy from the returned token so the symbol lives in exactly one
+ * place.
+ */
+export function glyphFor(action: ActionId, device: Device): string | null {
+  return GLYPHS[action][device] ?? null;
+}

--- a/src/render/onboarding-captions.test.ts
+++ b/src/render/onboarding-captions.test.ts
@@ -4,8 +4,10 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   captionForEvent,
   checkAndTrigger,
+  oneShotKeyForEvent,
   resetCaptions,
   triggered,
+  untrigger,
 } from './onboarding-captions.js';
 import type { SimEvent } from '../sim/telemetry.js';
 
@@ -213,5 +215,62 @@ describe('triggered map state', () => {
     expect(triggered.get('dig')).toBe(true);
     expect(triggered.get('rally')).toBe(true);
     expect(triggered.has('spider')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// untrigger — un-mark a dropped one-shot so it can re-fire (caption-queue overflow)
+// ---------------------------------------------------------------------------
+
+describe('untrigger', () => {
+  it('lets a previously-fired one-shot caption fire again', () => {
+    // checkAndTrigger marks the key BEFORE the caption reaches the bounded queue;
+    // if the queue drops it, untrigger restores the key so the next occurrence
+    // re-fires (the dropped caption never displayed).
+    expect(checkAndTrigger('dig')).not.toBeNull();
+    expect(checkAndTrigger('dig')).toBeNull();
+    untrigger('dig');
+    expect(triggered.has('dig')).toBe(false);
+    expect(checkAndTrigger('dig')).not.toBeNull();
+  });
+
+  it('only un-marks the given key', () => {
+    checkAndTrigger('dig');
+    checkAndTrigger('rally');
+    untrigger('dig');
+    expect(checkAndTrigger('dig')).not.toBeNull(); // re-fires
+    expect(checkAndTrigger('rally')).toBeNull(); // still suppressed
+  });
+
+  it('is a no-op for a key that never fired', () => {
+    expect(() => untrigger('spiderRampage')).not.toThrow();
+    expect(triggered.has('spiderRampage')).toBe(false);
+    // ...and the key still fires normally afterward.
+    expect(checkAndTrigger('spiderRampage')).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// oneShotKeyForEvent — event→one-shot-key lookup (drives un-mark-on-drop)
+// ---------------------------------------------------------------------------
+
+describe('oneShotKeyForEvent', () => {
+  it('returns the one-shot CaptionKey for a one-shot event', () => {
+    expect(oneShotKeyForEvent('invasion_start')).toBe('aiInvading');
+  });
+
+  it('returns null for a recurring event (recurring captions never dedup)', () => {
+    expect(oneShotKeyForEvent('spider_rampage_start')).toBeNull();
+  });
+
+  it('returns null for a caption-less / unknown event', () => {
+    expect(oneShotKeyForEvent('combat_kill')).toBeNull();
+    expect(oneShotKeyForEvent('not_a_real_event' as SimEvent['type'])).toBeNull();
+  });
+
+  it('is pure — it does not consume the one-shot (captionForEvent still fires)', () => {
+    expect(oneShotKeyForEvent('invasion_start')).toBe('aiInvading');
+    expect(triggered.has('aiInvading')).toBe(false);
+    expect(captionForEvent('invasion_start')).not.toBeNull();
   });
 });

--- a/src/render/onboarding-captions.ts
+++ b/src/render/onboarding-captions.ts
@@ -40,6 +40,22 @@ export function resetCaptions(): void {
 }
 
 /**
+ * Un-mark a one-shot caption key so it can fire again.
+ *
+ * checkAndTrigger/captionForEvent mark a key the moment they hand back the text,
+ * before the caption reaches the bounded caption queue. If the queue then DROPS
+ * that caption on overflow it would never display yet stay marked 'already shown'
+ * — losing a first-occurrence onboarding caption forever. UIScene calls this when
+ * a dropped caption carries a key so the trigger re-fires on the next occurrence.
+ *
+ * Recurring captions (e.g. spiderRampage) never populate `triggered`, so calling
+ * this for one of them is a harmless no-op.
+ */
+export function untrigger(key: CaptionKey): void {
+  triggered.delete(key);
+}
+
+/**
  * Check if a caption should fire for the first time this session.
  * Returns the text to display, or null if the caption already triggered.
  *
@@ -102,4 +118,14 @@ export function captionForEvent(eventType: SimEvent['type']): string | null {
     return checkAndTrigger(oneShotKey);
   }
   return null;
+}
+
+/**
+ * The one-shot CaptionKey an event maps to, or null for recurring / caption-less
+ * events. GameScene passes this to showCaption so a dropped one-shot event
+ * caption can be un-marked (re-fired) — without duplicating the event→key policy
+ * at the call site. Recurring events return null here (they never dedup).
+ */
+export function oneShotKeyForEvent(eventType: SimEvent['type']): CaptionKey | null {
+  return ONE_SHOT_EVENT_CAPTIONS.get(eventType) ?? null;
 }

--- a/src/render/pause-menu-layout.test.ts
+++ b/src/render/pause-menu-layout.test.ts
@@ -17,6 +17,7 @@ import {
 const ctx: PauseMenuRenderContext = {
   saveLoadEnabled: true,
   currentPheromoneOverlay: true,
+  currentHintStripVisible: true,
   currentSpeedMultiplier: 1,
   quitAndSurveyEnabled: false,
 };
@@ -93,9 +94,34 @@ describe('pauseMenuItems — main page', () => {
 });
 
 describe('pauseMenuItems — settings page', () => {
-  it('returns the pheromone toggle, speed cycle, and a back button', () => {
+  it('returns the pheromone, control-hints, reset-hints, speed, and back rows', () => {
     const items = pauseMenuItems('settings', ctx);
-    expect(items.map((i) => i.id)).toEqual(['pheromone-toggle', 'speed-cycle', 'back']);
+    expect(items.map((i) => i.id)).toEqual([
+      'pheromone-toggle',
+      'control-hints-toggle',
+      'reset-first-use-hints',
+      'speed-cycle',
+      'back',
+    ]);
+  });
+
+  it('control-hints toggle label reflects ON / OFF (Stage 3b)', () => {
+    expect(
+      pauseMenuItems('settings', { ...ctx, currentHintStripVisible: true }).find(
+        (i) => i.id === 'control-hints-toggle',
+      )!.label,
+    ).toContain('ON');
+    expect(
+      pauseMenuItems('settings', { ...ctx, currentHintStripVisible: false }).find(
+        (i) => i.id === 'control-hints-toggle',
+      )!.label,
+    ).toContain('OFF');
+  });
+
+  it('reset-first-use-hints row is present and enabled (Stage 3b)', () => {
+    expect(
+      pauseMenuItems('settings', ctx).find((i) => i.id === 'reset-first-use-hints')!.enabled,
+    ).toBe(true);
   });
 
   it('pheromone toggle label reflects the current ON state', () => {

--- a/src/render/pause-menu-layout.ts
+++ b/src/render/pause-menu-layout.ts
@@ -49,6 +49,10 @@ export type PauseMenuItemId =
   | 'debug-snapshot'
   | 'back'
   | 'pheromone-toggle'
+  // Stage 3b (issue #18) — Settings-page rows: toggle the static hint-strip
+  // legend, and reset the one-time first-use navigation hints.
+  | 'control-hints-toggle'
+  | 'reset-first-use-hints'
   | 'speed-cycle'
   // Issue #122 / ADR 0013 — "Quit & feedback" entry. Only emitted when the
   // playtrace feature is enabled (caller passes ctx.quitAndSurveyEnabled);
@@ -85,6 +89,11 @@ export interface PauseMenuRenderContext {
    *  returning the default, so reading the label from persisted state makes
    *  the toggle look broken. The in-mem flag is the authoritative truth. */
   currentPheromoneOverlay: boolean;
+  /** Stage 3b (issue #18) — current hint-strip legend visibility, for the
+   *  "Control hints: ON/OFF" row label. Sourced from the in-memory hintStripState
+   *  singleton by the caller (same authoritative-in-mem rationale as the
+   *  pheromone toggle), NOT from loadSettings(). */
+  currentHintStripVisible: boolean;
   /** Current speedMultiplier (1 | 2 | 4). The Settings page renders this in
    *  the "Speed: N×" cycle row. Source of truth is GameScene's live field —
    *  the menu reads via the onSpeedMultiplier callback at render time and
@@ -155,6 +164,16 @@ export function pauseMenuItems(page: PauseMenuPage, ctx: PauseMenuRenderContext)
     {
       id: 'pheromone-toggle',
       label: `Pheromone trails: ${ctx.currentPheromoneOverlay ? 'ON' : 'OFF'}`,
+      enabled: true,
+    },
+    {
+      id: 'control-hints-toggle',
+      label: `Control hints: ${ctx.currentHintStripVisible ? 'ON' : 'OFF'}`,
+      enabled: true,
+    },
+    {
+      id: 'reset-first-use-hints',
+      label: 'Reset first-use hints',
       enabled: true,
     },
     {

--- a/src/render/tooltips.test.ts
+++ b/src/render/tooltips.test.ts
@@ -1,0 +1,127 @@
+// tooltips.test.ts — Stage 3b (#5): control-widget hit-test (incl. the disabled
+// Chamber-on-surface) and ≤150-char copy.
+
+import { describe, it, expect } from 'vitest';
+import { HUD } from './sprites.js';
+import { toolButtonRect, speedControlRect } from './hud-controls.js';
+import {
+  tooltipTargetAt,
+  tooltipTextFor,
+  sameTooltipTarget,
+  type TooltipTarget,
+} from './tooltips.js';
+
+const center = (r: { x: number; y: number; w: number; h: number }) => ({
+  x: r.x + r.w / 2,
+  y: r.y + r.h / 2,
+});
+
+describe('tooltipTargetAt', () => {
+  it('hits HUD.STATS', () => {
+    const c = center(HUD.STATS);
+    expect(tooltipTargetAt(c.x, c.y, 'surface')?.kind).toBe('stats');
+  });
+
+  it('hits the view toggle', () => {
+    const c = center(HUD.VIEW_TOGGLE);
+    expect(tooltipTargetAt(c.x, c.y, 'surface')?.kind).toBe('view-toggle');
+  });
+
+  it('hits the colony toggle ONLY on the underground view', () => {
+    const c = center(HUD.UNDERGROUND_COLONY_TOGGLE);
+    expect(tooltipTargetAt(c.x, c.y, 'underground')?.kind).toBe('colony-toggle');
+    // On the surface the toggle isn't rendered, so its rect is not a tooltip
+    // target (and nothing else lives there).
+    expect(tooltipTargetAt(c.x, c.y, 'surface')).toBeNull();
+  });
+
+  it('hits an enabled tool button', () => {
+    const c = center(toolButtonRect(1)); // Dig
+    const t = tooltipTargetAt(c.x, c.y, 'underground');
+    expect(t).toEqual({ kind: 'tool', tool: 'dig', enabled: true, anchor: HUD.TOOLS });
+  });
+
+  it('STILL hits the DISABLED Chamber button on the surface (enabled:false)', () => {
+    const c = center(toolButtonRect(2)); // Chamber
+    const t = tooltipTargetAt(c.x, c.y, 'surface');
+    expect(t).toEqual({ kind: 'tool', tool: 'chamber', enabled: false, anchor: HUD.TOOLS });
+    // …and it's enabled underground.
+    const u = tooltipTargetAt(c.x, c.y, 'underground');
+    expect(u).toMatchObject({ kind: 'tool', tool: 'chamber', enabled: true });
+  });
+
+  it('hits the speed widget (pause + a preset)', () => {
+    const pause = center(speedControlRect(0));
+    expect(tooltipTargetAt(pause.x, pause.y, 'surface')).toMatchObject({
+      kind: 'speed',
+      control: 'pause',
+    });
+    const two = center(speedControlRect(2)); // 2×
+    expect(tooltipTargetAt(two.x, two.y, 'surface')).toMatchObject({ kind: 'speed', control: 2 });
+  });
+
+  it('hits the Forage↔Fight slider', () => {
+    const c = center(HUD.TRIANGLE);
+    expect(tooltipTargetAt(c.x, c.y, 'surface')?.kind).toBe('slider');
+  });
+
+  it('returns null over open world / the minimap (excluded)', () => {
+    expect(tooltipTargetAt(400, 300, 'surface')).toBeNull();
+    const m = center(HUD.MINIMAP);
+    expect(tooltipTargetAt(m.x, m.y, 'underground')).toBeNull();
+  });
+});
+
+describe('tooltipTextFor', () => {
+  const all: TooltipTarget[] = [
+    { kind: 'tool', tool: 'command', enabled: true, anchor: HUD.TOOLS },
+    { kind: 'tool', tool: 'dig', enabled: true, anchor: HUD.TOOLS },
+    { kind: 'tool', tool: 'chamber', enabled: true, anchor: HUD.TOOLS },
+    { kind: 'tool', tool: 'chamber', enabled: false, anchor: HUD.TOOLS },
+    { kind: 'speed', control: 'pause', anchor: HUD.SPEED },
+    { kind: 'speed', control: 2, anchor: HUD.SPEED },
+    { kind: 'view-toggle', anchor: HUD.VIEW_TOGGLE },
+    { kind: 'colony-toggle', anchor: HUD.UNDERGROUND_COLONY_TOGGLE },
+    { kind: 'slider', anchor: HUD.TRIANGLE },
+    { kind: 'stats', anchor: HUD.STATS },
+  ];
+
+  it('every tooltip is non-empty and ≤150 chars', () => {
+    for (const t of all) {
+      const text = tooltipTextFor(t);
+      expect(text.length).toBeGreaterThan(0);
+      expect(text.length, `"${text}" too long`).toBeLessThanOrEqual(150);
+    }
+  });
+
+  it('the disabled Chamber explains WHY it is inert', () => {
+    expect(
+      tooltipTextFor({ kind: 'tool', tool: 'chamber', enabled: false, anchor: HUD.TOOLS }),
+    ).toBe('Chamber — underground only');
+  });
+
+  it('STATS teaches the non-obvious ant-activity click', () => {
+    expect(tooltipTextFor({ kind: 'stats', anchor: HUD.STATS }).toLowerCase()).toContain(
+      'ant-activity',
+    );
+  });
+
+  it('includes the keyboard glyph where a key exists', () => {
+    expect(tooltipTextFor({ kind: 'view-toggle', anchor: HUD.VIEW_TOGGLE })).toContain('[Tab]');
+  });
+});
+
+describe('sameTooltipTarget', () => {
+  it('distinguishes different tools and matches same tool', () => {
+    const dig: TooltipTarget = { kind: 'tool', tool: 'dig', enabled: true, anchor: HUD.TOOLS };
+    const dig2: TooltipTarget = { kind: 'tool', tool: 'dig', enabled: true, anchor: HUD.TOOLS };
+    const cmd: TooltipTarget = { kind: 'tool', tool: 'command', enabled: true, anchor: HUD.TOOLS };
+    expect(sameTooltipTarget(dig, dig2)).toBe(true);
+    expect(sameTooltipTarget(dig, cmd)).toBe(false);
+  });
+
+  it('null handling', () => {
+    expect(sameTooltipTarget(null, null)).toBe(true);
+    expect(sameTooltipTarget(null, { kind: 'stats', anchor: HUD.STATS })).toBe(false);
+  });
+});

--- a/src/render/tooltips.ts
+++ b/src/render/tooltips.ts
@@ -1,0 +1,115 @@
+// tooltips.ts — Stage 3b controls rework (issue #18, component #5).
+//
+// Pure hit-test + copy for on-hover tooltips over the HUD CONTROL widgets: the
+// tool palette, speed widget, view toggle, colony toggle, the Forage↔Fight
+// slider, and HUD.STATS (whose tooltip teaches the non-obvious "click for ant
+// activity"). EXCLUDED: the minimap (hover vs click-nav ambiguity) and the
+// ant-activity panel popup (Codex R1#6/R2).
+//
+// Phaser-free: UIScene owns the hover-state machine, the delay timers, the
+// modal/teardown lifecycle, and the Text object; this module owns only the
+// "what is under the cursor + what should it say + where does it anchor" data,
+// so it is unit-testable. The tool hit-test uses toolButtonVisualAt so the
+// DISABLED Chamber-on-surface still tooltips (Codex R1#7).
+
+import { HUD } from './sprites.js';
+import type { ToolId } from './camera.js';
+import { toolButtonVisualAt, speedControlAt, type SpeedControl } from './hud-controls.js';
+import { isInsideSlider } from './triangle-widget.js';
+import { glyphFor } from './input-glyphs.js';
+
+export interface TooltipRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** A control widget under the cursor. `anchor` is the widget's screen rect so
+ *  UIScene can place the tooltip clear of it (never covering it). */
+export type TooltipTarget =
+  | { kind: 'tool'; tool: ToolId; enabled: boolean; anchor: TooltipRect }
+  | { kind: 'speed'; control: SpeedControl; anchor: TooltipRect }
+  | { kind: 'view-toggle'; anchor: TooltipRect }
+  | { kind: 'colony-toggle'; anchor: TooltipRect }
+  | { kind: 'slider'; anchor: TooltipRect }
+  | { kind: 'stats'; anchor: TooltipRect };
+
+function inRect(px: number, py: number, r: TooltipRect): boolean {
+  return px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h;
+}
+
+/**
+ * The control widget at (px, py), or null. Precedence mirrors UIScene's
+ * pointerdown dispatch (stats → view-toggle → colony → tools → speed → slider);
+ * the rects don't overlap, but a stable order keeps hit-test and click in
+ * agreement. The colony toggle is underground-only (it isn't rendered on the
+ * surface), matching isPointerOverHUD.
+ */
+export function tooltipTargetAt(
+  px: number,
+  py: number,
+  view: 'surface' | 'underground',
+): TooltipTarget | null {
+  if (inRect(px, py, HUD.STATS)) return { kind: 'stats', anchor: HUD.STATS };
+  if (inRect(px, py, HUD.VIEW_TOGGLE)) return { kind: 'view-toggle', anchor: HUD.VIEW_TOGGLE };
+  if (view === 'underground' && inRect(px, py, HUD.UNDERGROUND_COLONY_TOGGLE)) {
+    return { kind: 'colony-toggle', anchor: HUD.UNDERGROUND_COLONY_TOGGLE };
+  }
+  const toolHit = toolButtonVisualAt(px, py, view);
+  if (toolHit !== null) {
+    return { kind: 'tool', tool: toolHit.tool, enabled: toolHit.enabled, anchor: HUD.TOOLS };
+  }
+  const speedHit = speedControlAt(px, py);
+  if (speedHit !== null) return { kind: 'speed', control: speedHit, anchor: HUD.SPEED };
+  // The slider lives inside the HUD.TRIANGLE box (legacy field name).
+  if (isInsideSlider(px, py)) return { kind: 'slider', anchor: HUD.TRIANGLE };
+  return null;
+}
+
+/** True if two targets refer to the same widget (so UIScene doesn't restart the
+ *  show-delay while the cursor merely jitters within one control). */
+export function sameTooltipTarget(a: TooltipTarget | null, b: TooltipTarget | null): boolean {
+  if (a === null || b === null) return a === b;
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'tool' && b.kind === 'tool') return a.tool === b.tool;
+  if (a.kind === 'speed' && b.kind === 'speed') return a.control === b.control;
+  return true;
+}
+
+/**
+ * Tooltip copy for a target — ≤150 chars, action-first, glyphs from the table.
+ * The disabled Chamber teaches WHY it's inert; STATS teaches its non-obvious
+ * click; the speed presets surface the keyboard step keys too.
+ */
+function toolTooltipText(tool: ToolId, enabled: boolean): string {
+  switch (tool) {
+    case 'command':
+      return `Command ${glyphFor('TOOL_COMMAND', 'keyboard')} — click food, ground, or the spider to order ants`;
+    case 'dig':
+      return `Dig ${glyphFor('TOOL_DIG', 'keyboard')} — click or drag to mark tunnels to excavate`;
+    case 'chamber':
+      return enabled
+        ? `Chamber ${glyphFor('TOOL_CHAMBER', 'keyboard')} — place a chamber on dug-out or solid ground`
+        : 'Chamber — underground only';
+  }
+}
+
+export function tooltipTextFor(target: TooltipTarget): string {
+  switch (target.kind) {
+    case 'tool':
+      return toolTooltipText(target.tool, target.enabled);
+    case 'speed':
+      if (target.control === 'pause')
+        return `Pause / resume ${glyphFor('PAUSE_TOGGLE', 'keyboard')}`;
+      return `Set speed ${target.control}× — or ${glyphFor('SPEED_STEP_UP', 'keyboard')}/${glyphFor('SPEED_STEP_DOWN', 'keyboard')} to step`;
+    case 'view-toggle':
+      return `Switch surface / underground view ${glyphFor('VIEW_SWITCH', 'keyboard')}`;
+    case 'colony-toggle':
+      return `Switch which colony you're viewing ${glyphFor('COLONY_TOGGLE', 'keyboard')}`;
+    case 'slider':
+      return 'Forage ↔ Fight — drag to balance workers between foraging and fighting';
+    case 'stats':
+      return 'Colony population & food — click for the ant-activity breakdown';
+  }
+}

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -212,7 +212,7 @@ import {
 import {
   admitCaption,
   completeCaption,
-  clearPending,
+  clearPendingFirstUse,
   createCaptionQueueState,
   type CaptionQueueState,
   type CaptionRequest,
@@ -2062,7 +2062,7 @@ export class UIScene extends Phaser.Scene {
         // Stage 3b (#3): clear the persisted shown-flags AND drop any queued
         // first-use caption (clearPending) so the hints surface again cleanly.
         resetFirstUseHints();
-        clearPending(this.captionState);
+        clearPendingFirstUse(this.captionState);
         this.renderPauseMenuPage();
         return;
       }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -208,6 +208,28 @@ import {
   requestHideAntActivityPanel,
   applyPendingAntActivityPanelHide,
 } from './ant-activity-panel-state.js';
+// Stage 3b controls rework (issue #18) — navigation-teaching surfaces.
+import {
+  admitCaption,
+  completeCaption,
+  clearPending,
+  createCaptionQueueState,
+  type CaptionQueueState,
+  type CaptionRequest,
+} from './caption-queue.js';
+import { untrigger, type CaptionKey } from './onboarding-captions.js';
+import {
+  markFirstUseHintShown,
+  resetFirstUseHints,
+  type HintFirstUseId,
+} from './first-use-hints.js';
+import { hintStripState } from './hint-strip-state.js';
+import {
+  tooltipTargetAt,
+  tooltipTextFor,
+  sameTooltipTarget,
+  type TooltipTarget,
+} from './tooltips.js';
 import {
   pauseMenuItems,
   pageTitle,
@@ -266,6 +288,11 @@ const CAPTION_TOTAL_MS = 1500;
 
 /** Stage 1 controls rework — how long the "paused queue full" hint stays up. */
 const PAUSED_QUEUE_FULL_HINT_MS = 1500;
+
+/** Stage 3b (#5) — hover dwell before a tooltip appears, and the mouse-out grace
+ *  before it disappears. UAT-tunable (Rob). */
+const TOOLTIP_SHOW_DELAY_MS = 400;
+const TOOLTIP_HIDE_GRACE_MS = 1500;
 import { loadSettings, saveSettings } from '../platform/settings.js';
 import { hasSave, hasIncompatibleSave, getSaveInfo, deleteSave } from '../platform/save.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
@@ -397,6 +424,27 @@ export class UIScene extends Phaser.Scene {
   // "resume to continue"; running → "try again"). (Fix 3 / Codex P2.)
   private pausedQueueFullUntilMs = 0;
   private pausedQueueFullWasPaused = false;
+  // Stage 3b (issue #18, #3) — the ONE caption queue ALL callers route through
+  // (event captions, onboarding-captions, first-use hints). Pure policy lives in
+  // caption-queue.ts; this holds the live state + the Phaser Text/tween.
+  private captionState: CaptionQueueState = createCaptionQueueState();
+  // The Phaser Text of the caption currently displaying (null when idle). Tracked
+  // so a round restart can destroy an in-flight caption + its tween (UIScene is
+  // NOT relaunched on restart, so captionState would otherwise leak a prior-round
+  // caption — incl. falsely marking a first-use hint shown; ship-review R1#1/#3).
+  private activeCaptionText: Phaser.GameObjects.Text | null = null;
+  // Stage 3b (#5) — tooltip hover state machine. hoverTarget is the widget the
+  // cursor is over (null = none); the show timer fires after a dwell delay, the
+  // hide timer is the mouse-out grace. tooltipText is the live Phaser Text.
+  private hoverTarget: TooltipTarget | null = null;
+  private tooltipShowTimer: Phaser.Time.TimerEvent | null = null;
+  private tooltipHideTimer: Phaser.Time.TimerEvent | null = null;
+  private tooltipText: Phaser.GameObjects.Text | null = null;
+  // Stage 3b (#5) — last view/colony the tooltip state machine saw, so update()
+  // can detect a keyboard- or button-driven view/colony switch (which fires no
+  // pointermove) and cancel a now-stale tooltip. null = not yet sampled.
+  private lastTooltipView: ViewState['activeView'] | null = null;
+  private lastTooltipColonyId: ViewState['activeUndergroundColonyId'] | null = null;
   private gfx!: Phaser.GameObjects.Graphics;
   private antsText!: Phaser.GameObjects.Text;
   private foodText!: Phaser.GameObjects.Text;
@@ -487,6 +535,9 @@ export class UIScene extends Phaser.Scene {
   create() {
     this.gfx = this.add.graphics();
     this.dragState = createSliderDragState();
+    // Stage 3b (#2): seed the in-mem hint-strip visibility from persisted
+    // settings so a returning player's "hide legend" choice is honored on boot.
+    hintStripState.visible = loadSettings().hintStripVisible;
 
     // HUD-02 stats row — three Texts confined to the 200x24 HUD.STATS rect,
     // two-row layout. Row 1: antsText (white, left) + foodText (green, right-
@@ -791,6 +842,12 @@ export class UIScene extends Phaser.Scene {
       // Checked before other HUD zones so a click on the stats row can never
       // fall through to world input regardless of panel state.
       if (this.isInsideRect(pointer.x, pointer.y, HUD.STATS)) {
+        // The panel-open transition bypasses recomputeActiveOverlay (and the ant
+        // panel isn't part of anyOverlayOpen), so a tooltip shown by hovering
+        // STATS would linger over the freshly-opened popup until the next
+        // pointermove. Cancel it here, the one non-pointermove path that opens
+        // the panel.
+        this.cancelTooltip();
         toggleAntActivityPanel();
         return;
       }
@@ -889,15 +946,23 @@ export class UIScene extends Phaser.Scene {
     });
 
     this.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+      // Stage 3b (#5): tooltip hover tracking runs every move (it self-guards on
+      // drag / modal / ant-panel). Kept before the slider-drag short-circuit.
+      this.updateTooltipHover(pointer);
       if (!this.dragState.isDragging) return;
       if (!pointer.isDown) return;
       // 1-D slider: only x is consulted; pointer y is ignored within drag.
       this.dragState.targetRatio = screenToSliderRatio(pointer.x);
     });
 
+    // Stage 3b (#5): the cursor leaving the canvas hides any tooltip + cancels a
+    // pending show (Codex R1#14 — a timer must not outlive the hover).
+    this.input.on('gameout', () => this.cancelTooltip());
+
     // Belt-and-suspenders: clear overlay window state on scene shutdown to
     // prevent stale __phase9_ui surviving a scene restart.
     const teardown = () => {
+      this.cancelTooltip(); // Stage 3b (#5): no timer/Text may outlive the scene.
       this.hideGameOverOverlay();
       this.hideSavePromptOverlay();
       this.hideSaveLoadDialogOverlay();
@@ -961,6 +1026,24 @@ export class UIScene extends Phaser.Scene {
     // surface view would be a stale artifact.
     if (contextMenuState.visible && this.viewState.activeView !== 'underground') {
       hideContextMenu();
+    }
+
+    // Stage 3b (#5): cancel a stale tooltip when the view/colony changes without
+    // a pointer event. updateTooltipHover() — the only place that re-runs the
+    // view-dependent hit-test and tooltip copy — is wired to 'pointermove' only,
+    // but a Tab/X keypress or the view/colony-toggle buttons switch the view
+    // (game-scene toggleView/toggleUndergroundColony) with no cursor movement.
+    // Without this, a tooltip already on screen (e.g. the underground-only colony
+    // toggle) lingers over a widget that is no longer drawn. Mirrors the context-
+    // menu auto-dismiss above. The next pointermove rebuilds the correct tooltip.
+    if (
+      this.lastTooltipView !== this.viewState.activeView ||
+      this.lastTooltipColonyId !== this.viewState.activeUndergroundColonyId
+    ) {
+      // Skip the very first sample (null seed) so we don't cancel spuriously.
+      if (this.lastTooltipView !== null) this.cancelTooltip();
+      this.lastTooltipView = this.viewState.activeView;
+      this.lastTooltipColonyId = this.viewState.activeUndergroundColonyId;
     }
 
     const colony = world.colonies[PLAYER_COLONY_ID];
@@ -1244,21 +1327,60 @@ export class UIScene extends Phaser.Scene {
     this.recomputeActiveOverlay();
   }
 
-  // S6 — first-occurrence caption overlay (light onboarding).
-  public showCaption(text: string, screenX: number, screenY: number): void {
-    // Stage 1 controls rework (issue #18, Codex R4-1): captions render centered
-    // and can overlap the HUD.HINTS strip (e.g. the command captions at
-    // y≈CANVAS_H-80). When the caption's vertical band overlaps the strip, yield
-    // (hide) the strip for the caption's lifetime so the two don't collide.
-    // Caption height is ~22px (14px font + padding); HINTS is y..y+h.
-    const capTop = screenY - 14;
-    const capBottom = screenY + 14;
-    const stripTop = HUD.HINTS.y;
-    const stripBottom = HUD.HINTS.y + HUD.HINTS.h;
-    if (capTop < stripBottom && capBottom > stripTop) {
+  // S6 — first-occurrence caption overlay (light onboarding). Stage 3b (#3):
+  // event captions now route through the shared caption queue so they never
+  // paint on top of a first-use hint (or each other). Admitted as source:'event'.
+  //
+  // `captionKey` is the one-shot trigger key behind this caption, when there is
+  // one. checkAndTrigger/captionForEvent mark that key the moment they return the
+  // text — before the request reaches the bounded queue — so a caption dropped on
+  // overflow would stay marked 'already shown' yet never display, losing it for
+  // the session. Passing the key lets enqueueCaption un-mark it on drop so it
+  // re-fires. Omit for recurring captions (they don't dedup on `triggered`).
+  public showCaption(
+    text: string,
+    screenX: number,
+    screenY: number,
+    captionKey?: CaptionKey,
+  ): void {
+    this.enqueueCaption({ text, x: screenX, y: screenY, source: 'event', captionKey });
+  }
+
+  /**
+   * Stage 3b (#3) — display a one-time first-use navigation hint. Implements the
+   * FirstUseHintSink the trigger seams call. Renders top-center, clear of the
+   * bottom HUD strip. Admitted as source:'first-use' so an event caption
+   * outranks it. The shown flag is persisted only when it BEGINS displaying
+   * (beginCaption), never at enqueue — a dropped/coalesced hint re-triggers later.
+   */
+  public showFirstUseHint(id: HintFirstUseId, text: string): void {
+    this.enqueueCaption({ text, x: CANVAS_W / 2, y: 60, source: 'first-use', hintId: id });
+  }
+
+  /** Admit a caption through the shared policy; begin it now if the queue was
+   *  idle, else it is queued/coalesced/dropped per caption-queue.ts. A dropped
+   *  one-shot event caption (carrying a captionKey) is un-marked so it re-fires
+   *  next occurrence — it never displayed, mirroring mark-on-display for hints. */
+  private enqueueCaption(req: CaptionRequest): void {
+    const result = admitCaption(this.captionState, req);
+    if (result.begin) this.beginCaption(result.begin);
+    if (result.dropped?.captionKey !== undefined) untrigger(result.dropped.captionKey);
+  }
+
+  /** Render a caption Text + run its fade tween. Marks a first-use hint shown the
+   *  moment it begins (Codex R1#9). On finish, promotes any pending caption. */
+  private beginCaption(req: CaptionRequest): void {
+    if (req.source === 'first-use' && req.hintId !== undefined) {
+      markFirstUseHintShown(req.hintId as HintFirstUseId);
+    }
+    // Stage 1 (Codex R4-1): a caption whose vertical band overlaps the HUD.HINTS
+    // strip yields (hides) the strip for its lifetime so the two don't collide.
+    const capTop = req.y - 14;
+    const capBottom = req.y + 14;
+    if (capTop < HUD.HINTS.y + HUD.HINTS.h && capBottom > HUD.HINTS.y) {
       this.hintYieldUntilMs = this.time.now + CAPTION_TOTAL_MS;
     }
-    const captionText = this.add.text(screenX, screenY, text, {
+    const captionText = this.add.text(req.x, req.y, req.text, {
       fontSize: '14px',
       fontFamily: 'monospace',
       color: '#ffffcc',
@@ -1270,8 +1392,10 @@ export class UIScene extends Phaser.Scene {
     captionText.setOrigin(0.5, 0.5);
     captionText.setDepth(30);
     captionText.setAlpha(0);
+    this.activeCaptionText = captionText;
 
-    // Fade in, hold, fade out over 1500ms total.
+    // Fade in, hold, fade out over 1500ms total. The active caption is never
+    // preempted; on its final fade we promote the pending one (if any).
     this.tweens.add({
       targets: captionText,
       alpha: { from: 0, to: 1 },
@@ -1286,10 +1410,157 @@ export class UIScene extends Phaser.Scene {
           ease: 'Linear',
           onComplete: () => {
             captionText.destroy();
+            this.activeCaptionText = null;
+            this.onCaptionFinished();
           },
         });
       },
     });
+  }
+
+  /**
+   * Reset the caption queue for a new round (ship-review R1#1/#3). UIScene is
+   * launched once and survives GameScene's restartGame/retryGame, so — unlike the
+   * time-based yield/queue-full timers, which self-heal — the caption queue would
+   * otherwise carry a prior round's active/pending caption into the new game and
+   * (worse) promote a queued first-use hint that then marks itself shown for a
+   * round it never displayed in. GameScene calls this from resetSessionState,
+   * alongside resetCaptions()/resetFirstUseSession().
+   */
+  public resetCaptionsForRound(): void {
+    if (this.activeCaptionText !== null) {
+      this.tweens.killTweensOf(this.activeCaptionText);
+      this.activeCaptionText.destroy();
+      this.activeCaptionText = null;
+    }
+    this.captionState = createCaptionQueueState();
+    this.hintYieldUntilMs = 0;
+  }
+
+  /** Promote a queued caption once the active one has fully faded. */
+  private onCaptionFinished(): void {
+    const result = completeCaption(this.captionState);
+    if (result.begin) this.beginCaption(result.begin);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Stage 3b (#5) — control-widget tooltips (desktop hover only)
+  // ---------------------------------------------------------------------------
+
+  /** True if any modal overlay is on screen — tooltips never show over a modal. */
+  private anyOverlayOpen(): boolean {
+    return (
+      this.surveyGroup.length > 0 ||
+      this.saveLoadDialogGroup.length > 0 ||
+      this.pauseMenuGroup.length > 0 ||
+      this.gameOverGroup.length > 0 ||
+      this.savePromptGroup.length > 0 ||
+      this.difficultySelectGroup.length > 0
+    );
+  }
+
+  /** Per-move hover tracking that drives the tooltip show/hide timers. Called
+   *  from the pointermove handler. */
+  private updateTooltipHover(pointer: Phaser.Input.Pointer): void {
+    // No tooltips while dragging, over the ant-activity popup, or under a modal.
+    if (pointer.isDown || this.anyOverlayOpen() || antActivityPanelState.visible) {
+      this.cancelTooltip();
+      return;
+    }
+    const target = tooltipTargetAt(pointer.x, pointer.y, this.viewState.activeView);
+    if (sameTooltipTarget(target, this.hoverTarget)) return; // unchanged — let timers run
+    this.hoverTarget = target;
+    this.clearTooltipShowTimer();
+    if (target === null) {
+      // Left the widget — keep the tip up for a short grace, then hide.
+      this.startTooltipHideGrace();
+      return;
+    }
+    // Entered a (new) widget.
+    this.clearTooltipHideTimer();
+    if (this.tooltipText !== null) {
+      // A tip is already up; swap to the new widget immediately (no re-dwell).
+      this.showTooltipNow(target);
+    } else {
+      this.tooltipShowTimer = this.time.delayedCall(TOOLTIP_SHOW_DELAY_MS, () => {
+        this.tooltipShowTimer = null;
+        // Re-check on fire (Codex R1#14): still hovering the same widget, no modal.
+        if (!sameTooltipTarget(this.hoverTarget, target)) return;
+        if (this.anyOverlayOpen() || antActivityPanelState.visible) return;
+        this.showTooltipNow(target);
+      });
+    }
+  }
+
+  /** Create/replace the tooltip Text, positioned clear of the widget. */
+  private showTooltipNow(target: TooltipTarget): void {
+    this.clearTooltipHideTimer();
+    if (this.tooltipText !== null) {
+      this.tooltipText.destroy();
+      this.tooltipText = null;
+    }
+    const t = this.add.text(0, 0, tooltipTextFor(target), {
+      fontSize: '12px',
+      fontFamily: 'monospace',
+      color: '#ffffff',
+      backgroundColor: '#000000cc',
+      padding: { x: 6, y: 3 },
+      align: 'left',
+      wordWrap: { width: 220 },
+    });
+    t.setOrigin(0, 0);
+    t.setDepth(31);
+    // Never cover the element: below it for top-half anchors (so we don't run off
+    // the top edge), above it otherwise; center on the anchor, clamp to canvas.
+    const a = target.anchor;
+    const pad = 6;
+    const w = t.width;
+    const h = t.height;
+    const tx = Math.max(2, Math.min(a.x + a.w / 2 - w / 2, CANVAS_W - w - 2));
+    const below = a.y < CANVAS_H / 2;
+    const ty = Math.max(2, Math.min(below ? a.y + a.h + pad : a.y - h - pad, CANVAS_H - h - 2));
+    t.setPosition(tx, ty);
+    this.tooltipText = t;
+  }
+
+  private startTooltipHideGrace(): void {
+    this.clearTooltipShowTimer();
+    if (this.tooltipText === null) return; // nothing visible to grace-hide
+    this.clearTooltipHideTimer();
+    this.tooltipHideTimer = this.time.delayedCall(TOOLTIP_HIDE_GRACE_MS, () => {
+      this.tooltipHideTimer = null;
+      if (this.tooltipText !== null) {
+        this.tooltipText.destroy();
+        this.tooltipText = null;
+      }
+    });
+  }
+
+  private clearTooltipShowTimer(): void {
+    if (this.tooltipShowTimer !== null) {
+      this.tooltipShowTimer.remove(false);
+      this.tooltipShowTimer = null;
+    }
+  }
+
+  private clearTooltipHideTimer(): void {
+    if (this.tooltipHideTimer !== null) {
+      this.tooltipHideTimer.remove(false);
+      this.tooltipHideTimer = null;
+    }
+  }
+
+  /** Hard-cancel: hide the tooltip + kill both timers + clear hover. Called on
+   *  any overlay open/close (recomputeActiveOverlay), scene teardown, and
+   *  pointer/gameout (Codex R1#14). */
+  private cancelTooltip(): void {
+    this.clearTooltipShowTimer();
+    this.clearTooltipHideTimer();
+    if (this.tooltipText !== null) {
+      this.tooltipText.destroy();
+      this.tooltipText = null;
+    }
+    this.hoverTarget = null;
   }
 
   // Stage 2 controls rework (issue #18) — the invasion screen-edge flash MUST
@@ -1356,9 +1627,18 @@ export class UIScene extends Phaser.Scene {
       // Accurate message for the pause state captured at the drop (Fix 3): paused
       // → "resume to continue"; running → "try again" (transient burst). Reading
       // the live isPausedFn here instead would mis-message a drop whose state has
-      // since flipped, so we use the recorded flag.
+      // since flipped, so we use the recorded flag. The queue-full WARNING shows
+      // regardless of the legend toggle (Codex R1#3).
       this.hintText.setText(queueFullHint(this.pausedQueueFullWasPaused));
       this.hintText.setColor('#ffcc66');
+      return;
+    }
+    // Stage 3b (#2, Codex R1#3): the visibility toggle gates ONLY the static
+    // legend — the caption-yield (above) and the queue-full warning (above) stay
+    // visible. A hidden legend also frees HUD.HINTS from the input mask
+    // (camera-input reads the same hintStripState).
+    if (!hintStripState.visible) {
+      this.hintText.setVisible(false);
       return;
     }
     this.hintText.setText(hintTextFor(this.effectiveTool(), this.viewState.activeView));
@@ -1655,6 +1935,8 @@ export class UIScene extends Phaser.Scene {
       // returning the default, which would freeze the label and make the
       // toggle look broken. ViewState always reflects the current value.
       currentPheromoneOverlay: this.viewState.showPheromoneOverlay,
+      // Stage 3b (#2): hint-strip legend visibility from the in-mem singleton.
+      currentHintStripVisible: hintStripState.visible,
       // Settings page's "Speed: N×" row reads this each render so it
       // reflects writes from EITHER the row click OR the live 1/2/4
       // keyboard shortcuts on GameScene.
@@ -1760,6 +2042,27 @@ export class UIScene extends Phaser.Scene {
         const persisted = loadSettings();
         persisted.pheromoneOverlay = next;
         saveSettings(persisted);
+        this.renderPauseMenuPage();
+        return;
+      }
+      case 'control-hints-toggle': {
+        // Stage 3b (#2): flip the in-mem hint-strip legend visibility (the
+        // authoritative source, same rationale as the pheromone toggle) and
+        // best-effort persist it. renderHintStrip + isPointerOverHUD both read
+        // hintStripState live, so the legend and its input mask flip together.
+        const next = !hintStripState.visible;
+        hintStripState.visible = next;
+        const persisted = loadSettings();
+        persisted.hintStripVisible = next;
+        saveSettings(persisted);
+        this.renderPauseMenuPage();
+        return;
+      }
+      case 'reset-first-use-hints': {
+        // Stage 3b (#3): clear the persisted shown-flags AND drop any queued
+        // first-use caption (clearPending) so the hints surface again cleanly.
+        resetFirstUseHints();
+        clearPending(this.captionState);
         this.renderPauseMenuPage();
         return;
       }
@@ -2045,6 +2348,10 @@ export class UIScene extends Phaser.Scene {
    *  re-show — exactly the kind of observability lie round 1 was supposed
    *  to fix. This recompute reflects whatever overlay is still on screen. */
   private recomputeActiveOverlay(): void {
+    // Stage 3b (#5, Codex R1#14): any overlay open/close cancels a live/pending
+    // tooltip — this is the single chokepoint every show/hideOverlay routes
+    // through, so it covers pause/save/survey/game-over opening AND closing.
+    this.cancelTooltip();
     // Survey takes precedence over the bare game-over overlay so the
     // end-of-game flow lands on the highest-value screen for diagnostics.
     if (this.surveyGroup.length > 0) setActiveOverlay('survey');

--- a/tests/menu-and-dialog.spec.ts
+++ b/tests/menu-and-dialog.spec.ts
@@ -203,7 +203,9 @@ test.describe('Issue #115/#116 — single click triggers single dispatch', () =>
     await page.locator('canvas').first().click({ position: settingsRect });
     await page.waitForTimeout(120);
 
-    // Settings sub-screen has 3 items: pheromone-toggle, speed-cycle, back.
+    // Settings sub-screen items (Stage 3b): pheromone-toggle (i=0),
+    // control-hints-toggle (i=1), reset-first-use-hints (i=2), speed-cycle (i=3),
+    // back (i=4) — 5 rows.
     const toggleRect = await page.evaluate(() => {
       const CANVAS_W = 800,
         CANVAS_H = 592;
@@ -211,7 +213,7 @@ test.describe('Issue #115/#116 — single click triggers single dispatch', () =>
         BTN_H = 40,
         GAP = 10,
         TITLE_H = 56;
-      const n = 3;
+      const n = 5;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
       const x = (CANVAS_W - BTN_W) / 2;
@@ -561,7 +563,7 @@ test.describe('Round-6 (Codex P2) — pheromone toggle survives degraded storage
     await page.locator('canvas').first().click({ position: settingsRect });
     await page.waitForTimeout(120);
 
-    // Pheromone toggle is index 0 on the Settings sub-page.
+    // Pheromone toggle is index 0 on the Settings sub-page (Stage 3b: 5 rows).
     const toggleClickPos = await page.evaluate(() => {
       const CANVAS_W = 800,
         CANVAS_H = 592;
@@ -569,7 +571,7 @@ test.describe('Round-6 (Codex P2) — pheromone toggle survives degraded storage
         BTN_H = 40,
         GAP = 10,
         TITLE_H = 56;
-      const n = 3;
+      const n = 5;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
       const x = (CANVAS_W - BTN_W) / 2;
@@ -637,8 +639,9 @@ test.describe('Settings — Speed cycle row (UAT)', () => {
     await page.locator('canvas').first().click({ position: settingsRect });
     await page.waitForTimeout(120);
 
-    // On Settings page: [pheromone-toggle (i=0), speed-cycle (i=1), back (i=2)].
-    // Compute rect for i=1.
+    // On Settings page (Stage 3b, 5 rows): [pheromone-toggle (i=0),
+    // control-hints-toggle (i=1), reset-first-use-hints (i=2), speed-cycle (i=3),
+    // back (i=4)]. Compute rect for i=3.
     const speedRect = await page.evaluate(() => {
       const CANVAS_W = 800,
         CANVAS_H = 592;
@@ -646,11 +649,11 @@ test.describe('Settings — Speed cycle row (UAT)', () => {
         BTN_H = 40,
         GAP = 10,
         TITLE_H = 56;
-      const n = 3;
+      const n = 5;
       const stackHeight = TITLE_H + n * BTN_H + (n - 1) * GAP;
       const top = (CANVAS_H - stackHeight) / 2 + TITLE_H;
       const x = (CANVAS_W - BTN_W) / 2;
-      const speedY = top + 1 * (BTN_H + GAP);
+      const speedY = top + 3 * (BTN_H + GAP);
       return { x: x + BTN_W / 2, y: speedY + BTN_H / 2 };
     });
 


### PR DESCRIPTION
## Controls rework — Stage 3b: Navigation Teaching (#18)

Makes the controls **self-teaching, non-invasively** — a new player discovers pan / zoom / view-switch / the tool palette without a manual or tutorial wall. Three reactive surfaces, all rendered through **one** device-glyph resolver (a foundation for, not a solution to, Phase-6 touch).

Plan: `plan/controls-rework/PLAN-stage3b.md` (grilled with Rob + Codex-approved over 4 rounds).

### What changed
- **#1 Glyph resolver** — new `src/render/input-glyphs.ts`: a static `ActionId`→glyph table modelling the **real** Stage-3a bindings (one canonical glyph per action; keys bracketed, mouse as words). Anti-drift = an exact-glyph-**string** unit test + a keep-in-sync cross-ref comment paired with `game-scene.ts`'s hotkey block. No binding registry (deferred — keys are stable + non-rebindable).
- **#2 Hint strip** — `hintTextFor` now composes `glyphFor` output instead of hardcoded verbs. A visibility toggle gates **only** the static legend; the paused-queue-full warning + caption-yield stay visible. When the legend is hidden, `HUD.HINTS` is also dropped from `isPointerOverHUD` so there's no dead input zone.
- **#3 First-use hints** — one-time, cross-session nudges for the affordance-less gestures, fired on the **effect** (real pan / accepted zoom / a dig-drag that enqueues ≥1 mark) via thin callback seams at the input sites, plus the **proactive `[Tab]` nudge** (fires on the first world input of a fresh session, evaluated *after* the input so a Tab first-input self-suppresses). All captions (event captions, onboarding-captions, first-use) now route through **one** UIScene caption queue with a concrete policy (active never preempts · cap-1 pending · event > first-use · coalesce duplicate first-use · overflow drops first-use · a dropped one-shot un-marks so it re-fires). Shown-state persists as a JSON-safe `Record<HintId, boolean>`; a hint is marked shown **only when it begins displaying**.
- **#5 Tooltips** — hover tooltips (~400 ms show / ~1.5 s grace) on the control widgets: tool palette, speed widget, view toggle, colony toggle, Forage↔Fight slider, and `HUD.STATS` (whose tooltip teaches the non-obvious "click for ant activity"). A visual `{tool, enabled}` hit-test means the disabled Chamber-on-surface still tooltips while its click stays inert. Strict modal/teardown lifecycle (cancel on any overlay open/close, scene shutdown, pointer/gameout; re-check modal visibility before showing). Excludes the minimap + ant-panel popup. No keyboard-focus tooltips in v1.
- **Settings** — adds `hintStripVisible` (default true) + the first-use `Record`; permissive load migrates old blobs with no version bump. Pause-menu Settings submenu gains a "Control hints" toggle + a "Reset first-use hints" action.

### Scope discipline
**`src/render` + `src/input` + `src/platform` only.** Zero `src/sim` change, no `simVersion`, no determinism touch (`git diff main -- src/sim` is empty). Desktop-only — the #1 table is a touch foundation, not wired.

### Validation
- `npm run verify` green (prettier, eslint, tsc, lint:types, sim/asset guards, 2569 Vitest tests incl. new coverage for #1 exact-glyph-string, #3 effect-gating/mark-shown/reset/queue policy, #5 hit-test incl. disabled-Chamber, settings round-trip + migration).
- Internal `ship-review` (adversarial, multi-dimension): **passed** — caught + fixed a real one-shot-caption-loss bug (dropped-on-overflow captions now un-mark) and a shared-mutable-default in `settings.ts`.

### Game-feel / copy → Rob UAT (not blockers)
- **The one open call:** the `[Tab]` nudge is **proactive** (first world input) per the plan — vs a later reactive trigger.
- A first pan/scroll can chain two first-use hints (~3 s, queue-serialized) — feel call.
- Glyph styling, tooltip copy + delays, hint wording, caption fade duration.

### Low-severity advisories intentionally left for Codex
Tooltip view-coupling (correct for today's inputs), the `[Tab]` latch consumed on a no-op press (documented design tradeoff), and the two-hint chain above (game-feel).

Closes part of #18 (Stage 3b; issue stays open until UAT sign-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
