### PR TITLE
feat(render): spider rotates to face its movement direction (#216)

### DIFF
--- a/src/render/ant-facing-cache.test.ts
+++ b/src/render/ant-facing-cache.test.ts
@@ -6,7 +6,7 @@
 // IDs never inherit stale headings.
 
 import { describe, it, expect } from 'vitest';
-import { AntFacingCache, computeAntRotation } from './ant-facing-cache.js';
+import { AntFacingCache, computeAntRotation, SPIDER_FACING_ID } from './ant-facing-cache.js';
 
 describe('AntFacingCache', () => {
   it('first observation seeds from the raw delta (rotation matches atan2)', () => {
@@ -131,5 +131,49 @@ describe('computeAntRotation (helper)', () => {
     const cache = new AntFacingCache();
     computeAntRotation(cache, 1, 0, 16, 0, true);
     expect(cache.size).toBe(1);
+  });
+});
+
+// The singleton surface spider reuses this same cache for facing smoothing — it
+// just needs one stable key. SPIDER_FACING_ID reserves a negative slot that can
+// never collide with the non-negative array-index ids the ants use.
+describe('SPIDER_FACING_ID (issue #216 — spider reuses the ant facing cache)', () => {
+  it('is a negative key that cannot collide with non-negative ant ids', () => {
+    expect(SPIDER_FACING_ID).toBeLessThan(0);
+  });
+
+  it('smooths under the spider key without interfering with ant entries in the same cache', () => {
+    const cache = new AntFacingCache();
+    // An ant (id 0) heads right; the spider heads down — same cache instance.
+    cache.sample({ id: 0, zone: 0, dx: 16, dy: 0, useInterp: true });
+    const spider = cache.sample({
+      id: SPIDER_FACING_ID,
+      zone: 0,
+      dx: 0,
+      dy: 16,
+      useInterp: true,
+    });
+    expect(cache.size).toBe(2);
+    // Spider's first observation seeds raw atan2(-16, -0) = -π/2 (facing +y/down).
+    expect(spider).toBeCloseTo(-Math.PI / 2, 5);
+    // The ant entry is untouched: a stationary follow-up holds its rightward pose.
+    const ant = cache.sample({ id: 0, zone: 0, dx: 0, dy: 0, useInterp: true });
+    expect(Math.abs(ant)).toBeCloseTo(Math.PI, 5);
+  });
+
+  it('holds the prior rotation when the spider is stationary', () => {
+    const cache = new AntFacingCache();
+    const moving = cache.sample({ id: SPIDER_FACING_ID, zone: 0, dx: 0, dy: 16, useInterp: true });
+    const still = cache.sample({ id: SPIDER_FACING_ID, zone: 0, dx: 0, dy: 0, useInterp: true });
+    expect(still).toBe(moving);
+  });
+
+  it('evicts the spider entry on useInterp=false (just-spawned → default pose)', () => {
+    const cache = new AntFacingCache();
+    cache.sample({ id: SPIDER_FACING_ID, zone: 0, dx: 0, dy: 16, useInterp: true });
+    expect(cache.size).toBe(1);
+    const r = cache.sample({ id: SPIDER_FACING_ID, zone: 0, dx: 99, dy: 99, useInterp: false });
+    expect(r).toBe(0);
+    expect(cache.size).toBe(0);
   });
 });

--- a/src/render/ant-facing-cache.ts
+++ b/src/render/ant-facing-cache.ts
@@ -33,6 +33,14 @@ const DELTA_EPSILON = 0.01;
 /** Minimum blended heading magnitude to emit a rotation from. */
 const HEADING_EPSILON = 0.001;
 
+/**
+ * Reserved facing-cache key for the singleton surface spider. The cache is keyed
+ * by entity id, and ant ids are non-negative array indices, so a negative id can
+ * never collide with one. The spider reuses the exact same smoothing — its sprite,
+ * like the ants', has its head on -x — it just needs one stable key of its own.
+ */
+export const SPIDER_FACING_ID = -1;
+
 export interface AntFacingSample {
   id: number;
   /** Current zone (0 = surface, 1 = underground). Used for stale-zone eviction. */

--- a/src/render/ant-sprite-layer.ts
+++ b/src/render/ant-sprite-layer.ts
@@ -56,6 +56,15 @@ export interface SpiderSpriteDrawOptions {
   y: number;
   /** Hunger-derived multiplicative tint: 0xCCCCCC (idle) → 0xFF3300 (rampage). */
   tint: number;
+  /**
+   * Rotation in radians. Omit (or 0) for the sprite's native pose. Like the ant
+   * SVGs, the spider sprite renders with its head/front on the LEFT side of the
+   * texture (chelicerae + eyes + cephalothorax on -x), so callers that want the
+   * head to face movement direction (dx, dy) pass `Math.atan2(-dy, -dx)`. When
+   * the spider is stationary the caller holds the last rotation (via the shared
+   * facing cache) rather than snapping back to the default pose.
+   */
+  rotation?: number;
 }
 
 export interface AntSpriteLayer {

--- a/src/render/ant-sprite-pool.ts
+++ b/src/render/ant-sprite-pool.ts
@@ -95,7 +95,7 @@ export class AntSpritePool implements AntSpriteLayer {
     sprite.setTexture(SPIDER_TEXTURE);
     sprite.setPosition(opts.x, opts.y);
     sprite.setTint(opts.tint);
-    sprite.setRotation(0);
+    sprite.setRotation(opts.rotation ?? 0);
     sprite.setScale(1);
     sprite.setDepth(SPIDER_SPRITE_DEPTH);
     sprite.setVisible(true);

--- a/src/render/draw-surface.test.ts
+++ b/src/render/draw-surface.test.ts
@@ -104,6 +104,7 @@ class MockGfx implements GfxLike {
 class MockAntSprites implements AntSpriteLayer {
   calls: AntSpriteDrawOptions[] = [];
   staticCalls: StaticSpriteDrawOptions[] = [];
+  spiderCalls: SpiderSpriteDrawOptions[] = [];
   beginFrames = 0;
   endFrames = 0;
   beginFrame(): void {
@@ -115,8 +116,8 @@ class MockAntSprites implements AntSpriteLayer {
   drawStatic(opts: StaticSpriteDrawOptions): void {
     this.staticCalls.push({ ...opts });
   }
-  drawSpider(_opts: SpiderSpriteDrawOptions): void {
-    /* no-op in tests */
+  drawSpider(opts: SpiderSpriteDrawOptions): void {
+    this.spiderCalls.push({ ...opts });
   }
   endFrame(): void {
     this.endFrames++;
@@ -124,6 +125,7 @@ class MockAntSprites implements AntSpriteLayer {
   reset(): void {
     this.calls = [];
     this.staticCalls = [];
+    this.spiderCalls = [];
     this.beginFrames = 0;
     this.endFrames = 0;
   }
@@ -775,6 +777,176 @@ describe('drawSurfaceEntities — facing cache smoothing', () => {
       sprites.reset();
       drawSurfaceEntities(gfx, sprites, still, still, 1, cam, null, facing);
       expect(sprites.calls[0]!.rotation).toBe(settledRotation);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: spider facing direction (issue #216)
+//
+// The spider sprite, like the ant SVGs, has its head/front on -x natively
+// (chelicerae + eyes + cephalothorax on the left), so drawSurfaceEntities passes
+// rotation = atan2(-dy, -dx) to face the motion vector — reusing the ant
+// facing-smoothing logic under SPIDER_FACING_ID. Stationary → the prior smoothed
+// rotation holds; no prev (just spawned) → the default pose (0).
+// ---------------------------------------------------------------------------
+
+describe('drawSurfaceEntities — spider facing direction (issue #216)', () => {
+  function makeWorldWithSpiderAt(tileX: number, tileY: number): WorldState {
+    const w = createWorldState(1);
+    const spider: SpiderState = {
+      state: 'Patrolling',
+      posX: tileX << FP_SHIFT,
+      posY: tileY << FP_SHIFT,
+      lairTileX: tileX,
+      lairTileY: tileY,
+      territoryRadiusTiles: 24,
+      hp: SPIDER_HP_FULL,
+      attackCooldown: 0,
+      hungerTicks: 0,
+      nextHuntTick: 0,
+      huntStartTick: 0,
+      strikeStartTick: 0,
+      feedingStartTick: 0,
+      retreatStartTick: 0,
+      rampageStartTick: 0,
+      huntTargetTileX: -1,
+      huntTargetTileY: -1,
+      killsThisStrike: 0,
+      rampageKillsThisRampage: 0,
+      rampageTargetColonyId: -1,
+      chaseTargetAntId: -1,
+      chaseStartTick: 0,
+      killedThisTick: 0,
+      lastKillTileX: -1,
+      lastKillTileY: -1,
+      feedAwayTileX: -1,
+      feedAwayTileY: -1,
+      feedArrivedTick: -1,
+    };
+    w.spider = spider;
+    return w;
+  }
+
+  it('rotation defaults to 0 when prev == curr (stationary spider)', () => {
+    const gfx = new MockGfx();
+    const sprites = new MockAntSprites();
+    const world = makeWorldWithSpiderAt(5, 5);
+    const cam = makeCamera(5, 5);
+    drawSurfaceEntities(gfx, sprites, world, world, 0, cam);
+    expect(sprites.spiderCalls.length).toBe(1);
+    expect(sprites.spiderCalls[0]!.rotation).toBe(0);
+  });
+
+  it('no prev spider (just spawned) → default pose (rotation 0)', () => {
+    const gfx = new MockGfx();
+    const sprites = new MockAntSprites();
+    const prev = createWorldState(1); // prev.spider === null
+    const curr = makeWorldWithSpiderAt(5, 5);
+    const cam = makeCamera(5, 5);
+    drawSurfaceEntities(gfx, sprites, prev, curr, 1, cam);
+    expect(sprites.spiderCalls.length).toBe(1);
+    expect(sprites.spiderCalls[0]!.rotation).toBe(0);
+  });
+
+  it('moving right (+x): rotation has magnitude π (head flipped to face +x)', () => {
+    const gfx = new MockGfx();
+    const sprites = new MockAntSprites();
+    const prev = makeWorldWithSpiderAt(5, 5);
+    const curr = makeWorldWithSpiderAt(6, 5);
+    const cam = makeCamera(5, 5);
+    drawSurfaceEntities(gfx, sprites, prev, curr, 1, cam);
+    expect(sprites.spiderCalls.length).toBe(1);
+    expect(Math.abs(sprites.spiderCalls[0]!.rotation!)).toBeCloseTo(Math.PI, 5);
+  });
+
+  it('moving down (+y): rotation = -π/2', () => {
+    const gfx = new MockGfx();
+    const sprites = new MockAntSprites();
+    const prev = makeWorldWithSpiderAt(5, 5);
+    const curr = makeWorldWithSpiderAt(5, 6);
+    const cam = makeCamera(5, 5);
+    drawSurfaceEntities(gfx, sprites, prev, curr, 1, cam);
+    expect(sprites.spiderCalls[0]!.rotation).toBeCloseTo(-Math.PI / 2, 5);
+  });
+
+  it('moving up (-y): rotation = +π/2', () => {
+    const gfx = new MockGfx();
+    const sprites = new MockAntSprites();
+    const prev = makeWorldWithSpiderAt(5, 5);
+    const curr = makeWorldWithSpiderAt(5, 4);
+    const cam = makeCamera(5, 5);
+    drawSurfaceEntities(gfx, sprites, prev, curr, 1, cam);
+    expect(sprites.spiderCalls[0]!.rotation).toBeCloseTo(Math.PI / 2, 5);
+  });
+
+  it('moving left (-x): rotation = 0 (native head already points left)', () => {
+    const gfx = new MockGfx();
+    const sprites = new MockAntSprites();
+    const prev = makeWorldWithSpiderAt(5, 5);
+    const curr = makeWorldWithSpiderAt(4, 5);
+    const cam = makeCamera(5, 5);
+    drawSurfaceEntities(gfx, sprites, prev, curr, 1, cam);
+    expect(sprites.spiderCalls[0]!.rotation).toBeCloseTo(0, 5);
+  });
+
+  it('alternating right/down movement settles toward a diagonal rotation (no flicker)', () => {
+    const gfx = new MockGfx();
+    const sprites = new MockAntSprites();
+    const cam = makeCamera(10, 10);
+    const facing = new AntFacingCache();
+
+    // 8-step southeast zig-zag, one cardinal tile per frame. The shared cache
+    // low-pass-blends the alternating axis deltas into a stable diagonal heading
+    // instead of flipping right→down→right every tick.
+    let x = 5,
+      y = 5;
+    const path: Array<[number, number]> = [];
+    for (let i = 0; i < 8; i++) {
+      if (i % 2 === 0) x += 1;
+      else y += 1;
+      path.push([x, y]);
+    }
+
+    let prev = makeWorldWithSpiderAt(5, 5);
+    let lastRotation = 0;
+    for (const [nx, ny] of path) {
+      sprites.reset();
+      const curr = makeWorldWithSpiderAt(nx, ny);
+      drawSurfaceEntities(gfx, sprites, prev, curr, 1, cam, null, facing);
+      lastRotation = sprites.spiderCalls[0]!.rotation!;
+      prev = curr;
+    }
+
+    // Southeast motion → rotation in (-π, -π/2), nearer the diagonal (-3π/4)
+    // than either axis. Per-frame-raw rotation would instead oscillate between
+    // ≈ -π (right) and -π/2 (down) — the flicker the cache removes.
+    expect(lastRotation).toBeGreaterThan(-Math.PI);
+    expect(lastRotation).toBeLessThan(-Math.PI / 2);
+    const diag = (-3 * Math.PI) / 4;
+    expect(Math.abs(lastRotation - diag)).toBeLessThan(Math.abs(lastRotation - -Math.PI));
+    expect(Math.abs(lastRotation - diag)).toBeLessThan(Math.abs(lastRotation - -Math.PI / 2));
+  });
+
+  it('stationary spider holds its prior smoothed heading across idle frames', () => {
+    const gfx = new MockGfx();
+    const sprites = new MockAntSprites();
+    const cam = makeCamera(10, 10);
+    const facing = new AntFacingCache();
+
+    // Establish a rightward heading.
+    const prev1 = makeWorldWithSpiderAt(5, 5);
+    const curr1 = makeWorldWithSpiderAt(6, 5);
+    drawSurfaceEntities(gfx, sprites, prev1, curr1, 1, cam, null, facing);
+    const settled = sprites.spiderCalls[0]!.rotation!;
+    expect(Math.abs(settled)).toBeCloseTo(Math.PI, 5);
+
+    // Idle frames: prev == curr. Rotation must hold, not snap back to 0.
+    const still = makeWorldWithSpiderAt(6, 5);
+    for (let i = 0; i < 4; i++) {
+      sprites.reset();
+      drawSurfaceEntities(gfx, sprites, still, still, 1, cam, null, facing);
+      expect(sprites.spiderCalls[0]!.rotation).toBe(settled);
     }
   });
 });

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -22,7 +22,7 @@ import { FP_ONE } from '../sim/fixed.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
 import type { WorldState } from '../sim/types.js';
 import type { AntSpriteLayer } from './ant-sprite-layer.js';
-import { computeAntRotation, type AntFacingCache } from './ant-facing-cache.js';
+import { computeAntRotation, SPIDER_FACING_ID, type AntFacingCache } from './ant-facing-cache.js';
 import {
   TILE_SIZE_PX,
   COLOR_FOOD_PILE_NORMAL,
@@ -443,7 +443,20 @@ export function drawSurfaceEntities(
       // S6: linear tint gradient pale (#ffeecc) → deep red (#cc2020) by hungerFraction.
       const tint = lerpColor(0xffeecc, 0xcc2020, hungerFraction);
 
-      sprites.drawSpider({ x: spiderWorldX, y: spiderWorldY, tint });
+      // Facing: rotate the spider sprite so its head points along the motion
+      // vector, reusing the ant facing-smoothing logic under a reserved spider
+      // key. The spider is always on the surface (zone 0). Stationary → the cache
+      // holds the prior smoothed rotation; no prev (just spawned) → default pose.
+      const spiderRotation = computeAntRotation(
+        facing,
+        SPIDER_FACING_ID,
+        0,
+        currPxX - prevPxX,
+        currPxY - prevPxY,
+        useSpiderInterp,
+      );
+
+      sprites.drawSpider({ x: spiderWorldX, y: spiderWorldY, tint, rotation: spiderRotation });
 
       // Hunger ring (S3 → S6 polished): appears at 70% hunger, fades to full at 100%.
       if (hungerFraction > 0.7) {


### PR DESCRIPTION
## Summary

Closes #216. The spider sprite was drawn at a fixed orientation regardless of which way it moved. It now **rotates to face its direction of travel**, exactly like the ants already do — so it visibly turns as it hunts and patrols.

## Approach (mirrors the ants)

- **`SpiderSpriteDrawOptions.rotation?`** (`ant-sprite-layer.ts`) + `drawSpider` applies `opts.rotation ?? 0` (`ant-sprite-pool.ts`).
- **Reuses the ant facing-smoothing logic.** The spider draw path (`draw-surface.ts`) takes the prev→curr pixel delta it already computes and runs it through `computeAntRotation` / `AntFacingCache` under a reserved **`SPIDER_FACING_ID = -1`** key. Ant ids are non-negative array indices, so the negative key can never collide. The low-pass blend means a cardinal/diagonal zig-zag relaxes to a stable heading instead of flickering on the 4-connected grid; a stationary spider holds its last rotation; a just-spawned spider (no prev) falls back to the default pose.
- **Same forward axis as the ants.** The spider SVG's head/front is on −x (chelicerae + eyes + small cephalothorax on the left), so the existing `atan2(-dy, -dx)` convention applies directly — no extra offset.

## Render-only — no sim impact

Facing is derived from interpolated prev/curr **render** positions, not from any new sim field. **No `src/sim` change, no `simVersion` bump** (`git diff main -- src/sim` is empty). All 6 changed files live under `src/render`.

## Tests

12 new tests:
- `draw-surface.test.ts` — spider faces each cardinal (magnitudes π / −π/2 / +π/2 / 0), holds when stationary, defaults to 0 with no prev, and settles toward a diagonal under an alternating right/down zig-zag (the anti-flicker property).
- `ant-facing-cache.test.ts` — `SPIDER_FACING_ID` is negative, smooths under the spider key without disturbing ant entries in the same cache, holds-when-stationary, and evicts on spawn.

`npm run verify` green (prettier, eslint, tsc, lint:types, sim/asset guards, cycle check, 2711 Vitest tests). Internal `ship-review` came back clean (`passed: true`, 0 findings).

> Visual smoothness is encoded as deterministic unit-test assertions on the rotation math; final in-game eyeball UAT is the one remaining manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spider now rotates dynamically to face the direction of movement.
  * Smooth rotation transitions prevent visual jitter while moving.
  * Stationary spider retains its last-known heading.

* **Tests**
  * Added comprehensive test coverage for spider rotation behavior under various movement and stationary states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->