### PR TITLE
refactor(render): introduce LayoutContext seam for HUD/overlay geometry (#213)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,12 @@ Use strong language deliberately — these are non-negotiable invariants of the 
 - Runtime asset URLs in `src/render/` must be built from `import.meta.env.BASE_URL` (or the `assetsBase` registry value plumbed via `mount()`), never hard-coded as root-absolute (`/assets/...`) or relative (`./assets/...`). Hard-coded paths break the embedded library build at non-root deploy paths. See `vite.lib.config.ts` and `src/main.ts`.
 - The library entry point is `src/main.ts`. Adding new top-level exports there expands the public API surface — flag undocumented additions and ask for a JSDoc block matching the existing `MountOptions` / `MountedGame` / `mount` style.
 
+### Layout discipline (HUD/overlay geometry — issue #213)
+
+- HUD/overlay geometry is a pure function of a `LayoutContext` (`src/render/layout.ts`, `{ w, h }`), **not** of the fixed `CANVAS_W`/`CANVAS_H` constants or inline `800`/`592` literals. The game still renders at the fixed 800×592 logical resolution today; this is a *seam* so the eventual responsive/mobile work is "compute a `LayoutContext` from the real canvas + reflow on resize", not a refactor of every overlay under deadline.
+- A layout module takes `(…, layout)` and derives every canvas-relative coordinate from `layout.w` / `layout.h` (anchors, fractions, insets from an edge). **Blockers:** a new module-scope constant tied to the canvas size (e.g. `const CANVAS_W = 800` redefined locally, or a rect centered with a hard-coded `800 / 2`), a new inline `800`/`592` in an overlay/`ui-scene.ts` method, or importing `CANVAS_W`/`CANVAS_H` to compute overlay geometry. Canvas-**independent** constants (a fixed inset, a button size, an offset from another anchor) may stay plain constants — the rule targets dimensions a resize has to move.
+- Pattern to copy: `pause-menu-layout.ts`, `save-load-dialog-layout.ts`, `survey-overlay-layout.ts` (pure functions of `layout`), and `UIScene.layout` threading the single context into them. `HUD` in `sprites.ts` remains the canonical anchor table other modules derive from; `camera-adapter.ts` is the screen↔world authority and owns the canvas-size dependency for projection.
+
 ## Building and Running
 
 ```bash

--- a/src/render/layout.test.ts
+++ b/src/render/layout.test.ts
@@ -1,0 +1,24 @@
+// layout.test.ts — the LayoutContext seam (issue #213).
+
+import { describe, it, expect } from 'vitest';
+import { createLayoutContext, DEFAULT_LAYOUT } from './layout.js';
+import { CANVAS_W, CANVAS_H } from './sprites.js';
+
+describe('LayoutContext (issue #213)', () => {
+  it('DEFAULT_LAYOUT carries the fixed canvas size (CANVAS_W × CANVAS_H)', () => {
+    expect(DEFAULT_LAYOUT.w).toBe(CANVAS_W);
+    expect(DEFAULT_LAYOUT.h).toBe(CANVAS_H);
+  });
+
+  it('createLayoutContext() defaults to the fixed canvas size', () => {
+    const ctx = createLayoutContext();
+    expect(ctx.w).toBe(CANVAS_W);
+    expect(ctx.h).toBe(CANVAS_H);
+  });
+
+  it('createLayoutContext(w, h) carries explicit dimensions (the future responsive path)', () => {
+    const ctx = createLayoutContext(1024, 768);
+    expect(ctx.w).toBe(1024);
+    expect(ctx.h).toBe(768);
+  });
+});

--- a/src/render/layout.ts
+++ b/src/render/layout.ts
@@ -1,0 +1,46 @@
+// layout.ts — the LayoutContext seam (issue #213).
+//
+// HUD/overlay geometry must be a pure function of a LayoutContext rather than of
+// the fixed CANVAS_W/CANVAS_H constants or inline 800/592 literals. Today the
+// context simply carries the logical canvas size (w × h), so NOTHING about
+// rendering changes — the game still draws at the fixed 800×592 resolution. The
+// point is the SEAM: when the responsive/mobile work lands later it becomes
+// "compute a LayoutContext from the real canvas size + reflow on resize", not a
+// scavenger hunt through a dozen modules pulling 800/592 out of thin air.
+//
+// Convention (see code/AGENTS.md → "Layout discipline"): a layout module takes
+// `(…, layout)` and derives every canvas-relative coordinate from `layout.w` /
+// `layout.h` (anchors, fractions, insets from an edge). It must NOT import
+// CANVAS_W/CANVAS_H for geometry, redefine them locally, or hardcode 800/592.
+// Canvas-INDEPENDENT constants (a fixed inset, a button size, an offset from
+// another anchor) may stay plain constants — the rule targets dimensions tied to
+// the canvas size, which are exactly what a resize has to move.
+//
+// Future fields (safe-area insets, orientation, devicePixelRatio) hang off this
+// same object; adding them is the one place that needs to change.
+
+import { CANVAS_W, CANVAS_H } from './sprites.js';
+
+export interface LayoutContext {
+  /** Logical canvas width in pixels. */
+  readonly w: number;
+  /** Logical canvas height in pixels. */
+  readonly h: number;
+}
+
+/**
+ * Build a LayoutContext. Defaults to the fixed logical canvas size
+ * (CANVAS_W × CANVAS_H) — the only size the game renders at today. Pass explicit
+ * dimensions once the responsive work computes them from the real canvas.
+ */
+export function createLayoutContext(w: number = CANVAS_W, h: number = CANVAS_H): LayoutContext {
+  return { w, h };
+}
+
+/**
+ * The fixed-resolution LayoutContext (800×592) — the single instance every
+ * overlay consumes today. Swapping this for a resize-derived context (computed
+ * from the real canvas in UIScene) is the eventual mobile seam; until then it
+ * keeps the geometry byte-for-byte identical to the pre-seam constants.
+ */
+export const DEFAULT_LAYOUT: LayoutContext = createLayoutContext();

--- a/src/render/pause-menu-layout.test.ts
+++ b/src/render/pause-menu-layout.test.ts
@@ -1,18 +1,26 @@
 import { describe, it, expect } from 'vitest';
 import {
-  pauseMenuItems,
+  pauseMenuItems as pauseMenuItemsAt,
   pageTitle,
   itemAt,
   nextSpeedMultiplier,
-  CANVAS_W,
-  CANVAS_H,
   PAUSE_MENU_BUTTON_W,
   PAUSE_MENU_BUTTON_H,
   PAUSE_MENU_BUTTON_GAP,
+  type PauseMenuPage,
   type PauseMenuRenderContext,
 } from './pause-menu-layout.js';
+import { DEFAULT_LAYOUT, createLayoutContext } from './layout.js';
+import { CANVAS_W, CANVAS_H } from './sprites.js';
 // (DEFAULT_SETTINGS no longer imported — ctx now uses in-memory boolean
 // for currentPheromoneOverlay instead of a full Settings snapshot.)
+
+// Issue #213: pauseMenuItems now takes a LayoutContext. The existing geometry
+// tests assert parity at the fixed default layout (800×592); bind it here so the
+// call sites stay focused on item composition. The seam describe at the bottom
+// exercises a non-default LayoutContext.
+const pauseMenuItems = (page: PauseMenuPage, c: PauseMenuRenderContext) =>
+  pauseMenuItemsAt(page, c, DEFAULT_LAYOUT);
 
 const ctx: PauseMenuRenderContext = {
   saveLoadEnabled: true,
@@ -195,5 +203,21 @@ describe('itemAt', () => {
     const items = pauseMenuItems('main', { ...ctx, saveLoadEnabled: false });
     const saveLoad = items.find((i) => i.id === 'save-load')!;
     expect(itemAt(items, saveLoad.rect.x + 5, saveLoad.rect.y + 5)).toBeNull();
+  });
+});
+
+describe('pauseMenuItems — LayoutContext seam (issue #213)', () => {
+  it('horizontally centers the buttons on the passed layout width, not a fixed 800', () => {
+    const wide = createLayoutContext(1000, 700);
+    for (const i of pauseMenuItemsAt('main', ctx, wide)) {
+      expect(i.rect.x + i.rect.w / 2).toBeCloseTo(wide.w / 2, 5);
+    }
+  });
+
+  it('shifts the vertical stack down on a taller layout', () => {
+    const tall = createLayoutContext(CANVAS_W, CANVAS_H + 200);
+    const def = pauseMenuItemsAt('main', ctx, DEFAULT_LAYOUT);
+    const taller = pauseMenuItemsAt('main', ctx, tall);
+    expect(taller[0]!.rect.y).toBeGreaterThan(def[0]!.rect.y);
   });
 });

--- a/src/render/pause-menu-layout.ts
+++ b/src/render/pause-menu-layout.ts
@@ -6,8 +6,8 @@
 // Vitest without spinning up a Phaser scene.
 //
 // Layout: vertical stack of fixed-size buttons, centered horizontally on the
-// 800×592 canvas. Vertical anchor is the canvas centerline minus half the
-// stack height, so the stack stays visually centered as page contents change.
+// canvas (a LayoutContext). Vertical anchor is the canvas centerline minus half
+// the stack height, so the stack stays visually centered as page contents change.
 //
 // State machine (consumer drives, this module renders):
 //   main     → Resume / Save+Load / Settings → / Download debug log
@@ -20,12 +20,15 @@
 // (Settings type was imported here pre-round-6; removed when the
 // pheromone-toggle label moved to an in-memory ctx field per Codex P2.)
 
+import type { LayoutContext } from './layout.js';
+
 // ---------------------------------------------------------------------------
 // Geometry constants (canvas-local pixels)
+//
+// Button sizes/gaps/title-height are canvas-INDEPENDENT and stay constants; the
+// canvas-relative centering (stackRects) derives from the LayoutContext passed
+// in (issue #213). No local CANVAS_W/CANVAS_H — that was the layout debt.
 // ---------------------------------------------------------------------------
-
-export const CANVAS_W = 800;
-export const CANVAS_H = 592;
 
 export const PAUSE_MENU_BUTTON_W = 320;
 export const PAUSE_MENU_BUTTON_H = 40;
@@ -116,11 +119,11 @@ export interface PauseMenuRenderContext {
  * Compute the vertical center anchor for a stack of n buttons (with the title
  * gap), then derive each button's rect. Returns rects in render order top→bottom.
  */
-function stackRects(n: number): MenuItemRect[] {
+function stackRects(n: number, layout: LayoutContext): MenuItemRect[] {
   const stackHeight =
     PAUSE_MENU_TITLE_HEIGHT + n * PAUSE_MENU_BUTTON_H + (n - 1) * PAUSE_MENU_BUTTON_GAP;
-  const top = (CANVAS_H - stackHeight) / 2 + PAUSE_MENU_TITLE_HEIGHT;
-  const x = (CANVAS_W - PAUSE_MENU_BUTTON_W) / 2;
+  const top = (layout.h - stackHeight) / 2 + PAUSE_MENU_TITLE_HEIGHT;
+  const x = (layout.w - PAUSE_MENU_BUTTON_W) / 2;
   const rects: MenuItemRect[] = [];
   for (let i = 0; i < n; i++) {
     rects.push({
@@ -134,13 +137,17 @@ function stackRects(n: number): MenuItemRect[] {
 }
 
 /** Y-coordinate of the page title baseline (above the first button rect). */
-export function titleCenterY(itemCount: number): number {
-  const rects = stackRects(itemCount);
+export function titleCenterY(itemCount: number, layout: LayoutContext): number {
+  const rects = stackRects(itemCount, layout);
   return rects[0]!.y - PAUSE_MENU_TITLE_HEIGHT / 2;
 }
 
 /** Compose the menu items for the current page. */
-export function pauseMenuItems(page: PauseMenuPage, ctx: PauseMenuRenderContext): PauseMenuItem[] {
+export function pauseMenuItems(
+  page: PauseMenuPage,
+  ctx: PauseMenuRenderContext,
+  layout: LayoutContext,
+): PauseMenuItem[] {
   if (page === 'main') {
     const labels: Array<{ id: PauseMenuItemId; label: string; enabled: boolean }> = [
       { id: 'resume', label: 'Resume', enabled: true },
@@ -151,7 +158,7 @@ export function pauseMenuItems(page: PauseMenuPage, ctx: PauseMenuRenderContext)
     if (ctx.quitAndSurveyEnabled) {
       labels.push({ id: 'quit-and-survey', label: 'Quit & feedback', enabled: true });
     }
-    const rects = stackRects(labels.length);
+    const rects = stackRects(labels.length, layout);
     return labels.map((l, i) => ({
       id: l.id,
       label: l.label,
@@ -186,7 +193,7 @@ export function pauseMenuItems(page: PauseMenuPage, ctx: PauseMenuRenderContext)
     },
     { id: 'back', label: '<  Back', enabled: true },
   ];
-  const rects = stackRects(labels.length);
+  const rects = stackRects(labels.length, layout);
   return labels.map((l, i) => ({
     id: l.id,
     label: l.label,

--- a/src/render/save-load-dialog-layout.test.ts
+++ b/src/render/save-load-dialog-layout.test.ts
@@ -1,17 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import {
-  saveLoadDialogItems,
+  saveLoadDialogItems as saveLoadDialogItemsAt,
   formatSaveInfoLine,
   formatSaveTime,
   dialogTitle,
   firstButtonY,
   itemAt,
-  CANVAS_W,
   DIALOG_BUTTON_W,
   DIALOG_BUTTON_H,
   DIALOG_BUTTON_GAP,
   type SaveLoadDialogContext,
 } from './save-load-dialog-layout.js';
+import { DEFAULT_LAYOUT, createLayoutContext } from './layout.js';
+import { CANVAS_W } from './sprites.js';
 import type { SaveInfo } from '../platform/save.js';
 
 const baseCtx: SaveLoadDialogContext = {
@@ -19,6 +20,11 @@ const baseCtx: SaveLoadDialogContext = {
   hasIncompatibleSave: false,
   confirming: { delete: false, newGame: false },
 };
+
+// Issue #213: saveLoadDialogItems now takes a LayoutContext. Bind the fixed
+// default layout (800×592) so the existing parity assertions are unchanged; the
+// seam describe at the bottom exercises a non-default LayoutContext.
+const saveLoadDialogItems = (c: SaveLoadDialogContext) => saveLoadDialogItemsAt(c, DEFAULT_LAYOUT);
 
 describe('saveLoadDialogItems', () => {
   it('returns 5 items in the documented order', () => {
@@ -108,6 +114,15 @@ describe('saveLoadDialogItems', () => {
   it('first button starts at firstButtonY()', () => {
     const items = saveLoadDialogItems(baseCtx);
     expect(items[0]!.rect.y).toBe(firstButtonY());
+  });
+});
+
+describe('saveLoadDialogItems — LayoutContext seam (issue #213)', () => {
+  it('horizontally centers the buttons on the passed layout width, not a fixed 800', () => {
+    const wide = createLayoutContext(1000, 700);
+    for (const i of saveLoadDialogItemsAt(baseCtx, wide)) {
+      expect(i.rect.x + i.rect.w / 2).toBeCloseTo(wide.w / 2, 5);
+    }
   });
 });
 

--- a/src/render/save-load-dialog-layout.ts
+++ b/src/render/save-load-dialog-layout.ts
@@ -17,13 +17,15 @@
 //   - back       — close the dialog, return to the pause menu (no game changes)
 
 import type { SaveInfo } from '../platform/save.js';
+import type { LayoutContext } from './layout.js';
 
 // ---------------------------------------------------------------------------
-// Geometry constants (canvas-local pixels — 800 × 592)
+// Geometry constants (canvas-local pixels)
+//
+// Button sizes/gaps and the title/info anchors are canvas-INDEPENDENT and stay
+// constants; the canvas-relative centering (buttonRects) derives from the
+// LayoutContext passed in (issue #213). No local CANVAS_W/CANVAS_H.
 // ---------------------------------------------------------------------------
-
-export const CANVAS_W = 800;
-export const CANVAS_H = 592;
 
 export const DIALOG_BUTTON_W = 280;
 export const DIALOG_BUTTON_H = 36;
@@ -79,8 +81,8 @@ export interface SaveLoadDialogContext {
 // Layout
 // ---------------------------------------------------------------------------
 
-function buttonRects(buttonCount: number, firstY: number): DialogItemRect[] {
-  const x = (CANVAS_W - DIALOG_BUTTON_W) / 2;
+function buttonRects(buttonCount: number, firstY: number, layout: LayoutContext): DialogItemRect[] {
+  const x = (layout.w - DIALOG_BUTTON_W) / 2;
   const rects: DialogItemRect[] = [];
   for (let i = 0; i < buttonCount; i++) {
     rects.push({
@@ -99,7 +101,10 @@ export function firstButtonY(): number {
 }
 
 /** Compose the dialog items. Order is fixed; enabled flags reflect ctx. */
-export function saveLoadDialogItems(ctx: SaveLoadDialogContext): SaveLoadDialogItem[] {
+export function saveLoadDialogItems(
+  ctx: SaveLoadDialogContext,
+  layout: LayoutContext,
+): SaveLoadDialogItem[] {
   const saveExists = ctx.hasCompatibleSave;
   const items: Array<{
     id: SaveLoadDialogItemId;
@@ -143,7 +148,7 @@ export function saveLoadDialogItems(ctx: SaveLoadDialogContext): SaveLoadDialogI
       confirming: false,
     },
   ];
-  const rects = buttonRects(items.length, firstButtonY());
+  const rects = buttonRects(items.length, firstButtonY(), layout);
   return items.map((it, i) => ({ ...it, rect: rects[i]! }));
 }
 

--- a/src/render/survey-overlay-layout.test.ts
+++ b/src/render/survey-overlay-layout.test.ts
@@ -7,17 +7,30 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-  surveyRatingButtons,
-  surveyHitTest,
-  surveyConfirmationHitTest,
-  SURVEY_CANVAS_W,
-  SURVEY_SUBMIT_BUTTON_RECT,
-  SURVEY_SKIP_BUTTON_RECT,
+  surveyRatingButtons as surveyRatingButtonsAt,
+  surveyHitTest as surveyHitTestAt,
+  surveyConfirmationHitTest as surveyConfirmationHitTestAt,
+  surveySubmitButtonRect,
+  surveySkipButtonRect,
+  surveyFreeTextRect,
   SURVEY_BROKEN_CHECKBOX_RECT,
   SURVEY_UPLOAD_CHECKBOX_RECT,
-  SURVEY_FREE_TEXT_RECT,
   SURVEY_CONSENT_DISCLOSURE,
 } from './survey-overlay-layout.js';
+import { DEFAULT_LAYOUT, createLayoutContext } from './layout.js';
+
+// Issue #213: the overlay geometry is now a function of a LayoutContext. Bind the
+// fixed default layout (800×592) and evaluate the rect helpers to constants so
+// the existing parity assertions are unchanged. The seam describe at the bottom
+// proves the geometry responds to a different layout.
+const L = DEFAULT_LAYOUT;
+const surveyRatingButtons = () => surveyRatingButtonsAt(L);
+const surveyHitTest = (px: number, py: number) => surveyHitTestAt(px, py, L);
+const surveyConfirmationHitTest = (px: number, py: number) =>
+  surveyConfirmationHitTestAt(px, py, L);
+const SURVEY_SUBMIT_BUTTON_RECT = surveySubmitButtonRect(L);
+const SURVEY_SKIP_BUTTON_RECT = surveySkipButtonRect(L);
+const SURVEY_FREE_TEXT_RECT = surveyFreeTextRect(L);
 
 describe('surveyRatingButtons', () => {
   it('emits exactly five buttons numbered 1..5 in order', () => {
@@ -30,7 +43,7 @@ describe('surveyRatingButtons', () => {
     const first = btns[0]!.rect;
     const last = btns[4]!.rect;
     const leftMargin = first.x;
-    const rightMargin = SURVEY_CANVAS_W - (last.x + last.w);
+    const rightMargin = L.w - (last.x + last.w);
     // Allow a 1px slack for rounding.
     expect(Math.abs(leftMargin - rightMargin)).toBeLessThanOrEqual(1);
   });
@@ -85,7 +98,7 @@ describe('surveyHitTest — disjoint targets', () => {
   it('returns null on the panel background', () => {
     // A point in the title gap above the rating buttons should not hit
     // any interactive element.
-    expect(surveyHitTest(SURVEY_CANVAS_W / 2, 30)).toBeNull();
+    expect(surveyHitTest(L.w / 2, 30)).toBeNull();
   });
 });
 
@@ -117,5 +130,26 @@ describe('surveyConfirmationHitTest — issue #131', () => {
     expect(
       surveyConfirmationHitTest(SURVEY_SUBMIT_BUTTON_RECT.x - 10, SURVEY_SUBMIT_BUTTON_RECT.y - 10),
     ).toBeNull();
+  });
+});
+
+describe('survey layout — LayoutContext seam (issue #213)', () => {
+  it('keeps the submit/skip pair centered on a wider layout', () => {
+    const wide = createLayoutContext(1000, 700);
+    const submit = surveySubmitButtonRect(wide);
+    const skip = surveySkipButtonRect(wide);
+    // Group spans submit.x → skip.x+skip.w; its center tracks the layout center.
+    const groupCenter = (submit.x + (skip.x + skip.w)) / 2;
+    expect(groupCenter).toBeCloseTo(wide.w / 2, 5);
+  });
+
+  it('pushes the button row down on a taller layout (panel bottom follows height)', () => {
+    const tall = createLayoutContext(L.w, L.h + 200);
+    expect(surveySubmitButtonRect(tall).y).toBeGreaterThan(surveySubmitButtonRect(L).y);
+  });
+
+  it('spans the free-text + row-hit width across the layout (inset 80px each side)', () => {
+    const wide = createLayoutContext(1000, 700);
+    expect(surveyFreeTextRect(wide).w).toBe(wide.w - 160);
   });
 });

--- a/src/render/survey-overlay-layout.ts
+++ b/src/render/survey-overlay-layout.ts
@@ -5,7 +5,7 @@
 // hit-testing for the overlay so UIScene can spin up Phaser game objects
 // against fixed rects and Vitest can exercise hit-testing headlessly.
 //
-// Visual layout (canvas-local pixels, 800×592):
+// Visual layout (canvas-local pixels):
 //
 //   Title:              "Thanks for playing" / "Tell us what you think"
 //   Rating row:         five rating buttons 1..5, horizontal stack
@@ -20,14 +20,31 @@
 // overlay) or after the pause menu's "Quit & feedback" action. Layout is
 // identical between the two — only the title string differs slightly so
 // the player can tell the two paths apart (handled in UIScene at draw time).
+//
+// Issue #213 — layout discipline: canvas-relative geometry (panel bottom, full-
+// width rows, horizontally-centered button/rating groups) is a pure function of
+// a LayoutContext rather than a local SURVEY_CANVAS_W/H. Canvas-INDEPENDENT
+// anchors (the top inset, fixed row Ys, checkbox squares, button sizes) stay
+// constants — a resize only has to move the canvas-relative values.
 
-export const SURVEY_CANVAS_W = 800;
-export const SURVEY_CANVAS_H = 592;
+import type { LayoutContext } from './layout.js';
 
-/** Overall modal panel inset from the canvas edges. */
+/** Shared rect shape for the overlay's geometry helpers. */
+export interface SurveyRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Overall modal panel inset from the canvas edges. PANEL_INSET_X and the
+ *  PANEL_TOP_Y anchor are canvas-INDEPENDENT; the panel BOTTOM is inset from the
+ *  canvas bottom edge, so it derives from the LayoutContext. */
 const PANEL_INSET_X = 80;
 const PANEL_TOP_Y = 60;
-const PANEL_BOTTOM_Y = SURVEY_CANVAS_H - 60;
+function panelBottomY(layout: LayoutContext): number {
+  return layout.h - 60;
+}
 
 /** Title baseline Y — fixed offset from the panel top so the title doesn't
  *  drift when other rows resize. */
@@ -39,28 +56,38 @@ export const SURVEY_RATING_BUTTON_W = 56;
 export const SURVEY_RATING_BUTTON_H = 56;
 export const SURVEY_RATING_BUTTON_GAP = 12;
 
+/** Free-text affordance anchors. Y/H are canvas-INDEPENDENT (the checkbox rows
+ *  anchor off them); only the WIDTH spans the panel, so the rect itself is a
+ *  function of the LayoutContext — see {@link surveyFreeTextRect}. */
+export const SURVEY_FREE_TEXT_Y = SURVEY_RATING_ROW_Y + SURVEY_RATING_BUTTON_H + 30;
+export const SURVEY_FREE_TEXT_H = 100;
+
 /** Free-text input rect — a single-line affordance. DOM input element is
- *  positioned over this rect at runtime by UIScene. */
-export const SURVEY_FREE_TEXT_RECT = {
-  x: PANEL_INSET_X,
-  y: SURVEY_RATING_ROW_Y + SURVEY_RATING_BUTTON_H + 30,
-  w: SURVEY_CANVAS_W - 2 * PANEL_INSET_X,
-  h: 100,
-} as const;
+ *  positioned over this rect at runtime by UIScene. Width spans the panel
+ *  (canvas-relative), so this is derived from the LayoutContext. */
+export function surveyFreeTextRect(layout: LayoutContext): SurveyRect {
+  return {
+    x: PANEL_INSET_X,
+    y: SURVEY_FREE_TEXT_Y,
+    w: layout.w - 2 * PANEL_INSET_X,
+    h: SURVEY_FREE_TEXT_H,
+  };
+}
 
 /** Checkbox row constants — used by both the "Report as broken" and
  *  "Upload diagnostic snapshot" rows. */
 export const SURVEY_CHECKBOX_SIZE = 20;
 export const SURVEY_CHECKBOX_LABEL_GAP = 12;
 
-export const SURVEY_BROKEN_CHECKBOX_Y = SURVEY_FREE_TEXT_RECT.y + SURVEY_FREE_TEXT_RECT.h + 20;
+export const SURVEY_BROKEN_CHECKBOX_Y = SURVEY_FREE_TEXT_Y + SURVEY_FREE_TEXT_H + 20;
 export const SURVEY_UPLOAD_CHECKBOX_Y = SURVEY_BROKEN_CHECKBOX_Y + SURVEY_CHECKBOX_SIZE + 16;
 /** Two-line consent disclosure sits below the upload checkbox, indented to
  *  align with the label text. */
 export const SURVEY_CONSENT_TEXT_Y = SURVEY_UPLOAD_CHECKBOX_Y + SURVEY_CHECKBOX_SIZE + 6;
 
-/** Visible checkbox square rendered by UIScene. The clickable row hit
- *  zone is wider — see {@link SURVEY_BROKEN_ROW_HIT_RECT}. */
+/** Visible checkbox square rendered by UIScene. The clickable row hit zone is
+ *  wider — see {@link surveyBrokenRowHitRect}. Canvas-independent (fixed inset
+ *  + size). */
 export const SURVEY_BROKEN_CHECKBOX_RECT = {
   x: PANEL_INSET_X,
   y: SURVEY_BROKEN_CHECKBOX_Y,
@@ -68,8 +95,9 @@ export const SURVEY_BROKEN_CHECKBOX_RECT = {
   h: SURVEY_CHECKBOX_SIZE,
 } as const;
 
-/** Visible checkbox square rendered by UIScene. The clickable row hit
- *  zone is wider — see {@link SURVEY_UPLOAD_ROW_HIT_RECT}. */
+/** Visible checkbox square rendered by UIScene. The clickable row hit zone is
+ *  wider — see {@link surveyUploadRowHitRect}. Canvas-independent (fixed inset
+ *  + size). */
 export const SURVEY_UPLOAD_CHECKBOX_RECT = {
   x: PANEL_INSET_X,
   y: SURVEY_UPLOAD_CHECKBOX_Y,
@@ -81,47 +109,60 @@ export const SURVEY_UPLOAD_CHECKBOX_RECT = {
  *  renders a long label to the right ("Report this as a bug", "Upload
  *  diagnostic snapshot to help us debug…"). The label IS the affordance
  *  most users will aim for — especially on touch devices. These row hit
- *  rects cover the full row width so clicks on the label register as
+ *  rects cover the full panel width so clicks on the label register as
  *  checkbox toggles. The visible square is drawn off the narrower
- *  ..._CHECKBOX_RECT constants above. */
-const ROW_HIT_W = SURVEY_CANVAS_W - 2 * PANEL_INSET_X;
+ *  ..._CHECKBOX_RECT constants above. Full width is canvas-relative. */
+function rowHitWidth(layout: LayoutContext): number {
+  return layout.w - 2 * PANEL_INSET_X;
+}
 
-export const SURVEY_BROKEN_ROW_HIT_RECT = {
-  x: PANEL_INSET_X,
-  y: SURVEY_BROKEN_CHECKBOX_Y,
-  w: ROW_HIT_W,
-  h: SURVEY_CHECKBOX_SIZE,
-} as const;
+export function surveyBrokenRowHitRect(layout: LayoutContext): SurveyRect {
+  return {
+    x: PANEL_INSET_X,
+    y: SURVEY_BROKEN_CHECKBOX_Y,
+    w: rowHitWidth(layout),
+    h: SURVEY_CHECKBOX_SIZE,
+  };
+}
 
-export const SURVEY_UPLOAD_ROW_HIT_RECT = {
-  x: PANEL_INSET_X,
-  y: SURVEY_UPLOAD_CHECKBOX_Y,
-  w: ROW_HIT_W,
-  h: SURVEY_CHECKBOX_SIZE,
-} as const;
+export function surveyUploadRowHitRect(layout: LayoutContext): SurveyRect {
+  return {
+    x: PANEL_INSET_X,
+    y: SURVEY_UPLOAD_CHECKBOX_Y,
+    w: rowHitWidth(layout),
+    h: SURVEY_CHECKBOX_SIZE,
+  };
+}
 
-/** Button row at the bottom of the panel. */
+/** Button row at the bottom of the panel. Sizes/gap are canvas-independent; the
+ *  row Y (off the panel bottom) and the horizontal centering are not. */
 const BUTTON_W = 120;
 const BUTTON_H = 36;
 const BUTTON_GAP = 16;
-const BUTTON_ROW_Y = PANEL_BOTTOM_Y - BUTTON_H - 20;
+function buttonRowY(layout: LayoutContext): number {
+  return panelBottomY(layout) - BUTTON_H - 20;
+}
 
 /** Submit button — primary action, left side of the pair (centered as
  *  a 2-button group). */
-export const SURVEY_SUBMIT_BUTTON_RECT = {
-  x: SURVEY_CANVAS_W / 2 - BUTTON_W - BUTTON_GAP / 2,
-  y: BUTTON_ROW_Y,
-  w: BUTTON_W,
-  h: BUTTON_H,
-} as const;
+export function surveySubmitButtonRect(layout: LayoutContext): SurveyRect {
+  return {
+    x: layout.w / 2 - BUTTON_W - BUTTON_GAP / 2,
+    y: buttonRowY(layout),
+    w: BUTTON_W,
+    h: BUTTON_H,
+  };
+}
 
 /** Skip button — secondary action, right side. */
-export const SURVEY_SKIP_BUTTON_RECT = {
-  x: SURVEY_CANVAS_W / 2 + BUTTON_GAP / 2,
-  y: BUTTON_ROW_Y,
-  w: BUTTON_W,
-  h: BUTTON_H,
-} as const;
+export function surveySkipButtonRect(layout: LayoutContext): SurveyRect {
+  return {
+    x: layout.w / 2 + BUTTON_GAP / 2,
+    y: buttonRowY(layout),
+    w: BUTTON_W,
+    h: BUTTON_H,
+  };
+}
 
 /** Consent disclosure text. ADR 0013 §"Privacy" requires the overlay to
  *  warn the player that an upload leaks client IP + User-Agent at the edge.
@@ -136,15 +177,15 @@ export const SURVEY_CONSENT_DISCLOSURE =
 
 export interface SurveyRatingButton {
   rating: 1 | 2 | 3 | 4 | 5;
-  rect: { x: number; y: number; w: number; h: number };
+  rect: SurveyRect;
 }
 
 /** Build the five rating-button rects. Computed lazily (called once on
- *  overlay open) — the values are constant for the fixed canvas size so
+ *  overlay open) — the values are constant for a given canvas size so
  *  caching is not warranted. */
-export function surveyRatingButtons(): SurveyRatingButton[] {
+export function surveyRatingButtons(layout: LayoutContext): SurveyRatingButton[] {
   const totalW = 5 * SURVEY_RATING_BUTTON_W + 4 * SURVEY_RATING_BUTTON_GAP;
-  const startX = (SURVEY_CANVAS_W - totalW) / 2;
+  const startX = (layout.w - totalW) / 2;
   const out: SurveyRatingButton[] = [];
   for (let i = 0; i < 5; i++) {
     out.push({
@@ -164,11 +205,7 @@ export function surveyRatingButtons(): SurveyRatingButton[] {
 // Hit testing
 // ---------------------------------------------------------------------------
 
-function pointInRect(
-  px: number,
-  py: number,
-  r: { x: number; y: number; w: number; h: number },
-): boolean {
+function pointInRect(px: number, py: number, r: SurveyRect): boolean {
   return px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h;
 }
 
@@ -184,13 +221,13 @@ export type SurveyHitTarget =
 /** Topmost interactive element under the pointer, or null on background.
  *  Note: checkbox rows hit-test against the wider ROW_HIT rects so clicks
  *  on the label text register the same as clicks on the visible square. */
-export function surveyHitTest(px: number, py: number): SurveyHitTarget {
-  if (pointInRect(px, py, SURVEY_SUBMIT_BUTTON_RECT)) return { kind: 'submit' };
-  if (pointInRect(px, py, SURVEY_SKIP_BUTTON_RECT)) return { kind: 'skip' };
-  if (pointInRect(px, py, SURVEY_BROKEN_ROW_HIT_RECT)) return { kind: 'broken-checkbox' };
-  if (pointInRect(px, py, SURVEY_UPLOAD_ROW_HIT_RECT)) return { kind: 'upload-checkbox' };
-  if (pointInRect(px, py, SURVEY_FREE_TEXT_RECT)) return { kind: 'free-text' };
-  for (const btn of surveyRatingButtons()) {
+export function surveyHitTest(px: number, py: number, layout: LayoutContext): SurveyHitTarget {
+  if (pointInRect(px, py, surveySubmitButtonRect(layout))) return { kind: 'submit' };
+  if (pointInRect(px, py, surveySkipButtonRect(layout))) return { kind: 'skip' };
+  if (pointInRect(px, py, surveyBrokenRowHitRect(layout))) return { kind: 'broken-checkbox' };
+  if (pointInRect(px, py, surveyUploadRowHitRect(layout))) return { kind: 'upload-checkbox' };
+  if (pointInRect(px, py, surveyFreeTextRect(layout))) return { kind: 'free-text' };
+  for (const btn of surveyRatingButtons(layout)) {
     if (pointInRect(px, py, btn.rect)) {
       return { kind: 'rating', rating: btn.rating };
     }
@@ -203,8 +240,9 @@ export function surveyHitTest(px: number, py: number): SurveyHitTarget {
 export function surveyConfirmationHitTest(
   px: number,
   py: number,
+  layout: LayoutContext,
 ): { kind: 'new-game' } | { kind: 'retry' } | null {
-  if (pointInRect(px, py, SURVEY_SUBMIT_BUTTON_RECT)) return { kind: 'new-game' };
-  if (pointInRect(px, py, SURVEY_SKIP_BUTTON_RECT)) return { kind: 'retry' };
+  if (pointInRect(px, py, surveySubmitButtonRect(layout))) return { kind: 'new-game' };
+  if (pointInRect(px, py, surveySkipButtonRect(layout))) return { kind: 'retry' };
   return null;
 }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -230,14 +230,13 @@ import {
   sameTooltipTarget,
   type TooltipTarget,
 } from './tooltips.js';
+import { DEFAULT_LAYOUT, type LayoutContext } from './layout.js';
 import {
   pauseMenuItems,
   pageTitle,
   itemAt as pauseMenuItemAt,
   titleCenterY as pauseMenuTitleCenterY,
   nextSpeedMultiplier,
-  CANVAS_W as PAUSE_MENU_CANVAS_W,
-  CANVAS_H as PAUSE_MENU_CANVAS_H,
   type PauseMenuPage,
   type PauseMenuItem,
   type PauseMenuItemId,
@@ -254,17 +253,15 @@ import {
   type SaveLoadDialogItemId,
 } from './save-load-dialog-layout.js';
 import {
-  SURVEY_CANVAS_W,
-  SURVEY_CANVAS_H,
   SURVEY_TITLE_Y,
   SURVEY_RATING_ROW_Y,
-  SURVEY_FREE_TEXT_RECT,
+  surveyFreeTextRect,
   SURVEY_BROKEN_CHECKBOX_RECT,
   SURVEY_UPLOAD_CHECKBOX_RECT,
   SURVEY_CONSENT_TEXT_Y,
   SURVEY_CONSENT_DISCLOSURE,
-  SURVEY_SUBMIT_BUTTON_RECT,
-  SURVEY_SKIP_BUTTON_RECT,
+  surveySubmitButtonRect,
+  surveySkipButtonRect,
   SURVEY_CHECKBOX_LABEL_GAP,
   surveyRatingButtons,
   surveyHitTest,
@@ -373,6 +370,14 @@ const STATS_ROW2_Y = HUD.STATS.y + HUD_STATS_LAYOUT.row2YOffset;
 const STATS_TEXT_X = HUD.STATS.x + HUD_STATS_LAYOUT.leftTextInset;
 
 export class UIScene extends Phaser.Scene {
+  /**
+   * Issue #213 — the LayoutContext seam. All HUD/overlay geometry derives from
+   * this rather than fixed CANVAS_W/CANVAS_H or inline 800/592 literals. Fixed at
+   * the canvas size today (DEFAULT_LAYOUT = 800×592); the eventual responsive
+   * work recomputes it from the real canvas and reflows on resize.
+   */
+  private layout: LayoutContext = DEFAULT_LAYOUT;
+
   private viewState!: ViewState;
   // Lazy accessor — returns the live WorldState or undefined pre-boot.
   // GameScene stores a class-field world reference that is undefined until
@@ -1252,8 +1257,7 @@ export class UIScene extends Phaser.Scene {
   ): void {
     this.hideGameOverOverlay(); // clear any prior instance first
 
-    const W = 800;
-    const H = 592;
+    const { w: W, h: H } = this.layout;
 
     // Semi-transparent background — input-blocking to absorb clicks behind overlay.
     const bg = this.add.rectangle(W / 2, H / 2, W, H, 0x000000, 0.6);
@@ -1680,8 +1684,7 @@ export class UIScene extends Phaser.Scene {
   public showSavePromptOverlay(callbacks: { onContinue: () => void; onNewGame: () => void }): void {
     this.hideSavePromptOverlay(); // clear any prior instance first
 
-    const W = 800;
-    const H = 592;
+    const { w: W, h: H } = this.layout;
 
     // Semi-transparent background
     const bg = this.add.rectangle(W / 2, H / 2, W, H, 0x000000, 0.7);
@@ -1782,8 +1785,7 @@ export class UIScene extends Phaser.Scene {
   }): void {
     this.hideDifficultySelectOverlay();
 
-    const W = 800;
-    const H = 592;
+    const { w: W, h: H } = this.layout;
 
     const bg = this.add.rectangle(W / 2, H / 2, W, H, 0x000000, 0.75);
     bg.setInteractive();
@@ -1946,17 +1948,17 @@ export class UIScene extends Phaser.Scene {
       // callback → row hidden.
       quitAndSurveyEnabled: this.pauseMenuCallbacks?.onQuitAndSurvey !== undefined,
     };
-    const items = pauseMenuItems(page, ctx);
+    const items = pauseMenuItems(page, ctx, this.layout);
     this.pauseMenuVisibleItems = items;
 
     // Background scrim — input-blocking absorbs background clicks. Click-on-
     // background does NOT dismiss the menu (see pointerdown handler above);
     // dismissal is via Resume button or Esc key only.
     const bg = this.add.rectangle(
-      PAUSE_MENU_CANVAS_W / 2,
-      PAUSE_MENU_CANVAS_H / 2,
-      PAUSE_MENU_CANVAS_W,
-      PAUSE_MENU_CANVAS_H,
+      this.layout.w / 2,
+      this.layout.h / 2,
+      this.layout.w,
+      this.layout.h,
       0x000000,
       0.7,
     );
@@ -1966,8 +1968,8 @@ export class UIScene extends Phaser.Scene {
 
     // Title — "Paused" or "Settings" depending on page.
     const title = this.add.text(
-      PAUSE_MENU_CANVAS_W / 2,
-      pauseMenuTitleCenterY(items.length),
+      this.layout.w / 2,
+      pauseMenuTitleCenterY(items.length, this.layout),
       pageTitle(page),
       { fontSize: '32px', fontFamily: 'monospace', color: '#ffffff' },
     );
@@ -2155,17 +2157,17 @@ export class UIScene extends Phaser.Scene {
       hasIncompatibleSave: incompatible,
       confirming: { ...this.saveLoadDialogConfirming },
     };
-    const items = saveLoadDialogItems(ctx);
+    const items = saveLoadDialogItems(ctx, this.layout);
     this.saveLoadDialogVisibleItems = items;
     const info = getSaveInfo();
 
     // Background scrim — slightly darker than the pause menu so the layered
     // overlay reads as "deeper than the menu underneath."
     const bg = this.add.rectangle(
-      PAUSE_MENU_CANVAS_W / 2,
-      PAUSE_MENU_CANVAS_H / 2,
-      PAUSE_MENU_CANVAS_W,
-      PAUSE_MENU_CANVAS_H,
+      this.layout.w / 2,
+      this.layout.h / 2,
+      this.layout.w,
+      this.layout.h,
       0x000000,
       0.85,
     );
@@ -2174,7 +2176,7 @@ export class UIScene extends Phaser.Scene {
     this.saveLoadDialogGroup.push(bg);
 
     // Title
-    const title = this.add.text(PAUSE_MENU_CANVAS_W / 2, DIALOG_TITLE_Y, saveLoadDialogTitle(), {
+    const title = this.add.text(this.layout.w / 2, DIALOG_TITLE_Y, saveLoadDialogTitle(), {
       fontSize: '28px',
       fontFamily: 'monospace',
       color: '#ffffff',
@@ -2186,7 +2188,7 @@ export class UIScene extends Phaser.Scene {
     // Info line — live state of saved-game (or "no save" / "incompatible save").
     const infoLineColor = ctx.hasIncompatibleSave && info === null ? '#ffaa00' : '#aaaaaa';
     const infoLine = this.add.text(
-      PAUSE_MENU_CANVAS_W / 2,
+      this.layout.w / 2,
       DIALOG_INFO_Y,
       formatSaveInfoLine(info, ctx.hasIncompatibleSave),
       { fontSize: '13px', fontFamily: 'monospace', color: infoLineColor },
@@ -2201,7 +2203,7 @@ export class UIScene extends Phaser.Scene {
     if (this.saveLoadDialogFlash !== 'none') {
       const flashColor = this.saveLoadDialogFlash === 'saved' ? '#88ee88' : '#ff7766';
       const flashText = this.saveLoadDialogFlash === 'saved' ? 'Saved' : 'Save failed';
-      const flash = this.add.text(PAUSE_MENU_CANVAS_W / 2, DIALOG_INFO_Y + 18, flashText, {
+      const flash = this.add.text(this.layout.w / 2, DIALOG_INFO_Y + 18, flashText, {
         fontSize: '12px',
         fontFamily: 'monospace',
         color: flashColor,
@@ -2483,10 +2485,10 @@ export class UIScene extends Phaser.Scene {
 
     // Background scrim — opaque-ish so the game beneath reads as paused.
     const bg = this.add.rectangle(
-      SURVEY_CANVAS_W / 2,
-      SURVEY_CANVAS_H / 2,
-      SURVEY_CANVAS_W,
-      SURVEY_CANVAS_H,
+      this.layout.w / 2,
+      this.layout.h / 2,
+      this.layout.w,
+      this.layout.h,
       0x000000,
       0.85,
     );
@@ -2498,7 +2500,7 @@ export class UIScene extends Phaser.Scene {
     // For pause-menu-quit, show a generic "Quitting" heading.
     if (this.surveyState.quitFromPauseMenu) {
       const title = this.add.text(
-        SURVEY_CANVAS_W / 2,
+        this.layout.w / 2,
         SURVEY_TITLE_Y,
         'Quitting — tell us what you think',
         { fontSize: '22px', fontFamily: 'monospace', color: '#ffffff' },
@@ -2510,7 +2512,7 @@ export class UIScene extends Phaser.Scene {
       const { text: outcomeText, color: outcomeColor } = formatOutcomeTitle(
         this.surveyState.outcome,
       );
-      const outcomeLabel = this.add.text(SURVEY_CANVAS_W / 2, SURVEY_TITLE_Y - 5, outcomeText, {
+      const outcomeLabel = this.add.text(this.layout.w / 2, SURVEY_TITLE_Y - 5, outcomeText, {
         fontSize: '28px',
         fontFamily: 'monospace',
         color: '#' + outcomeColor.toString(16).padStart(6, '0'),
@@ -2521,7 +2523,7 @@ export class UIScene extends Phaser.Scene {
 
       const causeText = formatCauseSubtitle(this.surveyState.outcome, this.surveyState.cause);
       const secondLine = causeText !== '' ? causeText : 'Tell us what you think:';
-      const causeLabel = this.add.text(SURVEY_CANVAS_W / 2, SURVEY_TITLE_Y + 33, secondLine, {
+      const causeLabel = this.add.text(this.layout.w / 2, SURVEY_TITLE_Y + 33, secondLine, {
         fontSize: '16px',
         fontFamily: 'monospace',
         color: '#cccccc',
@@ -2533,7 +2535,7 @@ export class UIScene extends Phaser.Scene {
 
     // Rating label — clarifies what 1–5 means.
     const ratingLabel = this.add.text(
-      SURVEY_CANVAS_W / 2,
+      this.layout.w / 2,
       SURVEY_RATING_ROW_Y - 26,
       'Rate your experience (1 = poor, 5 = great)',
       { fontSize: '13px', fontFamily: 'monospace', color: '#aaaaaa' },
@@ -2544,7 +2546,7 @@ export class UIScene extends Phaser.Scene {
 
     // Rating row — five buttons. Selected button renders with a green
     // fill so the choice is visible at a glance.
-    const ratings = surveyRatingButtons();
+    const ratings = surveyRatingButtons(this.layout);
     for (const btn of ratings) {
       const selected = this.surveyState.rating === btn.rating;
       const fillColor = selected ? 0x22aa22 : 0x333333;
@@ -2565,7 +2567,7 @@ export class UIScene extends Phaser.Scene {
 
     // Free-text rect background (the actual editable surface is a DOM
     // textarea positioned over the canvas below — see ensureSurveyTextarea).
-    const ft = SURVEY_FREE_TEXT_RECT;
+    const ft = surveyFreeTextRect(this.layout);
     const ftBg = this.add.rectangle(ft.x + ft.w / 2, ft.y + ft.h / 2, ft.w, ft.h, 0x222222, 1);
     ftBg.setDepth(41);
     this.surveyGroup.push(ftBg);
@@ -2596,7 +2598,7 @@ export class UIScene extends Phaser.Scene {
         fontSize: '11px',
         fontFamily: 'monospace',
         color: '#aaaaaa',
-        wordWrap: { width: SURVEY_CANVAS_W - 2 * SURVEY_BROKEN_CHECKBOX_RECT.x },
+        wordWrap: { width: this.layout.w - 2 * SURVEY_BROKEN_CHECKBOX_RECT.x },
       },
     );
     consent.setDepth(42);
@@ -2605,8 +2607,8 @@ export class UIScene extends Phaser.Scene {
     // Submit + Skip buttons. Submit is disabled until a rating is picked
     // so the survey row always carries a 1-5 value; Skip is always live.
     const submitEnabled = this.surveyState.rating !== 0;
-    this.drawSurveyButton(SURVEY_SUBMIT_BUTTON_RECT, 'Submit', submitEnabled);
-    this.drawSurveyButton(SURVEY_SKIP_BUTTON_RECT, 'Skip', true);
+    this.drawSurveyButton(surveySubmitButtonRect(this.layout), 'Submit', submitEnabled);
+    this.drawSurveyButton(surveySkipButtonRect(this.layout), 'Skip', true);
   }
 
   /** Issue #131 — render the post-submit/skip confirmation screen. Shows a
@@ -2614,10 +2616,10 @@ export class UIScene extends Phaser.Scene {
    *  seed). The buttons reuse the Submit/Skip positions from the form phase. */
   private renderSurveyConfirmation(): void {
     const bg = this.add.rectangle(
-      SURVEY_CANVAS_W / 2,
-      SURVEY_CANVAS_H / 2,
-      SURVEY_CANVAS_W,
-      SURVEY_CANVAS_H,
+      this.layout.w / 2,
+      this.layout.h / 2,
+      this.layout.w,
+      this.layout.h,
       0x000000,
       0.85,
     );
@@ -2628,7 +2630,7 @@ export class UIScene extends Phaser.Scene {
     const resultText = this.surveyState.confirmedSubmit
       ? 'Survey submitted — thanks for playing!'
       : 'Thanks for playing!';
-    const title = this.add.text(SURVEY_CANVAS_W / 2, SURVEY_CANVAS_H / 2 - 40, resultText, {
+    const title = this.add.text(this.layout.w / 2, this.layout.h / 2 - 40, resultText, {
       fontSize: '22px',
       fontFamily: 'monospace',
       color: '#ffffff',
@@ -2637,8 +2639,8 @@ export class UIScene extends Phaser.Scene {
     title.setDepth(41);
     this.surveyGroup.push(title);
 
-    this.drawSurveyButton(SURVEY_SUBMIT_BUTTON_RECT, 'New Game', true);
-    this.drawSurveyButton(SURVEY_SKIP_BUTTON_RECT, 'Retry', true);
+    this.drawSurveyButton(surveySubmitButtonRect(this.layout), 'New Game', true);
+    this.drawSurveyButton(surveySkipButtonRect(this.layout), 'Retry', true);
   }
 
   /** Helper — draw a checkbox square + label for the survey overlay. */
@@ -2767,8 +2769,8 @@ export class UIScene extends Phaser.Scene {
     const canvas = this.game.canvas;
     if (canvas === null) return;
     const canvasRect = canvas.getBoundingClientRect();
-    const scaleX = canvasRect.width / SURVEY_CANVAS_W;
-    const scaleY = canvasRect.height / SURVEY_CANVAS_H;
+    const scaleX = canvasRect.width / this.layout.w;
+    const scaleY = canvasRect.height / this.layout.h;
     const ta = this.surveyTextarea;
     // The textarea is absolutely-positioned and sits in `document.body` or
     // in `canvas.parentElement` (see ensureSurveyTextarea). For an
@@ -2808,10 +2810,11 @@ export class UIScene extends Phaser.Scene {
       originX = canvasRect.left;
       originY = canvasRect.top;
     }
-    ta.style.left = `${originX + SURVEY_FREE_TEXT_RECT.x * scaleX}px`;
-    ta.style.top = `${originY + SURVEY_FREE_TEXT_RECT.y * scaleY}px`;
-    ta.style.width = `${SURVEY_FREE_TEXT_RECT.w * scaleX}px`;
-    ta.style.height = `${SURVEY_FREE_TEXT_RECT.h * scaleY}px`;
+    const ft = surveyFreeTextRect(this.layout);
+    ta.style.left = `${originX + ft.x * scaleX}px`;
+    ta.style.top = `${originY + ft.y * scaleY}px`;
+    ta.style.width = `${ft.w * scaleX}px`;
+    ta.style.height = `${ft.h * scaleY}px`;
   }
 
   /** Dispatch a click on the survey overlay. Called from the pointerdown
@@ -2821,7 +2824,7 @@ export class UIScene extends Phaser.Scene {
     // Issue #131 — when the confirmation screen is showing, use the
     // confirmation hit-test (New Game / Retry) instead of the form hit-test.
     if (this.surveyState.showConfirmation) {
-      const hit = surveyConfirmationHitTest(px, py);
+      const hit = surveyConfirmationHitTest(px, py, this.layout);
       if (hit === null) return;
       const cb = this.surveyCallbacks;
       this.hideSurveyOverlay();
@@ -2830,7 +2833,7 @@ export class UIScene extends Phaser.Scene {
       return;
     }
 
-    const hit = surveyHitTest(px, py);
+    const hit = surveyHitTest(px, py, this.layout);
     if (hit === null) return;
     switch (hit.kind) {
       case 'rating':


### PR DESCRIPTION
## Summary

Closes #213. Introduces a **`LayoutContext` seam** so HUD/overlay geometry stops accumulating absolute-pixel debt — making the eventual responsive/mobile work a bounded refactor instead of a 9-module scavenger hunt. **No behavior change**: the game still renders at the fixed 800×592 logical resolution.

## What changed

- **New `src/render/layout.ts`** — `LayoutContext { w, h }` + `createLayoutContext(w?, h?)` + `DEFAULT_LAYOUT` (= `CANVAS_W`×`CANVAS_H`). The convention lives in the file header.
- **Three overlay layout modules** (`pause-menu-layout`, `save-load-dialog-layout`, `survey-overlay-layout`) are now pure functions of a `LayoutContext`. Their local `CANVAS_W/H` / `SURVEY_CANVAS_W/H` are deleted; canvas-relative geometry derives from `layout.w`/`layout.h`. Survey's canvas-spanning rects (`SURVEY_FREE_TEXT_RECT`, submit/skip buttons, row-hit rects) became `(layout)` functions; canvas-independent anchors (insets, fixed row Ys, checkbox squares, button sizes) stayed constants.
- **`ui-scene.ts`** — a single `this.layout` field; the three inline `const W = 800; const H = 592;` blocks are gone; `this.layout` is threaded into every overlay layout call (~14 sites).
- **`code/AGENTS.md`** — new "Layout discipline" review-guideline codifying the rule for new layout code.

## Scope (as agreed)

Overlay layout modules only. **Intentionally left out of the seam:**
- `HUD` in `sprites.ts` stays the canonical absolute-pixel anchor table that `triangle-widget`/`minimap`/`ant-activity` derive from.
- `camera-adapter.ts` remains the single screen↔world authority owning the canvas-size dependency for projection.

**Stale-premise note:** issue step 4 (derive `VIEWPORT_*_TILES` from ctx) is already satisfied — the Stage 2 controls rework deleted the fixed tile viewport in favor of a world-pixel camera, so there's no viewport-tile duplication left to fix.

## Tests

- Existing overlay layout tests bind `DEFAULT_LAYOUT` and assert **byte-identical geometry** at 800×592 (the parity proof).
- New **seam tests** prove geometry responds to a non-default `LayoutContext` (centering tracks `layout.w`, the stack/button-row shifts with `layout.h`, free-text width spans the layout).
- New `layout.test.ts`.
- `npm run verify` green (format, eslint, tsc, lint:types, sim/asset guards, cycles, **2720 Vitest tests**, +9 new). Internal `ship-review` clean (`passed:true`, 0 findings).

Render-layer only — no `src/sim` change, no determinism exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored geometry calculations for UI overlays (pause menu, save/load dialog, survey) to use a flexible, context-driven layout system, replacing hardcoded canvas dimensions.

* **Tests**
  * Added comprehensive test coverage for the layout context infrastructure, validating overlay geometry behavior across various screen dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->