### PR TITLE
#235 — gate per-tick O(grid) rebuilds + tick-cost benchmark baseline

### DIFF
--- a/bench/tick-cost.bench.ts
+++ b/bench/tick-cost.bench.ts
@@ -15,7 +15,14 @@ import { describe, it } from 'vitest';
 import { createScenario } from '../src/sim/scenario.js';
 import { tick } from '../src/sim/tick.js';
 import { PLAYER_COLONY_ID } from '../src/sim/constants.js';
+import { createWorldState, allocateEntityId, LATEST_SIM_VERSION } from '../src/sim/types.js';
+import type { WorldState } from '../src/sim/types.js';
+import { createColonyRecord } from '../src/sim/colony/colony-store.js';
 import type { ColonyId } from '../src/sim/colony/colony-store.js';
+import { initAnt } from '../src/sim/ant/ant-store.js';
+import { createUndergroundGrid, ugSet, UndergroundTileState, Zone } from '../src/sim/terrain.js';
+import { ChamberType, AntTask } from '../src/sim/enums.js';
+import { FP_SHIFT } from '../src/sim/fixed.js';
 import type { SimCommand } from '../src/sim/commands.js';
 
 const SEED = 42;
@@ -77,5 +84,114 @@ describe('whole-sim tick-cost benchmark (#235 — informational)', () => {
     ticksPerSec('idle', idleScript);
     ticksPerSec('excavation', excavationScript);
     ticksPerSec('combat', combatScript);
+  });
+});
+
+// A brood-heavy colony (Queen chamber + Nursery + brood) — the case the #235
+// step-9 second-loop gate actually helps, since createScenario has no chambers.
+// Times the SAME world gated (normal) vs forced (broodFieldDirty=true every tick,
+// = the pre-#235 unconditional recompute) so the delta IS the gating win, with no
+// dependence on comparing against another build.
+const BROOD_CID = PLAYER_COLONY_ID as ColonyId;
+function buildBroodColony(): WorldState {
+  const world = createWorldState(1337, 256);
+  world.simVersion = LATEST_SIM_VERSION;
+  const ug = createUndergroundGrid(20, 20);
+  world.undergroundGrids[BROOD_CID] = ug;
+  for (let dy = 0; dy < 3; dy++)
+    for (let dx = 0; dx < 3; dx++) ugSet(ug, 2 + dx, 2 + dy, UndergroundTileState.Open);
+  const q = allocateEntityId(world);
+  initAnt(world.ants, q, {
+    colonyId: BROOD_CID,
+    posX: 3 << FP_SHIFT,
+    posY: 3 << FP_SHIFT,
+    speed: 0,
+    zone: Zone.Underground,
+  });
+  const c = createColonyRecord(BROOD_CID, q);
+  c.entrances = [];
+  c.rallyPoint = null;
+  c.digFlowFieldDirty = false;
+  c.foodFlowFieldDirty = false;
+  c.broodFieldDirty = false;
+  c.foodStored = 500_000;
+  world.colonies[BROOD_CID] = c;
+  c.chambers.push({
+    chamberId: 1,
+    chamberType: ChamberType.Queen,
+    foodStored: 0,
+    posX: 2 << FP_SHIFT,
+    posY: 2 << FP_SHIFT,
+    width: 3,
+    height: 3,
+  });
+  for (let dy = 0; dy < 3; dy++)
+    for (let dx = 0; dx < 3; dx++) ugSet(ug, 12 + dx, 12 + dy, UndergroundTileState.Open);
+  c.chambers.push({
+    chamberId: 2,
+    chamberType: ChamberType.Nursery,
+    foodStored: 0,
+    posX: 12 << FP_SHIFT,
+    posY: 12 << FP_SHIFT,
+    width: 3,
+    height: 3,
+  });
+  for (let x = 4; x <= 13; x++) ugSet(ug, x, 3, UndergroundTileState.Open);
+  for (let y = 3; y <= 13; y++) ugSet(ug, 13, y, UndergroundTileState.Open);
+  for (let i = 0; i < 8; i++) {
+    const id = allocateEntityId(world);
+    initAnt(world.ants, id, {
+      colonyId: BROOD_CID,
+      posX: (3 + (i % 2)) << FP_SHIFT,
+      posY: (3 + (i % 2)) << FP_SHIFT,
+      task: AntTask.Idle,
+    });
+    c.workers.push(id);
+    c.workerCount += 1;
+  }
+  for (let i = 0; i < 2; i++) {
+    const id = allocateEntityId(world);
+    initAnt(world.ants, id, {
+      colonyId: BROOD_CID,
+      posX: (10 + i) << FP_SHIFT,
+      posY: 3 << FP_SHIFT,
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
+    });
+    c.larvae.push(id);
+    c.larvaeCount += 1;
+  }
+  return world;
+}
+
+function timeBroodColony(force: boolean): number {
+  {
+    const warm = buildBroodColony();
+    for (let t = 0; t < WARMUP_TICKS; t++) tick(warm, []);
+  }
+  const world = buildBroodColony();
+  const start = performance.now();
+  for (let t = 0; t < TICKS; t++) {
+    if (force)
+      for (const key in world.colonies) {
+        if (!Object.hasOwn(world.colonies, key)) continue;
+        world.colonies[key as unknown as ColonyId]!.broodFieldDirty = true;
+      }
+    tick(world, []);
+  }
+  const elapsedMs = performance.now() - start;
+  return TICKS / (elapsedMs / 1000);
+}
+
+describe('step-9 brood-field gate win (#235 — informational)', () => {
+  it('gated vs forced (every-tick recompute) on a brood-heavy colony', () => {
+    const gated = timeBroodColony(false);
+    const forced = timeBroodColony(true);
+    const speedup = ((gated - forced) / forced) * 100;
+    // eslint-disable-next-line no-console -- bench output is the deliverable
+    console.log(
+      `[tick-cost] brood gated=${gated.toFixed(0)} forced=${forced.toFixed(0)} ticks/sec  (gate saves ${speedup.toFixed(1)}%)`,
+    );
   });
 });

--- a/bench/tick-cost.bench.ts
+++ b/bench/tick-cost.bench.ts
@@ -1,0 +1,81 @@
+// bench/tick-cost.bench.ts — whole-sim tick-cost benchmark (#235).
+//
+// Invocation: cd code && npx vitest run --config bench/vitest.bench.config.ts
+//
+// INFORMATIONAL ONLY — not run by `npm run verify` / CI (matches the #188
+// rationale: instrumented/timing runs are local-only, never CI-gated). Prints
+// ticks/sec for three whole-sim workloads at a pinned seed so the #235 gating
+// PRs (brood-field dirty-gate, step-9 rebuild split) can quantify their win:
+// run this, record idle/excavation/combat ticks/sec BEFORE and AFTER the gate,
+// paste the delta into the PR body.
+//
+// Lives outside src/sim/ so performance.now is allowed (the simSafetyConfig
+// ESLint glob does not apply here).
+import { describe, it } from 'vitest';
+import { createScenario } from '../src/sim/scenario.js';
+import { tick } from '../src/sim/tick.js';
+import { PLAYER_COLONY_ID } from '../src/sim/constants.js';
+import type { ColonyId } from '../src/sim/colony/colony-store.js';
+import type { SimCommand } from '../src/sim/commands.js';
+
+const SEED = 42;
+const TICKS = 2000;
+const WARMUP_TICKS = 200; // JIT warmup on a throwaway world
+const PC = PLAYER_COLONY_ID as ColonyId;
+
+function ticksPerSec(label: string, buildScript: () => SimCommand[][]): void {
+  // Warmup a throwaway world to let the JIT settle before timing.
+  {
+    const warm = createScenario(SEED);
+    const script = buildScript();
+    for (let t = 0; t < WARMUP_TICKS; t++) tick(warm, script[t] ?? []);
+  }
+  const world = createScenario(SEED);
+  const script = buildScript();
+  const start = performance.now();
+  for (let t = 0; t < TICKS; t++) tick(world, script[t] ?? []);
+  const elapsedMs = performance.now() - start;
+  const tps = TICKS / (elapsedMs / 1000);
+  // eslint-disable-next-line no-console -- bench output is the deliverable
+  console.log(
+    `[tick-cost] ${label.padEnd(16)} ${tps.toFixed(0).padStart(8)} ticks/sec  (${elapsedMs.toFixed(1)}ms / ${TICKS} ticks)`,
+  );
+}
+
+// idle — early-game, no player input (foraging/nursing/lifecycle only).
+function idleScript(): SimCommand[][] {
+  return [];
+}
+
+// excavation-heavy — ~10 dig marks over the first 100 ticks keeps diggers
+// churning digFlowFieldDirty (the step-9 rebuild hot path #235 PR3 narrows).
+function excavationScript(): SimCommand[][] {
+  const c: SimCommand[][] = [];
+  let t = 0;
+  for (let i = 0; i < 10; i++) {
+    const tileX = 20 + ((i * 3) % 12);
+    const tileY = 2 + i;
+    c[t] = [{ type: 'MarkDigTile', colonyId: PC, tileX, tileY, issuedAtTick: t }];
+    t += 10;
+  }
+  return c;
+}
+
+// combat-heavy — rally the player's fighters + let the ENEMY_COLONY_ID AI invade;
+// deaths exercise killAnt (the brood-field dirty trigger #235 PR2 adds).
+function combatScript(): SimCommand[][] {
+  const c: SimCommand[][] = [];
+  c[0] = [{ type: 'SetRallyPoint', colonyId: PC, tileX: 64, tileY: 64, issuedAtTick: 0 }];
+  c[20] = [
+    { type: 'SetBehaviorRatio', colonyId: PC, ratio: { forage: 3, fight: 7 }, issuedAtTick: 20 },
+  ];
+  return c;
+}
+
+describe('whole-sim tick-cost benchmark (#235 — informational)', () => {
+  it('reports ticks/sec for idle / excavation-heavy / combat-heavy workloads', () => {
+    ticksPerSec('idle', idleScript);
+    ticksPerSec('excavation', excavationScript);
+    ticksPerSec('combat', combatScript);
+  });
+});

--- a/bench/vitest.bench.config.ts
+++ b/bench/vitest.bench.config.ts
@@ -15,5 +15,9 @@ export default defineConfig({
   test: {
     include: ['bench/**/*.bench.ts'],
     environment: 'node',
+    // #235 — let tick-cost.bench.ts's console.log ticks/sec lines reach stdout
+    // (Vitest intercepts console by default). The pheromone bench uses expect(),
+    // so this only affects console-printing benches.
+    disableConsoleIntercept: true,
   },
 });

--- a/src/platform/__snapshots__/apply-commands-golden.test.ts.snap
+++ b/src/platform/__snapshots__/apply-commands-golden.test.ts.snap
@@ -59,6 +59,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > C
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -110,6 +111,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > C
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -383,6 +385,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > D
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -440,6 +443,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > D
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -713,6 +717,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > M
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -764,6 +769,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > M
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -1037,6 +1043,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > M
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -1088,6 +1095,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > M
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -1361,6 +1369,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > M
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -1412,6 +1421,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > M
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -1685,6 +1695,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > N
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -1736,6 +1747,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > N
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -2009,6 +2021,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > P
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -2060,6 +2073,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > P
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -2333,6 +2347,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > S
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -2384,6 +2399,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > S
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -2657,6 +2673,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > S
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -2708,6 +2725,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > S
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -2981,6 +2999,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > S
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -3032,6 +3051,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > S
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -3305,6 +3325,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > S
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -3356,6 +3377,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > S
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -3651,6 +3673,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > e
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -3702,6 +3725,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > e
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -3975,6 +3999,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > i
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -4026,6 +4051,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > i
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -4299,6 +4325,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > m
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -4353,6 +4380,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > m
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {
@@ -4626,6 +4654,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > u
   ],
   "colonies": {
     "1": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 1,
       "computedAllocation": {
@@ -4677,6 +4706,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > u
       ],
     },
     "2": {
+      "broodFieldDirty": false,
       "chambers": [],
       "colonyId": 2,
       "computedAllocation": {

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -813,7 +813,6 @@ function serializeColony(c: ColonyRecord): SerializedColony {
     digFlowFieldDirty: c.digFlowFieldDirty,
     foodFlowFieldDirty: c.foodFlowFieldDirty,
     broodFieldDirty: c.broodFieldDirty, // #235
-
     killCount: c.killCount,
     priorityFoodPileId: c.priorityFoodPileId,
     eggIntervalNumerator: c.eggIntervalNumerator,

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -501,6 +501,7 @@ interface SerializedColony {
   rallyPoint: { tileX: number; tileY: number } | null;
   digFlowFieldDirty: boolean;
   foodFlowFieldDirty: boolean;
+  broodFieldDirty?: boolean; // #235 — optional: absent on pre-#235 saves (deserialize defaults false)
   killCount: number;
   priorityFoodPileId: FoodPileId | null;
   eggIntervalNumerator: number;
@@ -811,6 +812,8 @@ function serializeColony(c: ColonyRecord): SerializedColony {
     rallyPoint: c.rallyPoint === null ? null : { ...c.rallyPoint },
     digFlowFieldDirty: c.digFlowFieldDirty,
     foodFlowFieldDirty: c.foodFlowFieldDirty,
+    broodFieldDirty: c.broodFieldDirty, // #235
+
     killCount: c.killCount,
     priorityFoodPileId: c.priorityFoodPileId,
     eggIntervalNumerator: c.eggIntervalNumerator,
@@ -1123,6 +1126,7 @@ function deserializeColony(s: SerializedColony): ColonyRecord {
   c.rallyPoint = s.rallyPoint === null ? null : { ...s.rallyPoint };
   c.digFlowFieldDirty = s.digFlowFieldDirty;
   c.foodFlowFieldDirty = s.foodFlowFieldDirty;
+  c.broodFieldDirty = s.broodFieldDirty ?? false; // #235 — absent on pre-#235 saves; tick-1 firstDigCompute forces recompute regardless
   c.killCount = s.killCount;
   c.priorityFoodPileId = s.priorityFoodPileId;
   c.queenLastEggTick = s.queenLastEggTick;

--- a/src/render/minimap.test.ts
+++ b/src/render/minimap.test.ts
@@ -239,6 +239,7 @@ const stubColonies: WorldState['colonies'] = {
     rallyPoint: null,
     digFlowFieldDirty: false,
     foodFlowFieldDirty: false,
+    broodFieldDirty: false,
     killCount: 0,
     priorityFoodPileId: null,
     queenLastEggTick: -300,

--- a/src/sim/ant/ant-nursing.ts
+++ b/src/sim/ant/ant-nursing.ts
@@ -200,9 +200,11 @@ export function tickNurseActions(world: WorldState, chamberFlowFields?: ChamberF
     ants.carryingBroodId[id] = broodId;
     ants.carriedBy[broodId] = id;
     ants.subTask[id] = NursingSubState.Feeding;
-    // Carried brood is no longer a pickup seed — the next per-tick
-    // recompute of the `nursing` field in tick.ts step 9 will exclude
-    // it because `carriedBy[broodId] !== -1`. No dirty flag needed.
+    // #235 — the brood just left the pickup-seed set (carried brood is excluded
+    // by carriedBy !== -1), so the pickup/deposit fields must rebuild. Formerly
+    // this was invisible because those fields recomputed unconditionally every
+    // tick; now step-9's second loop is gated on broodFieldDirty.
+    colony.broodFieldDirty = true;
     continue;
   }
 }
@@ -571,6 +573,10 @@ function depositCarriedBrood(
   // Clear both ends of the carry pointer.
   ants.carryingBroodId[nurseId] = -1;
   ants.carriedBy[broodId] = -1;
+  // #235 — the brood moved into a Nursery (changing that Nursery's fill level,
+  // which the V24 capacity-aware deposit field seeds on) and its carried state
+  // flipped; rebuild the pickup/deposit fields.
+  colony.broodFieldDirty = true;
   // S4 V21+: nurse enters Attending substate and dwells at the Nursery tile
   // for NURSE_ATTEND_DWELL_TICKS, accelerating adjacent larvae. Pre-V21:
   // carrier returns to Idle immediately; step 10a re-allocates next tick.

--- a/src/sim/ant/ant-store.ts
+++ b/src/sim/ant/ant-store.ts
@@ -482,6 +482,12 @@ export function clearRecentTiles(ants: AntComponents, id: EntityId): void {
 /**
  * Mark entity `id` as dead. O(1) — no array mutation, no swap-remove.
  * The colony-bucket system (Plan 03) handles slot reuse.
+ *
+ * TEST-ONLY today: every PRODUCTION kill routes through combat.ts `killAnt`
+ * (the 5-arg version), which also sets `colony.broodFieldDirty` (#235) so the
+ * nursing pickup/deposit fields rebuild when a brood dies or a carrier is orphaned.
+ * This bare helper does NOT flag it — do NOT route a brood/carrier death through it
+ * from production code, or the gated field would go stale.
  */
 export function killAnt(ants: AntComponents, id: EntityId): void {
   ants.alive[id] = 0;

--- a/src/sim/chamber-flow-gating.test.ts
+++ b/src/sim/chamber-flow-gating.test.ts
@@ -20,7 +20,7 @@ import { initAnt } from './ant/ant-store.js';
 import { createUndergroundGrid, ugSet, UndergroundTileState, Zone } from './terrain.js';
 import { ChamberType, AntTask } from './enums.js';
 import { FP_SHIFT } from './fixed.js';
-import { LARVA_MATURE_TICKS } from './constants.js';
+import { LARVA_MATURE_TICKS, FOOD_CHAMBER_CAPACITY } from './constants.js';
 import { tick, __getChamberFlowFieldsForTest } from './tick.js';
 import { killAnt } from './combat.js';
 import { tickFoodConsumption } from './colony/colony-system.js';
@@ -86,6 +86,22 @@ function buildBroodColony(seed: number): WorldState {
     height: 3,
   });
 
+  // FoodStorage (3x3 Open) at (5,6) — its foodStored is toggled across the
+  // isFoodChamberDepositable boundary in the loop to fire foodFlowFieldDirty, so
+  // the #235 PR3 food-decouple (food field rebuilds on food OR topology; the other
+  // five first-loop fields on topology only) is exercised.
+  for (let dy = 0; dy < 3; dy++)
+    for (let dx = 0; dx < 3; dx++) ugSet(underground, 5 + dx, 6 + dy, UndergroundTileState.Open);
+  colony.chambers.push({
+    chamberId: 3,
+    chamberType: ChamberType.FoodStorage,
+    foodStored: 0,
+    posX: 5 << FP_SHIFT,
+    posY: 6 << FP_SHIFT,
+    width: 3,
+    height: 3,
+  });
+
   // Tunnel connecting Queen (2..4,2..4) to Nursery (12..14,12..14).
   for (let x = 4; x <= 13; x++) ugSet(underground, x, 3, UndergroundTileState.Open);
   for (let y = 3; y <= 13; y++) ugSet(underground, 13, y, UndergroundTileState.Open);
@@ -138,6 +154,8 @@ function chamberFieldSig(world: WorldState): string {
     const cid = Number(key);
     parts.push(`${cid}:n:${Array.from(cff.nursing[cid] ?? []).join(',')}`);
     parts.push(`${cid}:d:${Array.from(cff.nurseDeposit[cid] ?? []).join(',')}`);
+    // #235 PR3 — the food field is not serialized, so compare it here directly.
+    parts.push(`${cid}:f:${Array.from(cff.food[cid] ?? []).join(',')}`);
   }
   return parts.join('|');
 }
@@ -152,17 +170,39 @@ describe('chamber-flow gating (#235) — gated ≡ force-recompute-every-tick', 
       const f = buildBroodColony(seed); // forced (baseline)
       const ga = g.ants;
       const gc = g.colonies[COLONY_ID]!;
+      const fc = f.colonies[COLONY_ID]!;
+      const gFood = gc.chambers.find((ch) => ch.chamberType === ChamberType.FoodStorage)!;
+      const fFood = fc.chambers.find((ch) => ch.chamberType === ChamberType.FoodStorage)!;
       let layEvents = 0;
       let carryTicks = 0;
       let gatedSkips = 0;
+      let foodFull = false;
       let prevLastEgg = gc.queenLastEggTick;
       let prevSig = chamberFieldSig(g);
       for (let t = 0; t < TICKS; t++) {
+        // Toggle the FoodStorage chamber across the depositable boundary every 40
+        // ticks, in BOTH worlds identically, and set foodFlowFieldDirty (the sole
+        // trigger of that flag in the real sim = a deposit crossing full↔not-full).
+        // This exercises PR3's food-decouple: G rebuilds ONLY the food field, F (all
+        // flags forced) rebuilds every field — the food field must still match.
+        if (t % 40 === 0) {
+          foodFull = !foodFull;
+          const fv = foodFull ? FOOD_CHAMBER_CAPACITY : 0;
+          gFood.foodStored = fv;
+          fFood.foodStored = fv;
+          gc.foodFlowFieldDirty = true;
+          fc.foodFlowFieldDirty = true;
+        }
         tick(g, []);
-        // Force every-tick recompute in F: dirty every colony BEFORE its tick.
+        // F = the full pre-#235 baseline: force EVERY first-loop + second-loop
+        // recompute (dig/food/brood dirty) before its tick, so any gate G applies
+        // that changes output would diverge here.
         for (const key in f.colonies) {
           if (!Object.hasOwn(f.colonies, key)) continue;
-          f.colonies[key as unknown as ColonyId]!.broodFieldDirty = true;
+          const c = f.colonies[key as unknown as ColonyId]!;
+          c.digFlowFieldDirty = true;
+          c.foodFlowFieldDirty = true;
+          c.broodFieldDirty = true;
         }
         tick(f, []);
 
@@ -170,7 +210,7 @@ describe('chamber-flow gating (#235) — gated ≡ force-recompute-every-tick', 
         const gSig = chamberFieldSig(g);
         if (gSig !== chamberFieldSig(f)) {
           throw new Error(
-            `seed ${seed}: chamber fields diverged at tick ${t} — missing broodFieldDirty trigger`,
+            `seed ${seed}: chamber fields (nursing/deposit/food) diverged at tick ${t} — a gated rebuild went stale (missing broodFieldDirty trigger, or the PR3 food-decouple is unsafe)`,
           );
         }
         if (serialize(g) !== serialize(f)) {

--- a/src/sim/chamber-flow-gating.test.ts
+++ b/src/sim/chamber-flow-gating.test.ts
@@ -1,0 +1,249 @@
+// chamber-flow-gating.test.ts — #235 differential gate.
+//
+// PR2 gates tick.ts step-9's SECOND loop (the every-tick nursing-pickup + V24
+// nursery-deposit O(grid) BFS rebuilds) behind ColonyRecord.broodFieldDirty. This
+// is safe ONLY IF every real input-change to those fields sets the flag. This test
+// is the proof: two worlds tick in lockstep from an identical brood-churning
+// colony — world G ticks normally (gated), world F forces broodFieldDirty=true
+// before every tick (= the pre-#235 unconditional recompute). serialize(G) must
+// equal serialize(F) every tick; a divergence means a MISSING trigger (fix the
+// trigger — never gate a divergence behind a simVersion).
+import { describe, it, expect } from 'vitest';
+import {
+  createWorldState,
+  allocateEntityId,
+  LATEST_SIM_VERSION,
+  type WorldState,
+} from './types.js';
+import { createColonyRecord, type ColonyId } from './colony/colony-store.js';
+import { initAnt } from './ant/ant-store.js';
+import { createUndergroundGrid, ugSet, UndergroundTileState, Zone } from './terrain.js';
+import { ChamberType, AntTask } from './enums.js';
+import { FP_SHIFT } from './fixed.js';
+import { LARVA_MATURE_TICKS } from './constants.js';
+import { tick, __getChamberFlowFieldsForTest } from './tick.js';
+import { killAnt } from './combat.js';
+import { tickFoodConsumption } from './colony/colony-system.js';
+import { tickLifecycleTransitions } from './colony/lifecycle-system.js';
+// eslint-disable-next-line no-restricted-imports -- #235 differential proof needs the platform serializer (telemetry.test.ts:8 pattern)
+import { serializeWorldState } from '../platform/save.js';
+
+const COLONY_ID = 1 as ColonyId;
+const MAX_TEST_ENTITIES = 256;
+
+/**
+ * A brood-churning colony: Queen chamber (queen lays on cadence) + Nursery
+ * (nurses carry+deposit) + connecting tunnel, all carved Open so the BFS fields
+ * have topology; a fed colony so laying/maturation proceed; several workers the
+ * allocator turns into nurses; a couple of seeded larvae to prime nursing. Built
+ * identically for both G and F from the same seed.
+ */
+function buildBroodColony(seed: number): WorldState {
+  const world = createWorldState(seed, MAX_TEST_ENTITIES);
+  world.simVersion = LATEST_SIM_VERSION;
+  const underground = createUndergroundGrid(20, 20);
+  world.undergroundGrids[COLONY_ID] = underground;
+
+  // Queen chamber (3x3 Open) at (2,2) + queen ant inside.
+  for (let dy = 0; dy < 3; dy++)
+    for (let dx = 0; dx < 3; dx++) ugSet(underground, 2 + dx, 2 + dy, UndergroundTileState.Open);
+  const queenId = allocateEntityId(world);
+  initAnt(world.ants, queenId, {
+    colonyId: COLONY_ID,
+    posX: 3 << FP_SHIFT,
+    posY: 3 << FP_SHIFT,
+    speed: 0,
+    zone: Zone.Underground, // egg-laying Gate 6 requires the queen Underground + inside the Queen chamber
+  });
+  const colony = createColonyRecord(COLONY_ID, queenId);
+  colony.entrances = [];
+  colony.rallyPoint = null;
+  colony.digFlowFieldDirty = false;
+  colony.foodFlowFieldDirty = false;
+  colony.broodFieldDirty = false;
+  colony.foodStored = 500_000; // plenty — queen lays, larvae feed, no starvation
+  world.colonies[COLONY_ID] = colony;
+  colony.chambers.push({
+    chamberId: 1,
+    chamberType: ChamberType.Queen,
+    foodStored: 0,
+    posX: 2 << FP_SHIFT,
+    posY: 2 << FP_SHIFT,
+    width: 3,
+    height: 3,
+  });
+
+  // Nursery (3x3 Open) at (12,12).
+  for (let dy = 0; dy < 3; dy++)
+    for (let dx = 0; dx < 3; dx++) ugSet(underground, 12 + dx, 12 + dy, UndergroundTileState.Open);
+  colony.chambers.push({
+    chamberId: 2,
+    chamberType: ChamberType.Nursery,
+    foodStored: 0,
+    posX: 12 << FP_SHIFT,
+    posY: 12 << FP_SHIFT,
+    width: 3,
+    height: 3,
+  });
+
+  // Tunnel connecting Queen (2..4,2..4) to Nursery (12..14,12..14).
+  for (let x = 4; x <= 13; x++) ugSet(underground, x, 3, UndergroundTileState.Open);
+  for (let y = 3; y <= 13; y++) ugSet(underground, 13, y, UndergroundTileState.Open);
+
+  // Workers (allocator turns some into nurses) near the Queen chamber.
+  for (let i = 0; i < 8; i++) {
+    const id = allocateEntityId(world);
+    initAnt(world.ants, id, {
+      colonyId: COLONY_ID,
+      posX: (3 + (i % 2)) << FP_SHIFT,
+      posY: (3 + (i % 2)) << FP_SHIFT,
+      task: AntTask.Idle,
+    });
+    colony.workers.push(id);
+    colony.workerCount += 1;
+  }
+
+  // Prime a couple of larvae on the tunnel outside the Nursery so nursing fires.
+  // Real brood are stationary (speed 0, Idle, Underground) — matching the queen's
+  // egg-lay initAnt; without speed 0 the movement system would drift them, which
+  // is not a real input-change and would spuriously fail the differential.
+  for (let i = 0; i < 2; i++) {
+    const id = allocateEntityId(world);
+    initAnt(world.ants, id, {
+      colonyId: COLONY_ID,
+      posX: (10 + i) << FP_SHIFT,
+      posY: 3 << FP_SHIFT,
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
+    });
+    colony.larvae.push(id);
+    colony.larvaeCount += 1;
+  }
+
+  return world;
+}
+
+function serialize(world: WorldState): string {
+  return JSON.stringify(serializeWorldState(world));
+}
+
+// Compact string of the gated chamber fields (nursing pickup + V24 deposit) for
+// every colony, so a mismatch localizes the stale-field tick before behavioral drift.
+function chamberFieldSig(world: WorldState): string {
+  const cff = __getChamberFlowFieldsForTest(world);
+  const parts: string[] = [];
+  for (const key in world.colonies) {
+    if (!Object.hasOwn(world.colonies, key)) continue;
+    const cid = Number(key);
+    parts.push(`${cid}:n:${Array.from(cff.nursing[cid] ?? []).join(',')}`);
+    parts.push(`${cid}:d:${Array.from(cff.nurseDeposit[cid] ?? []).join(',')}`);
+  }
+  return parts.join('|');
+}
+
+describe('chamber-flow gating (#235) — gated ≡ force-recompute-every-tick', () => {
+  const SEEDS = [1337, 4242, 9001];
+  const TICKS = 2000;
+
+  for (const seed of SEEDS) {
+    it(`seed ${seed}: ${TICKS} ticks of a brood-churning colony stay byte-identical`, () => {
+      const g = buildBroodColony(seed); // gated (normal)
+      const f = buildBroodColony(seed); // forced (baseline)
+      const ga = g.ants;
+      const gc = g.colonies[COLONY_ID]!;
+      let layEvents = 0;
+      let carryTicks = 0;
+      let gatedSkips = 0;
+      let prevLastEgg = gc.queenLastEggTick;
+      let prevSig = chamberFieldSig(g);
+      for (let t = 0; t < TICKS; t++) {
+        tick(g, []);
+        // Force every-tick recompute in F: dirty every colony BEFORE its tick.
+        for (const key in f.colonies) {
+          if (!Object.hasOwn(f.colonies, key)) continue;
+          f.colonies[key as unknown as ColonyId]!.broodFieldDirty = true;
+        }
+        tick(f, []);
+
+        // Field-level localizer first (pinpoints the stale tick), then full state.
+        const gSig = chamberFieldSig(g);
+        if (gSig !== chamberFieldSig(f)) {
+          throw new Error(
+            `seed ${seed}: chamber fields diverged at tick ${t} — missing broodFieldDirty trigger`,
+          );
+        }
+        if (serialize(g) !== serialize(f)) {
+          throw new Error(`seed ${seed}: world state diverged at tick ${t}`);
+        }
+
+        // Observe trigger activity (proves the run is non-vacuous) and gate action.
+        if (gc.queenLastEggTick !== prevLastEgg) {
+          layEvents++;
+          prevLastEgg = gc.queenLastEggTick;
+        }
+        if (gc.workers.some((id) => ga.carryingBroodId[id] !== -1)) carryTicks++;
+        if (gSig === prevSig) gatedSkips++; // field unchanged → the gate correctly skipped a rebuild
+        prevSig = gSig;
+      }
+      // Non-vacuity: the run actually exercised the lay + pickup/deposit triggers,
+      // AND the gate actually skipped rebuilds on the (many) no-change ticks — i.e.
+      // this proves gated-and-equal, not every-tick-recompute-and-trivially-equal.
+      expect(layEvents, 'queen never laid — egg-lay trigger unexercised').toBeGreaterThanOrEqual(2);
+      expect(
+        carryTicks,
+        'no nurse ever carried — pickup/deposit triggers unexercised',
+      ).toBeGreaterThan(0);
+      expect(
+        gatedSkips,
+        'gate never skipped a rebuild — test does not exercise gating',
+      ).toBeGreaterThan(1000);
+    }, 30_000);
+  }
+});
+
+describe('broodFieldDirty triggers (#235) — the two hardest, deterministically', () => {
+  it('a carrier carrying a brood, killed, sets broodFieldDirty', () => {
+    const world = buildBroodColony(1337);
+    const colony = world.colonies[COLONY_ID]!;
+    const ants = world.ants;
+    // Make a worker carry a larva, then clear the flag and kill the carrier.
+    const carrier = colony.workers[0]!;
+    const brood = colony.larvae[0]!;
+    ants.carryingBroodId[carrier] = brood;
+    ants.carriedBy[brood] = carrier;
+    colony.broodFieldDirty = false;
+    killAnt(world, carrier, null, null, 'Ant');
+    expect(colony.broodFieldDirty).toBe(true);
+  });
+
+  it('a larva starving to death sets broodFieldDirty', () => {
+    const world = buildBroodColony(1337);
+    const colony = world.colonies[COLONY_ID]!;
+    const ants = world.ants;
+    // Call tickFoodConsumption directly (a full tick would clear the flag in
+    // step-9's second loop after the death). No food + a 1-tick timer → death.
+    colony.foodStored = 0;
+    const larva = colony.larvae[0]!;
+    ants.starvationTimer[larva] = 1;
+    colony.broodFieldDirty = false;
+    tickFoodConsumption(world, colony);
+    expect(ants.alive[larva]).toBe(0);
+    expect(colony.broodFieldDirty).toBe(true);
+  });
+
+  it('a larva maturing to worker sets broodFieldDirty', () => {
+    const world = buildBroodColony(1337);
+    const colony = world.colonies[COLONY_ID]!;
+    const ants = world.ants;
+    // Age a larva to the brink so one lifecycle step promotes it (Nursery present
+    // → not broodFrozen). Call tickLifecycleTransitions directly (a full tick would
+    // clear the flag in step-9's second loop after the promotion).
+    const larva = colony.larvae[0]!;
+    ants.age[larva] = LARVA_MATURE_TICKS - 1;
+    colony.broodFieldDirty = false;
+    tickLifecycleTransitions(world, colony);
+    expect(colony.workers).toContain(larva);
+    expect(colony.broodFieldDirty).toBe(true);
+  });
+});

--- a/src/sim/chamber-flow-gating.test.ts
+++ b/src/sim/chamber-flow-gating.test.ts
@@ -20,10 +20,10 @@ import { initAnt } from './ant/ant-store.js';
 import { createUndergroundGrid, ugSet, UndergroundTileState, Zone } from './terrain.js';
 import { ChamberType, AntTask } from './enums.js';
 import { FP_SHIFT } from './fixed.js';
-import { LARVA_MATURE_TICKS, FOOD_CHAMBER_CAPACITY } from './constants.js';
+import { LARVA_MATURE_TICKS, FOOD_CHAMBER_CAPACITY, EGG_HATCH_TICKS } from './constants.js';
 import { tick, __getChamberFlowFieldsForTest } from './tick.js';
 import { killAnt } from './combat.js';
-import { tickFoodConsumption } from './colony/colony-system.js';
+import { tickFoodConsumption, checkPendingChambers } from './colony/colony-system.js';
 import { tickLifecycleTransitions } from './colony/lifecycle-system.js';
 // eslint-disable-next-line no-restricted-imports -- #235 differential proof needs the platform serializer (telemetry.test.ts:8 pattern)
 import { serializeWorldState } from '../platform/save.js';
@@ -135,6 +135,30 @@ function buildBroodColony(seed: number): WorldState {
     });
     colony.larvae.push(id);
     colony.larvaeCount += 1;
+  }
+
+  // Seed a few eggs on DISTINCT Queen-chamber tiles with OFF-CADENCE ages so their
+  // egg→larva hatches land on ticks that do NOT coincide with a queen lay. This
+  // breaks the lay/hatch cadence resonance that would otherwise let a lay trigger
+  // mask a missing hatch trigger, so the differential exercises the hatch reorder.
+  const eggSeeds: Array<[number, number, number]> = [
+    [2, 2, EGG_HATCH_TICKS - 137],
+    [4, 2, EGG_HATCH_TICKS - 289],
+    [2, 4, EGG_HATCH_TICKS - 431],
+  ];
+  for (const [tx, ty, age] of eggSeeds) {
+    const id = allocateEntityId(world);
+    initAnt(world.ants, id, {
+      colonyId: COLONY_ID,
+      posX: tx << FP_SHIFT,
+      posY: ty << FP_SHIFT,
+      task: AntTask.Idle,
+      speed: 0,
+      zone: Zone.Underground,
+    });
+    world.ants.age[id] = age;
+    colony.eggs.push(id);
+    colony.eggCount += 1;
   }
 
   return world;
@@ -284,6 +308,57 @@ describe('broodFieldDirty triggers (#235) — the two hardest, deterministically
     colony.broodFieldDirty = false;
     tickLifecycleTransitions(world, colony);
     expect(colony.workers).toContain(larva);
+    expect(colony.broodFieldDirty).toBe(true);
+  });
+
+  it('an egg hatching to a larva sets broodFieldDirty (seed-order reorder)', () => {
+    // The hatch swap-removes from eggs[] and appends to larvae[], reordering the
+    // pickup/deposit BFS seed enumeration — so it MUST rebuild the fields even
+    // though the brood stays on the same tile. Age an egg to the brink and step
+    // lifecycle directly (a full tick would clear the flag in step-9).
+    const world = buildBroodColony(1337);
+    const colony = world.colonies[COLONY_ID]!;
+    const ants = world.ants;
+    const eggId = allocateEntityId(world);
+    initAnt(world.ants, eggId, {
+      colonyId: COLONY_ID,
+      posX: 3 << FP_SHIFT,
+      posY: 2 << FP_SHIFT,
+      speed: 0,
+      zone: Zone.Underground,
+    });
+    ants.age[eggId] = EGG_HATCH_TICKS - 1;
+    colony.eggs.push(eggId);
+    colony.eggCount += 1;
+    colony.broodFieldDirty = false;
+    tickLifecycleTransitions(world, colony);
+    expect(colony.larvae).toContain(eggId);
+    expect(colony.broodFieldDirty).toBe(true);
+  });
+
+  it('a chamber promoting over an all-Open footprint sets broodFieldDirty', () => {
+    // PlaceChamber over already-Open tiles marks zero tiles, so step-9 consumed
+    // digFlowFieldDirty before this step-11 promotion — the new Nursery must flag
+    // broodFieldDirty here or its pickup/deposit seeds go stale. Set up a pending
+    // Nursery over a carved-Open footprint and run checkPendingChambers directly.
+    const world = buildBroodColony(1337);
+    const colony = world.colonies[COLONY_ID]!;
+    const underground = world.undergroundGrids[COLONY_ID]!;
+    // Carve a 3x3 Open footprint at (15,2) and queue a Nursery there.
+    for (let dy = 0; dy < 3; dy++)
+      for (let dx = 0; dx < 3; dx++) ugSet(underground, 15 + dx, 2 + dy, UndergroundTileState.Open);
+    world.pendingChambers['1:15:2'] = {
+      colonyId: COLONY_ID,
+      chamberType: ChamberType.Nursery,
+      anchorTileX: 15,
+      anchorTileY: 2,
+      width: 3,
+      height: 3,
+    };
+    const before = colony.chambers.length;
+    colony.broodFieldDirty = false;
+    checkPendingChambers(world);
+    expect(colony.chambers.length).toBe(before + 1);
     expect(colony.broodFieldDirty).toBe(true);
   });
 });

--- a/src/sim/colony/colony-store.ts
+++ b/src/sim/colony/colony-store.ts
@@ -147,15 +147,23 @@ export interface ColonyRecord {
    *
    *  Trigger sites (every real input-change to those fields MUST set this true):
    *    - lifecycle-system.ts   egg lay (new reclaimable seed)
+   *    - lifecycle-system.ts   egg→larva hatch (swap-remove + push REORDERS the
+   *                            eggs-then-larvae BFS seed enumeration; the flow BFS
+   *                            is first-claim-wins on equidistant tiles, so a tie
+   *                            tile's direction can flip — NOT output-inert)
    *    - lifecycle-system.ts   larva→worker promotion (brood leaves the set)
    *    - lifecycle-system.ts   worker lifespan death (defensive: carried-brood orphan)
    *    - larva-maturation.ts   larva→worker promotion (2nd promotion site)
    *    - colony-system.ts      larva starvation death
+   *    - colony-system.ts      checkPendingChambers chamber promotion (a new Nursery
+   *                            joins the seed/exclusion set; needed for the all-Open
+   *                            PlaceChamber path where no tile-flip dirties step 9)
    *    - ant-nursing.ts        nurse pickup (carriedBy set) + depositCarriedBrood
    *    - combat.ts killAnt     brood death AND carrier-death orphan
-   *  NOT triggers (output-identical): egg→larva hatch (list move, same tile/entity);
-   *  carried-brood per-tick position sync (carried brood is excluded by
-   *  isBroodReclaimable); tickDeathCleanup swap-remove (alive=0 already excluded). */
+   *  NOT triggers (output-identical): carried-brood per-tick position sync (carried
+   *  brood is excluded by isBroodReclaimable); tickDeathCleanup swap-remove of an
+   *  already-dead brood (the death that set alive=0 already flagged, and the removal
+   *  happens after that tick's step 9). */
   broodFieldDirty: boolean;
 
   /** Phase 9 / CMBT-06/07 / PRD §1a — cumulative count of enemies killed by this colony's ants.

--- a/src/sim/colony/colony-store.ts
+++ b/src/sim/colony/colony-store.ts
@@ -162,8 +162,13 @@ export interface ColonyRecord {
    *    - combat.ts killAnt     brood death AND carrier-death orphan
    *  NOT triggers (output-identical): carried-brood per-tick position sync (carried
    *  brood is excluded by isBroodReclaimable); tickDeathCleanup swap-remove of an
-   *  already-dead brood (the death that set alive=0 already flagged, and the removal
-   *  happens after that tick's step 9). */
+   *  already-dead brood. The swap-remove DOES reorder the surviving seeds (same
+   *  first-claim-wins hazard as the hatch above), but it is safe because the death
+   *  that set alive=0 already flagged and that flag is still UNCONSUMED at the first
+   *  step-9 following the reorder: starvation death flags at step 3 → cleanup reorders
+   *  at step 5 → step 9 (same tick) recomputes; combat/spider death flags at step 17
+   *  → the flag persists to T+1 where step-5 cleanup reorders and T+1 step 9 consumes
+   *  it. (killAnt itself never touches eggs[]/larvae[], only alive + carry pointers.) */
   broodFieldDirty: boolean;
 
   /** Phase 9 / CMBT-06/07 / PRD §1a — cumulative count of enemies killed by this colony's ants.

--- a/src/sim/colony/colony-store.ts
+++ b/src/sim/colony/colony-store.ts
@@ -137,6 +137,27 @@ export interface ColonyRecord {
    *  Cleared by tick.ts step 9 after recompute. Initialized to false. */
   foodFlowFieldDirty: boolean;
 
+  /** #235 — set true when any INPUT to the nursing-pickup / V24 nursery-deposit
+   *  fields changes, so tick.ts step-9's second loop can gate those every-tick
+   *  O(grid) BFS rebuilds instead of running them unconditionally. Cleared by that
+   *  loop after recompute; also forced true by the step-9 FIRST loop whenever it
+   *  recomputes (topology change / first-compute-on-load), which is what makes a
+   *  loaded world recompute on tick 1 regardless of the deserialized value.
+   *  Assigned caller-side (factory does not init), like digFlowFieldDirty.
+   *
+   *  Trigger sites (every real input-change to those fields MUST set this true):
+   *    - lifecycle-system.ts   egg lay (new reclaimable seed)
+   *    - lifecycle-system.ts   larva→worker promotion (brood leaves the set)
+   *    - lifecycle-system.ts   worker lifespan death (defensive: carried-brood orphan)
+   *    - larva-maturation.ts   larva→worker promotion (2nd promotion site)
+   *    - colony-system.ts      larva starvation death
+   *    - ant-nursing.ts        nurse pickup (carriedBy set) + depositCarriedBrood
+   *    - combat.ts killAnt     brood death AND carrier-death orphan
+   *  NOT triggers (output-identical): egg→larva hatch (list move, same tile/entity);
+   *  carried-brood per-tick position sync (carried brood is excluded by
+   *  isBroodReclaimable); tickDeathCleanup swap-remove (alive=0 already excluded). */
+  broodFieldDirty: boolean;
+
   /** Phase 9 / CMBT-06/07 / PRD §1a — cumulative count of enemies killed by this colony's ants.
    *  Incremented inside combat.killAnt (Plan 02) when ants from this colony win a combat round.
    *  Initialized to 0 in createColonyRecord. Round-trips through copyWorldState + save. */
@@ -179,8 +200,9 @@ export interface ColonyRecord {
 //   colony.rallyPoint        = null;
 //   colony.digFlowFieldDirty  = false;
 //   colony.foodFlowFieldDirty = false;
+//   colony.broodFieldDirty    = false;  // #235
 // Callers: createScenario (Plan 07), copyWorldState new-colony fallback (Plan 03 Task 2),
-// deserializeColony (save.ts — defaults `foodFlowFieldDirty` to false on pre-#15 saves).
+// deserializeColony (save.ts — defaults `foodFlowFieldDirty`/`broodFieldDirty` to false on old saves).
 //
 // Default values (Phase 2 fields):
 //   - foodStored=0, workerCount=0, eggCount=0, larvaeCount=0, nurseCount=0

--- a/src/sim/colony/colony-system.ts
+++ b/src/sim/colony/colony-system.ts
@@ -630,6 +630,16 @@ export function checkPendingChambers(world: WorldState): void {
         width: pc.width,
         height: pc.height,
       });
+      // #235 — a new chamber changes the pickup/deposit field seed sets (a Nursery
+      // enters the deposit seeds + pickup's inside-Nursery exclusion). The normal
+      // dug-to-completion path is covered by the completing tile-flip's
+      // digFlowFieldDirty, but a PlaceChamber over an ALREADY-Open footprint marks
+      // zero tiles, so step-9 (step 8) already consumed digFlowFieldDirty before this
+      // step-11 promotion — nothing would recompute. Flag here so step 9 rebuilds
+      // next tick (matches the pre-#235 every-tick second loop). Set only
+      // broodFieldDirty (not digFlowFieldDirty): pre-#235 the first-loop chamber
+      // fields were likewise NOT healed on the all-Open path, so keep byte-identical.
+      colony.broodFieldDirty = true;
 
       // Remove PendingChamber by key (safe during for-in iteration — delete is allowed)
       delete world.pendingChambers[key];

--- a/src/sim/colony/colony-system.ts
+++ b/src/sim/colony/colony-system.ts
@@ -386,6 +386,7 @@ export function tickFoodConsumption(world: WorldState, colony: ColonyRecord): vo
       ants.starvationTimer[id] = timer;
       if (timer <= 0) {
         ants.alive[id] = 0;
+        colony.broodFieldDirty = true; // #235 — a larva (reclaimable seed) died
       }
     }
   }

--- a/src/sim/colony/larva-maturation.ts
+++ b/src/sim/colony/larva-maturation.ts
@@ -148,6 +148,7 @@ export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): vo
       ants.speed[larvaId] = WORKER_BASE_SPEED;
       colony.workers.push(larvaId);
       colony.workerCount += 1;
+      colony.broodFieldDirty = true; // #235 — brood left the reclaimable set (larva→worker, 2nd promotion site)
       // If a nurse was carrying this larva (Feeding state), drop the carry.
       // The new worker keeps the carrier's last position (posX/posY were synced).
       const carrierId = ants.carriedBy[larvaId]!;

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -320,6 +320,12 @@ export function tickLifecycleTransitions(world: WorldState, colony: ColonyRecord
       ants.starvationTimer[id] = STARVATION_GRACE_TICKS;
       colony.larvae.push(id);
       colony.larvaeCount += 1;
+      // #235 — the brood stays on the same tile, but the swap-remove from eggs[]
+      // and append to larvae[] REORDER the pickup/deposit BFS seed enumeration
+      // (eggs-then-larvae, array order; the flow-field BFS is first-claim-wins on
+      // equidistant tiles), so an equidistant tile's step direction can flip. NOT
+      // output-inert — the field must rebuild.
+      colony.broodFieldDirty = true;
     }
   }
 

--- a/src/sim/colony/lifecycle-system.ts
+++ b/src/sim/colony/lifecycle-system.ts
@@ -246,6 +246,7 @@ export function tickQueenEggProduction(world: WorldState, colony: ColonyRecord):
 
   colony.eggs.push(eggId);
   colony.eggCount += 1;
+  colony.broodFieldDirty = true; // #235 — new reclaimable brood seed for the pickup/deposit fields
   colony.queenLastEggTick = world.tick; // update after lay so next interval is measured from here
 }
 
@@ -354,6 +355,7 @@ export function tickLifecycleTransitions(world: WorldState, colony: ColonyRecord
       ants.speed[id] = WORKER_BASE_SPEED;
       colony.workers.push(id);
       colony.workerCount += 1;
+      colony.broodFieldDirty = true; // #235 — brood left the reclaimable set (larva→worker)
       // Issue #17 Phase 1 — if a nurse was carrying this larva when
       // it matured, drop the carry. The new worker stays at the carrier's
       // current tile (posX/posY were synced last tick); the carrier
@@ -399,6 +401,7 @@ export function tickLifecycleTransitions(world: WorldState, colony: ColonyRecord
     // Lifespan check — effectively disabled in Phase 6 (WORKER_LIFESPAN_TICKS = 0x7FFFFFFF)
     if (workerAge >= ants.lifespan[id]!) {
       ants.alive[id] = 0;
+      colony.broodFieldDirty = true; // #235 — defensive: a dying worker could be carrying brood (orphan)
       // Note: dead workers are removed on the NEXT tick's backwards iteration pass
       // (the worker remains in colony.workers until then — Plan 09 death cleanup
       // will handle immediate removal once implemented)

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -444,6 +444,13 @@ export function killAnt(
   const victimColony = world.colonies[victimColonyId];
   const isQueenVictim = victimColony !== undefined && antIndex === victimColony.queenEntityId;
 
+  // #235 — a death may remove a reclaimable brood seed (brood killed) OR orphan a
+  // carried brood (a carrier died — carry pointers cleared just above at :427-435),
+  // both of which change the pickup/deposit field seed set. Over-triggering on
+  // worker/fighter deaths is deliberate (correct + simple; deaths are rare vs the
+  // every-tick recompute this gate replaces).
+  if (victimColony !== undefined) victimColony.broodFieldDirty = true;
+
   // combat_kill is only emitted for Ant/Spider kills; Environment is reserved (no event).
   if (killerKind !== 'Environment') {
     emitEvent(world, {

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -83,6 +83,7 @@ function serializeWorldState(w: WorldState): string {
             reconcileCountdown: c.reconcileCountdown,
             killCount: c.killCount,
             digFlowFieldDirty: c.digFlowFieldDirty,
+            broodFieldDirty: c.broodFieldDirty, // #235
             eggs: [...c.eggs],
             larvae: [...c.larvae],
             workers: [...c.workers],

--- a/src/sim/scenario.ts
+++ b/src/sim/scenario.ts
@@ -213,6 +213,7 @@ function initColony(
   colony.rallyPoint = null;
   colony.digFlowFieldDirty = false;
   colony.foodFlowFieldDirty = false;
+  colony.broodFieldDirty = false; // #235
   colony.foodStored = STARTING_FOOD;
 
   // Phase 9 playability: seed each colony with one pre-excavated open entrance

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -989,82 +989,94 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
       computeDigFlowField(underground, out, queue);
     }
 
-    // Recompute entrance flow-field on the same topology-changed signal that
-    // drives dig recompute: tile state flips (Solid↔Marked↔BeingDug↔Open) and
-    // entrance designation/completion all mutate reachability through tunnels.
-    const entOut = ensureEntranceFlowField(entranceFlowFields, colony.colonyId, gridSize);
-    const entQueue = entranceFlowFields.queues[colony.colonyId]!;
-    computeEntranceFlowField(underground, colony.entrances ?? [], entOut, entQueue);
+    // #235 — split the every-recompute group. Only TOPOLOGY changes (tile flips /
+    // first-compute-on-load) affect the entrance, surface-entrance, nursing-legacy,
+    // queen, and nurseDeposit-legacy fields; foodFlowFieldDirty fires ONLY when a
+    // FoodStorage chamber crosses the full↔not-full boundary, which changes ONLY
+    // the food field's saturated-seed set (via isFoodChamberDepositable) and nothing
+    // else. So gate the five non-food computes on topology alone, and the food
+    // compute on topology OR food. Net: a food-fill-only tick rebuilds one field,
+    // not six. (Dig transitions still rebuild the chamber fields — those BFS-traverse
+    // Open+BeingDug and seed from Open tiles in chamber footprints, so a
+    // Marked→BeingDug claim genuinely changes their output; NOT decoupled here.)
+    const topologyDirty = colony.digFlowFieldDirty || firstDigCompute || firstEntranceCompute;
 
-    // Issue #63 (v11+) — surface entrance flow field. Recomputed on the
-    // same cadence as the underground entrance field. Tile features are
-    // static post-init, so the only inputs that change are the entrance
-    // list (open/closed). Recomputing every dirty cycle is generous but
-    // simple; future optimization could gate on entrance-changed-only.
-    const sfcOut = ensureSurfaceEntranceFlowField(entranceFlowFields, colony.colonyId);
-    const sfcQueue = entranceFlowFields.surfaceQueues[colony.colonyId]!;
-    computeSurfaceEntranceFlowField(world, colony.entrances ?? [], sfcOut, sfcQueue);
+    if (topologyDirty) {
+      // Recompute entrance flow-field on the topology-changed signal: tile state
+      // flips (Solid↔Marked↔BeingDug↔Open) and entrance designation/completion all
+      // mutate reachability through tunnels.
+      const entOut = ensureEntranceFlowField(entranceFlowFields, colony.colonyId, gridSize);
+      const entQueue = entranceFlowFields.queues[colony.colonyId]!;
+      computeEntranceFlowField(underground, colony.entrances ?? [], entOut, entQueue);
 
-    // Recompute chamber flow-fields on the same cycle. Chamber completion
-    // (which flips tile states from Marked/BeingDug to Open) is one of the
-    // signals that sets digFlowFieldDirty upstream, so this cadence is
-    // sufficient to keep the fields fresh. Issue #15: the food field also
-    // recomputes when foodFlowFieldDirty fires (set when a FoodStorage chamber
-    // crosses the full↔not-full boundary) so carriers redirect away from full
-    // chambers without waiting for an unrelated topology change.
+      // Issue #63 (v11+) — surface entrance flow field, same cadence as the
+      // underground entrance field. Its only inputs are topology + the entrance list.
+      const sfcOut = ensureSurfaceEntranceFlowField(entranceFlowFields, colony.colonyId);
+      const sfcQueue = entranceFlowFields.surfaceQueues[colony.colonyId]!;
+      computeSurfaceEntranceFlowField(world, colony.entrances ?? [], sfcOut, sfcQueue);
+    }
+
+    // Chamber flow-fields. ensureChamberFlowFields is idempotent (returns the cached
+    // buffers or allocates on first compute), so it is safe to call whenever the loop
+    // body runs; the individual computes below are gated.
     const chamberBufs = ensureChamberFlowFields(chamberFlowFields, colony.colonyId, gridSize);
-    computeChamberFlowField(
-      underground,
-      colony.chambers,
-      FOOD_CHAMBER_TYPES,
-      chamberBufs.food,
-      chamberBufs.queue,
-      // Issue #15 follow-up: saturated chambers (free space <
-      // FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP) must not seed the BFS — otherwise
-      // a carrier mid-traversal across a near-full chamber gets pinned by
-      // the queen-drain-then-redeposit oscillation. Shared with the deposit
-      // path in ant-system.ts via `isFoodChamberDepositable`, so seed
-      // exclusion and deposit refusal stay in lockstep.
-      isFoodChamberDepositable,
-    );
-    computeChamberFlowField(
-      underground,
-      colony.chambers,
-      NURSING_CHAMBER_TYPES,
-      chamberBufs.nursing,
-      chamberBufs.queue,
-    );
-    computeChamberFlowField(
-      underground,
-      colony.chambers,
-      QUEEN_CHAMBER_TYPES,
-      chamberBufs.queen,
-      chamberBufs.queue,
-    );
-    // Issue #17 Phase 1 — Nursery-only deposit field for v10+ carrying nurses.
-    // Pre-v10 the field is allocated but unread; computed alongside the other
-    // chamber fields for code symmetry — no measurable cost.
-    // Issue #173 (V24+): the capacity-aware deposit field is rebuilt every tick
-    // in the loop below; here we compute only the legacy nearest-seed field for
-    // pre-V24 byte-identical replay.
-    if (world.simVersion < SIM_VERSION_V24_NURSERY_CAPACITY) {
+    if (topologyDirty || colony.foodFlowFieldDirty) {
       computeChamberFlowField(
         underground,
         colony.chambers,
-        NURSERY_CHAMBER_TYPES,
-        chamberBufs.nurseDeposit,
+        FOOD_CHAMBER_TYPES,
+        chamberBufs.food,
+        chamberBufs.queue,
+        // Issue #15 follow-up: saturated chambers (free space <
+        // FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP) must not seed the BFS — otherwise
+        // a carrier mid-traversal across a near-full chamber gets pinned by
+        // the queen-drain-then-redeposit oscillation. Shared with the deposit
+        // path in ant-system.ts via `isFoodChamberDepositable`, so seed
+        // exclusion and deposit refusal stay in lockstep.
+        isFoodChamberDepositable,
+      );
+    }
+    if (topologyDirty) {
+      computeChamberFlowField(
+        underground,
+        colony.chambers,
+        NURSING_CHAMBER_TYPES,
+        chamberBufs.nursing,
         chamberBufs.queue,
       );
+      computeChamberFlowField(
+        underground,
+        colony.chambers,
+        QUEEN_CHAMBER_TYPES,
+        chamberBufs.queen,
+        chamberBufs.queue,
+      );
+      // Issue #17 Phase 1 — Nursery-only deposit field for v10+ carrying nurses.
+      // Pre-v10 the field is allocated but unread; computed alongside the other
+      // chamber fields for code symmetry — no measurable cost.
+      // Issue #173 (V24+): the capacity-aware deposit field is rebuilt every tick
+      // in the loop below; here we compute only the legacy nearest-seed field for
+      // pre-V24 byte-identical replay.
+      if (world.simVersion < SIM_VERSION_V24_NURSERY_CAPACITY) {
+        computeChamberFlowField(
+          underground,
+          colony.chambers,
+          NURSERY_CHAMBER_TYPES,
+          chamberBufs.nurseDeposit,
+          chamberBufs.queue,
+        );
+      }
     }
 
     colony.digFlowFieldDirty = false;
     colony.foodFlowFieldDirty = false;
-    // #235 — the first loop just recomputed the chamber topology (or is doing the
-    // first-compute-on-load), so the pickup/deposit fields the second loop owns are
-    // now stale; force their rebuild. This is ALSO what makes a loaded world recompute
-    // on tick 1 (firstDigCompute is always true on a fresh per-world cache), so the
-    // deserialized broodFieldDirty value can never leave a stale field.
-    colony.broodFieldDirty = true;
+    // #235 — a TOPOLOGY recompute (or first-compute-on-load) makes the pickup/deposit
+    // fields the second loop owns stale; force their rebuild. Gated on topologyDirty
+    // (not any dirty): a food-fill-only tick changes neither topology nor brood, so it
+    // must not force an unnecessary pickup/deposit recompute. firstDigCompute (⊂
+    // topologyDirty) is always true on a fresh per-world cache, so a loaded world still
+    // recomputes on tick 1 regardless of the deserialized broodFieldDirty value.
+    if (topologyDirty) colony.broodFieldDirty = true;
   }
 
   // Issue #17 Phase 1 — under v10+, the `nursing` chamber-flow field is

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -146,6 +146,16 @@ function getFlowFieldCaches(world: WorldState): FlowFieldCaches {
 }
 
 /**
+ * #235 — TEST-ONLY accessor for the per-world chamber flow-field cache (nursing
+ * pickup + V24 nurseDeposit fields), so chamber-flow-gating.test.ts can assert the
+ * gated recompute is elementwise-identical to a force-recompute-every-tick baseline.
+ * Not part of the production API.
+ */
+export function __getChamberFlowFieldsForTest(world: WorldState): ChamberFlowFields {
+  return getFlowFieldCaches(world).chamber;
+}
+
+/**
  * Drop all per-world flow-field scratch.
  *
  * As of issue #160 this is no longer required for cross-world correctness —
@@ -1049,20 +1059,35 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
 
     colony.digFlowFieldDirty = false;
     colony.foodFlowFieldDirty = false;
+    // #235 — the first loop just recomputed the chamber topology (or is doing the
+    // first-compute-on-load), so the pickup/deposit fields the second loop owns are
+    // now stale; force their rebuild. This is ALSO what makes a loaded world recompute
+    // on tick 1 (firstDigCompute is always true on a fresh per-world cache), so the
+    // deserialized broodFieldDirty value can never leave a stale field.
+    colony.broodFieldDirty = true;
   }
 
   // Issue #17 Phase 1 — under v10+, the `nursing` chamber-flow field is
   // re-seeded from Queen Open tiles AND any uncarried-brood-entity tile
-  // outside Nursery (the v10 pickup field). Brood positions move with their
-  // carriers each tick, so the field MUST recompute every tick (not just
-  // on dirty signal) to stay in sync. Overwrites the buffer that the
+  // outside Nursery (the v10 pickup field). Overwrites the buffer that the
   // dirty-gated block above filled with the legacy NURSING_CHAMBER_TYPES
   // seeding — pre-v10 worlds keep the legacy seeding (Queen+Nursery).
+  //
+  // #235 — formerly recomputed EVERY tick "because brood positions move with
+  // their carriers". But CARRIED brood is excluded from both fields by
+  // isBroodReclaimable, so per-tick carrier motion is invisible to field output;
+  // only the discrete inputs (a brood laid / promoted / died, or a nurse
+  // pickup/deposit) change it. So gate on colony.broodFieldDirty, set by those
+  // input-changes (see the ColonyRecord.broodFieldDirty trigger list) and forced
+  // true by the first loop above. The differential test (chamber-flow-gating.test)
+  // proves this is output-identical to the old unconditional recompute; a divergence
+  // there means a missing trigger — fix the trigger, never gate behind a simVersion.
   for (const key in world.colonies) {
     if (!Object.hasOwn(world.colonies, key)) continue;
     const colony = world.colonies[key as unknown as ColonyId]!;
     const underground = world.undergroundGrids[colony.colonyId];
     if (!underground) continue;
+    if (!colony.broodFieldDirty) continue; // #235 — skip the O(grid) BFS rebuild when no brood input changed
     const gridSize = underground.width * underground.height;
     const chamberBufs = ensureChamberFlowFields(chamberFlowFields, colony.colonyId, gridSize);
     computeNursingPickupField(
@@ -1091,6 +1116,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         chamberBufs.queue,
       );
     }
+    colony.broodFieldDirty = false; // #235 — consumed; the second loop is the sole clearer
   }
 
   // ---------------------------------------------------------------------------

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -999,6 +999,7 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
       fresh.rallyPoint = null;
       fresh.digFlowFieldDirty = false;
       fresh.foodFlowFieldDirty = false;
+      fresh.broodFieldDirty = false; // #235
       fresh.killCount = 0;
       fresh.priorityFoodPileId = null;
     }
@@ -1092,6 +1093,8 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
     d.digFlowFieldDirty = s.digFlowFieldDirty;
     // foodFlowFieldDirty (issue #15) — boolean assignment
     d.foodFlowFieldDirty = s.foodFlowFieldDirty;
+    // broodFieldDirty (#235) — boolean assignment
+    d.broodFieldDirty = s.broodFieldDirty;
   }
 
   // --- pheromoneGrids: delete stale dst keys; upsert each src grid ---


### PR DESCRIPTION
**Wave C · C1 · PR-3** (arch-review Phase-4/6 perf pre-work). Closes #235.

Three commits (bench → gate → split). Detailed design in the [#235 comment](https://github.com/LightAxe/subterrans/issues/235).

## 1. Tick-cost benchmark baseline (informational, not CI-gated per #188)
`bench/tick-cost.bench.ts` — idle / excavation / combat ticks/sec at a pinned seed, plus a **brood-heavy gated-vs-forced** variant that isolates the gate's win (no cross-build comparison needed).

## 2. Brood-field dirty-gate (the main win)
step-9's second loop recomputed the nursing-pickup + V24 nursery-deposit **O(grid) BFS fields every tick per colony**. But carried brood are excluded from both (`isBroodReclaimable`), so per-tick carrier motion is invisible to output — only discrete brood-input changes matter. New serialized `ColonyRecord.broodFieldDirty` gates the loop; the first loop forces it true on topology change / first-compute-on-load, so a **loaded world always recomputes on tick 1** regardless of the deserialized value. 8 triggers wired (lay, both promotions, worker death, starvation, nurse pickup + deposit, combat killAnt).

## 3. step-9 rebuild split
`foodFlowFieldDirty` (FoodStorage full↔not-full) changes **only** the food field's seed set, so a food-fill-only tick now rebuilds **1 field, not 6** (the 5 topology-only fields gate on `topologyDirty`). Dig transitions still rebuild the chamber fields (they genuinely change on `Marked→BeingDug`) — deliberately not decoupled.

## Why the byte-gate does NOT gate this PR (plan correction 6)
`broodFieldDirty` is a new `SerializedColony` key (deserialized `?? false`, **no `SAVE_FORMAT_VERSION` bump** — back-compatible shape addition), so the cross-build byte-gate diverges purely on the added key. The gate instead is:
- **`chamber-flow-gating.test.ts` differential** — world **G** (fully gated) ≡ world **F** (forces dig+food+brood dirty every tick = the full pre-#235 baseline), byte-identical **each tick × 3 seeds × 2000 ticks**, comparing the serialized state AND the nursing/deposit/**food** fields directly (fields aren't serialized). The gate skips >1000/2000 rebuilds while matching. **Mutation-tested**: dropping the food gate diverges at tick 40.
- **3 direct trigger tests**: killAnt-orphan, larva starvation, larva maturation.
- **byte-gate PR2→PR3 byte-identical** on `createScenario` (the food-decouple path isn't reached there — no FoodStorage — so PR3 is a no-op on the common path).

## Evidence
- `npm run verify` green — **2771 passed | 1 skipped**.
- Bench (brood-heavy, 20×20): gate saves ~5% (scales up with real 128×64 grids + brood/nursery count).

## simVersion
None. No RNG path touched; `broodFieldDirty` is back-compatible (`?? false`), no format bump. A divergence in the differential = a missing trigger — fix the trigger, never gate behind a simVersion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShzYQ9mtDjHeUNmte3X2i6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved simulation efficiency by rebuilding brood-related flow fields only when needed, reducing unnecessary work during ticks.
  * Added benchmark coverage for idle, excavation-heavy, combat-heavy, and brood-heavy workloads to track throughput.

* **Bug Fixes**
  * Kept brood-related colony state in sync after key events like feeding, death, maturation, egg laying, and combat.
  * Improved save/load and state-copy consistency so brood dirty state is preserved correctly.
  * Strengthened determinism and gating tests to ensure simulation results remain identical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->