### PR TITLE
chore(sim): reap dead ≤V30 simVersion gates — spider + colony-system (#247 batch 3)

### DIFF
--- a/src/sim/ant/ant-dig.ts
+++ b/src/sim/ant/ant-dig.ts
@@ -69,7 +69,7 @@ export function tickSearchLeash(world: WorldState): void {
     // re-promoted into a state this leash would immediately demote. V27 scopes
     // it to colonies that own a FoodStorage chamber (the mature-colony pile-up);
     // pre-V27 keeps the chamberless-inclusive at-cap demotion for replay.
-    forageBackpressure[colony.colonyId] = colonyForageBackpressure(colony, world.simVersion);
+    forageBackpressure[colony.colonyId] = colonyForageBackpressure(colony);
   }
 
   for (let id = 0; id < world.nextEntityId; id++) {

--- a/src/sim/ant/ant-dig.ts
+++ b/src/sim/ant/ant-dig.ts
@@ -66,9 +66,8 @@ export function tickSearchLeash(world: WorldState): void {
 
     // Shared forager-backpressure gate — kept in lockstep with the #126 step-10a
     // idle-promotion suppression (colony-system.ts) so a forager is never
-    // re-promoted into a state this leash would immediately demote. V27 scopes
-    // it to colonies that own a FoodStorage chamber (the mature-colony pile-up);
-    // pre-V27 keeps the chamberless-inclusive at-cap demotion for replay.
+    // re-promoted into a state this leash would immediately demote. Scoped to
+    // colonies that own a FoodStorage chamber (the mature-colony pile-up of #126).
     forageBackpressure[colony.colonyId] = colonyForageBackpressure(colony);
   }
 

--- a/src/sim/colony/colony-system.test.ts
+++ b/src/sim/colony/colony-system.test.ts
@@ -26,7 +26,7 @@ import {
   checkEntranceCompletion,
   tickDeadDiggerCleanup,
 } from './colony-system.js';
-import { createWorldState, LATEST_SIM_VERSION } from '../types.js';
+import { createWorldState } from '../types.js';
 import { createColonyRecord } from './colony-store.js';
 import { initAnt } from '../ant/ant-store.js';
 import { AntTask, ChamberType } from '../enums.js';
@@ -147,21 +147,21 @@ function addEgg(world: WorldState, colony: ColonyRecord): number {
 describe('withdrawFood', () => {
   it('1. success — returns true and decrements foodStored', () => {
     const { colony } = setupWorldWithQueen(100);
-    const result = withdrawFood(colony, 50, LATEST_SIM_VERSION);
+    const result = withdrawFood(colony, 50);
     expect(result).toBe(true);
     expect(colony.foodStored).toBe(50);
   });
 
   it('2. insufficient — returns false, foodStored unchanged', () => {
     const { colony } = setupWorldWithQueen(10);
-    const result = withdrawFood(colony, 50, LATEST_SIM_VERSION);
+    const result = withdrawFood(colony, 50);
     expect(result).toBe(false);
     expect(colony.foodStored).toBe(10);
   });
 
   it('3. exact amount — returns true, foodStored reaches 0', () => {
     const { colony } = setupWorldWithQueen(50);
-    const result = withdrawFood(colony, 50, LATEST_SIM_VERSION);
+    const result = withdrawFood(colony, 50);
     expect(result).toBe(true);
     expect(colony.foodStored).toBe(0);
   });
@@ -181,7 +181,7 @@ describe('withdrawFood', () => {
       width: 1,
       height: 1,
     });
-    const result = withdrawFood(colony, 50, LATEST_SIM_VERSION);
+    const result = withdrawFood(colony, 50);
     expect(result).toBe(true);
     expect(colony.chambers[0]!.foodStored).toBe(150); // chamber drained
     expect(colony.foodStored).toBe(100); // pool untouched
@@ -198,7 +198,7 @@ describe('withdrawFood', () => {
       width: 1,
       height: 1,
     });
-    const result = withdrawFood(colony, 50, LATEST_SIM_VERSION);
+    const result = withdrawFood(colony, 50);
     expect(result).toBe(true);
     expect(colony.chambers[0]!.foodStored).toBe(0); // chamber drained first
     expect(colony.foodStored).toBe(80); // remaining 20 from pool
@@ -239,17 +239,17 @@ describe('withdrawFood', () => {
 
     // Tiny drain from chamber 0 — saturated → still saturated (free space < HYST).
     // Must NOT fire dirty (this is the queen-drain oscillation case).
-    withdrawFood(colony, 1, LATEST_SIM_VERSION);
+    withdrawFood(colony, 1);
     expect(colony.foodFlowFieldDirty).toBe(false);
 
     // Drain enough to cross the saturation boundary — saturated → depositable.
     // Chamber 0 now has free space == HYST. Must fire dirty.
-    withdrawFood(colony, HYST - 1, LATEST_SIM_VERSION);
+    withdrawFood(colony, HYST - 1);
     expect(colony.foodFlowFieldDirty).toBe(true);
 
     // Reset. Further drain in the depositable band — must NOT re-fire.
     colony.foodFlowFieldDirty = false;
-    withdrawFood(colony, 1, LATEST_SIM_VERSION);
+    withdrawFood(colony, 1);
     expect(colony.foodFlowFieldDirty).toBe(false);
 
     // Drain across both chambers within the depositable band — must NOT fire.
@@ -263,7 +263,7 @@ describe('withdrawFood', () => {
     // early-return — assertion would pass vacuously without exercising the
     // drain loop.)
     colony.foodFlowFieldDirty = false;
-    expect(withdrawFood(colony, 4707, LATEST_SIM_VERSION)).toBe(true);
+    expect(withdrawFood(colony, 4707)).toBe(true);
     expect(colony.foodFlowFieldDirty).toBe(false);
     expect(colony.chambers[0]!.foodStored).toBe(0);
     expect(colony.chambers[1]!.foodStored).toBe(0);

--- a/src/sim/colony/colony-system.ts
+++ b/src/sim/colony/colony-system.ts
@@ -26,12 +26,7 @@
 // No Math.floor, no floats, no division operator.
 
 import type { WorldState } from '../types.js';
-import {
-  allocateEntityId,
-  INVALID_ENTITY_ID,
-  SIM_VERSION_V3,
-  SIM_VERSION_V27_FORAGE_BACKPRESSURE,
-} from '../types.js';
+import { allocateEntityId, INVALID_ENTITY_ID } from '../types.js';
 import type { ChamberRecord, ColonyRecord } from './colony-store.js';
 import type { ColonyId } from './colony-store.js';
 import {
@@ -153,13 +148,9 @@ export function colonyHasNoDepositTarget(colony: ColonyRecord): boolean {
  * via the universal #27 wait-wake gate, which keys on `colonyHasNoDepositTarget`
  * directly — so a full chamberless pool stays topped off without dispatching new
  * foragers needlessly.)
- *
- * Pre-V27 keeps the chamberless-inclusive at-cap behaviour the #42 demotion
- * recorded, for byte-identical replay.
  */
-export function colonyForageBackpressure(colony: ColonyRecord, simVersion: number): boolean {
+export function colonyForageBackpressure(colony: ColonyRecord): boolean {
   if (!colonyHasNoDepositTarget(colony)) return false;
-  if (simVersion < SIM_VERSION_V27_FORAGE_BACKPRESSURE) return true;
   for (let c = 0; c < colony.chambers.length; c++) {
     if (colony.chambers[c]!.chamberType === ChamberType.FoodStorage) return true;
   }
@@ -170,20 +161,11 @@ export function colonyForageBackpressure(colony: ColonyRecord, simVersion: numbe
  * Attempt to withdraw `amount` food. All-or-nothing: returns false (no
  * partial withdrawal) if the colony's combined stored food is below `amount`.
  *
- * Drain order is deterministic and gated on `simVersion`:
- *
- *   simVersion === LEGACY_SIM_VERSION (2): FoodStorage chambers in
- *     colony.chambers array order, then the entrance-shaft pool. Each
- *     source contributes up to its current contents. Issue #15 baseline.
- *
- *   simVersion === LATEST_SIM_VERSION (3): drain the FoodStorage chamber
- *     with the highest fill level first; on ties, lowest array index wins
- *     (matches LEGACY semantics on equal fills, so single-chamber colonies
- *     have identical behavior across versions). Then the entrance pool.
- *     Reduces flow-field re-seed thrash when many chambers cluster near
- *     saturation: drain-fullest concentrates the saturated→depositable
- *     crossing on one chamber at a time instead of cycling through several.
- *     Closes issue #27.
+ * Drain order: the FoodStorage chamber with the highest fill level first; on
+ * ties, lowest array index wins. Then the entrance-shaft pool. Draining
+ * fullest-first reduces flow-field re-seed thrash when many chambers cluster
+ * near saturation — it concentrates the saturated→depositable crossing on one
+ * chamber at a time instead of cycling through several (closes issue #27).
  *
  * Issue #15 follow-up — flow-field dirty: fires only when a chamber crosses
  * the saturation→depositable boundary (per isFoodChamberDepositable), not
@@ -193,60 +175,43 @@ export function colonyForageBackpressure(colony: ColonyRecord, simVersion: numbe
  * the oscillation cycle described in the FOOD_CHAMBER_DEPOSIT_HYSTERESIS_FP
  * constant docs.
  */
-export function withdrawFood(colony: ColonyRecord, amount: number, simVersion: number): boolean {
+export function withdrawFood(colony: ColonyRecord, amount: number): boolean {
   if (colonyFoodTotal(colony) < amount) return false;
 
   let remaining = amount;
-  if (simVersion >= SIM_VERSION_V3) {
-    // LATEST: drain fullest-first, array-index tie-break. Outer `while`
-    // re-scans on each iteration; in steady state both production callers
-    // (queen 2 fp, larva 1 fp) terminate after iteration 1 because the
-    // fullest chamber holds far more than the drain amount. Theoretical
-    // worst case (tiny dribbles across many chambers) is O(N²) but does
-    // not arise in any current call path. If a future caller drains an
-    // amount that may exceed several chambers' holdings, replace this
-    // with a single-pass merge over a pre-sorted view.
-    while (remaining > 0) {
-      let pickIdx = -1;
-      let pickFill = -1;
-      for (let i = 0; i < colony.chambers.length; i++) {
-        const ch = colony.chambers[i]!;
-        if (ch.chamberType !== ChamberType.FoodStorage) continue;
-        if (ch.foodStored <= 0) continue;
-        if (ch.foodStored > pickFill) {
-          pickFill = ch.foodStored;
-          pickIdx = i;
-        }
-      }
-      if (pickIdx < 0) break; // no chamber has food
-
-      const ch = colony.chambers[pickIdx]!;
-      const wasDepositable = isFoodChamberDepositable(ch);
-      const take = ch.foodStored < remaining ? ch.foodStored : remaining;
-      ch.foodStored -= take;
-      remaining -= take;
-      // `wasDepositable` is recomputed each outer iteration; the dirty
-      // fire is naturally idempotent across the saturation crossing —
-      // once a chamber is depositable, subsequent picks that still drain
-      // it observe wasDepositable=true and skip the dirty write.
-      if (!wasDepositable && isFoodChamberDepositable(ch)) {
-        colony.foodFlowFieldDirty = true;
-      }
-    }
-  } else {
-    // LEGACY (simVersion <= 2): array-order drain — issue #15 baseline.
-    // Replays of pre-#27 saves continue to use this path verbatim.
-    for (let i = 0; i < colony.chambers.length && remaining > 0; i++) {
+  // Drain fullest-first, array-index tie-break. Outer `while` re-scans on
+  // each iteration; in steady state both production callers (queen 2 fp,
+  // larva 1 fp) terminate after iteration 1 because the fullest chamber
+  // holds far more than the drain amount. Theoretical worst case (tiny
+  // dribbles across many chambers) is O(N²) but does not arise in any
+  // current call path. If a future caller drains an amount that may exceed
+  // several chambers' holdings, replace this with a single-pass merge over
+  // a pre-sorted view.
+  while (remaining > 0) {
+    let pickIdx = -1;
+    let pickFill = -1;
+    for (let i = 0; i < colony.chambers.length; i++) {
       const ch = colony.chambers[i]!;
       if (ch.chamberType !== ChamberType.FoodStorage) continue;
       if (ch.foodStored <= 0) continue;
-      const wasDepositable = isFoodChamberDepositable(ch);
-      const take = ch.foodStored < remaining ? ch.foodStored : remaining;
-      ch.foodStored -= take;
-      remaining -= take;
-      if (!wasDepositable && isFoodChamberDepositable(ch)) {
-        colony.foodFlowFieldDirty = true;
+      if (ch.foodStored > pickFill) {
+        pickFill = ch.foodStored;
+        pickIdx = i;
       }
+    }
+    if (pickIdx < 0) break; // no chamber has food
+
+    const ch = colony.chambers[pickIdx]!;
+    const wasDepositable = isFoodChamberDepositable(ch);
+    const take = ch.foodStored < remaining ? ch.foodStored : remaining;
+    ch.foodStored -= take;
+    remaining -= take;
+    // `wasDepositable` is recomputed each outer iteration; the dirty
+    // fire is naturally idempotent across the saturation crossing —
+    // once a chamber is depositable, subsequent picks that still drain
+    // it observe wasDepositable=true and skip the dirty write.
+    if (!wasDepositable && isFoodChamberDepositable(ch)) {
+      colony.foodFlowFieldDirty = true;
     }
   }
 
@@ -354,17 +319,10 @@ export function largestNurseryTileCount(colony: ColonyRecord): number {
 export function tickFoodConsumption(world: WorldState, colony: ColonyRecord): void {
   const ants = world.ants;
 
-  // Issue #27 — drain order varies by sim version (see withdrawFood JSDoc);
-  // capture once so both queen and larva loops use a consistent value for
-  // the entire tick (defensive — `world.simVersion` is sticky on load and
-  // can't change mid-tick, but pulling it once costs nothing and keeps the
-  // intent local).
-  const simVersion = world.simVersion;
-
   // Queen (CLNY-04) — reset on success, decrement + death-check on fail.
   const queenId = colony.queenEntityId;
   if (ants.alive[queenId] === 1) {
-    if (withdrawFood(colony, QUEEN_FOOD_PER_TICK, simVersion)) {
+    if (withdrawFood(colony, QUEEN_FOOD_PER_TICK)) {
       colony.queenStarvationTimer = STARVATION_GRACE_TICKS;
     } else {
       colony.queenStarvationTimer -= 1;
@@ -378,7 +336,7 @@ export function tickFoodConsumption(world: WorldState, colony: ColonyRecord): vo
   for (let i = 0; i < colony.larvae.length; i++) {
     const id = colony.larvae[i]!;
     if (ants.alive[id] !== 1) continue;
-    if (withdrawFood(colony, LARVA_FOOD_PER_TICK, simVersion)) {
+    if (withdrawFood(colony, LARVA_FOOD_PER_TICK)) {
       ants.starvationTimer[id] = STARVATION_GRACE_TICKS;
     } else {
       // Non-null assertion: id is a valid entity index, bounds verified by colony.larvae membership.

--- a/src/sim/determinism.test.ts
+++ b/src/sim/determinism.test.ts
@@ -377,57 +377,6 @@ describe('issue #27: simVersion plumbing', () => {
     const r2 = runSimulation(42, 800);
     expect(r1).toBe(r2);
   });
-
-  it('LEGACY vs LATEST simVersion produce different state at the same seed when chambers diverge', async () => {
-    // No tools to flip simVersion mid-run — but we can construct a colony
-    // with two chambers of unequal fill and compare the two drain orders
-    // directly. The integration-level test above proves determinism within
-    // a version; this test proves the algorithms genuinely differ.
-    const { withdrawFood } = await import('./colony/colony-system.js');
-    const { createColonyRecord } = await import('./colony/colony-store.js');
-    const { ChamberType } = await import('./enums.js');
-    const { LEGACY_SIM_VERSION, LATEST_SIM_VERSION } = await import('./types.js');
-
-    function buildColony() {
-      const c = createColonyRecord(1, 0);
-      c.entrances = [];
-      c.rallyPoint = null;
-      c.digFlowFieldDirty = false;
-      c.foodFlowFieldDirty = false;
-      c.foodStored = 0;
-      c.chambers.push({
-        chamberId: 1,
-        chamberType: ChamberType.FoodStorage,
-        foodStored: 100,
-        posX: 0,
-        posY: 0,
-        width: 1,
-        height: 1,
-      });
-      c.chambers.push({
-        chamberId: 2,
-        chamberType: ChamberType.FoodStorage,
-        foodStored: 200,
-        posX: 0,
-        posY: 0,
-        width: 1,
-        height: 1,
-      });
-      return c;
-    }
-
-    const cLegacy = buildColony();
-    withdrawFood(cLegacy, 50, LEGACY_SIM_VERSION);
-    // v2: array-order — chambers[0] (100) drains first → 50, chambers[1] untouched.
-    expect(cLegacy.chambers[0]!.foodStored).toBe(50);
-    expect(cLegacy.chambers[1]!.foodStored).toBe(200);
-
-    const cLatest = buildColony();
-    withdrawFood(cLatest, 50, LATEST_SIM_VERSION);
-    // v3: fullest-first — chambers[1] (200) drains first → 150, chambers[0] untouched.
-    expect(cLatest.chambers[0]!.foodStored).toBe(100);
-    expect(cLatest.chambers[1]!.foodStored).toBe(150);
-  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/sim/forager-backpressure.test.ts
+++ b/src/sim/forager-backpressure.test.ts
@@ -196,7 +196,7 @@ describe('#126 V27 forager storage backpressure', () => {
       // The pool is full → carriers WOULD park (no deposit target)...
       expect(colonyHasNoDepositTarget(colony)).toBe(true);
       // ...but promotion/demotion backpressure is NOT applied to a chamberless colony.
-      expect(colonyForageBackpressure(colony, world.simVersion)).toBe(false);
+      expect(colonyForageBackpressure(colony)).toBe(false);
 
       tick(world, []);
       expect(foragerCount(world, idleIds)).toBeGreaterThan(0); // idle ants still promoted

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -147,27 +147,65 @@ describe('tickSpider', () => {
     });
   });
 
-  describe('Patrolling → Hunting transition', () => {
-    it('stays Patrolling when no workers in range', () => {
+  describe('Patrolling → Hunting transition (V23 telegraphed density hunt)', () => {
+    // Hunt entry is gated in tickSpiderV23 behind hunger + past-grace + the
+    // chase→hunt→rampage precedence: a hungry, active spider with no lone ant
+    // in chase range but a dense worker tile in hunt range telegraphs a hunt.
+    // (The pre-V23 sated/in-grace/chase-range entry was reaped with
+    // tickSpiderV22 — a sated or in-grace spider stays Patrolling, covered by
+    // the hunger-gate and start-of-match-grace describes.)
+    const SX = 64;
+    const SY = 32;
+    // Two workers on ONE tile just past chase radius → in hunt range (12), so
+    // no opportunistic chase pre-empts the telegraphed hunt.
+    const HUNT_TILE_X = SX + SPIDER_CHASE_TRIGGER_RADIUS + 2;
+
+    it('enters Hunting on a dense worker tile in hunt range when hungry and off cooldown', () => {
       const world = makeWorld();
-      world.spider = makeSpider();
-      world.spider.nextHuntTick = 0;
-      // No workers placed
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      world.spider = makeSpider({
+        posX: SX << FP_SHIFT,
+        posY: SY << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS,
+      });
+      world.spider.nextHuntTick = 0; // off cooldown
+      world.tick = SPIDER_GRACE_TICKS; // past grace → active
+      placeWorker(world, HUNT_TILE_X, SY);
+      placeWorker(world, HUNT_TILE_X, SY);
+
       tickSpider(world);
-      expect(world.spider.state).toBe('Patrolling');
+
+      expect(world.spider.state).toBe('Hunting');
+      expect(world.spider.huntStartTick).toBe(SPIDER_GRACE_TICKS);
+      expect(world.spider.huntTargetTileX).toBe(HUNT_TILE_X);
+      expect(world.spider.huntTargetTileY).toBe(SY);
+      const started = world.events.find((e) => e.type === 'spider_hunt_start');
+      expect(started).toBeDefined();
+      if (started?.type === 'spider_hunt_start') {
+        expect(started.payload.targetWorkers).toBe(2);
+      }
     });
 
-    it('stays Patrolling when tick < nextHuntTick even with workers present', () => {
+    it('does NOT enter Hunting while on cooldown (tick < nextHuntTick) — camps instead', () => {
       const world = makeWorld();
-      const spiderTileX = 64;
-      const spiderTileY = 32;
-      world.spider = makeSpider({ posX: spiderTileX << FP_SHIFT, posY: spiderTileY << FP_SHIFT });
-      world.spider.nextHuntTick = 9999;
-      placeWorker(world, spiderTileX + 2, spiderTileY);
-      placeWorker(world, spiderTileX + 2, spiderTileY);
+      world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
+      world.spider = makeSpider({
+        posX: SX << FP_SHIFT,
+        posY: SY << FP_SHIFT,
+        hungerTicks: HUNGRY_TICKS,
+      });
+      world.tick = SPIDER_GRACE_TICKS; // past grace
+      world.spider.nextHuntTick = world.tick + 100; // hunt on cooldown
+      placeWorker(world, HUNT_TILE_X, SY);
+      placeWorker(world, HUNT_TILE_X, SY);
 
       tickSpider(world);
-      expect(world.spider.state).toBe('Patrolling');
+
+      // A hungry spider that can't hunt (on cooldown) camps an entrance
+      // (Rampaging) rather than staying Patrolling — no hunt is telegraphed.
+      expect(world.spider.state).not.toBe('Hunting');
+      expect(world.spider.state).toBe('Rampaging');
+      expect(world.events.some((e) => e.type === 'spider_hunt_start')).toBe(false);
     });
   });
 
@@ -1319,8 +1357,9 @@ describe('tickSpider', () => {
       // and retreat AT LEAST a full SPIDER_FEED_RETREAT_TILES from the kill
       // (pre-fix, an outward pick collapsed to the edge at distance 0). #247 made
       // the edge-margin clamp unconditional, so at the corner the spider is first
-      // nudged off the edge by the margin and then retreats — the distance is
-      // therefore >= the full retreat, and can never collapse back to 0.
+      // nudged off the edge by the margin and then retreats — the endpoint sits
+      // exactly SPIDER_FEED_RETREAT_TILES + SPIDER_EDGE_MARGIN_TILES from the kill
+      // in every hash direction, and can never collapse back to 0.
       world.spider = makeSpider({
         posX: 0 << FP_SHIFT,
         posY: 0 << FP_SHIFT,
@@ -1342,7 +1381,9 @@ describe('tickSpider', () => {
       expect(fx).toBeLessThanOrEqual(SURFACE_GRID_WIDTH - 1);
       expect(fy).toBeGreaterThanOrEqual(0);
       expect(fy).toBeLessThanOrEqual(SURFACE_GRID_HEIGHT - 1);
-      expect(Math.abs(fx) + Math.abs(fy)).toBeGreaterThanOrEqual(SPIDER_FEED_RETREAT_TILES);
+      expect(Math.abs(fx) + Math.abs(fy)).toBe(
+        SPIDER_FEED_RETREAT_TILES + SPIDER_EDGE_MARGIN_TILES,
+      );
     });
 
     it('a Rampaging kill with no fighter adjacent → Feeding emits spider_rampage_end(quota_met)', () => {

--- a/src/sim/spider.test.ts
+++ b/src/sim/spider.test.ts
@@ -6,7 +6,6 @@ import {
   createWorldState,
   SIM_VERSION_V19_AI_STATE,
   SIM_VERSION_V20_SPIDER,
-  SIM_VERSION_V22_DIFFICULTY,
   SIM_VERSION_V23_SPIDER_AGGRO,
   SIM_VERSION_V26_SPIDER_EDGE_MARGIN,
   SIM_VERSION_V31_SPIDER_TERRAIN,
@@ -24,10 +23,8 @@ import {
   SPIDER_HP_FULL,
   SPIDER_TELEGRAPH_TICKS,
   SPIDER_STRIKE_TICKS,
-  SPIDER_FEEDING_TICKS,
   SPIDER_HUNT_INTERVAL_TICKS,
   SPIDER_HUNGER_MAX_TICKS,
-  SPIDER_RAMPAGE_KILL_QUOTA,
   SPIDER_CHASE_TRIGGER_RADIUS,
   SPIDER_DEFENSE_TRIGGER_RADIUS,
   SPIDER_CHASE_MAX_TICKS,
@@ -151,24 +148,6 @@ describe('tickSpider', () => {
   });
 
   describe('Patrolling → Hunting transition', () => {
-    it('transitions to Hunting when tick >= nextHuntTick and workers are present', () => {
-      const world = makeWorld();
-      const spiderTileX = 64;
-      const spiderTileY = 32;
-      world.spider = makeSpider({ posX: spiderTileX << FP_SHIFT, posY: spiderTileY << FP_SHIFT });
-      world.spider.nextHuntTick = 0; // trigger immediately
-
-      // Place 2 workers near spider
-      placeWorker(world, spiderTileX + 2, spiderTileY);
-      placeWorker(world, spiderTileX + 2, spiderTileY);
-
-      tickSpider(world);
-      expect(world.spider.state).toBe('Hunting');
-      expect(world.spider.huntStartTick).toBe(0);
-      expect(world.spider.huntTargetTileX).toBe(spiderTileX + 2);
-      expect(world.spider.huntTargetTileY).toBe(spiderTileY);
-    });
-
     it('stays Patrolling when no workers in range', () => {
       const world = makeWorld();
       world.spider = makeSpider();
@@ -224,25 +203,6 @@ describe('tickSpider', () => {
     });
   });
 
-  describe('Striking → Feeding transition (kill path)', () => {
-    it('transitions to Feeding after SPIDER_STRIKE_TICKS when kills > 0', () => {
-      const world = makeWorld();
-      world.spider = makeSpider({
-        state: 'Striking',
-        strikeStartTick: 0,
-        killsThisStrike: 3,
-        huntTargetTileX: 65,
-        huntTargetTileY: 32,
-      });
-      world.tick = SPIDER_STRIKE_TICKS;
-
-      tickSpider(world);
-      expect(world.spider.state).toBe('Feeding');
-      expect(world.spider.feedingStartTick).toBe(SPIDER_STRIKE_TICKS);
-      expect(world.spider.hungerTicks).toBe(0); // reset on Feeding entry
-    });
-  });
-
   describe('Striking → Patrolling transition (scatter/frustrate path)', () => {
     it('transitions to Patrolling after SPIDER_STRIKE_TICKS with zero kills', () => {
       const world = makeWorld();
@@ -282,36 +242,11 @@ describe('tickSpider', () => {
     });
   });
 
-  describe('Feeding → Patrolling transition', () => {
-    it('returns to Patrolling after SPIDER_FEEDING_TICKS', () => {
-      const world = makeWorld();
-      world.spider = makeSpider({
-        state: 'Feeding',
-        feedingStartTick: 0,
-        huntTargetTileX: -1,
-        huntTargetTileY: -1,
-      });
-      world.tick = SPIDER_FEEDING_TICKS;
-
-      tickSpider(world);
-      expect(world.spider.state).toBe('Patrolling');
-      expect(world.spider.nextHuntTick).toBe(SPIDER_FEEDING_TICKS + SPIDER_HUNT_INTERVAL_TICKS);
-    });
-  });
-
   // ---------------------------------------------------------------------------
   // Hunger accrual and reset
   // ---------------------------------------------------------------------------
 
   describe('hunger accrual', () => {
-    it('accrues hungerTicks every tick while not Feeding', () => {
-      const world = makeWorld();
-      world.spider = makeSpider({ state: 'Patrolling', hungerTicks: 10 });
-      world.tick = 0;
-      tickSpider(world);
-      expect(world.spider.hungerTicks).toBe(11);
-    });
-
     it('does not accrue hungerTicks while Feeding', () => {
       const world = makeWorld();
       world.spider = makeSpider({
@@ -323,102 +258,9 @@ describe('tickSpider', () => {
       tickSpider(world);
       expect(world.spider.hungerTicks).toBe(50); // unchanged
     });
-
-    it('resets hungerTicks on Feeding entry from Striking', () => {
-      const world = makeWorld();
-      world.spider = makeSpider({
-        state: 'Striking',
-        strikeStartTick: 0,
-        killsThisStrike: 2,
-        hungerTicks: 500,
-        huntTargetTileX: 65,
-        huntTargetTileY: 32,
-      });
-      world.tick = SPIDER_STRIKE_TICKS;
-      tickSpider(world);
-      expect(world.spider.state).toBe('Feeding');
-      expect(world.spider.hungerTicks).toBe(0);
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Rampage trigger
-  // ---------------------------------------------------------------------------
-
-  describe('Patrolling → Rampaging transition', () => {
-    it('triggers Rampaging when hungerTicks reaches SPIDER_HUNGER_MAX_TICKS[1]', () => {
-      const world = makeWorld();
-      world.spider = makeSpider({
-        state: 'Patrolling',
-        // hungerTicks will be incremented before the check, so set to max - 1
-        hungerTicks: SPIDER_HUNGER_MAX_TICKS[1] - 1,
-      });
-      world.tick = 0;
-
-      tickSpider(world);
-      // After increment: hungerTicks = SPIDER_HUNGER_MAX_TICKS[1]; triggers rampaging.
-      expect(world.spider.state).toBe('Rampaging');
-      expect(world.spider.rampageKillsThisRampage).toBe(0);
-    });
   });
 
   describe('rampageTargetColonyId — weighted colony selection', () => {
-    it('sets rampageTargetColonyId on Rampaging entry and clears it on exit', () => {
-      const world = makeWorld();
-      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = createColonyRecord(
-        PLAYER_COLONY_ID,
-        0,
-      );
-      world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!.entrances = [];
-      world.colonies[ENEMY_COLONY_ID as unknown as ColonyId] = createColonyRecord(
-        ENEMY_COLONY_ID,
-        1,
-      );
-      world.colonies[ENEMY_COLONY_ID as unknown as ColonyId]!.entrances = [];
-      world.spider = makeSpider({
-        state: 'Patrolling',
-        hungerTicks: SPIDER_HUNGER_MAX_TICKS[1] - 1,
-      });
-      world.tick = 0;
-
-      tickSpider(world);
-      expect(world.spider.state).toBe('Rampaging');
-      expect(
-        world.spider.rampageTargetColonyId === PLAYER_COLONY_ID ||
-          world.spider.rampageTargetColonyId === ENEMY_COLONY_ID,
-      ).toBe(true);
-
-      // Transition to Feeding via kill quota — target should be cleared.
-      world.spider.rampageKillsThisRampage = SPIDER_RAMPAGE_KILL_QUOTA;
-      tickSpider(world);
-      expect(world.spider.state).toBe('Feeding');
-      expect(world.spider.rampageTargetColonyId).toBe(-1);
-    });
-
-    it('always targets a valid colony (not -1) when both colonies exist', () => {
-      // Run 20 rampages across varying seeds and ticks; none should produce -1.
-      for (let seed = 1; seed <= 20; seed++) {
-        const world = makeWorld(seed * 1000);
-        world.colonies[PLAYER_COLONY_ID as unknown as ColonyId] = createColonyRecord(
-          PLAYER_COLONY_ID,
-          0,
-        );
-        world.colonies[PLAYER_COLONY_ID as unknown as ColonyId]!.entrances = [];
-        world.colonies[ENEMY_COLONY_ID as unknown as ColonyId] = createColonyRecord(
-          ENEMY_COLONY_ID,
-          1,
-        );
-        world.colonies[ENEMY_COLONY_ID as unknown as ColonyId]!.entrances = [];
-        world.spider = makeSpider({
-          state: 'Patrolling',
-          hungerTicks: SPIDER_HUNGER_MAX_TICKS[1] - 1,
-        });
-        world.tick = seed * 100;
-        tickSpider(world);
-        expect(world.spider.rampageTargetColonyId).toBeGreaterThan(0);
-      }
-    });
-
     it('distributes targets across both colonies over many rampages (not always same colony)', () => {
       // Over 50 rampages with varying ticks, both colonies should be chosen at least once.
       const chosen = new Set<number>();
@@ -635,53 +477,6 @@ describe('tickSpider', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // HP regeneration
-  // ---------------------------------------------------------------------------
-
-  describe('HP regeneration', () => {
-    it('regenerates 1 HP per 20 ticks while Retreating', () => {
-      const world = makeWorld();
-      world.spider = makeSpider({ state: 'Retreating', hp: 40, retreatStartTick: 0 });
-      world.tick = 20;
-
-      tickSpider(world);
-      expect(world.spider.hp).toBe(41);
-    });
-
-    it('does not exceed SPIDER_HP_FULL', () => {
-      const world = makeWorld();
-      world.spider = makeSpider({
-        state: 'Retreating',
-        hp: SPIDER_HP_FULL - 1,
-        retreatStartTick: 0,
-      });
-      world.tick = 20;
-
-      tickSpider(world);
-      expect(world.spider.hp).toBe(SPIDER_HP_FULL);
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Rampaging: kill quota triggers Feeding
-  // ---------------------------------------------------------------------------
-
-  describe('Rampaging → Feeding via kill quota', () => {
-    it('transitions to Feeding when rampageKillsThisRampage reaches SPIDER_RAMPAGE_KILL_QUOTA', () => {
-      const world = makeWorld();
-      world.spider = makeSpider({
-        state: 'Rampaging',
-        rampageKillsThisRampage: SPIDER_RAMPAGE_KILL_QUOTA,
-      });
-      world.tick = 100;
-
-      tickSpider(world);
-      expect(world.spider.state).toBe('Feeding');
-      expect(world.spider.hungerTicks).toBe(0);
-    });
-  });
-
-  // ---------------------------------------------------------------------------
   // V23 (#146): Chasing — opportunistic chase of a nearby ant
   // ---------------------------------------------------------------------------
 
@@ -761,21 +556,6 @@ describe('tickSpider', () => {
       tickSpider(world);
 
       expect(world.spider.state).not.toBe('Chasing');
-      expect(world.spider.chaseTargetAntId).toBe(-1);
-    });
-
-    it('does NOT chase under a pre-V23 (V22) world — old-replay guard', () => {
-      const world = makeWorld();
-      world.simVersion = SIM_VERSION_V22_DIFFICULTY;
-      const sx = 64;
-      const sy = 32;
-      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
-      world.spider.nextHuntTick = 9999;
-      placeWorker(world, sx + 1, sy);
-
-      tickSpider(world);
-
-      expect(world.spider.state).toBe('Patrolling');
       expect(world.spider.chaseTargetAntId).toBe(-1);
     });
 
@@ -968,21 +748,6 @@ describe('tickSpider', () => {
       world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT, hungerTicks: 0 });
       world.spider.nextHuntTick = 9999;
       placeFighter(world, sx + SPIDER_DEFENSE_TRIGGER_RADIUS + 1, sy); // out of defense range
-
-      tickSpider(world);
-
-      expect(world.spider.state).toBe('Patrolling');
-      expect(world.spider.chaseTargetAntId).toBe(-1);
-    });
-
-    it('does NOT self-defend under a pre-V23 (V22) world — old-replay guard', () => {
-      const world = makeWorld();
-      world.simVersion = SIM_VERSION_V22_DIFFICULTY;
-      const sx = 64;
-      const sy = 32;
-      world.spider = makeSpider({ posX: sx << FP_SHIFT, posY: sy << FP_SHIFT });
-      world.spider.nextHuntTick = 9999;
-      placeFighter(world, sx + SPIDER_CHASE_TRIGGER_RADIUS + 1, sy);
 
       tickSpider(world);
 
@@ -1551,8 +1316,11 @@ describe('tickSpider', () => {
       world.simVersion = SIM_VERSION_V23_SPIDER_AGGRO;
       // Kill tile == spider tile at the (0,0) corner → dx==dy==0 takes the hash
       // fallback. Whichever cardinal it picks, the endpoint must stay in-bounds
-      // and a full SPIDER_FEED_RETREAT_TILES from the kill (pre-fix, an outward
-      // pick collapsed to the edge at distance 0).
+      // and retreat AT LEAST a full SPIDER_FEED_RETREAT_TILES from the kill
+      // (pre-fix, an outward pick collapsed to the edge at distance 0). #247 made
+      // the edge-margin clamp unconditional, so at the corner the spider is first
+      // nudged off the edge by the margin and then retreats — the distance is
+      // therefore >= the full retreat, and can never collapse back to 0.
       world.spider = makeSpider({
         posX: 0 << FP_SHIFT,
         posY: 0 << FP_SHIFT,
@@ -1574,7 +1342,7 @@ describe('tickSpider', () => {
       expect(fx).toBeLessThanOrEqual(SURFACE_GRID_WIDTH - 1);
       expect(fy).toBeGreaterThanOrEqual(0);
       expect(fy).toBeLessThanOrEqual(SURFACE_GRID_HEIGHT - 1);
-      expect(Math.abs(fx) + Math.abs(fy)).toBe(SPIDER_FEED_RETREAT_TILES);
+      expect(Math.abs(fx) + Math.abs(fy)).toBeGreaterThanOrEqual(SPIDER_FEED_RETREAT_TILES);
     });
 
     it('a Rampaging kill with no fighter adjacent → Feeding emits spider_rampage_end(quota_met)', () => {
@@ -1764,15 +1532,6 @@ describe('tickSpider', () => {
       expect(tileXOf()).toBe(M);
       expect(tileYOf()).toBe(rowY);
       expect(world.spider!.state).toBe('Chasing');
-    });
-
-    it('V23 control: same chase pins the spider against the west edge (pre-fix behavior)', () => {
-      const { world, tileXOf } = chaseTowardWestEdge(SIM_VERSION_V23_SPIDER_AGGRO);
-
-      for (let t = 0; t < 20; t++) tickSpider(world);
-
-      // Without the V26 clamp the spider reaches the ant's tile at the very edge.
-      expect(tileXOf()).toBe(0);
     });
 
     it('V26: chasing an ant into the NW corner clamps BOTH axes to the margin', () => {

--- a/src/sim/spider.ts
+++ b/src/sim/spider.ts
@@ -11,14 +11,8 @@ import { getScratch } from './scratch.js';
 import {
   SPIDER_HP_FULL,
   SPIDER_HUNT_INTERVAL_TICKS,
-  SPIDER_HUNGER_MAX_TICKS,
   SPIDER_TELEGRAPH_TICKS,
   SPIDER_STRIKE_TICKS,
-  SPIDER_FEEDING_TICKS,
-  SPIDER_HP_REGEN_PER_20_TICKS,
-  SPIDER_RAMPAGE_RETREAT_HP,
-  SPIDER_RETREAT_MIN_TICKS,
-  SPIDER_RAMPAGE_KILL_QUOTA,
   SPIDER_RAMPAGE_MAX_TICKS,
   SPIDER_HUNT_SEARCH_RADIUS_TILES,
   SPIDER_HUNT_MIN_TARGET_WORKERS,
@@ -40,12 +34,7 @@ import {
   PHEROMONE_CAP,
   SPIDER_EDGE_MARGIN_TILES,
 } from './constants.js';
-import {
-  SIM_VERSION_V23_SPIDER_AGGRO,
-  SIM_VERSION_V26_SPIDER_EDGE_MARGIN,
-  SIM_VERSION_V31_SPIDER_TERRAIN,
-  SIM_VERSION_V32_AI_OP_VALIDATION,
-} from './types.js';
+import { SIM_VERSION_V31_SPIDER_TERRAIN, SIM_VERSION_V32_AI_OP_VALIDATION } from './types.js';
 import { FP_SHIFT } from './fixed.js';
 import { surfaceMovementAt, SurfaceMovementEffect } from './surface-features.js';
 import { ensureSurfaceGoalField, SURFACE_GOAL_UNREACHED } from './surface-routing.js';
@@ -407,7 +396,7 @@ export function isSpiderPassable(world: WorldState, tileX: number, tileY: number
 }
 
 /** V31 (#225) gate wrapper for the live (V23) path. Pre-V31 delegates verbatim to
- *  moveTowardTile (frozen tickSpiderV22 relies on that body staying identical).
+ *  moveTowardTile (the shared surface-movement helper).
  *  V31+: one axis step per tick (SPIDER_SPEED === FP_ONE, so an axis step lands
  *  exactly one tile over), refusing HardBlock destinations — preferred axis
  *  (ax >= ay → X, moveTowardTile's tie-break) first, then the other axis if it
@@ -556,42 +545,6 @@ function clampSpiderWithinEdgeMargin(spider: SpiderState): void {
   if (spider.posX > maxX) spider.posX = maxX;
   if (spider.posY < minY) spider.posY = minY;
   if (spider.posY > maxY) spider.posY = maxY;
-}
-
-/** Move spider in a deterministic patrol arc within territory radius of lair. */
-function tickPatrolMovement(world: WorldState, spider: SpiderState): void {
-  // Simple deterministic patrol: move in a clockwise square orbit around lair.
-  // Uses world.tick to pick a target corner deterministically (no rng draws).
-  const r = spider.territoryRadiusTiles >> 1; // patrol at half radius
-  const phase = (world.tick >> 6) & 3; // change quadrant every 64 ticks
-  const lx = spider.lairTileX;
-  const ly = spider.lairTileY;
-  let tx: number;
-  let ty: number;
-  switch (phase) {
-    case 0:
-      tx = lx + r;
-      ty = ly - r;
-      break;
-    case 1:
-      tx = lx + r;
-      ty = ly + r;
-      break;
-    case 2:
-      tx = lx - r;
-      ty = ly + r;
-      break;
-    default:
-      tx = lx - r;
-      ty = ly - r;
-      break;
-  }
-  // Clamp target within grid
-  if (tx < 0) tx = 0;
-  if (tx >= SURFACE_GRID_WIDTH) tx = SURFACE_GRID_WIDTH - 1;
-  if (ty < 0) ty = 0;
-  if (ty >= SURFACE_GRID_HEIGHT) ty = SURFACE_GRID_HEIGHT - 1;
-  moveTowardTile(spider, tx, ty);
 }
 
 // ---------------------------------------------------------------------------
@@ -775,326 +728,9 @@ export function tickSpider(world: WorldState): void {
     return;
   }
 
-  // Version dispatch: V23+ uses the hunger-gated meandering predator; V22 and
-  // earlier use the frozen lair-orbit/scheduled-rampage behavior (byte-identical).
-  if (world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO) {
-    tickSpiderV23(world, spider);
-    return;
-  }
-  tickSpiderV22(world, spider);
-}
-
-// ---------------------------------------------------------------------------
-// tickSpiderV22 — frozen pre-V23 behavior (lair orbit + scheduled rampage).
-// Verbatim move of the original tickSpider body. Do NOT modify: V22-and-earlier
-// replays must stay byte-identical.
-// ---------------------------------------------------------------------------
-function tickSpiderV22(world: WorldState, spider: SpiderState): void {
-  // HP regeneration: 1 HP per 20 ticks while Retreating or Feeding.
-  if (
-    (spider.state === 'Retreating' || spider.state === 'Feeding') &&
-    world.tick % 20 === 0 &&
-    spider.hp < SPIDER_HP_FULL
-  ) {
-    spider.hp += SPIDER_HP_REGEN_PER_20_TICKS;
-    if (spider.hp > SPIDER_HP_FULL) spider.hp = SPIDER_HP_FULL;
-  }
-
-  // Hunger accrual: only while not Feeding.
-  if (spider.state !== 'Feeding') {
-    spider.hungerTicks += 1;
-  }
-
-  // --- Priority retreating-threshold check (applies to Striking, Chasing, Rampaging) ---
-  // This runs before state-specific logic so a combat-damaged spider retreats
-  // immediately, even on the same tick its duration would have expired.
-  if (
-    (spider.state === 'Striking' || spider.state === 'Chasing' || spider.state === 'Rampaging') &&
-    spider.hp < SPIDER_RAMPAGE_RETREAT_HP
-  ) {
-    if (spider.state === 'Striking') {
-      emitSpiderHuntEnd(world, 'swarm_retreat', spider.killsThisStrike);
-    } else if (spider.state === 'Chasing') {
-      emitSpiderChaseEnd(world, 'retreat');
-    } else {
-      emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
-    }
-    clearSpiderPairingSentinels(world);
-    spider.state = 'Retreating';
-    spider.retreatStartTick = world.tick;
-    spider.huntTargetTileX = -1;
-    spider.huntTargetTileY = -1;
-    spider.chaseTargetAntId = -1;
-    spider.hungerTicks = 0; // prevent immediate re-rampaging on return to Patrolling
-    spider.rampageTargetColonyId = -1;
-    world.spiderPriorityColonyId = null;
-    // Fall through to movement + pheromone below.
-  }
-
-  // --- State machine transitions ---
-  switch (spider.state) {
-    case 'Patrolling': {
-      // Hunger check first: rampaging wins over hunting on same tick.
-      if (spider.hungerTicks >= SPIDER_HUNGER_MAX_TICKS[tierIndex(world.difficulty)]) {
-        spider.state = 'Rampaging';
-        spider.rampageStartTick = world.tick;
-        spider.rampageKillsThisRampage = 0;
-        spider.rampageTargetColonyId = pickRampageTarget(world, spider);
-        emitEvent(world, {
-          tick: world.tick,
-          type: 'spider_rampage_start',
-          payload: {
-            lairTile: { x: spider.lairTileX, y: spider.lairTileY },
-            hungerTicks: spider.hungerTicks,
-          },
-        });
-      } else {
-        // V23 (#146): opportunistic chase — a lone ant within trigger radius takes
-        // precedence over the scheduled tile-density hunt (but not over rampaging).
-        const chaseId =
-          world.simVersion >= SIM_VERSION_V23_SPIDER_AGGRO ? findChaseTarget(world, spider) : -1;
-        if (chaseId >= 0) {
-          spider.state = 'Chasing';
-          spider.chaseTargetAntId = chaseId;
-          spider.chaseStartTick = world.tick;
-          emitEvent(world, {
-            tick: world.tick,
-            type: 'spider_chase_start',
-            payload: {
-              targetAntId: chaseId,
-              targetTile: {
-                x: world.ants.posX[chaseId]! >> FP_SHIFT,
-                y: world.ants.posY[chaseId]! >> FP_SHIFT,
-              },
-            },
-          });
-        } else if (world.tick >= spider.nextHuntTick) {
-          const target = findHuntTarget(world, spider);
-          if (target !== null) {
-            spider.state = 'Hunting';
-            spider.huntTargetTileX = target.x;
-            spider.huntTargetTileY = target.y;
-            spider.huntStartTick = world.tick;
-            emitEvent(world, {
-              tick: world.tick,
-              type: 'spider_hunt_start',
-              payload: {
-                reticleTile: { x: target.x, y: target.y, grid: 'surface' },
-                targetWorkers: target.workerCount,
-              },
-            });
-          } else {
-            // No qualifying workers in range — postpone hunt by one interval to preserve
-            // the 1200-tick cadence rather than re-scanning every tick.
-            spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
-          }
-        }
-      }
-      break;
-    }
-
-    case 'Hunting': {
-      if (world.tick - spider.huntStartTick >= SPIDER_TELEGRAPH_TICKS) {
-        spider.state = 'Striking';
-        spider.strikeStartTick = world.tick;
-        spider.killsThisStrike = 0;
-      }
-      break;
-    }
-
-    case 'Chasing': {
-      // Combat ran at step 17 (this tick) before tickSpider, so a catch shows up as a
-      // dead target here. Exit on catch / escape underground / leash-timeout; otherwise
-      // keep pursuing (movement happens in the movement switch below).
-      const tid = spider.chaseTargetAntId;
-      const targetAlive = tid >= 0 && world.ants.alive[tid] === 1;
-      if (!targetAlive) {
-        // Target died — treat as a successful catch (hunger satisfied).
-        emitSpiderChaseEnd(world, 'kill');
-        clearSpiderPairingSentinels(world);
-        spider.state = 'Patrolling';
-        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
-        spider.chaseTargetAntId = -1;
-        spider.hungerTicks = 0;
-      } else if (world.ants.zone[tid] !== 0) {
-        // Target reached safety underground — abandon.
-        emitSpiderChaseEnd(world, 'escape');
-        clearSpiderPairingSentinels(world);
-        spider.state = 'Patrolling';
-        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
-        spider.chaseTargetAntId = -1;
-      } else if (world.tick - spider.chaseStartTick >= SPIDER_CHASE_MAX_TICKS) {
-        // Safety leash expired — give up and return to patrol.
-        emitSpiderChaseEnd(world, 'leash');
-        clearSpiderPairingSentinels(world);
-        spider.state = 'Patrolling';
-        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
-        spider.chaseTargetAntId = -1;
-      }
-      break;
-    }
-
-    case 'Striking': {
-      // Duration check (retreat threshold was already handled above).
-      if (world.tick - spider.strikeStartTick >= SPIDER_STRIKE_TICKS) {
-        if (spider.killsThisStrike > 0) {
-          emitSpiderHuntEnd(world, 'kill', spider.killsThisStrike);
-          clearSpiderPairingSentinels(world);
-          spider.state = 'Feeding';
-          spider.feedingStartTick = world.tick;
-          spider.hungerTicks = 0; // CF-P0-006: reset on Feeding entry
-          spider.huntTargetTileX = -1;
-          spider.huntTargetTileY = -1;
-          world.spiderPriorityColonyId = null;
-        } else {
-          emitSpiderHuntEnd(world, 'scatter', 0);
-          clearSpiderPairingSentinels(world);
-          spider.state = 'Patrolling';
-          spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
-          spider.huntTargetTileX = -1;
-          spider.huntTargetTileY = -1;
-          world.spiderPriorityColonyId = null;
-        }
-      }
-      break;
-    }
-
-    case 'Feeding': {
-      if (world.tick >= spider.feedingStartTick + SPIDER_FEEDING_TICKS) {
-        spider.state = 'Patrolling';
-        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
-        spider.huntTargetTileX = -1;
-        spider.huntTargetTileY = -1;
-      }
-      break;
-    }
-
-    case 'Rampaging': {
-      // Quota check: fed enough brood.
-      if (spider.rampageKillsThisRampage >= SPIDER_RAMPAGE_KILL_QUOTA) {
-        emitSpiderRampageEnd(world, 'quota_met', spider.rampageKillsThisRampage, false);
-        clearSpiderPairingSentinels(world);
-        spider.state = 'Feeding';
-        spider.feedingStartTick = world.tick;
-        spider.hungerTicks = 0;
-        spider.rampageTargetColonyId = -1;
-        world.spiderPriorityColonyId = null;
-      } else if (world.tick - spider.rampageStartTick >= SPIDER_RAMPAGE_MAX_TICKS) {
-        // Timeout: no ants surfaced at entrance — treat as failed rampage and retreat.
-        emitSpiderRampageEnd(world, 'retreated', spider.rampageKillsThisRampage, false);
-        clearSpiderPairingSentinels(world);
-        spider.state = 'Retreating';
-        spider.retreatStartTick = world.tick;
-        spider.huntTargetTileX = -1;
-        spider.huntTargetTileY = -1;
-        spider.hungerTicks = 0; // prevent immediate re-rampaging on return to Patrolling
-        spider.rampageTargetColonyId = -1;
-        world.spiderPriorityColonyId = null;
-      }
-      break;
-    }
-
-    case 'Retreating': {
-      if (
-        spider.hp >= SPIDER_HP_FULL &&
-        world.tick >= spider.retreatStartTick + SPIDER_RETREAT_MIN_TICKS
-      ) {
-        spider.state = 'Patrolling';
-        spider.nextHuntTick = world.tick + SPIDER_HUNT_INTERVAL_TICKS;
-      }
-      break;
-    }
-  }
-
-  // --- Movement ---
-  // Cache nearest entrance for Rampaging once per tick (used by both movement and pheromone seeding).
-  // Self-heal: a Rampaging spider loaded from a save predating rampageTargetColonyId derives
-  // its target here so behavior is consistent with a spider that never reloaded.
-  if (spider.state === 'Rampaging' && spider.rampageTargetColonyId < 0) {
-    spider.rampageTargetColonyId = pickRampageTarget(world, spider);
-  }
-  const rampageNearest =
-    spider.state === 'Rampaging'
-      ? findNearestEntrance(world, spider, spider.rampageTargetColonyId)
-      : null;
-  switch (spider.state) {
-    case 'Patrolling': {
-      tickPatrolMovement(world, spider);
-      break;
-    }
-    case 'Hunting': {
-      moveTowardTile(spider, spider.huntTargetTileX, spider.huntTargetTileY);
-      break;
-    }
-    case 'Striking': {
-      // Stay on target tile.
-      moveTowardTile(spider, spider.huntTargetTileX, spider.huntTargetTileY);
-      break;
-    }
-    case 'Chasing': {
-      // Pursue the target ant's current tile each tick (transition logic above already
-      // handled dead/underground/leash-expired targets, so the id is live here).
-      const tid = spider.chaseTargetAntId;
-      if (tid >= 0 && world.ants.alive[tid] === 1) {
-        moveTowardTile(
-          spider,
-          world.ants.posX[tid]! >> FP_SHIFT,
-          world.ants.posY[tid]! >> FP_SHIFT,
-        );
-      }
-      break;
-    }
-    case 'Feeding':
-    case 'Retreating': {
-      moveTowardTile(spider, spider.lairTileX, spider.lairTileY);
-      break;
-    }
-    case 'Rampaging': {
-      if (rampageNearest !== null) {
-        // Park ON the entrance tile. The pre-descent gate (#165, ant-system.ts)
-        // holds surface ants here instead of letting them descend before combat,
-        // and spider combat scans the spider's own tile — so blockading the
-        // entrance tile itself is what actually catches entrance traffic,
-        // regardless of which direction the ant approached from. (Parking one
-        // tile above only caught ants approaching from that side.)
-        moveTowardTile(spider, rampageNearest.x, rampageNearest.y);
-      }
-      break;
-    }
-  }
-
-  // --- Danger pheromone seeding ---
-  // Surface states: Patrolling, Hunting, Chasing, Striking, Rampaging (while on surface)
-  const isOnSurface = spider.state !== 'Feeding' && spider.state !== 'Retreating';
-  if (isOnSurface) {
-    seedDangerPheromone(world, spider);
-  }
-
-  // --- scatterReticleTile shadow field: written at end for next tick's step 13e ---
-  // Hunting/Striking scatter around the hunt target tile; Chasing (V23) scatters around
-  // the pursued ant's current tile so nearby non-fighters flee the chase.
-  const chaseTid = spider.chaseTargetAntId;
-  const chaseReticleValid =
-    spider.state === 'Chasing' && chaseTid >= 0 && world.ants.alive[chaseTid] === 1;
-  if (spider.state === 'Hunting' || spider.state === 'Striking') {
-    if (world.scatterReticleTile === null) {
-      world.scatterReticleTile = { x: spider.huntTargetTileX, y: spider.huntTargetTileY };
-    } else {
-      world.scatterReticleTile.x = spider.huntTargetTileX;
-      world.scatterReticleTile.y = spider.huntTargetTileY;
-    }
-  } else if (chaseReticleValid) {
-    const rx = world.ants.posX[chaseTid]! >> FP_SHIFT;
-    const ry = world.ants.posY[chaseTid]! >> FP_SHIFT;
-    if (world.scatterReticleTile === null) {
-      world.scatterReticleTile = { x: rx, y: ry };
-    } else {
-      world.scatterReticleTile.x = rx;
-      world.scatterReticleTile.y = ry;
-    }
-  } else {
-    world.scatterReticleTile = null;
-  }
+  // #247 — the V23+ hunger-gated meandering predator is unconditional (MIN=V30);
+  // the frozen pre-V23 tickSpiderV22 dispatch + 306-line function were reaped.
+  tickSpiderV23(world, spider);
 }
 
 // ---------------------------------------------------------------------------
@@ -1154,8 +790,7 @@ export function computeFeedAwayTile(world: WorldState, spider: SpiderState): voi
   // edge-margin clamp (step 6b) can't strand the spider short of feedAwayTile —
   // an exact-equality arrival gate against an unreachable margin-band tile would
   // livelock Feeding (heal never starts). Pre-V26 the band is the full grid.
-  const margin =
-    world.simVersion >= SIM_VERSION_V26_SPIDER_EDGE_MARGIN ? SPIDER_EDGE_MARGIN_TILES : 0;
+  const margin = SPIDER_EDGE_MARGIN_TILES; // #247 — V26 spider-edge-margin unconditional (MIN=V30)
   spider.feedAwayTileX = feedRetreatCoord(kx, signX, SURFACE_GRID_WIDTH, margin);
   spider.feedAwayTileY = feedRetreatCoord(ky, signY, SURFACE_GRID_HEIGHT, margin);
   // V31 (#225): the retreat endpoint ignores passability, so it can land inside a
@@ -1609,9 +1244,8 @@ function tickSpiderV23(world: WorldState, spider: SpiderState): void {
   // its centered 3-tile sprite never clips off-screen when it chases/fights an ant
   // into a corner. Runs after the movement switch (before pheromone seeding reads
   // the position) so the deposited danger trail matches the clamped location.
-  if (world.simVersion >= SIM_VERSION_V26_SPIDER_EDGE_MARGIN) {
-    clampSpiderWithinEdgeMargin(spider);
-  }
+  // #247 — V26 spider-edge-margin unconditional (MIN=V30)
+  clampSpiderWithinEdgeMargin(spider);
 
   // 7. Danger pheromone — all surface states (everything except Feeding).
   if (spider.state !== 'Feeding') {

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1313,8 +1313,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // Idle when forage was the colony's sole unmet demand. The persisted
     // `colony.computedAllocation.forage` is left untouched (WR-02), so
     // renderer/HUD/autosave still read the canonical allocation and forage
-    // promotion resumes once a chamber frees or the queen drains the pool. Pre-V27
-    // saves keep the churn for byte-identical replay.
+    // promotion resumes once a chamber frees or the queen drains the pool.
     // #247 — V27 forage-backpressure unconditional (MIN=V30)
     if (needForage > 0 && colonyForageBackpressure(colony)) {
       needForage = 0;

--- a/src/sim/tick.ts
+++ b/src/sim/tick.ts
@@ -1316,7 +1316,7 @@ export function tick(world: WorldState, commands: readonly SimCommand[]): GameOu
     // promotion resumes once a chamber frees or the queen drains the pool. Pre-V27
     // saves keep the churn for byte-identical replay.
     // #247 — V27 forage-backpressure unconditional (MIN=V30)
-    if (needForage > 0 && colonyForageBackpressure(colony, world.simVersion)) {
+    if (needForage > 0 && colonyForageBackpressure(colony)) {
       needForage = 0;
     }
 


### PR DESCRIPTION
## #247 batch 3 — reap dead ≤V30 simVersion gates: **spider + colony-system** (final batch)

`MIN_ACCEPTED_SIM_VERSION = V30`, so every `simVersion >= VNN` gate with `VNN ≤ V30`
is always-true in production and every `simVersion < VNN` branch is dead. This is the
**last** #247 batch (batches 1 & 2 merged in #260/#261). It clears the two remaining
subsystems and **closes #247** + completes **C1** of the arch-review Wave C.

`constants.ts` was audited and has **no** real gates — its `simVersion >=` matches are all
JSDoc prose, not code — so it needs no PR.

### 3a — spider (`4292f9a`)
- **V23 aggro dispatch** → unconditional `tickSpiderV23`; delete the frozen **306-line
  `tickSpiderV22`** pre-V23 replay body (unreachable at MIN=V30).
- **V26 spider-edge-margin** ×2 → unconditional clamp.
- Cascade: 6 orphaned `SPIDER_*` constant imports, the orphaned `tickPatrolMovement`
  helper, and the `SIM_VERSION_V23/V26` imports.
- **Live gates preserved:** V31×4 (spider terrain, #225) + V32 (AI-op, #226).
- Tests: delete **14 dead pins** that asserted `tickSpiderV22` / pre-V26 behavior at
  now-unloadable V20/V22 worlds (state-machine timing, HP regen, kill quota, the two
  "does NOT …under a pre-V23 (V22)" old-replay guards, the "V23 control: pre-fix" edge
  test). Their live equivalents are covered by the dedicated V23 describes (hunger gate,
  feed-after-kill, no-quota rampage, Chasing, grace period, edge-margin).
- **One judgment call:** the corner-kill hash-fallback P2 regression test is *retargeted*,
  not deleted — the now-unconditional edge clamp nudges the endpoint inward first, so it
  asserts the retreat is `>=` (not `==`) `SPIDER_FEED_RETREAT_TILES`. This still guards the
  original collapse-to-0 bug (an in-bounds-only check would pass a collapse to (0,0)).

### 3b — colony-system (`143ff73`)
- **`withdrawFood` `>= SIM_VERSION_V3`** (V3=3) → unwrap the fullest-first drain, delete the
  dead pre-#27 array-order legacy branch; drop the `simVersion` param.
- **`colonyForageBackpressure` `< SIM_VERSION_V27`** early-return → delete; the
  FoodStorage-chamber scan is unconditional; drop the `simVersion` param.
- Param-removal cascade: `tickFoodConsumption` (drops the captured local), `tick.ts`
  step-10a backpressure, `ant-dig.ts` snapshot, and the `withdrawFood`/backpressure test
  sites. Delete determinism.test.ts's "LEGACY vs LATEST … produce different state" contrast
  test — there's only one drain algorithm now, so the contrast is impossible (and its 3-arg
  calls no longer typecheck); within-version drain-fullest determinism stays covered by the
  sibling LATEST test.
- `types.ts` simVersion changelog left intact — it documents version *meaning* for replay
  lineage, not live branching.

### Verification
- **Byte-identical** for all loadable versions — the byte-gate (fresh-V33 `tick()`) is
  byte-identical vs `main`. Over-reap net = the both-sides **V31–V33 version suites** in
  `verify` (the byte-gate is blind to over-reaps of live gates since fresh V33 makes them
  always-true) — all green.
- `npm run verify` full: **2756 passed | 1 skipped**, all guards clean.
- Cross-model reviewed by Fable (Codex substitute — over quota).

Net after this PR: `MIN_ACCEPTED=V30`, `LATEST=V33`, only live V31/V32/V33 gates remain in
the reaped subsystems.

Closes #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved food handling so withdrawals now use a single, consistent priority order.
  * Colony foraging backpressure and idle reassignment now follow the colony’s current state more reliably.
  * Spider movement and edge clamping are now applied consistently, reducing odd boundary behavior.
  * Updated and simplified related tests to reflect the current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->