### PR TITLE
#247 (batch 1/2) — reap dead ≤V30 simVersion gates: ant-combat-targeting, ant-movement, combat

### DIFF
--- a/src/sim/ant/ant-combat-targeting.test.ts
+++ b/src/sim/ant/ant-combat-targeting.test.ts
@@ -12,7 +12,6 @@ import {
   createWorldState,
   allocateEntityId,
   SIM_VERSION_V17_COMBAT_AGGRO,
-  SIM_VERSION_V22_DIFFICULTY,
   SIM_VERSION_V23_SPIDER_AGGRO,
 } from '../types.js';
 import { createColonyRecord } from '../colony/colony-store.js';
@@ -489,33 +488,9 @@ describe('updateFightAntTargets', () => {
     expect(world.ants.targetPosY[fighter]).toBe(spider.posY);
   });
 
-  it('V23 gate: a pre-V23 (V22) world shows no spider auto-aggro', () => {
-    const world = createWorldState(42, MAX_TEST_ENTITIES);
-    world.simVersion = SIM_VERSION_V22_DIFFICULTY;
-    const colA = createColonyRecord(COLONY_ID, 0);
-    colA.entrances = [];
-    colA.rallyPoint = { tileX: 50, tileY: 5 };
-    colA.digFlowFieldDirty = false;
-    world.colonies[COLONY_ID] = colA;
-
-    const fighter = allocateEntityId(world);
-    initAnt(world.ants, fighter, {
-      colonyId: COLONY_ID,
-      posX: 10 << FP_SHIFT,
-      posY: 10 << FP_SHIFT,
-      task: AntTask.Fighting,
-      subTask: 0,
-    });
-    world.ants.zone[fighter] = Zone.Surface;
-
-    const spider = placeAggroSpider(world, 11, 10); // dist 1, but gate is closed pre-V23
-
-    updateFightAntTargets(world);
-
-    // No auto-aggro: fighter follows the rally, not the spider.
-    expect(world.ants.targetPosX[fighter]).toBe((50 << FP_SHIFT) + (FP_ONE >> 1));
-    expect(world.ants.targetPosX[fighter]).not.toBe(spider.posX);
-  });
+  // #247 — the "pre-V23 world shows no spider auto-aggro" pinning test was removed:
+  // MIN_ACCEPTED_SIM_VERSION is V30, so no V22 world can load; the reaped gate's
+  // legacy branch is unreachable in production.
 });
 
 // ---------------------------------------------------------------------------

--- a/src/sim/ant/ant-combat-targeting.ts
+++ b/src/sim/ant/ant-combat-targeting.ts
@@ -6,7 +6,7 @@ import { FIGHT_AGGRO_RADIUS } from '../constants.js';
 import { AntTask } from '../enums.js';
 import { FP_ONE, FP_SHIFT } from '../fixed.js';
 import { Zone, type UndergroundGrid } from '../terrain.js';
-import { SIM_VERSION_V23_SPIDER_AGGRO, type WorldState } from '../types.js';
+import type { WorldState } from '../types.js';
 import { DIR_DX, DIR_DY, canEnterUndergroundTile, packStep } from './ant-motion.js';
 import type { AntComponents } from './ant-store.js';
 import type { ScratchArena } from '../scratch.js';
@@ -265,7 +265,7 @@ export function updateFightAntTargets(world: WorldState): void {
       // The spider is targetable in ANY state: fighters may pursue a Feeding spider to
       // interrupt its heal (tickSpiderV23 forfeits the heal once a fighter is adjacent).
       let nearestIsSpider = false;
-      if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO && world.spider !== null) {
+      if (world.spider !== null) {
         const spTileX = world.spider.posX >> FP_SHIFT;
         const spTileY = world.spider.posY >> FP_SHIFT;
         const dist = Math.abs(spTileX - aggroTileX) + Math.abs(spTileY - aggroTileY);

--- a/src/sim/ant/ant-movement.ts
+++ b/src/sim/ant/ant-movement.ts
@@ -35,10 +35,7 @@ import {
   surfaceGoalDistance,
 } from '../surface-routing.js';
 import { UndergroundTileState, Zone, ugGet } from '../terrain.js';
-import {
-  SIM_VERSION_V33_OCCUPANCY_CENTER,
-  type WorldState,
-} from '../types.js';
+import { SIM_VERSION_V33_OCCUPANCY_CENTER, type WorldState } from '../types.js';
 import {
   pickInvaderUndergroundStep,
   pickNearestHostileUnderground,
@@ -1361,9 +1358,7 @@ export function tickAntMovement(
           // recalled-invader block earlier in tickAntMovement.
           const ownColonyForAscent = world.colonies[ants.colonyId[id]!];
           const isRecallingFromForeign =
-            !inOwnGrid &&
-            ownColonyForAscent != null &&
-            ownColonyForAscent.rallyPoint == null; // #247 — V25 unconditional (MIN=V30)
+            !inOwnGrid && ownColonyForAscent != null && ownColonyForAscent.rallyPoint == null; // #247 — V25 unconditional (MIN=V30)
           const skipAscent = task === AntTask.Fighting && !inOwnGrid && !isRecallingFromForeign;
           if (!skipAscent) {
             const lookupColonyId = ants.currentGridColonyId[id]!;

--- a/src/sim/ant/ant-movement.ts
+++ b/src/sim/ant/ant-movement.ts
@@ -36,7 +36,6 @@ import {
 } from '../surface-routing.js';
 import { UndergroundTileState, Zone, ugGet } from '../terrain.js';
 import {
-  SIM_VERSION_V25_RALLY_RECALL,
   SIM_VERSION_V33_OCCUPANCY_CENTER,
   type WorldState,
 } from '../types.js';
@@ -714,11 +713,7 @@ export function tickAntMovement(
         // for byte-identical replay of pre-V25 saves. Must stay in lockstep with the
         // ascent `isRecallingFromForeign` / `skipAscent` predicate in the
         // surface-ascent block later in tickAntMovement.
-        const isRecalling =
-          ownColony != null &&
-          (world.simVersion >= SIM_VERSION_V25_RALLY_RECALL
-            ? ownColony.rallyPoint == null
-            : ownColony.targetRatio.fight === 0 || ownColony.rallyPoint == null);
+        const isRecalling = ownColony != null && ownColony.rallyPoint == null; // #247 — V25 unconditional (MIN=V30)
 
         if (isRecalling) {
           // Recalled invader: navigate toward the nearest foreign entrance exit
@@ -1368,10 +1363,7 @@ export function tickAntMovement(
           const isRecallingFromForeign =
             !inOwnGrid &&
             ownColonyForAscent != null &&
-            (world.simVersion >= SIM_VERSION_V25_RALLY_RECALL
-              ? ownColonyForAscent.rallyPoint == null
-              : ownColonyForAscent.targetRatio.fight === 0 ||
-                ownColonyForAscent.rallyPoint == null);
+            ownColonyForAscent.rallyPoint == null; // #247 — V25 unconditional (MIN=V30)
           const skipAscent = task === AntTask.Fighting && !inOwnGrid && !isRecallingFromForeign;
           if (!skipAscent) {
             const lookupColonyId = ants.currentGridColonyId[id]!;

--- a/src/sim/ant/ant-movement.ts
+++ b/src/sim/ant/ant-movement.ts
@@ -705,12 +705,11 @@ export function tickAntMovement(
         // null colony is treated as NOT recalled (matches isRecallingFromForeign guard
         // in skipAscent) — missing colony record is a defensive fallback, not a recall.
         // V25 (#174): recall keys on the rally point alone — a cleared rally means
-        // "come home". Pre-V25 also recalled on fight===0, which fought an explicit
-        // rally on the enemy entrance and bounced invaders at the shaft. Kept gated
-        // for byte-identical replay of pre-V25 saves. Must stay in lockstep with the
-        // ascent `isRecallingFromForeign` / `skipAscent` predicate in the
-        // surface-ascent block later in tickAntMovement.
-        const isRecalling = ownColony != null && ownColony.rallyPoint == null; // #247 — V25 unconditional (MIN=V30)
+        // "come home". (#247: the pre-V25 fight===0 recall branch was reaped — MIN=V30 —
+        // so this is unconditional now.) Must stay in lockstep with the ascent
+        // `isRecallingFromForeign` / `skipAscent` predicate in the surface-ascent block
+        // later in tickAntMovement.
+        const isRecalling = ownColony != null && ownColony.rallyPoint == null;
 
         if (isRecalling) {
           // Recalled invader: navigate toward the nearest foreign entrance exit
@@ -1350,15 +1349,13 @@ export function tickAntMovement(
           const inOwnGrid = ants.currentGridColonyId[id] === ants.colonyId[id];
           // Recalled invaders must be able to exit the enemy underground, so
           // skipAscent is cleared for them. V25 (#174): recall keys on a cleared
-          // rally alone. Pre-V25 also recalled on fight===0, which made invaders
-          // ascend the moment they reached tileY=0 on the enemy entrance column
-          // even with a rally explicitly set there, producing a descend/ascend
-          // bounce. Kept gated for byte-identical replay. Must match the
-          // underground recall-navigation `isRecalling` predicate in the
-          // recalled-invader block earlier in tickAntMovement.
+          // rally alone. (#247: the pre-V25 fight===0 recall branch was reaped —
+          // MIN=V30 — so this is unconditional now.) Must match the underground
+          // recall-navigation `isRecalling` predicate in the recalled-invader block
+          // earlier in tickAntMovement.
           const ownColonyForAscent = world.colonies[ants.colonyId[id]!];
           const isRecallingFromForeign =
-            !inOwnGrid && ownColonyForAscent != null && ownColonyForAscent.rallyPoint == null; // #247 — V25 unconditional (MIN=V30)
+            !inOwnGrid && ownColonyForAscent != null && ownColonyForAscent.rallyPoint == null;
           const skipAscent = task === AntTask.Fighting && !inOwnGrid && !isRecallingFromForeign;
           if (!skipAscent) {
             const lookupColonyId = ants.currentGridColonyId[id]!;

--- a/src/sim/combat.test.ts
+++ b/src/sim/combat.test.ts
@@ -595,17 +595,8 @@ describe('spider combat gate (V23 #146/#147)', () => {
     expect(spider.hp).toBe(SPIDER_HP_FULL - COMBAT_DAMAGE_BASE);
   });
 
-  it('Patrolling spider takes NO damage under a pre-V23 (V22) world — old-replay guard', () => {
-    const { world, cid1 } = makeWorldWith2Colonies();
-    world.simVersion = SIM_VERSION_V22_DIFFICULTY;
-    const fighter = spawnFighter(world, cid1, 5, 7, Zone.Surface);
-    const spider = placeSpider(world, 5, 7, 'Patrolling');
-    armFighterAgainstSpider(world, fighter);
-
-    detectAndResolveCombat(world, new Rng(world.rngState));
-
-    expect(spider.hp).toBe(SPIDER_HP_FULL); // gate closed pre-V23
-  });
+  // #247 — "Patrolling spider takes NO damage under pre-V23" pinning test removed
+  // (V22 unloadable under MIN=V30; the reaped gate is unconditional now).
 
   it('Striking spider still engages even under a pre-V23 world (unchanged behavior)', () => {
     const { world, cid1 } = makeWorldWith2Colonies();
@@ -673,19 +664,8 @@ describe('spider-pairing sentinel cleanup (V23 Codex P1)', () => {
     expect(world.ants.combatOpponentId[ant]).toBe(-1);
   });
 
-  it('does NOT clear off-tile -2 under a pre-V23 (V22) world — old-replay guard', () => {
-    const { world, cid1 } = makeWorldWith2Colonies();
-    world.simVersion = SIM_VERSION_V22_DIFFICULTY;
-    placeSpider(world, 5, 7, 'Striking');
-    const ant = spawnFighter(world, cid1, 9, 9, Zone.Surface);
-    world.ants.combatOpponentId[ant] = -2;
-
-    detectAndResolveCombat(world, new Rng(world.rngState));
-
-    // V22 clears -2 only via clearSpiderPairingSentinels on episode exit, never
-    // in this pass — byte-identical guard.
-    expect(world.ants.combatOpponentId[ant]).toBe(-2);
-  });
+  // #247 — "does NOT clear off-tile -2 under pre-V23" pinning test removed
+  // (V22 unloadable under MIN=V30; the reaped gate is unconditional now).
 });
 
 // ---------------------------------------------------------------------------
@@ -840,18 +820,8 @@ describe('combat boundary fold (V26 #181)', () => {
     expect(world.ants.combatOpponentId[fighter]).toBe(-1);
   });
 
-  it('pre-V26 (V25) does NOT fold: exact same-tile matching only', () => {
-    // Guard: boundary fold is V26-only. Pre-V26 worlds keep exact same-tile matching.
-    const r = makeWorldWith2Colonies();
-    r.world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO; // V25 or earlier
-    const fighter = spawnFighter(r.world, r.cid1, 0, 10, Zone.Surface); // margin band
-    placeSpider(r.world, 3, 10, 'Chasing'); // boundary
-
-    detectAndResolveCombat(r.world, new Rng(r.world.rngState));
-
-    // No pairing in pre-V26.
-    expect(r.world.ants.combatOpponentId[fighter]).toBe(-1);
-  });
+  // #247 — "pre-V26 does NOT fold" pinning test removed (V25 unloadable under
+  // MIN=V30; the V26 boundary fold is unconditional now).
 
   it('interior spider at the same Y row as margin-band ant does NOT fold', () => {
     // Fold only triggers when spider is ON a boundary tile. An interior spider

--- a/src/sim/combat.ts
+++ b/src/sim/combat.ts
@@ -17,7 +17,6 @@ import { Rng } from './rng.js';
 import { AntTask } from './enums.js';
 import { makeTileKey } from './tile-key.js';
 import type { WorldState, KillerKind, QueenDeathContext } from './types.js';
-import { SIM_VERSION_V23_SPIDER_AGGRO, SIM_VERSION_V26_SPIDER_EDGE_MARGIN } from './types.js';
 import type { ColonyId } from './colony/colony-store.js';
 import type { Zone } from './terrain.js';
 import { FP_SHIFT } from './fixed.js';
@@ -141,7 +140,7 @@ export function detectAndResolveCombat(world: WorldState, _rng: Rng): void {
   //     preserving it for ants still on the tile so resolveSpiderCombatOnTile can
   //     continue their windup. (Codex P1.)
   const spider = world.spider;
-  const v23Spider = spider !== null && world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO;
+  const v23Spider = spider !== null; // #247 — V23 spider-aggro unconditional (MIN=V30)
   const spiderTileX = v23Spider ? spider.posX >> FP_SHIFT : -1;
   const spiderTileY = v23Spider ? spider.posY >> FP_SHIFT : -1;
   // V26: mirror the boundary fold in resolveSpiderCombatOnTile (gated identically
@@ -153,7 +152,7 @@ export function detectAndResolveCombat(world: WorldState, _rng: Rng): void {
   // in passive states, collapsing the fold to exact same-tile matching.
   const v26EdgeStale =
     v23Spider &&
-    world.simVersion >= SIM_VERSION_V26_SPIDER_EDGE_MARGIN &&
+    // #247 — V26 spider-edge-margin unconditional (MIN=V30)
     (spider.state === 'Chasing' || spider.state === 'Striking' || spider.state === 'Rampaging');
   const staleMargin = v26EdgeStale ? SPIDER_EDGE_MARGIN_TILES : 0;
   const staleLoX = staleMargin;
@@ -206,7 +205,8 @@ export function detectAndResolveCombat(world: WorldState, _rng: Rng): void {
     const spiderCombatActive =
       ss === 'Striking' ||
       ss === 'Rampaging' ||
-      (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO && ss !== 'Feeding' && ss !== 'Retreating');
+      // #247 — V23 spider-aggro unconditional (MIN=V30)
+      (ss !== 'Feeding' && ss !== 'Retreating');
     if (spiderCombatActive) {
       resolveSpiderCombatOnTile(world);
     }
@@ -587,8 +587,8 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
   // bite any ant sharing its row/column up to `margin` tiles away. In passive
   // states margin = 0, so only exact same-tile matching applies (as pre-V26).
   const v26Edge =
-    world.simVersion >= SIM_VERSION_V26_SPIDER_EDGE_MARGIN &&
-    (spider.state === 'Chasing' || spider.state === 'Striking' || spider.state === 'Rampaging');
+    // #247 — V26 spider-edge-margin unconditional (MIN=V30)
+    spider.state === 'Chasing' || spider.state === 'Striking' || spider.state === 'Rampaging';
   const margin = v26Edge ? SPIDER_EDGE_MARGIN_TILES : 0;
   const loX = margin;
   const hiX = SURFACE_GRID_WIDTH - 1 - margin;
@@ -642,7 +642,7 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
   // worker merely sharing the tile. Pre-V23 never reaches here in Patrolling (gate is
   // Striking/Rampaging only), so this is V23-only by construction.
   if (
-    world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO &&
+    // #247 — V23 spider-aggro unconditional (MIN=V30)
     spider.state === 'Patrolling' &&
     !hasFighter
   ) {
@@ -740,11 +740,10 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
     if (antDies) {
       if (spider.state === 'Striking') spider.killsThisStrike += 1;
       if (spider.state === 'Rampaging') spider.rampageKillsThisRampage += 1;
-      if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO) {
-        spider.killedThisTick = 1;
-        spider.lastKillTileX = spiderTileX;
-        spider.lastKillTileY = spiderTileY;
-      }
+      // #247 — V23 spider-aggro unconditional (MIN=V30)
+      spider.killedThisTick = 1;
+      spider.lastKillTileX = spiderTileX;
+      spider.lastKillTileY = spiderTileY;
       killAnt(world, swarmRetaliationTarget, null, null, 'Spider');
     }
     return;
@@ -802,11 +801,10 @@ export function resolveSpiderCombatOnTile(world: WorldState): void {
   if (antDies2) {
     if (spider.state === 'Striking') spider.killsThisStrike += 1;
     if (spider.state === 'Rampaging') spider.rampageKillsThisRampage += 1;
-    if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO) {
-      spider.killedThisTick = 1;
-      spider.lastKillTileX = spiderTileX;
-      spider.lastKillTileY = spiderTileY;
-    }
+    // #247 — V23 spider-aggro unconditional (MIN=V30)
+    spider.killedThisTick = 1;
+    spider.lastKillTileX = spiderTileX;
+    spider.lastKillTileY = spiderTileY;
     killAnt(world, activeAntIdx, null, null, 'Spider');
   }
 }

--- a/src/sim/invasion-routing.test.ts
+++ b/src/sim/invasion-routing.test.ts
@@ -37,7 +37,6 @@ import { tick } from './tick.js';
 import {
   allocateEntityId,
   LATEST_SIM_VERSION,
-  SIM_VERSION_V24_NURSERY_CAPACITY,
   SIM_VERSION_V25_RALLY_RECALL,
 } from './types.js';
 import { initAnt } from './ant/ant-store.js';
@@ -396,26 +395,7 @@ describe('invasion-routing — foreign recall keys on rally, not fight ratio (#1
     expect(world.ants.task[playerAntId]).toBe(AntTask.Fighting);
   });
 
-  it('V24 control: same scenario bounces the invader back to the surface (pre-fix behavior)', () => {
-    const { world, playerAntId } = descendCommittedInvader();
-    // Pin the sim to the pre-#174 version: recall still fires on fight===0.
-    world.simVersion = SIM_VERSION_V24_NURSERY_CAPACITY;
-    world.colonies[PLAYER_COLONY_ID]!.targetRatio.fight = 0;
-
-    expect(world.simVersion).toBeLessThan(SIM_VERSION_V25_RALLY_RECALL);
-
-    // Under V24 the fight===0 disjunct recalls the invader: it routes to the
-    // entrance exit and ascends. Confirm it reaches the Surface within the
-    // window — the exact bounce that V25 eliminates.
-    let surfaced = false;
-    for (let t = 0; t < HOLD_TICKS; t++) {
-      const cmds = world.commandQueue.splice(0);
-      tick(world, cmds);
-      if (world.ants.zone[playerAntId] === Zone.Surface) {
-        surfaced = true;
-        break;
-      }
-    }
-    expect(surfaced).toBe(true);
-  });
+  // #247 — the "V24 control (pre-fix bounce)" test was removed: it pinned the sim
+  // to V24 to exercise the pre-V25 fight===0 recall disjunct, which the V25 gate reap
+  // deleted. MIN_ACCEPTED_SIM_VERSION is V30, so no V24 world can load in production.
 });

--- a/src/sim/invasion-routing.test.ts
+++ b/src/sim/invasion-routing.test.ts
@@ -34,11 +34,7 @@
 import { describe, it, expect } from 'vitest';
 import { createScenario } from './scenario.js';
 import { tick } from './tick.js';
-import {
-  allocateEntityId,
-  LATEST_SIM_VERSION,
-  SIM_VERSION_V25_RALLY_RECALL,
-} from './types.js';
+import { allocateEntityId, LATEST_SIM_VERSION, SIM_VERSION_V25_RALLY_RECALL } from './types.js';
 import { initAnt } from './ant/ant-store.js';
 import { AntTask } from './enums.js';
 import { Zone, UndergroundTileState, ugSet } from './terrain.js';


### PR DESCRIPTION
**Wave C · C1 · PR-5 (batch 1 of 2)**. Advances #247 (does NOT close it — per its own "reap in small batches, one subsystem per PR" playbook).

`MIN_ACCEPTED_SIM_VERSION` is V30, so every `simVersion >= VNN` gate with `VNN ≤ V30` is unconditionally true in production (no loadable save < V30). This batch reaps the dead ≤V30 gates in **3 subsystems** (10 gates), one commit each:

| Subsystem | Gates reaped | Pinning tests deleted |
|---|---|---|
| ant-combat-targeting | V23 spider-aggro (1) | 1 (pre-V23 V22) |
| ant-movement | V25 rally-recall (2) | 1 (V24 control, in invasion-routing.test) |
| combat | V23 spider-aggro (5) + V26 edge-margin (2) | 3 (pre-V23/V26) |

Each reap deletes the dead legacy branch, makes the `>=` side unconditional (no other rewording), and deletes the tests that pinned the removed behavior by setting `simVersion` to an unloadable version. **Registry entries in `types.ts` are kept** (history + save validation).

## Safety / gates
- **Byte-gate byte-identical** vs `main` after each subsystem (fresh-V33 worlds take the surviving `>=` branch).
- **The over-reap net is the both-sides V31–V33 version suites** in `npm run verify`, NOT the byte-gate (which runs V33 worlds where a *live* gate is always-true → blind to an over-reap). Wave B interleaved **live** V31/V32/V33 gates into `spider.ts`/`tick.ts`/`ant-movement.ts` — this batch **surgically avoids** them (spider V31×4/V32, tick V32, ant-movement V33 untouched); `spider.test` 92 green confirms.
- `npm run verify` green — **2773 passed | 1 skipped**.

## Remaining (batch 2, #247 stays open)
`ant-nursing` (V24×3), `tick` (V24×2/V27), `spider` (V23×2/V26×2 — avoiding the live V31/V32), `colony-system` (V27/V3), `constants` (V14×3/V8). Split out because several are dead-`else`-branch deletions (larger legacy-code removals) that warrant their own focused review pass rather than being rushed into this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShzYQ9mtDjHeUNmte3X2i6