### PR TITLE
#229 — serializer completeness guard + cross-engine byte-identity proof

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/LightAxe/subterrans/issues"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.6.0"
   },
   "scripts": {
     "dev": "vite",

--- a/scripts/cross-engine-hash.ts
+++ b/scripts/cross-engine-hash.ts
@@ -1,0 +1,31 @@
+// scripts/cross-engine-hash.ts
+// #229 — Node side of the cross-engine byte-identity proof. Prints ONE line:
+//   "<seed> <ticks> <hash>"
+// The Playwright spec (tests/cross-engine-determinism.spec.ts) parses this,
+// relays the SAME (seed, ticks) to the browser harness, and compares hashes.
+//
+// Run: node --experimental-strip-types scripts/cross-engine-hash.ts
+//
+// Mirrors run-sim.ts's .js->.ts resolve hook — Node's --experimental-strip-types
+// does not remap the TypeScript .js-import convention, so we register a hook
+// before the dynamic import. Do NOT edit run-sim.ts (fixed FNDN-08 proof).
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register(
+  'data:text/javascript,' +
+    encodeURIComponent(`
+    export async function resolve(specifier, context, nextResolve) {
+      if (specifier.endsWith('.js')) {
+        const tsSpec = specifier.slice(0, -3) + '.ts';
+        try { return await nextResolve(tsSpec, context); } catch (_) {}
+      }
+      return nextResolve(specifier, context);
+    }
+  `),
+  pathToFileURL('./'),
+);
+
+// Dynamic import runs after hook registration — the .js paths inside run-canned resolve correctly.
+const { runCannedHash, CE_SEED, CE_TICKS } = await import('../tests/cross-engine/run-canned.ts');
+console.log(`${CE_SEED} ${CE_TICKS} ${runCannedHash(CE_SEED, CE_TICKS)}`);

--- a/src/platform/byte-gate.test.ts
+++ b/src/platform/byte-gate.test.ts
@@ -3,7 +3,8 @@
 //
 // Lives in platform/ (NOT sim/) because the sacred sim→platform import boundary
 // forbids a sim/ file from importing the full save serializer; platform→sim is
-// allowed, so here we get BOTH createScenario/tick AND save.ts serializeWorldState.
+// allowed, so here we get BOTH createScenario/tick AND (via world-hash.ts) the
+// save.ts serializer used by hashWorldState.
 //
 // NOT a normal-suite test: env-gated, SKIPS unless BYTE_GATE_MODE is set, so
 // `npm run verify` stays green and no golden hash is committed (PLAN.md D2 — a
@@ -22,9 +23,8 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { tick } from '../sim/tick.js';
 import { createScenario } from '../sim/scenario.js';
-import { serializeWorldState } from './save.js';
+import { hashWorldState } from './world-hash.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
-import type { WorldState } from '../sim/types.js';
 import type { SimCommand } from '../sim/commands.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
 
@@ -33,19 +33,8 @@ const FILE = process.env.BYTE_GATE_FILE ?? '';
 const CHECKPOINT_EVERY = 25; // hash cadence for first-divergence localization
 const PC = PLAYER_COLONY_ID as ColonyId;
 
-// FNV-1a over a string — fast, deterministic change-detection hash (not crypto).
-function fnv1a(s: string): string {
-  let h = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) {
-    h ^= s.charCodeAt(i);
-    h = Math.imul(h, 0x01000193);
-  }
-  return (h >>> 0).toString(16).padStart(8, '0');
-}
-
-function hashWorld(world: WorldState): string {
-  return fnv1a(JSON.stringify(serializeWorldState(world)));
-}
+// #229 — fnv1a + hashWorldState moved to world-hash.ts (shared with the
+// cross-engine determinism proof); imported above.
 
 // Fixed command schedule: dig downward (diggers + descent toward the enemy grid →
 // underground movement + invader/combat paths) and pivot the fight ratio — exercises
@@ -129,9 +118,9 @@ function runScenario(scn: Scenario): ScenarioResult {
   const checkpoints: Array<[number, string]> = [];
   for (let t = 0; t < scn.ticks; t++) {
     tick(world, scn.commands[t] ?? []);
-    if ((t + 1) % CHECKPOINT_EVERY === 0) checkpoints.push([t + 1, hashWorld(world)]);
+    if ((t + 1) % CHECKPOINT_EVERY === 0) checkpoints.push([t + 1, hashWorldState(world)]);
   }
-  return { final: hashWorld(world), checkpoints };
+  return { final: hashWorldState(world), checkpoints };
 }
 
 function firstDivergentTick(a: ScenarioResult, b: ScenarioResult): number {

--- a/src/platform/save-schema.ts
+++ b/src/platform/save-schema.ts
@@ -1,0 +1,109 @@
+/**
+ * #229 — canonical serialized-vs-transient field schema (single source of truth).
+ *
+ * These lists MIRROR the hand-written `serializeWorldState` / `serializeAnts`
+ * bodies in `save.ts` (they do NOT drive them). Their job is to let
+ * `serializer-completeness.test.ts` assert that the live struct's key set is
+ * EXACTLY partitioned into "serialized" and "deliberately transient" — so a new
+ * `WorldState` / `AntComponents` field that nobody added to either list fails a
+ * test loudly, instead of silently escaping every byte-identity assertion (the
+ * `search*` gap that determinism.test.ts:75-83 documents was exactly this class).
+ *
+ * Typed as `(keyof WorldState)[]` / `(keyof AntComponents)[]`, so a field RENAME
+ * or REMOVAL fails `tsc` here first. Placed in `platform/` (not `save.ts`) to
+ * keep the ~2,000-line serializer untouched and give the browser-run cross-engine
+ * test a lean import graph.
+ */
+import type { WorldState } from '../sim/types.js';
+import type { AntComponents } from '../sim/ant/ant-store.js';
+
+/**
+ * The 22 real `WorldState` fields `serializeWorldState` emits (save.ts:958-1010).
+ * Order is irrelevant — the completeness test compares as sets.
+ */
+export const SERIALIZED_WORLD_FIELDS: readonly (keyof WorldState)[] = [
+  'tick',
+  'rngState',
+  'nextEntityId',
+  'simVersion',
+  'difficulty',
+  'terrainSeed',
+  'commandQueue',
+  'ants',
+  'colonies',
+  'pheromoneGrids',
+  'surface',
+  'bakedSurfaceEffect',
+  'undergroundGrids',
+  'foodPiles',
+  'recentlyDepletedFood',
+  'pendingChambers',
+  'droppedCombatKillCount',
+  'droppedStructuralCount',
+  'aiState',
+  'spider',
+  'spiderPriorityColonyId',
+  'scatterReticleTile',
+];
+
+/**
+ * `WorldState` fields DELIBERATELY not serialized — each WHY verified against
+ * `types.ts` `createWorldState` / `copyWorldState` and `serializeWorldState`.
+ */
+export const TRANSIENT_WORLD_FIELDS: readonly (keyof WorldState)[] = [
+  'events', // telemetry ring; reset to [] on load, replay re-emits (types.ts:768, save.ts:974 "skip events")
+  'surfaceComponentMask', // DERIVED connectivity mask, lazily rebuilt (types.ts:760)
+  'surfaceGoalFields', // DERIVED per-target BFS cache (types.ts:761)
+  'surfaceGoalBfsScratch', // pure BFS scratch, overwritten before read (types.ts:762)
+  'pendingQueenDeathContexts', // within-tick transient, cleared every tick (types.ts:772, copyWorldState:817-819)
+];
+
+/**
+ * The 35 real `AntComponents` SoA fields covered by `serializeAnts`.
+ * `recentTilesX/Y/Head` are persisted via the packed `recentTiles` encoding, so
+ * they appear here (real struct fields), NOT `recentTiles` (a serialization key,
+ * not a struct field). `pathErr` is NOT here — #243 deleted the runtime field;
+ * `serializeAnts` still emits an all-zeros `pathErr` KEY (a write-only save
+ * vestige, save.ts:454/764), which the serializer-tie test accounts for
+ * explicitly rather than via this struct-field list.
+ */
+export const SERIALIZED_ANT_SOA_FIELDS: readonly (keyof AntComponents)[] = [
+  'posX',
+  'posY',
+  'colonyId',
+  'task',
+  'subTask',
+  'speed',
+  'foodCarrying',
+  'starvationTimer',
+  'age',
+  'alive',
+  'lifespan',
+  'zone',
+  'digTileX',
+  'digTileY',
+  'digTicksRemaining',
+  'targetPosX',
+  'targetPosY',
+  'searchWave',
+  'searchHeadingX',
+  'searchHeadingY',
+  'searchHeadingTicks',
+  'searchPrevTileX',
+  'searchPrevTileY',
+  'searchPauseTicks',
+  'currentGridColonyId',
+  'waitingDeposit',
+  'recentTilesX',
+  'recentTilesY',
+  'recentTilesHead',
+  'carryingBroodId',
+  'carriedBy',
+  'hp',
+  'homeGroundBonusHp',
+  'attackCooldown',
+  'combatOpponentId',
+];
+
+/** Every `AntComponents` field is persisted today — none deliberately transient. */
+export const TRANSIENT_ANT_FIELDS: readonly (keyof AntComponents)[] = [];

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -93,12 +93,17 @@ export const SAVE_KEY = 'subterrans:save:v3' as const;
 export const AUTOSAVE_INTERVAL_MS = 30_000 as const;
 
 export class SaveVersionMismatchError extends Error {
-  constructor(
-    public expected: number,
-    public got: number,
-  ) {
+  // #229 — explicit fields (not `constructor(public …)` parameter properties):
+  // parameter properties are unsupported by Node's strip-only TypeScript loader,
+  // and the cross-engine determinism proof runs save.ts under `node
+  // --experimental-strip-types`. Behaviour is identical (pure desugaring).
+  expected: number;
+  got: number;
+  constructor(expected: number, got: number) {
     super(`Save format version mismatch: expected ${expected}, got ${got}`);
     this.name = 'SaveVersionMismatchError';
+    this.expected = expected;
+    this.got = got;
   }
 }
 
@@ -115,12 +120,14 @@ export class SaveVersionMismatchError extends Error {
  * fresh without deleting; user can recover by upgrading the build.
  */
 export class FutureSimVersionError extends Error {
-  constructor(
-    public got: number,
-    public latest: number,
-  ) {
+  // #229 — explicit fields (see SaveVersionMismatchError): strip-only Node compat.
+  got: number;
+  latest: number;
+  constructor(got: number, latest: number) {
     super(`Save's simVersion (${got}) is newer than this build's LATEST (${latest})`);
     this.name = 'FutureSimVersionError';
+    this.got = got;
+    this.latest = latest;
   }
 }
 
@@ -161,12 +168,15 @@ export const MIN_ACCEPTED_SIM_VERSION = SIM_VERSION_V30_UNDERGROUND_EMBEDDING_GU
 export const DELIBERATE_WINDOW_BREAK_AT: number | null = null;
 
 export class OldSimVersionError extends Error {
-  constructor(public got: number | null) {
+  // #229 — explicit field (see SaveVersionMismatchError): strip-only Node compat.
+  got: number | null;
+  constructor(got: number | null) {
     const gotStr = got !== null ? String(got) : 'unknown';
     super(
       `Save is from an older version (simVersion=${gotStr}); minimum accepted is ${MIN_ACCEPTED_SIM_VERSION}. Please start a new game.`,
     );
     this.name = 'OldSimVersionError';
+    this.got = got;
   }
 }
 

--- a/src/platform/serializer-completeness.test.ts
+++ b/src/platform/serializer-completeness.test.ts
@@ -1,0 +1,96 @@
+/**
+ * #229 — serializer completeness guard.
+ *
+ * Proves the `save-schema.ts` lists EXACTLY partition the live struct keys, and
+ * that they stay tied to what `serializeWorldState` / `serializeAnts` actually
+ * emit. A new `WorldState` / `AntComponents` field that nobody serialized (and
+ * nobody deliberately allow-listed as transient) fails the struct-partition test
+ * loudly — closing the "forgotten serialized field" gap that silently omitted six
+ * `search*` fields until Phase 9 (see determinism.test.ts:75-83).
+ *
+ * This test lives in `platform/` and imports `save.ts` (same layer) + sim
+ * factories (platform is above sim) — no boundary disable needed.
+ */
+import { describe, it, expect } from 'vitest';
+import { createWorldState } from '../sim/types.js';
+import { createScenario } from '../sim/scenario.js';
+import { serializeWorldState, deserializeWorldState } from './save.js';
+import {
+  SERIALIZED_WORLD_FIELDS,
+  TRANSIENT_WORLD_FIELDS,
+  SERIALIZED_ANT_SOA_FIELDS,
+  TRANSIENT_ANT_FIELDS,
+} from './save-schema.js';
+
+// Ring fields persisted via the packed `recentTiles` key rather than as themselves.
+const RING_FIELDS = ['recentTilesX', 'recentTilesY', 'recentTilesHead'];
+
+describe('serializer completeness (#229) — struct partition', () => {
+  it('every WorldState field is serialized xor deliberately transient', () => {
+    const liveKeys = new Set(Object.keys(createWorldState(1337)));
+    const listed = new Set<string>([
+      ...(SERIALIZED_WORLD_FIELDS as readonly string[]),
+      ...(TRANSIENT_WORLD_FIELDS as readonly string[]),
+    ]);
+    // unlisted → add to serializeWorldState + SERIALIZED_WORLD_FIELDS, OR to
+    //            TRANSIENT_WORLD_FIELDS with a reason.
+    // stale    → field no longer exists on WorldState; drop it from save-schema.
+    const unlisted = [...liveKeys].filter((k) => !listed.has(k));
+    const stale = [...listed].filter((k) => !liveKeys.has(k));
+    expect({ unlisted, stale }).toEqual({ unlisted: [], stale: [] });
+  });
+
+  it('every AntComponents field is serialized xor deliberately transient', () => {
+    const liveKeys = new Set(Object.keys(createWorldState(1337).ants));
+    const listed = new Set<string>([
+      ...(SERIALIZED_ANT_SOA_FIELDS as readonly string[]),
+      ...(TRANSIENT_ANT_FIELDS as readonly string[]),
+    ]);
+    const unlisted = [...liveKeys].filter((k) => !listed.has(k));
+    const stale = [...listed].filter((k) => !liveKeys.has(k));
+    expect({ unlisted, stale }).toEqual({ unlisted: [], stale: [] });
+  });
+
+  it('serialized and transient lists are disjoint (world + ant)', () => {
+    const worldOverlap = (SERIALIZED_WORLD_FIELDS as readonly string[]).filter((f) =>
+      (TRANSIENT_WORLD_FIELDS as readonly string[]).includes(f),
+    );
+    const antOverlap = (SERIALIZED_ANT_SOA_FIELDS as readonly string[]).filter((f) =>
+      (TRANSIENT_ANT_FIELDS as readonly string[]).includes(f),
+    );
+    expect({ worldOverlap, antOverlap }).toEqual({ worldOverlap: [], antOverlap: [] });
+  });
+});
+
+describe('serializer completeness (#229) — serializer tie', () => {
+  it('serializeWorldState emits exactly SERIALIZED_WORLD_FIELDS', () => {
+    const emitted = new Set(Object.keys(serializeWorldState(createScenario(1337))));
+    const listed = new Set(SERIALIZED_WORLD_FIELDS as readonly string[]);
+    const extra = [...emitted].filter((k) => !listed.has(k));
+    const missing = [...listed].filter((k) => !emitted.has(k));
+    expect({ extra, missing }).toEqual({ extra: [], missing: [] });
+  });
+
+  it('serializeAnts emits SoA fields (ring packed) + count + the pathErr vestige', () => {
+    // Expected emitted ant keys = `count` + every SoA field EXCEPT the ring trio
+    // (persisted via the packed `recentTiles` key) + `recentTiles` + the
+    // still-emitted `pathErr` zeros vestige (#243 — a serialization key with no
+    // backing runtime field, so it is NOT in SERIALIZED_ANT_SOA_FIELDS).
+    const expected = new Set<string>([
+      'count',
+      ...(SERIALIZED_ANT_SOA_FIELDS as readonly string[]).filter((f) => !RING_FIELDS.includes(f)),
+      'recentTiles',
+      'pathErr',
+    ]);
+    const emitted = new Set(Object.keys(serializeWorldState(createScenario(1337)).ants));
+    const extra = [...emitted].filter((k) => !expected.has(k));
+    const missing = [...expected].filter((k) => !emitted.has(k));
+    expect({ extra, missing }).toEqual({ extra: [], missing: [] });
+  });
+
+  it('every serialized world field survives a serialize→deserialize round-trip', () => {
+    const restored = deserializeWorldState(serializeWorldState(createScenario(1337)));
+    const missing = (SERIALIZED_WORLD_FIELDS as readonly string[]).filter((f) => !(f in restored));
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/platform/serializer-completeness.test.ts
+++ b/src/platform/serializer-completeness.test.ts
@@ -26,6 +26,11 @@ import {
 const RING_FIELDS = ['recentTilesX', 'recentTilesY', 'recentTilesHead'];
 
 describe('serializer completeness (#229) — struct partition', () => {
+  // NOTE: this partitions the RUNTIME keys via Object.keys(createWorldState/.ants).
+  // An OPTIONAL field (`foo?: T`) that the factory leaves unassigned would not
+  // appear in Object.keys and would silently dodge this guard — so every field must
+  // be assigned by createWorldState/createAntComponents (even to `undefined`).
+  // WorldState + AntComponents have ZERO optional fields today; keep it that way.
   it('every WorldState field is serialized xor deliberately transient', () => {
     const liveKeys = new Set(Object.keys(createWorldState(1337)));
     const listed = new Set<string>([

--- a/src/platform/world-hash.ts
+++ b/src/platform/world-hash.ts
@@ -1,0 +1,24 @@
+/**
+ * #229 — shared deterministic world-state hash, extracted from byte-gate.test.ts
+ * so the same hasher is reused by the env-gated byte gate AND the cross-engine
+ * (Node vs headless Chromium) determinism proof. Sim-only import graph (types +
+ * save) so it loads under bare `node --experimental-strip-types` and under Vite
+ * in the browser — do NOT add `import.meta` / Vite-only syntax here.
+ */
+import type { WorldState } from '../sim/types.js';
+import { serializeWorldState } from './save.js';
+
+/** FNV-1a over a string — fast, deterministic change-detection hash (not crypto). */
+export function fnv1a(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+/** Deterministic content hash of a world's serialized state (8 hex chars). */
+export function hashWorldState(world: WorldState): string {
+  return fnv1a(JSON.stringify(serializeWorldState(world)));
+}

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -39,68 +39,32 @@ import type { WorldState } from './types.js';
 import type { SimCommand } from './commands.js';
 import type { ColonyId } from './colony/colony-store.js';
 import { createScenario } from './scenario.js';
+// eslint-disable-next-line no-restricted-imports -- #229: this SCEN-06 serializer consumes the canonical serialized-field list from the platform layer (same pattern as telemetry.test.ts:8)
+import { SERIALIZED_ANT_SOA_FIELDS } from '../platform/save-schema.js';
 
 // ---------------------------------------------------------------------------
 // Helper: deterministic serialization
 // ---------------------------------------------------------------------------
 
 function serializeWorldState(w: WorldState): string {
+  // #229 — list-driven ant block: the serialized SoA columns come from the
+  // canonical schema (save-schema.ts) so a newly-added persisted ant field
+  // cannot silently escape this SCEN-06 byte-identity compare. Coverage-identical
+  // to the prior hand-rolled literal — SERIALIZED_ANT_SOA_FIELDS is exactly the
+  // 35 fields it enumerated (incl. recentTilesX/Y/Head raw); only key ORDER in
+  // the emitted string changes, which is irrelevant to the same-serializer
+  // self-compare (r1===r2, r1!==r3).
+  const antsOut: Record<string, number[]> = {};
+  for (const f of SERIALIZED_ANT_SOA_FIELDS) {
+    antsOut[f] = Array.from(w.ants[f] as ArrayLike<number>);
+  }
   return JSON.stringify({
     tick: w.tick,
     rngState: w.rngState,
     nextEntityId: w.nextEntityId,
     simVersion: w.simVersion,
     commandQueue: w.commandQueue.map((c) => ({ ...c })),
-    ants: {
-      posX: Array.from(w.ants.posX),
-      posY: Array.from(w.ants.posY),
-      alive: Array.from(w.ants.alive),
-      age: Array.from(w.ants.age),
-      task: Array.from(w.ants.task),
-      subTask: Array.from(w.ants.subTask),
-      speed: Array.from(w.ants.speed),
-      lifespan: Array.from(w.ants.lifespan),
-      colonyId: Array.from(w.ants.colonyId),
-      foodCarrying: Array.from(w.ants.foodCarrying),
-      starvationTimer: Array.from(w.ants.starvationTimer),
-      // Phase 7 ant fields:
-      zone: Array.from(w.ants.zone),
-      digTileX: Array.from(w.ants.digTileX),
-      digTileY: Array.from(w.ants.digTileY),
-      digTicksRemaining: Array.from(w.ants.digTicksRemaining),
-      targetPosX: Array.from(w.ants.targetPosX),
-      targetPosY: Array.from(w.ants.targetPosY),
-      // Phase 09.1 Chunk 0 — grid-of-occupancy byte (new SoA field).
-      currentGridColonyId: Array.from(w.ants.currentGridColonyId),
-      // Phase 9 — 6 previously-omitted SoA fields (pre-existing serializer
-      // gap closed here per 09.1-00-PLAN). If closure surfaces a latent
-      // non-deterministic divergence in one of these fields, revert ONLY the
-      // 6 search* lines and document in 09.1-MEMO.md §5 Deviations Log.
-      searchWave: Array.from(w.ants.searchWave),
-      searchHeadingX: Array.from(w.ants.searchHeadingX),
-      searchHeadingY: Array.from(w.ants.searchHeadingY),
-      searchHeadingTicks: Array.from(w.ants.searchHeadingTicks),
-      searchPrevTileX: Array.from(w.ants.searchPrevTileX),
-      searchPrevTileY: Array.from(w.ants.searchPrevTileY),
-      // Issue #27 — carrier wait flag (new SoA field). Must round-trip in
-      // determinism asserts so a divergence in wait-state would break the
-      // byte-identical compare.
-      waitingDeposit: Array.from(w.ants.waitingDeposit),
-      // Issue #35 — pause counter. Divergence changes future tick output, so the
-      // determinism compare must include it.
-      searchPauseTicks: Array.from(w.ants.searchPauseTicks),
-      // Phase 9 / S3 combat fields — spider writes these every tick; omitting
-      // them would silently pass even if resolveSpiderCombatOnTile diverges.
-      hp: Array.from(w.ants.hp),
-      homeGroundBonusHp: Array.from(w.ants.homeGroundBonusHp),
-      attackCooldown: Array.from(w.ants.attackCooldown),
-      combatOpponentId: Array.from(w.ants.combatOpponentId),
-      carryingBroodId: Array.from(w.ants.carryingBroodId),
-      carriedBy: Array.from(w.ants.carriedBy),
-      recentTilesX: Array.from(w.ants.recentTilesX),
-      recentTilesY: Array.from(w.ants.recentTilesY),
-      recentTilesHead: Array.from(w.ants.recentTilesHead),
-    },
+    ants: antsOut,
     colonies: Object.keys(w.colonies)
       .sort()
       .reduce(

--- a/tests/cross-engine-determinism.spec.ts
+++ b/tests/cross-engine-determinism.spec.ts
@@ -5,6 +5,13 @@
  * is the only gate that compares a Node-run sim to a headless-Chromium-run sim
  * for the same (seed, script) — and cross-engine byte identity is the single
  * load-bearing assumption of Phase 7 lockstep (and Phase 6 mobile Safari/WebView).
+ *
+ * SCOPE: this covers the Node(V8) <-> Chromium(V8) axis — transform-vs-loader,
+ * embedder, and future V8-version drift. The JSC/WebKit axis (iOS Safari /
+ * WKWebView, the actual Phase-6 target) is NOT yet exercised here — tracked as a
+ * follow-up (#254); the harness is engine-agnostic, so it only needs a Playwright
+ * `webkit` project + a CI browser install.
+ *
  * Auto-matched by testMatch:/.*\.spec\.ts/ — runs in the existing e2e job.
  */
 import { test, expect } from '@playwright/test';

--- a/tests/cross-engine-determinism.spec.ts
+++ b/tests/cross-engine-determinism.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * #229 — cross-engine determinism proof.
+ *
+ * Every existing byte-identity test runs two worlds inside ONE Node process. This
+ * is the only gate that compares a Node-run sim to a headless-Chromium-run sim
+ * for the same (seed, script) — and cross-engine byte identity is the single
+ * load-bearing assumption of Phase 7 lockstep (and Phase 6 mobile Safari/WebView).
+ * Auto-matched by testMatch:/.*\.spec\.ts/ — runs in the existing e2e job.
+ */
+import { test, expect } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+
+test('Node and headless Chromium produce byte-identical sim state for the canned scenario', async ({
+  page,
+}) => {
+  // --- Node side: run the canned scenario under bare `node --experimental-strip-types`.
+  // The script owns the canonical (seed, ticks) and prints "<seed> <ticks> <hash>".
+  const nodeOut = execFileSync(
+    'node',
+    ['--experimental-strip-types', 'scripts/cross-engine-hash.ts'],
+    {
+      encoding: 'utf8',
+    },
+  ).trim();
+  const [seedStr, ticksStr, nodeHash] = nodeOut.split(/\s+/);
+  const seed = Number(seedStr);
+  const ticks = Number(ticksStr);
+  expect(Number.isInteger(seed), `bad seed from node script: "${nodeOut}"`).toBe(true);
+  expect(Number.isInteger(ticks), `bad ticks from node script: "${nodeOut}"`).toBe(true);
+  expect(nodeHash).toMatch(/^[0-9a-f]{8}$/);
+  expect(nodeHash).not.toBe('00000000');
+
+  // --- Browser side: same scenario via the Vite-served harness, invoked with the
+  // SAME (seed, ticks) the Node script used, so any divergence is engine-attributable.
+  await page.goto('/tests/cross-engine/harness.html');
+  await page.waitForFunction(
+    () => typeof (window as unknown as { __simHash?: unknown }).__simHash === 'function',
+  );
+  const browserHash = await page.evaluate(
+    ([s, t]) =>
+      (window as unknown as { __simHash: (a: number, b: number) => string }).__simHash(s, t),
+    [seed, ticks] as [number, number],
+  );
+
+  expect(browserHash, 'Node hash !== Chromium hash — engine-dependent nondeterminism').toBe(
+    nodeHash,
+  );
+});

--- a/tests/cross-engine/harness-entry.ts
+++ b/tests/cross-engine/harness-entry.ts
@@ -1,0 +1,17 @@
+/**
+ * #229 — browser entry for the cross-engine determinism harness. Vite transforms
+ * this .ts on the fly when harness.html loads and exposes the canned-scenario
+ * hasher on `window`, so the Playwright spec can invoke it via page.evaluate and
+ * compare against the Node-computed hash.
+ */
+import { runCannedHash } from './run-canned.js';
+
+declare global {
+  interface Window {
+    __simHash?: (seed: number, ticks: number) => string;
+  }
+}
+
+window.__simHash = (seed: number, ticks: number): string => runCannedHash(seed, ticks);
+
+export {};

--- a/tests/cross-engine/harness.html
+++ b/tests/cross-engine/harness.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>cross-engine determinism harness (#229)</title>
+  </head>
+  <body>
+    <!-- Vite serves this at /tests/cross-engine/harness.html and transforms the .ts entry
+         on the fly. harness-entry.ts sets window.__simHash for the Playwright spec. -->
+    <script type="module" src="./harness-entry.ts"></script>
+  </body>
+</html>

--- a/tests/cross-engine/run-canned.ts
+++ b/tests/cross-engine/run-canned.ts
@@ -1,0 +1,52 @@
+/**
+ * #229 — the single canned scenario BOTH engines run for the cross-engine
+ * byte-identity proof (Node via scripts/cross-engine-hash.ts, headless Chromium
+ * via harness.html). Sim-only import graph so it loads under bare
+ * `node --experimental-strip-types` AND under Vite in the browser — do NOT add
+ * `import.meta` or any Vite-only syntax here (the whole point is engine-agnostic
+ * execution).
+ */
+import { createScenario } from '../../src/sim/scenario.js';
+import { tick } from '../../src/sim/tick.js';
+import { hashWorldState } from '../../src/platform/world-hash.js';
+import { PLAYER_COLONY_ID } from '../../src/sim/constants.js';
+import type { ColonyId } from '../../src/sim/colony/colony-store.js';
+import type { SimCommand } from '../../src/sim/commands.js';
+
+/** Pinned tuple — both engines must run this exact (seed, ticks). */
+export const CE_SEED = 1337;
+export const CE_TICKS = 3000;
+
+const PC = PLAYER_COLONY_ID as ColonyId;
+
+/**
+ * Fixed command script (byte-gate `digFightScript` shape): diggers + descent
+ * toward the enemy grid, a fight-ratio pivot (combat paths), and a surface rally
+ * — so the run exercises the movement / dig / combat-targeting / foraging
+ * clusters, not just passive idling. Deterministic; no Math.random / wall-clock.
+ */
+function cannedScript(): SimCommand[][] {
+  const c: SimCommand[][] = [];
+  c[0] = [{ type: 'MarkDigTile', colonyId: PC, tileX: 24, tileY: 2, issuedAtTick: 0 }];
+  c[5] = [{ type: 'MarkDigTile', colonyId: PC, tileX: 24, tileY: 6, issuedAtTick: 5 }];
+  c[10] = [{ type: 'MarkDigTile', colonyId: PC, tileX: 24, tileY: 12, issuedAtTick: 10 }];
+  c[20] = [{ type: 'MarkDigTile', colonyId: PC, tileX: 30, tileY: 18, issuedAtTick: 20 }];
+  c[40] = [
+    { type: 'SetBehaviorRatio', colonyId: PC, ratio: { forage: 5, fight: 5 }, issuedAtTick: 40 },
+  ];
+  c[60] = [{ type: 'SetRallyPoint', colonyId: PC, tileX: 30, tileY: 20, issuedAtTick: 60 }];
+  c[200] = [
+    { type: 'SetBehaviorRatio', colonyId: PC, ratio: { forage: 2, fight: 8 }, issuedAtTick: 200 },
+  ];
+  return c;
+}
+
+/** Build the canned world, tick `ticks` times feeding the fixed script, return the 8-hex state hash. */
+export function runCannedHash(seed: number, ticks: number): string {
+  const world = createScenario(seed);
+  const script = cannedScript();
+  for (let t = 0; t < ticks; t++) {
+    tick(world, script[t] ?? []);
+  }
+  return hashWorldState(world);
+}


### PR DESCRIPTION
**Wave C · C1 · PR-1** (arch-review Phase-7 pre-work). Closes #229.

Two independent halves, both **sim-trajectory byte-identical, no simVersion / SAVE_FORMAT_VERSION bump**. Detailed design in the [#229 comment](https://github.com/LightAxe/subterrans/issues/229); this PR follows it with two corrections noted below.

## 1. Serializer completeness guard
- **`save-schema.ts`** — single-source-of-truth `SERIALIZED_*` / `TRANSIENT_*` field lists, typed `keyof WorldState` / `keyof AntComponents` (a rename/removal fails `tsc`).
- **`serializer-completeness.test.ts`** — asserts the live struct key sets are *exactly* partitioned into serialized-vs-transient, and stay tied to what `serializeWorldState`/`serializeAnts` actually emit. A new persisted field nobody serialized now fails loudly (the gap that silently dropped six `search*` fields until Phase 9).
- **`determinism.test.ts`** — the hand-rolled ant block becomes list-driven from the schema (coverage-identical; only key order changes, irrelevant to the same-serializer self-compare).

## 2. Cross-engine byte-identity proof
- Node (`node --experimental-strip-types`) vs headless Chromium (Vite + Playwright) run the **same canned scenario** (3000 ticks, dig/fight/rally script) and must hash **identically** — the first gate that compares two *engines*, not two runs in one process. This is the load-bearing assumption of Phase 7 lockstep + Phase 6 WebView.
- `fnv1a`+`hashWorldState` extracted to **`world-hash.ts`** (byte-gate now imports it).

## Two corrections vs the issue spec (surfaced by the Wave-C plan / build)
- **`pathErr`**: the spec assumed #243 would *delete* it. Reality: the runtime field is gone but `save.ts` still emits an all-zeros `pathErr` **key**. So it's dropped from `SERIALIZED_ANT_SOA_FIELDS` **and** the serializer-tie assertion special-cases the still-emitted vestige key.
- **`save.ts` strip-compat**: the spec assumed `--experimental-strip-types` would just work, but `save.ts`'s three typed-error classes used `constructor(public …)` **parameter properties**, which strip-only Node can't parse. Converted to explicit-field desugaring — behaviour-identical (`save.test.ts` 182 green).

## Evidence
- `npm run verify` green — **2760 passed | 1 skipped** (+7 completeness tests).
- `npm run test:e2e -- tests/cross-engine-determinism.spec.ts` green (Node hash === Chromium hash).
- byte-gate capture→verify round-trips after the hasher extraction.

## simVersion
None. No serialized shape change, no RNG path touched. `MIN_ACCEPTED`/`LATEST` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShzYQ9mtDjHeUNmte3X2i6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cross-engine determinism gate comparing Node and browser simulation hashes.
  * Introduced deterministic world-state hashing for consistent comparisons.
  * Added a serializer completeness schema and a new serializer completeness test.
* **Tests**
  * Updated determinism checks to build serialized ant data from the shared save schema.
  * Added an end-to-end cross-engine Playwright spec and browser harness for the gate.
* **Bug Fixes**
  * Improved stability of save version-mismatch error field declarations without changing error text.
* **Chores**
  * Raised the minimum required Node.js version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->