### PR TITLE
#247 (batch 2) — reap dead ≤V30 simVersion gates: ant-nursing, tick step-9/forage

### DIFF
--- a/src/sim/ant/ant-nursing.test.ts
+++ b/src/sim/ant/ant-nursing.test.ts
@@ -8,7 +8,6 @@ import {
   allocateEntityId,
   SIM_VERSION_V9_CANCEL_DROPS_PENDING,
   SIM_VERSION_V10_VISIBLE_BROOD_CARRY,
-  SIM_VERSION_V23_SPIDER_AGGRO,
   SIM_VERSION_V24_NURSERY_CAPACITY,
 } from '../types.js';
 import { createColonyRecord } from '../colony/colony-store.js';
@@ -1533,13 +1532,9 @@ describe('Nursery brood deposit — capacity-aware spread, real pipeline (#173, 
     expect(inB).toBeLessThanOrEqual(12);
   });
 
-  it('V23 control: the same 13 carriers funnel into the nearest Nursery A; B stays empty (old behavior preserved)', () => {
-    const { world, colony, underground, A, B } = mkWorld(SIM_VERSION_V23_SPIDER_AGGRO);
-    const driver = makeDriver(world, colony, underground);
-    for (let n = 0; n < 13; n++) driver.carryOne(400);
-    expect(broodCountIn(world, colony, A)).toBe(13); // all funneled to nearest (stacked)
-    expect(broodCountIn(world, colony, B)).toBe(0); // far Nursery never used
-  });
+  // #247 — "V23 control: carriers funnel into nearest Nursery (pre-V24 modulo)"
+  // pinning test removed: V23 unloadable under MIN=V30; the pre-V24 modulo-slot
+  // branch it exercised was reaped (occupancy-aware placement is unconditional).
 
   it('V24 saturation: when EVERY Nursery is full, a carrier overflow-deposits (stacks) rather than piling up forever', () => {
     // When no Nursery has free capacity anywhere, deferring forever would pile up

--- a/src/sim/ant/ant-nursing.ts
+++ b/src/sim/ant/ant-nursing.ts
@@ -88,8 +88,8 @@ export function tickNurseActions(world: WorldState, chamberFlowFields?: ChamberF
       // non-full Nursery, or — when none is reachable — the fallback Nursery).
       // A carrier merely TRANSITING a full Nursery toward a non-full one sits on
       // a step tile (0..3), so it keeps moving instead of overflowing the full
-      // Nursery. Pre-V24 — or when no field is supplied (unit tests that drive
-      // tickNurseActions directly) — keeps the original isInsideNursery deposit.
+      // Nursery. When no field is supplied (unit tests that drive tickNurseActions
+      // directly) the else keeps the original isInsideNursery deposit.
       let shouldDeposit: boolean;
       // #247 — V24 gate reaped (MIN=V30); the else still handles the no-field case
       // (unit tests that drive tickNurseActions without chamberFlowFields).
@@ -312,8 +312,8 @@ function findUncarriedBroodOnTile(
 }
 
 /**
- * Compute a deposit position within a single Nursery `chamber`, spread
- * across its Open tiles by `broodId % openCount` in row-major order.
+ * Compute a deposit position within a single Nursery `chamber`: the first
+ * UNOCCUPIED Open tile in row-major order (occupancy per `tileHasResidentBrood`).
  * Returns `null` if no underground grid or no Open tile exists in that chamber.
  *
  * Used by `depositCarriedBrood` (v10+) to keep brood in the specific chamber

--- a/src/sim/ant/ant-nursing.ts
+++ b/src/sim/ant/ant-nursing.ts
@@ -9,7 +9,7 @@ import { NURSE_ATTEND_DWELL_TICKS } from '../constants.js';
 import { AntTask, ChamberType, NursingSubState } from '../enums.js';
 import { FP_ONE, FP_SHIFT } from '../fixed.js';
 import { UndergroundTileState, Zone, type UndergroundGrid, ugGet } from '../terrain.js';
-import { SIM_VERSION_V24_NURSERY_CAPACITY, type WorldState } from '../types.js';
+import type { WorldState } from '../types.js';
 import { isInsideQueenChamber } from './ant-motion.js';
 import { isBroodReclaimable, type AntComponents } from './ant-store.js';
 
@@ -91,7 +91,9 @@ export function tickNurseActions(world: WorldState, chamberFlowFields?: ChamberF
       // Nursery. Pre-V24 — or when no field is supplied (unit tests that drive
       // tickNurseActions directly) — keeps the original isInsideNursery deposit.
       let shouldDeposit: boolean;
-      if (world.simVersion >= SIM_VERSION_V24_NURSERY_CAPACITY && chamberFlowFields !== undefined) {
+      // #247 — V24 gate reaped (MIN=V30); the else still handles the no-field case
+      // (unit tests that drive tickNurseActions without chamberFlowFields).
+      if (chamberFlowFields !== undefined) {
         const field = chamberFlowFields.nurseDeposit[colonyId];
         const underground = world.undergroundGrids[colonyId];
         shouldDeposit =
@@ -346,30 +348,17 @@ function computeDepositPositionInChamber(
   // caller keeps the brood at the carrier's current tile, preserving the
   // one-per-tile invariant (the brood is re-deposited on a later tick once a
   // tile frees up).
-  if (world.simVersion >= SIM_VERSION_V24_NURSERY_CAPACITY) {
-    for (let ty = 0; ty < chamber.height; ty++) {
-      for (let tx = 0; tx < chamber.width; tx++) {
-        const cx = bx + tx;
-        const cy = by + ty;
-        if (ugGet(underground, cx, cy) !== UndergroundTileState.Open) continue;
-        if (tileHasResidentBrood(world, colony, broodId, cx, cy)) continue;
-        return { x: (cx << FP_SHIFT) + (FP_ONE >> 1), y: (cy << FP_SHIFT) + (FP_ONE >> 1) };
-      }
-    }
-    return null;
-  }
-
-  const targetIndex = broodId % openCount;
-  let cursor = 0;
+  // #247 — V24 occupancy-aware placement is unconditional (MIN=V30). The legacy
+  // `broodId % openCount` modulo-slot fallback that followed was dead (this block
+  // always returns a tile or null) and is reaped. (openCount is still read by the
+  // openCount===0 early-return guard above.)
   for (let ty = 0; ty < chamber.height; ty++) {
     for (let tx = 0; tx < chamber.width; tx++) {
       const cx = bx + tx;
       const cy = by + ty;
       if (ugGet(underground, cx, cy) !== UndergroundTileState.Open) continue;
-      if (cursor === targetIndex) {
-        return { x: (cx << FP_SHIFT) + (FP_ONE >> 1), y: (cy << FP_SHIFT) + (FP_ONE >> 1) };
-      }
-      cursor++;
+      if (tileHasResidentBrood(world, colony, broodId, cx, cy)) continue;
+      return { x: (cx << FP_SHIFT) + (FP_ONE >> 1), y: (cy << FP_SHIFT) + (FP_ONE >> 1) };
     }
   }
   return null;
@@ -525,7 +514,8 @@ function depositCarriedBrood(
   //     sustained saturation (e.g. a colony with a single Nursery and continuous
   //     egg-laying) deferring forever would pile up carriers and starve brood
   //     transport. Falls through to the carrier-tile drop below.
-  if (pos === null && world.simVersion >= SIM_VERSION_V24_NURSERY_CAPACITY) {
+  if (pos === null) {
+    // #247 — V24 gate reaped (MIN=V30)
     const underground = world.undergroundGrids[colony.colonyId];
     // Issue #173 (V24+): only DEFER if a non-full Nursery is reachable from the
     // carrier's CURRENT tile over the walkable graph. A non-full Nursery that

--- a/src/sim/forager-backpressure.test.ts
+++ b/src/sim/forager-backpressure.test.ts
@@ -9,9 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import { tick } from './tick.js';
 import { createWorldState, allocateEntityId } from './types.js';
-import {
-  SIM_VERSION_V27_FORAGE_BACKPRESSURE,
-} from './types.js';
+import { SIM_VERSION_V27_FORAGE_BACKPRESSURE } from './types.js';
 import { initAnt } from './ant/ant-store.js';
 import { createColonyRecord, type ColonyId } from './colony/colony-store.js';
 import { colonyHasNoDepositTarget, colonyForageBackpressure } from './colony/colony-system.js';

--- a/src/sim/forager-backpressure.test.ts
+++ b/src/sim/forager-backpressure.test.ts
@@ -203,8 +203,7 @@ describe('#126 V27 forager storage backpressure', () => {
     });
   });
 
-  // (c) — version gate. Identical saturated setup: V26 still promotes (the old
-  // churn), V27 suppresses. This proves the gate, not just same-version parity.
+  // (c) — suppression under a saturated state.
   describe('(c) forage-backpressure suppression', () => {
     // #247 — the "V26 promotes idle ants (pre-fix churn)" control was removed: V26 is
     // unloadable under MIN=V30 and the reaped V27 gate makes suppression unconditional.

--- a/src/sim/forager-backpressure.test.ts
+++ b/src/sim/forager-backpressure.test.ts
@@ -10,7 +10,6 @@ import { describe, it, expect } from 'vitest';
 import { tick } from './tick.js';
 import { createWorldState, allocateEntityId } from './types.js';
 import {
-  SIM_VERSION_V26_SPIDER_EDGE_MARGIN,
   SIM_VERSION_V27_FORAGE_BACKPRESSURE,
 } from './types.js';
 import { initAnt } from './ant/ant-store.js';
@@ -208,16 +207,10 @@ describe('#126 V27 forager storage backpressure', () => {
 
   // (c) — version gate. Identical saturated setup: V26 still promotes (the old
   // churn), V27 suppresses. This proves the gate, not just same-version parity.
-  describe('(c) V26-vs-V27 gate', () => {
-    it('V26 promotes idle ants into Foraging (pre-fix churn)', () => {
-      const { world, idleIds } = buildSaturatedWorld({
-        simVersion: SIM_VERSION_V26_SPIDER_EDGE_MARGIN,
-      });
-      tick(world, []);
-      expect(foragerCount(world, idleIds)).toBeGreaterThan(0);
-    });
-
-    it('V27 suppresses promotion under the identical saturated state', () => {
+  describe('(c) forage-backpressure suppression', () => {
+    // #247 — the "V26 promotes idle ants (pre-fix churn)" control was removed: V26 is
+    // unloadable under MIN=V30 and the reaped V27 gate makes suppression unconditional.
+    it('suppresses promotion under a saturated state', () => {
       const { world, idleIds } = buildSaturatedWorld({
         simVersion: SIM_VERSION_V27_FORAGE_BACKPRESSURE,
       });

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1104,8 +1104,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // tick like the pickup field above (a Nursery's fill level changes as
     // carriers deposit). A full Nursery drops out of the preferred seed set so
     // carriers route to a non-full one; the two-pass fallback keeps every
-    // reachable carrier routed to SOME Nursery. Pre-V24 uses the dirty-gated
-    // nearest-seed field above.
+    // reachable carrier routed to SOME Nursery.
     // #247 — V24 capacity-aware deposit field is unconditional (MIN=V30).
     computeNurseryDepositField(
       underground,

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -3,8 +3,6 @@ import type { WorldState } from './types.js';
 import {
   allocateEntityId,
   INVALID_ENTITY_ID,
-  SIM_VERSION_V24_NURSERY_CAPACITY,
-  SIM_VERSION_V27_FORAGE_BACKPRESSURE,
   SIM_VERSION_V32_AI_OP_VALIDATION,
 } from './types.js';
 import { tickSpider } from './spider.js';
@@ -89,7 +87,6 @@ import {
   createChamberFlowFields,
   FOOD_CHAMBER_TYPES,
   NURSING_CHAMBER_TYPES,
-  NURSERY_CHAMBER_TYPES,
   QUEEN_CHAMBER_TYPES,
 } from './chamber-flow.js';
 import type { ChamberFlowFields } from './chamber-flow.js';
@@ -1059,21 +1056,9 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
         chamberBufs.queen,
         chamberBufs.queue,
       );
-      // Issue #17 Phase 1 — Nursery-only deposit field for v10+ carrying nurses.
-      // Pre-v10 the field is allocated but unread; computed alongside the other
-      // chamber fields for code symmetry — no measurable cost.
-      // Issue #173 (V24+): the capacity-aware deposit field is rebuilt every tick
-      // in the loop below; here we compute only the legacy nearest-seed field for
-      // pre-V24 byte-identical replay.
-      if (world.simVersion < SIM_VERSION_V24_NURSERY_CAPACITY) {
-        computeChamberFlowField(
-          underground,
-          colony.chambers,
-          NURSERY_CHAMBER_TYPES,
-          chamberBufs.nurseDeposit,
-          chamberBufs.queue,
-        );
-      }
+      // #247 — the pre-V24 legacy nearest-seed nurseDeposit compute (a
+      // `simVersion < V24` block) was reaped: unreachable under MIN=V30. The V24+
+      // capacity-aware deposit field is rebuilt every tick in the second loop below.
     }
 
     colony.digFlowFieldDirty = false;
@@ -1125,17 +1110,16 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // carriers route to a non-full one; the two-pass fallback keeps every
     // reachable carrier routed to SOME Nursery. Pre-V24 uses the dirty-gated
     // nearest-seed field above.
-    if (world.simVersion >= SIM_VERSION_V24_NURSERY_CAPACITY) {
-      computeNurseryDepositField(
-        underground,
-        colony.chambers,
-        world.ants,
-        colony.eggs,
-        colony.larvae,
-        chamberBufs.nurseDeposit,
-        chamberBufs.queue,
-      );
-    }
+    // #247 — V24 capacity-aware deposit field is unconditional (MIN=V30).
+    computeNurseryDepositField(
+      underground,
+      colony.chambers,
+      world.ants,
+      colony.eggs,
+      colony.larvae,
+      chamberBufs.nurseDeposit,
+      chamberBufs.queue,
+    );
     colony.broodFieldDirty = false; // #235 — consumed; the second loop is the sole clearer
   }
 
@@ -1336,11 +1320,8 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // renderer/HUD/autosave still read the canonical allocation and forage
     // promotion resumes once a chamber frees or the queen drains the pool. Pre-V27
     // saves keep the churn for byte-identical replay.
-    if (
-      world.simVersion >= SIM_VERSION_V27_FORAGE_BACKPRESSURE &&
-      needForage > 0 &&
-      colonyForageBackpressure(colony, world.simVersion)
-    ) {
+    // #247 — V27 forage-backpressure unconditional (MIN=V30)
+    if (needForage > 0 && colonyForageBackpressure(colony, world.simVersion)) {
       needForage = 0;
     }
 

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1,10 +1,6 @@
 // src/sim/tick.ts — Phase 9 19-step tick dispatcher.
 import type { WorldState } from './types.js';
-import {
-  allocateEntityId,
-  INVALID_ENTITY_ID,
-  SIM_VERSION_V32_AI_OP_VALIDATION,
-} from './types.js';
+import { allocateEntityId, INVALID_ENTITY_ID, SIM_VERSION_V32_AI_OP_VALIDATION } from './types.js';
 import { tickSpider } from './spider.js';
 import { MAX_COMMANDS_PER_TICK, type SimCommand } from './commands.js';
 import { GameOutcome, checkQueenDeath, checkTiebreaks } from './game-over.js';


### PR DESCRIPTION
**Wave C · C1 · PR-5 (batch 2)**. Advances #247 (still does NOT close it — spider + colony-system remain as batch 3, see below).

Reaps dead ≤V30 gates (unconditionally true under `MIN_ACCEPTED=V30`) in 2 more subsystems:

| Subsystem | Gates reaped | Notes |
|---|---|---|
| **ant-nursing** | V24 ×3 | capacity-aware deposit predicate (else KEPT — handles the no-field unit-test path), occupancy-aware placement (legacy `broodId%openCount` modulo fallback **deleted as dead**), defer-vs-overflow decision. 1 pre-V24 pinning test deleted. |
| **tick** step-9 + forage | V24 ×2, V27 | pre-V24 legacy `nurseDeposit` compute (a `< V24` block — deleted), V24 `computeNurseryDepositField` (unwrapped), V27 forage-backpressure conjunct. 1 pre-V27 churn pinning test deleted. **Live V32 AI-op-validation gate untouched.** |

## Safety
- **Byte-gate byte-identical** vs `main` after each subsystem.
- Over-reap net = the both-sides V31–V33 version suites in `verify` (not the byte-gate). The live V32 gate in `tick.ts` and all spider V31/V32 gates are untouched.
- `npm run verify` green — **2771 passed | 1 skipped**.

## Deferred to batch 3 (#247 stays open)
- **spider** — the V23 dispatch gate reap deletes the frozen 306-line `tickSpiderV22` function, which cascades into 6 orphaned constants, a helper, **and ~14 pre-V23 (V20-default) unit tests** whose live-V23 coverage equivalent needs auditing before deletion. Too large/interconnected to bundle safely here — warrants a focused PR.
- **colony-system** — `withdrawFood` (V3) + `colonyForageBackpressure` (V27) both orphan a now-unused `simVersion` param whose removal cascades to prod + ~10 test call-sites + a determinism legacy-vs-latest pinning test.
- **constants** — no real gates (the `simVersion >=` matches there are all JSDoc prose, not code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShzYQ9mtDjHeUNmte3X2i6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Nursery brood placement now more reliably uses open, unoccupied spaces and falls back more consistently when no space is available.
  - Forager backpressure handling is now stricter, reducing unnecessary promotion to foraging when storage is already saturated.
  - Updated ant simulation routing so newer nursery behavior is applied consistently across the latest simulation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->