### PR TITLE
#230 — command pipeline: pushCommand chokepoint + provenance + overflow observability

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -263,6 +263,18 @@ const nonSimTestCommandQueueOverride = {
   },
 };
 
+/** #230 — root-level src files (only src/main.ts today, the Phaser bootstrap) match
+ *  neither simSafetyConfig (src/sim/**) nor nonSimMutationGuard (render|input|platform),
+ *  so the commandQueue-push ban would not cover them. `src/*.ts` matches root files
+ *  only (`*` does not cross `/`), so this adds JUST the ban there without clobbering
+ *  the layer configs. No FNDN-07 tripwire needed — main.ts has no world access. */
+const rootSrcCommandQueueBan = {
+  files: ['src/*.ts'],
+  rules: {
+    'no-restricted-syntax': ['error', commandQueuePushBanSelector],
+  },
+};
+
 export default [
   baseConfig,
   simSafetyConfig,
@@ -270,4 +282,5 @@ export default [
   simModuleStateConfig,
   simTestImportOverride,
   nonSimTestCommandQueueOverride,
+  rootSrcCommandQueueBan,
 ];

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -63,6 +63,41 @@ const simFloatDivisionSelectors = [
   },
 ];
 
+/** #230 — ban raw `<x>.commandQueue.push(...)`: every producer must route through
+ *  pushCommand(world, cmd) (src/sim/commands.ts), the single provenance chokepoint.
+ *  Added to BOTH no-restricted-syntax arrays (simSafetyConfig for src/sim, and
+ *  nonSimMutationGuard for render/input/platform) since it applies across layers.
+ *  The chokepoint itself carries an inline disable; the game-loop `.splice` drain is
+ *  not matched (`.splice`, not `.push`); non-sim test files re-drop it below. */
+const commandQueuePushBanSelector = {
+  selector:
+    "CallExpression[callee.type='MemberExpression'][callee.property.name='push']" +
+    "[callee.object.type='MemberExpression'][callee.object.property.name='commandQueue']",
+  message:
+    'Route through pushCommand(world, cmd) (src/sim/commands.ts) — the #230 provenance chokepoint. Raw world.commandQueue.push bypasses it.',
+};
+
+/** FNDN-07 tripwire selectors — direct writes/updates to WorldState sim-state fields
+ *  from a non-sim layer. Extracted so the non-sim TEST override (#230) can keep the
+ *  tripwire active (test fixtures that write world.tick carry their own inline
+ *  disables) while dropping ONLY the commandQueue-push ban. */
+const nonSimWriteTripwireSelectors = [
+  {
+    // Tripwire: catches `world.tick = ...`, `world.rngState = ...`, whole-field replacement.
+    selector:
+      "AssignmentExpression[left.type='MemberExpression'][left.property.name=/^(tick|rngState|nextEntityId|ants|colonies|pheromoneGrids|surface|undergroundGrids|pendingChambers)$/]",
+    message:
+      'FNDN-07 tripwire: direct write to WorldState sim-state field from non-sim layer. Push a SimCommand onto world.commandQueue instead (PRD §5). [Nested writes like world.colonies[id].x are not caught by lint — see grep guard.]',
+  },
+  {
+    // Tripwire: catches `world.tick++`, `--world.nextEntityId`, etc.
+    selector:
+      "UpdateExpression[argument.type='MemberExpression'][argument.property.name=/^(tick|rngState|nextEntityId|ants|colonies|pheromoneGrids|surface|undergroundGrids|pendingChambers)$/]",
+    message:
+      'FNDN-07 tripwire: UpdateExpression on WorldState sim-state field from non-sim layer. Mutations happen inside tick(); use a SimCommand.',
+  },
+];
+
 /** Sim-layer-specific safety rules — mirrors PRD §6 Rule Sets 1 & 2 verbatim.
  *  Applied ONLY to src/sim/**\/*.ts.
  */
@@ -150,6 +185,7 @@ const simSafetyConfig = {
     'no-restricted-syntax': [
       'error',
       ...simFloatDivisionSelectors,
+      commandQueuePushBanSelector, // #230
       {
         selector: 'ImportExpression',
         message:
@@ -185,20 +221,8 @@ const nonSimMutationGuard = {
   rules: {
     'no-restricted-syntax': [
       'error',
-      {
-        // Tripwire: catches `world.tick = ...`, `world.rngState = ...`, whole-field replacement.
-        selector:
-          "AssignmentExpression[left.type='MemberExpression'][left.property.name=/^(tick|rngState|nextEntityId|ants|colonies|pheromoneGrids|surface|undergroundGrids|pendingChambers)$/]",
-        message:
-          'FNDN-07 tripwire: direct write to WorldState sim-state field from non-sim layer. Push a SimCommand onto world.commandQueue instead (PRD §5). [Nested writes like world.colonies[id].x are not caught by lint — see grep guard.]',
-      },
-      {
-        // Tripwire: catches `world.tick++`, `--world.nextEntityId`, etc.
-        selector:
-          "UpdateExpression[argument.type='MemberExpression'][argument.property.name=/^(tick|rngState|nextEntityId|ants|colonies|pheromoneGrids|surface|undergroundGrids|pendingChambers)$/]",
-        message:
-          'FNDN-07 tripwire: UpdateExpression on WorldState sim-state field from non-sim layer. Mutations happen inside tick(); use a SimCommand.',
-      },
+      ...nonSimWriteTripwireSelectors,
+      commandQueuePushBanSelector, // #230 — raw push bypasses the provenance chokepoint
     ],
   },
 };
@@ -227,10 +251,23 @@ const simTestImportOverride = {
   },
 };
 
+/** #230 — non-sim TEST files (render/input/platform) build command queues directly
+ *  as fixtures, so drop ONLY the commandQueue-push ban for them while KEEPING the
+ *  FNDN-07 write tripwire (some fixtures write world.tick with their own inline
+ *  disables, which would go unused if the whole rule were turned off). Sim test files
+ *  are handled by simTestImportOverride above. Must come after nonSimMutationGuard. */
+const nonSimTestCommandQueueOverride = {
+  files: ['src/render/**/*.test.ts', 'src/input/**/*.test.ts', 'src/platform/**/*.test.ts'],
+  rules: {
+    'no-restricted-syntax': ['error', ...nonSimWriteTripwireSelectors],
+  },
+};
+
 export default [
   baseConfig,
   simSafetyConfig,
   nonSimMutationGuard,
   simModuleStateConfig,
   simTestImportOverride,
+  nonSimTestCommandQueueOverride,
 ];

--- a/src/input/command-queue.ts
+++ b/src/input/command-queue.ts
@@ -35,7 +35,7 @@
 // The isPaused param is retained so callers can pass it uniformly, but it no
 // longer gates the cap (it never needed to — the cap is the same either way).
 
-import { MAX_COMMANDS_PER_TICK, type SimCommand } from '../sim/commands.js';
+import { MAX_COMMANDS_PER_TICK, pushCommand, type SimCommand } from '../sim/commands.js';
 import type { WorldState } from '../sim/types.js';
 
 /**
@@ -84,6 +84,5 @@ export function enqueueCommand(world: WorldState, cmd: SimCommand, isPaused: boo
       return false;
     }
   }
-  world.commandQueue.push(cmd);
-  return true;
+  return pushCommand(world, cmd); // #230 — the input-side cap stays here; the actual push routes through the chokepoint
 }

--- a/src/input/command-queue.ts
+++ b/src/input/command-queue.ts
@@ -84,5 +84,5 @@ export function enqueueCommand(world: WorldState, cmd: SimCommand, isPaused: boo
       return false;
     }
   }
-  return pushCommand(world, cmd); // #230 — the input-side cap stays here; the actual push routes through the chokepoint
+  return pushCommand(world, cmd, 'player'); // #230 — the input-side cap stays here; the actual push routes through the chokepoint
 }

--- a/src/platform/__snapshots__/apply-commands-golden.test.ts.snap
+++ b/src/platform/__snapshots__/apply-commands-golden.test.ts.snap
@@ -3433,6 +3433,7 @@ exports[`applyCommands golden differential (byte-identity of the extraction) > S
     {
       "colonyId": 2,
       "issuedAtTick": 0,
+      "origin": "sim",
       "type": "ClearRallyPoint",
     },
   ],

--- a/src/platform/save-schema.ts
+++ b/src/platform/save-schema.ts
@@ -56,6 +56,7 @@ export const TRANSIENT_WORLD_FIELDS: readonly (keyof WorldState)[] = [
   'surfaceGoalFields', // DERIVED per-target BFS cache (types.ts:761)
   'surfaceGoalBfsScratch', // pure BFS scratch, overwritten before read (types.ts:762)
   'pendingQueenDeathContexts', // within-tick transient, cleared every tick (types.ts:772, copyWorldState:817-819)
+  'droppedCommandOverflowCount', // #230 — transient session counter, reset to 0 on load (like events)
 ];
 
 /**

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -1629,6 +1629,7 @@ export function deserializeWorldState(s: SerializedWorldState): WorldState {
     recentlyDepletedFood: validatedRecentlyDepleted.map((r) => ({ ...r })),
     pendingChambers,
     events: [],
+    droppedCommandOverflowCount: 0, // #230 — transient, reset on load
     pendingQueenDeathContexts: [],
     aiState: deserializeAIStateArray(s),
     spider: _deserializedSpider,

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -13,6 +13,7 @@ import type {
   SetBehaviorRatioCommand,
   SyncAIStateCommand,
 } from '../sim/commands.js';
+import { pushCommand } from '../sim/commands.js';
 import { ChamberType } from '../sim/enums.js';
 import { UndergroundTileState, ugGet } from '../sim/terrain.js';
 import { FP_SHIFT } from '../sim/fixed.js';
@@ -166,7 +167,7 @@ export function aiInitialSetup(world: WorldState, colony: ColonyRecord): void {
       surfaceTileY: 0, // surface row
       issuedAtTick: world.tick,
     };
-    world.commandQueue.push(designateCmd);
+    pushCommand(world, designateCmd);
   }
 }
 
@@ -248,7 +249,7 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
             tileY: ty,
             issuedAtTick: world.tick,
           };
-          world.commandQueue.push(cmd);
+          pushCommand(world, cmd);
           budget -= 1;
         }
       }
@@ -294,7 +295,7 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(cand.tileX, cand.tileY);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      world.commandQueue.push({
+      pushCommand(world, {
         type: 'MarkDigTile',
         colonyId: colony.colonyId,
         tileX: cand.tileX,
@@ -328,7 +329,7 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      world.commandQueue.push({
+      pushCommand(world, {
         type: 'MarkDigTile',
         colonyId: colony.colonyId,
         tileX: tx,
@@ -345,7 +346,7 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      world.commandQueue.push({
+      pushCommand(world, {
         type: 'MarkDigTile',
         colonyId: colony.colonyId,
         tileX: tx,
@@ -362,7 +363,7 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      world.commandQueue.push({
+      pushCommand(world, {
         type: 'MarkDigTile',
         colonyId: colony.colonyId,
         tileX: tx,
@@ -379,7 +380,7 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      world.commandQueue.push({
+      pushCommand(world, {
         type: 'MarkDigTile',
         colonyId: colony.colonyId,
         tileX: tx,
@@ -414,7 +415,7 @@ export function aiChamberPlacement(world: WorldState, colony: ColonyRecord): voi
         anchorTileY: placement.tileY,
         issuedAtTick: world.tick,
       };
-      world.commandQueue.push(cmd);
+      pushCommand(world, cmd);
     }
   }
   // Food storage — if food stockpile crossed threshold and no FoodStorage yet.
@@ -457,7 +458,7 @@ export function aiChamberPlacement(world: WorldState, colony: ColonyRecord): voi
         anchorTileY: placement.tileY,
         issuedAtTick: world.tick,
       };
-      world.commandQueue.push(cmd);
+      pushCommand(world, cmd);
     }
   }
   // Nursery — gate rewritten per plan 09.1-01 Task 2 (Option B, bootstrap-aware):
@@ -493,7 +494,7 @@ export function aiChamberPlacement(world: WorldState, colony: ColonyRecord): voi
           anchorTileY: placement.tileY,
           issuedAtTick: world.tick,
         };
-        world.commandQueue.push(cmd);
+        pushCommand(world, cmd);
       }
     }
   }
@@ -514,7 +515,7 @@ export function aiEntranceDesignation(world: WorldState, colony: ColonyRecord): 
         surfaceTileY: 0,
         issuedAtTick: world.tick,
       };
-      world.commandQueue.push(cmd);
+      pushCommand(world, cmd);
       return;
     }
   }
@@ -626,7 +627,7 @@ function _pushSyncAIState(world: WorldState, aiColonyId: ColonyId): void {
     operationAttackerDeaths: rec.operationAttackerDeaths,
     operationDefenderDeaths: rec.operationDefenderDeaths,
   };
-  world.commandQueue.push(cmd);
+  pushCommand(world, cmd);
 }
 
 /** Sync the AI colony behavior ratio to its current state. */
@@ -654,7 +655,7 @@ function _syncBehaviorRatioToAIState(
       ratio: { ...targetRatio },
       issuedAtTick: world.tick,
     };
-    world.commandQueue.push(setRatioCmd);
+    pushCommand(world, setRatioCmd);
   }
 }
 
@@ -678,7 +679,7 @@ function aiStateMachineTick_probeEntry(
   if (fighters.length < AI_PROBE_FIGHTER_COUNT) return; // not enough fighters
 
   // Push StartAIOperation so tick.ts applies setAIRallyOperation sim-side (ADR-0007).
-  world.commandQueue.push({
+  pushCommand(world, {
     type: 'StartAIOperation',
     colonyId: aiColonyId,
     kind: 'Probe',
@@ -745,7 +746,7 @@ function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
     if (fighters.length < 3) return;
 
     // Push StartAIOperation so tick.ts applies setAIRallyOperation sim-side (ADR-0007).
-    world.commandQueue.push({
+    pushCommand(world, {
       type: 'StartAIOperation',
       colonyId: aiColonyId,
       kind: 'Invasion',
@@ -904,7 +905,7 @@ function _emitSetRallyPoint(
     tileY,
     issuedAtTick: world.tick,
   };
-  world.commandQueue.push(cmd);
+  pushCommand(world, cmd);
 }
 
 // --- Helpers ---

--- a/src/render/ai-controller.ts
+++ b/src/render/ai-controller.ts
@@ -167,7 +167,7 @@ export function aiInitialSetup(world: WorldState, colony: ColonyRecord): void {
       surfaceTileY: 0, // surface row
       issuedAtTick: world.tick,
     };
-    pushCommand(world, designateCmd);
+    pushCommand(world, designateCmd, 'ai');
   }
 }
 
@@ -249,7 +249,7 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
             tileY: ty,
             issuedAtTick: world.tick,
           };
-          pushCommand(world, cmd);
+          pushCommand(world, cmd, 'ai');
           budget -= 1;
         }
       }
@@ -295,13 +295,17 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(cand.tileX, cand.tileY);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      pushCommand(world, {
-        type: 'MarkDigTile',
-        colonyId: colony.colonyId,
-        tileX: cand.tileX,
-        tileY: cand.tileY,
-        issuedAtTick: world.tick,
-      });
+      pushCommand(
+        world,
+        {
+          type: 'MarkDigTile',
+          colonyId: colony.colonyId,
+          tileX: cand.tileX,
+          tileY: cand.tileY,
+          issuedAtTick: world.tick,
+        },
+        'ai',
+      );
       budget -= 1;
     }
   }
@@ -329,13 +333,17 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      pushCommand(world, {
-        type: 'MarkDigTile',
-        colonyId: colony.colonyId,
-        tileX: tx,
-        tileY: ty,
-        issuedAtTick: world.tick,
-      });
+      pushCommand(
+        world,
+        {
+          type: 'MarkDigTile',
+          colonyId: colony.colonyId,
+          tileX: tx,
+          tileY: ty,
+          issuedAtTick: world.tick,
+        },
+        'ai',
+      );
       budget -= 1;
     }
     // Bottom border
@@ -346,13 +354,17 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      pushCommand(world, {
-        type: 'MarkDigTile',
-        colonyId: colony.colonyId,
-        tileX: tx,
-        tileY: ty,
-        issuedAtTick: world.tick,
-      });
+      pushCommand(
+        world,
+        {
+          type: 'MarkDigTile',
+          colonyId: colony.colonyId,
+          tileX: tx,
+          tileY: ty,
+          issuedAtTick: world.tick,
+        },
+        'ai',
+      );
       budget -= 1;
     }
     // Left border
@@ -363,13 +375,17 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      pushCommand(world, {
-        type: 'MarkDigTile',
-        colonyId: colony.colonyId,
-        tileX: tx,
-        tileY: ty,
-        issuedAtTick: world.tick,
-      });
+      pushCommand(
+        world,
+        {
+          type: 'MarkDigTile',
+          colonyId: colony.colonyId,
+          tileX: tx,
+          tileY: ty,
+          issuedAtTick: world.tick,
+        },
+        'ai',
+      );
       budget -= 1;
     }
     // Right border
@@ -380,13 +396,17 @@ export function aiDigHeuristic(world: WorldState, colony: ColonyRecord): void {
       const k = tileKey(tx, ty);
       if (seenMarks.has(k)) continue;
       seenMarks.add(k);
-      pushCommand(world, {
-        type: 'MarkDigTile',
-        colonyId: colony.colonyId,
-        tileX: tx,
-        tileY: ty,
-        issuedAtTick: world.tick,
-      });
+      pushCommand(
+        world,
+        {
+          type: 'MarkDigTile',
+          colonyId: colony.colonyId,
+          tileX: tx,
+          tileY: ty,
+          issuedAtTick: world.tick,
+        },
+        'ai',
+      );
       budget -= 1;
     }
   }
@@ -415,7 +435,7 @@ export function aiChamberPlacement(world: WorldState, colony: ColonyRecord): voi
         anchorTileY: placement.tileY,
         issuedAtTick: world.tick,
       };
-      pushCommand(world, cmd);
+      pushCommand(world, cmd, 'ai');
     }
   }
   // Food storage — if food stockpile crossed threshold and no FoodStorage yet.
@@ -458,7 +478,7 @@ export function aiChamberPlacement(world: WorldState, colony: ColonyRecord): voi
         anchorTileY: placement.tileY,
         issuedAtTick: world.tick,
       };
-      pushCommand(world, cmd);
+      pushCommand(world, cmd, 'ai');
     }
   }
   // Nursery — gate rewritten per plan 09.1-01 Task 2 (Option B, bootstrap-aware):
@@ -494,7 +514,7 @@ export function aiChamberPlacement(world: WorldState, colony: ColonyRecord): voi
           anchorTileY: placement.tileY,
           issuedAtTick: world.tick,
         };
-        pushCommand(world, cmd);
+        pushCommand(world, cmd, 'ai');
       }
     }
   }
@@ -515,7 +535,7 @@ export function aiEntranceDesignation(world: WorldState, colony: ColonyRecord): 
         surfaceTileY: 0,
         issuedAtTick: world.tick,
       };
-      pushCommand(world, cmd);
+      pushCommand(world, cmd, 'ai');
       return;
     }
   }
@@ -627,7 +647,7 @@ function _pushSyncAIState(world: WorldState, aiColonyId: ColonyId): void {
     operationAttackerDeaths: rec.operationAttackerDeaths,
     operationDefenderDeaths: rec.operationDefenderDeaths,
   };
-  pushCommand(world, cmd);
+  pushCommand(world, cmd, 'ai');
 }
 
 /** Sync the AI colony behavior ratio to its current state. */
@@ -655,7 +675,7 @@ function _syncBehaviorRatioToAIState(
       ratio: { ...targetRatio },
       issuedAtTick: world.tick,
     };
-    pushCommand(world, setRatioCmd);
+    pushCommand(world, setRatioCmd, 'ai');
   }
 }
 
@@ -679,15 +699,19 @@ function aiStateMachineTick_probeEntry(
   if (fighters.length < AI_PROBE_FIGHTER_COUNT) return; // not enough fighters
 
   // Push StartAIOperation so tick.ts applies setAIRallyOperation sim-side (ADR-0007).
-  pushCommand(world, {
-    type: 'StartAIOperation',
-    colonyId: aiColonyId,
-    kind: 'Probe',
-    rallyTileX: target.tileX,
-    rallyTileY: target.tileY,
-    fighterIds: fighters,
-    issuedAtTick: world.tick,
-  });
+  pushCommand(
+    world,
+    {
+      type: 'StartAIOperation',
+      colonyId: aiColonyId,
+      kind: 'Probe',
+      rallyTileX: target.tileX,
+      rallyTileY: target.tileY,
+      fighterIds: fighters,
+      issuedAtTick: world.tick,
+    },
+    'ai',
+  );
 
   // Emit SetRallyPoint SimCommand so world.rallyPoint is set for fighters.
   _emitSetRallyPoint(world, aiColonyId, target.tileX, target.tileY);
@@ -746,15 +770,19 @@ function aiInvasionTick(world: WorldState, aiColonyId: ColonyId): void {
     if (fighters.length < 3) return;
 
     // Push StartAIOperation so tick.ts applies setAIRallyOperation sim-side (ADR-0007).
-    pushCommand(world, {
-      type: 'StartAIOperation',
-      colonyId: aiColonyId,
-      kind: 'Invasion',
-      rallyTileX: targetEntrance.surfaceTileX,
-      rallyTileY: targetEntrance.surfaceTileY,
-      fighterIds: fighters,
-      issuedAtTick: world.tick,
-    });
+    pushCommand(
+      world,
+      {
+        type: 'StartAIOperation',
+        colonyId: aiColonyId,
+        kind: 'Invasion',
+        rallyTileX: targetEntrance.surfaceTileX,
+        rallyTileY: targetEntrance.surfaceTileY,
+        fighterIds: fighters,
+        issuedAtTick: world.tick,
+      },
+      'ai',
+    );
     _emitSetRallyPoint(world, aiColonyId, targetEntrance.surfaceTileX, targetEntrance.surfaceTileY);
     return;
   }
@@ -905,7 +933,7 @@ function _emitSetRallyPoint(
     tileY,
     issuedAtTick: world.tick,
   };
-  pushCommand(world, cmd);
+  pushCommand(world, cmd, 'ai');
 }
 
 // --- Helpers ---

--- a/src/sim/ai-state.ts
+++ b/src/sim/ai-state.ts
@@ -352,7 +352,7 @@ function _checkProbingToWarFooting(
         colonyId: aiColonyId,
         issuedAtTick: world.tick,
       };
-      pushCommand(world, clearCmd);
+      pushCommand(world, clearCmd, 'sim');
     }
     aiState.state = 'WarFooting';
     aiState.enteredTick = world.tick;
@@ -449,7 +449,7 @@ function _endInvasion(
     colonyId: aiColonyId,
     issuedAtTick: world.tick,
   };
-  pushCommand(world, clearCmd);
+  pushCommand(world, clearCmd, 'sim');
   aiState.state = 'Recovery';
   aiState.enteredTick = world.tick;
   aiState.recoveryEndTick = world.tick + AI_RECOVERY_DURATION_TICKS[tierIndex(world.difficulty)];

--- a/src/sim/ai-state.ts
+++ b/src/sim/ai-state.ts
@@ -12,6 +12,7 @@
 import type { WorldState, AIStateRecord } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 import type { ClearRallyPointCommand } from './commands.js';
+import { pushCommand } from './commands.js';
 import { emitEvent } from './telemetry.js';
 import { AntTask, ChamberType } from './enums.js';
 import { Zone } from './terrain.js';
@@ -351,7 +352,7 @@ function _checkProbingToWarFooting(
         colonyId: aiColonyId,
         issuedAtTick: world.tick,
       };
-      world.commandQueue.push(clearCmd);
+      pushCommand(world, clearCmd);
     }
     aiState.state = 'WarFooting';
     aiState.enteredTick = world.tick;
@@ -448,7 +449,7 @@ function _endInvasion(
     colonyId: aiColonyId,
     issuedAtTick: world.tick,
   };
-  world.commandQueue.push(clearCmd);
+  pushCommand(world, clearCmd);
   aiState.state = 'Recovery';
   aiState.enteredTick = world.tick;
   aiState.recoveryEndTick = world.tick + AI_RECOVERY_DURATION_TICKS[tierIndex(world.difficulty)];

--- a/src/sim/commands.test.ts
+++ b/src/sim/commands.test.ts
@@ -11,8 +11,10 @@ import {
   type SetRallyPointCommand,
   type ClearRallyPointCommand,
   MAX_COMMANDS_PER_TICK,
+  pushCommand,
 } from './commands.js';
 import { ChamberType } from './enums.js';
+import { createWorldState } from './types.js';
 
 describe('SimCommand', () => {
   describe('NoOpCommand assignability', () => {
@@ -358,6 +360,33 @@ describe('SimCommand', () => {
       const b: SimCommand = { type: 'ClearRallyPoint', colonyId: 1, issuedAtTick: 0 };
       expect(a.type).toBe('SetRallyPoint');
       expect(b.type).toBe('ClearRallyPoint');
+    });
+  });
+
+  describe('pushCommand provenance (#230)', () => {
+    it('stamps origin in place and appends the same object to the queue', () => {
+      const world = createWorldState(1);
+      const cmd: SimCommand = { type: 'NoOp', issuedAtTick: 5 };
+      const ok = pushCommand(world, cmd, 'ai');
+      expect(ok).toBe(true);
+      expect(cmd.origin).toBe('ai');
+      expect(world.commandQueue.at(-1)).toBe(cmd); // same reference, no copy
+      expect(world.commandQueue).toHaveLength(1);
+    });
+
+    it('stamps each of the three provenances', () => {
+      const world = createWorldState(2);
+      pushCommand(world, { type: 'NoOp', issuedAtTick: 0 }, 'player');
+      pushCommand(world, { type: 'NoOp', issuedAtTick: 1 }, 'ai');
+      pushCommand(world, { type: 'NoOp', issuedAtTick: 2 }, 'sim');
+      expect(world.commandQueue.map((c) => c.origin)).toEqual(['player', 'ai', 'sim']);
+    });
+
+    it('a pre-provenance command (no origin) is valid and unread by replay (origin optional forever)', () => {
+      // Old inputLogs carry commands WITHOUT origin. They must remain assignable to
+      // SimCommand and apply unchanged — no handler branches on origin.
+      const legacy: SimCommand = { type: 'NoOp', issuedAtTick: 0 };
+      expect(legacy.origin).toBeUndefined();
     });
   });
 

--- a/src/sim/commands.test.ts
+++ b/src/sim/commands.test.ts
@@ -15,6 +15,7 @@ import {
 } from './commands.js';
 import { ChamberType } from './enums.js';
 import { createWorldState } from './types.js';
+import { tick } from './tick.js';
 
 describe('SimCommand', () => {
   describe('NoOpCommand assignability', () => {
@@ -387,6 +388,30 @@ describe('SimCommand', () => {
       // SimCommand and apply unchanged — no handler branches on origin.
       const legacy: SimCommand = { type: 'NoOp', issuedAtTick: 0 };
       expect(legacy.origin).toBeUndefined();
+    });
+  });
+
+  describe('droppedCommandOverflowCount (#230)', () => {
+    it('counts exactly the non-Sync commands dropped past MAX_COMMANDS_PER_TICK', () => {
+      const world = createWorldState(3);
+      expect(world.droppedCommandOverflowCount).toBe(0); // fresh world starts at 0
+      const n = MAX_COMMANDS_PER_TICK + 6; // 70
+      const cmds: SimCommand[] = Array.from({ length: n }, (_, i) => ({
+        type: 'NoOp' as const,
+        issuedAtTick: i,
+      }));
+      tick(world, cmds);
+      expect(world.droppedCommandOverflowCount).toBe(6); // 70 - 64
+    });
+
+    it('does not count when at/under the cap', () => {
+      const world = createWorldState(4);
+      const cmds: SimCommand[] = Array.from({ length: MAX_COMMANDS_PER_TICK }, (_, i) => ({
+        type: 'NoOp' as const,
+        issuedAtTick: i,
+      }));
+      tick(world, cmds);
+      expect(world.droppedCommandOverflowCount).toBe(0);
     });
   });
 

--- a/src/sim/commands.ts
+++ b/src/sim/commands.ts
@@ -4,7 +4,7 @@
 // Phase 7 adds 3 variants: CancelDigMark, PlaceChamber, DesignateEntrance.
 
 import type { ColonyId, BehaviorRatio } from './colony/colony-store.js';
-import type { AIState } from './types.js';
+import type { AIState, WorldState } from './types.js';
 import type { ChamberType } from './enums.js';
 
 export interface SimCommandBase {
@@ -142,3 +142,19 @@ export type SimCommand =
   | MarkSpiderPriorityCommand;
 
 export const MAX_COMMANDS_PER_TICK = 64; // PRD §5 line 680 — FIFO silent-drop beyond cap
+
+/**
+ * #230 — the single sanctioned `commandQueue.push` chokepoint. EVERY producer
+ * (player input via enqueueCommand, the render AI controller, and sim self-emits)
+ * routes through here so the queue has one provenance seam for Phase 7 netcode. A
+ * lint rule (eslint.config.ts) bans raw `world.commandQueue.push` everywhere else.
+ *
+ * Returns a boolean that always resolves `true` today — it reserves the Phase-7
+ * reject signature (per-producer budgets / an ack channel) without implementing it,
+ * so no caller yet needs to handle a refusal. Pure pass-through: byte-identical replay.
+ */
+export function pushCommand(world: WorldState, cmd: SimCommand): boolean {
+  // eslint-disable-next-line no-restricted-syntax -- the single sanctioned commandQueue.push chokepoint (#230)
+  world.commandQueue.push(cmd);
+  return true;
+}

--- a/src/sim/commands.ts
+++ b/src/sim/commands.ts
@@ -7,8 +7,20 @@ import type { ColonyId, BehaviorRatio } from './colony/colony-store.js';
 import type { AIState, WorldState } from './types.js';
 import type { ChamberType } from './enums.js';
 
+/**
+ * #230 — provenance of a queued command, stamped by pushCommand. Phase 7 netcode
+ * will BROADCAST 'player' input, ASSIGN AUTHORITY for 'ai' policy output, and
+ * LOCALLY REGENERATE (never broadcast) 'sim' self-emits. Pure metadata today — no
+ * handler branches on it, so replay ignores it and it needs no simVersion bump.
+ */
+export type CommandOrigin = 'player' | 'ai' | 'sim';
+
 export interface SimCommandBase {
   readonly issuedAtTick: number; // tick-stamped per PRD §5
+  /** #230 — stamped by pushCommand; ABSENT on pre-provenance logs. Kept optional
+   *  forever (old inputLogs must keep loading) and non-readonly (only pushCommand
+   *  writes it, post-construction). */
+  origin?: CommandOrigin;
 }
 
 export interface NoOpCommand extends SimCommandBase {
@@ -153,7 +165,8 @@ export const MAX_COMMANDS_PER_TICK = 64; // PRD §5 line 680 — FIFO silent-dro
  * reject signature (per-producer budgets / an ack channel) without implementing it,
  * so no caller yet needs to handle a refusal. Pure pass-through: byte-identical replay.
  */
-export function pushCommand(world: WorldState, cmd: SimCommand): boolean {
+export function pushCommand(world: WorldState, cmd: SimCommand, origin: CommandOrigin): boolean {
+  cmd.origin = origin; // in-place stamp — allocation-free; every producer hands a freshly-built literal
   // eslint-disable-next-line no-restricted-syntax -- the single sanctioned commandQueue.push chokepoint (#230)
   world.commandQueue.push(cmd);
   return true;

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -303,7 +303,15 @@ export function applyCommands(world: WorldState, commands: readonly SimCommand[]
   for (let i = 0; i < commands.length; i++) {
     const cmd = commands[i]!;
     if (cmd.type === 'SyncAIState') continue;
-    if (nonSyncCmdCount >= MAX_COMMANDS_PER_TICK) break;
+    if (nonSyncCmdCount >= MAX_COMMANDS_PER_TICK) {
+      // #230 — the FIFO drop past the cap was formerly silent. Count the dropped
+      // gameplay (non-Sync) commands into the transient session counter for
+      // observability. Transient + unserialized ⇒ byte-identical replay.
+      for (let j = i; j < commands.length; j++) {
+        if (commands[j]!.type !== 'SyncAIState') world.droppedCommandOverflowCount++;
+      }
+      break;
+    }
     nonSyncCmdCount++;
     switch (cmd.type) {
       case 'NoOp':

--- a/src/sim/types.test.ts
+++ b/src/sim/types.test.ts
@@ -29,10 +29,11 @@ describe('WorldState', () => {
       expect(world.rngState).toBe(4294967295);
     });
 
-    it('has exactly twenty-seven fields (… + PR 4 baked/component + PR 5 goal-field cache + BFS scratch)', () => {
+    it('has exactly twenty-eight fields (… + PR 4 baked/component + PR 5 goal-field cache + BFS scratch + #230 overflow counter)', () => {
       const world = createWorldState(0);
       const keys = Object.keys(world);
-      expect(keys).toHaveLength(27);
+      expect(keys).toHaveLength(28);
+      expect(keys).toContain('droppedCommandOverflowCount'); // #230 (transient)
       expect(keys).toContain('bakedSurfaceEffect'); // PR 4
       expect(keys).toContain('surfaceComponentMask'); // PR 4
       expect(keys).toContain('surfaceGoalFields'); // PR 5

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -695,6 +695,14 @@ export interface WorldState {
   droppedStructuralCount: number;
 
   /**
+   * #230 — TRANSIENT (not serialized, reset to 0 on load, like `events`): count of
+   * gameplay (non-Sync) commands dropped this SESSION past MAX_COMMANDS_PER_TICK. An
+   * observability signal for the formerly-silent FIFO drop; a plain field NOT
+   * emitEvent (which could bump the PERSISTED dropped* counters at the 2000-event cap).
+   */
+  droppedCommandOverflowCount: number;
+
+  /**
    * S1 — transient per-colony queen-kill context. Written by combat.killAnt when
    * a queen dies; read and cleared by checkQueenDeath later the same tick.
    * Index by victim colonyId. Empty array between ticks.
@@ -766,6 +774,7 @@ export function createWorldState(seed: number, maxEntities: number = MAX_ENTITIE
     pendingChambers: {}, // empty Record; PlaceChamberCommand creates entries
     // S0b — telemetry fields.
     events: [],
+    droppedCommandOverflowCount: 0, // #230 — transient
     droppedCombatKillCount: 0,
     droppedStructuralCount: 0,
     // S1 — transient; cleared between ticks by combat resolver.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -823,6 +823,8 @@ export function copyWorldState(src: WorldState, dst: WorldState): void {
   // droppedCombatKillCount / droppedStructuralCount are also telemetry-only.
   dst.droppedCombatKillCount = src.droppedCombatKillCount;
   dst.droppedStructuralCount = src.droppedStructuralCount;
+  // droppedCommandOverflowCount (#230): transient session counter — intentionally
+  // NOT copied to the render double-buffer (nothing reads prevState's value), like events.
   // pendingQueenDeathContexts: transient within-tick (cleared by checkQueenDeath every tick,
   // always null at the tick boundary when copyWorldState runs). No render code reads it,
   // so no copy is needed and the allocation is skipped to preserve zero-alloc steady state.


### PR DESCRIPTION
**Wave C · C1 · PR-4** (arch-review Phase-7 pre-work). Closes #230. SyncAIState retirement deferred to #258 (rationale below).

Three commits, all **byte-identical replay / no simVersion bump**.

## 1. Single pushCommand chokepoint
All 19 `commandQueue` producers (16 render ai-controller, 2 sim ai-state self-emits, 1 input `enqueueCommand`) route through one sim-owned `pushCommand(world, cmd, origin)`; a lint rule bans raw `world.commandQueue.push` across every layer (the `.splice` drain is untouched). `pushCommand` returns a boolean (always true today) reserving the Phase-7 reject signature. Pure pass-through — byte-gate byte-identical.

## 2. Command provenance
Optional `CommandOrigin` (`'player' | 'ai' | 'sim'`) stamped in-place by the chokepoint. Phase-7 netcode will broadcast player input, assign authority for AI output, locally regenerate sim self-emits. No handler branches on it → replay ignores it, old inputLogs (no origin) load unchanged, no deserializer change. It's a back-compat **live-save** shape addition: it reaches serialized state only when a stamped command sits in the queue at a save boundary (the byte-gate's `tick()`-only harness has an empty queue, so it stays byte-identical there; the apply-commands SyncAIState golden — which *does* queue a sim self-emit — legitimately gains `"origin":"sim"`).

## 3. Overflow observability
Transient `world.droppedCommandOverflowCount` (reset `0` on load, like `events`; a plain field, NOT `emitEvent` which could bump the persisted `dropped*` counters at the 2000-event cap) counts the formerly-silent FIFO drop past the 64-command cap. Registered in #229's `TRANSIENT_WORLD_FIELDS`.

## SyncAIState retirement → deferred to #258
The design's PR3 (delete the redundant `SyncAIState` echo) needs a live-loop→replay parity test that drives the AI through **Probing/Invading** — but the AI-only integration harness (passive-observer player) **never leaves Peacetime** (empirically confirmed at 4000 *and* 12000 ticks; 1 `SyncAIState` ever pushed), so the echo's redundancy can't be proven here and the existing code comment asserts it's load-bearing. Per the plan's pre-decision, **defer rather than delete on unproven-safe** (no V34). #258 tracks it with a proper player-pressure harness.

## Evidence
- `npm run verify` green — **2778 passed | 1 skipped**.
- byte-gate byte-identical vs `main` after the chokepoint, after provenance, and after the overflow counter.
- `commands.test`: provenance stamping + old-log tolerance + overflow-count (70 cmds → 6 dropped); lint ban mutation-verified to fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShzYQ9mtDjHeUNmte3X2i6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command handling now tracks where commands come from, improving command provenance and consistency.
  * Added a new session-only counter to record when commands are dropped because the queue is full.

* **Bug Fixes**
  * Fixed command enqueueing so multiple parts of the app use the same safe path instead of writing directly to the queue.
  * Command overflow is now counted during processing, making dropped commands easier to detect and diagnose.
  * Saved worlds now restore the new counter to a known default value on load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->