### PR TITLE
feat(platform): async StorageDriver seam (#234 PR1 of 3)

### DIFF
--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   SAVE_FORMAT_VERSION,
   SAVE_KEY,
@@ -21,6 +21,12 @@ import {
   unpackBakedSurfaceEffect,
   type SaveFile,
 } from './save.js';
+import {
+  setStorageDriver,
+  getStorageDriver,
+  LocalStorageDriver,
+  type StorageDriver,
+} from './storage.js';
 import { createScenario } from '../sim/scenario.js';
 import { tick } from '../sim/tick.js';
 import {
@@ -614,10 +620,10 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   });
 
   describe('SaveFile envelope (PRD §8a: version + seed + inputLog + snapshot)', () => {
-    it('hasSave returns false when localStorage empty', () => {
-      expect(hasSave()).toBe(false);
+    it('hasSave returns false when localStorage empty', async () => {
+      expect(await hasSave()).toBe(false);
     });
-    it('hasSave returns true when valid envelope present', () => {
+    it('hasSave returns true when valid envelope present', async () => {
       const w = createScenario(42);
       localStorage.setItem(
         SAVE_KEY,
@@ -628,13 +634,13 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: serializeWorldState(w),
         } satisfies SaveFile),
       );
-      expect(hasSave()).toBe(true);
+      expect(await hasSave()).toBe(true);
     });
-    it('hasSave returns false on malformed JSON', () => {
+    it('hasSave returns false on malformed JSON', async () => {
       localStorage.setItem(SAVE_KEY, 'not-json');
-      expect(hasSave()).toBe(false);
+      expect(await hasSave()).toBe(false);
     });
-    it('hasSave returns false on mismatched version', () => {
+    it('hasSave returns false on mismatched version', async () => {
       const w = createScenario(42);
       localStorage.setItem(
         SAVE_KEY,
@@ -645,9 +651,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: serializeWorldState(w),
         }),
       );
-      expect(hasSave()).toBe(false);
+      expect(await hasSave()).toBe(false);
     });
-    it('rejects v1 saves (issue #15 — chamber-authoritative food storage)', () => {
+    it('rejects v1 saves (issue #15 — chamber-authoritative food storage)', async () => {
       // Pre-#15 saves stored the entire stockpile in `colony.foodStored`
       // and projected slices into `chamber.foodStored` on each reconcile.
       // Loading them under v2 would either double-count (slices + pool) or
@@ -664,10 +670,10 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: serializeWorldState(w),
         }),
       );
-      expect(hasSave()).toBe(false);
-      expect(loadSave()).toBeNull();
+      expect(await hasSave()).toBe(false);
+      expect(await loadSave()).toBeNull();
     });
-    it('loadSave returns a SaveFile with seed + inputLog + snapshot fields', () => {
+    it('loadSave returns a SaveFile with seed + inputLog + snapshot fields', async () => {
       const w = createScenario(42);
       const inputLog: SimCommand[] = [
         {
@@ -687,17 +693,17 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: serializeWorldState(w),
         } satisfies SaveFile),
       );
-      const loaded = loadSave();
+      const loaded = await loadSave();
       expect(loaded).not.toBeNull();
       expect(loaded!.seed).toBe(42);
       expect(loaded!.inputLog.length).toBe(1);
       expect(loaded!.snapshot).toBeDefined();
     });
-    it('loadSave returns null on malformed JSON (never throws)', () => {
+    it('loadSave returns null on malformed JSON (never throws)', async () => {
       localStorage.setItem(SAVE_KEY, '{ bad }');
-      expect(loadSave()).toBeNull();
+      expect(await loadSave()).toBeNull();
     });
-    it('deleteSave removes the key and does not throw on missing', () => {
+    it('deleteSave removes the key and does not throw on missing', async () => {
       localStorage.setItem(
         SAVE_KEY,
         JSON.stringify({
@@ -707,24 +713,24 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: serializeWorldState(createScenario(1)),
         }),
       );
-      deleteSave();
+      await deleteSave();
       expect(localStorage.getItem(SAVE_KEY)).toBeNull();
-      expect(() => deleteSave()).not.toThrow();
+      await expect(deleteSave()).resolves.not.toThrow();
     });
   });
 
   describe('tickAutosave gating', () => {
-    it('does not save before interval elapsed (returns lastSaveMs unchanged)', () => {
+    it('does not save before interval elapsed (returns lastSaveMs unchanged)', async () => {
       const w = createScenario(42);
       const prev = 1000;
-      const result = tickAutosave(42, [], w, prev, prev + AUTOSAVE_INTERVAL_MS - 1);
+      const result = await tickAutosave(42, [], w, prev, prev + AUTOSAVE_INTERVAL_MS - 1);
       expect(result).toBe(prev);
       expect(localStorage.getItem(SAVE_KEY)).toBeNull();
     });
-    it('writes SaveFile after interval elapsed (returns nowMs)', () => {
+    it('writes SaveFile after interval elapsed (returns nowMs)', async () => {
       const w = createScenario(42);
       const now = AUTOSAVE_INTERVAL_MS + 500;
-      const result = tickAutosave(42, [], w, 0, now);
+      const result = await tickAutosave(42, [], w, 0, now);
       expect(result).toBe(now);
       const raw = localStorage.getItem(SAVE_KEY);
       expect(raw).not.toBeNull();
@@ -732,7 +738,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(env.version).toBe(SAVE_FORMAT_VERSION);
       expect(env.seed).toBe(42);
     });
-    it('returns nowMs on setItem throw — honors cooldown to prevent retry storm (#80)', () => {
+    it('returns nowMs on setItem throw — honors cooldown to prevent retry storm (#80)', async () => {
       const w = createScenario(42);
       // Spy on the actual localStorage instance (InMemoryStorage replaces Storage.prototype on Node 25)
       const spy = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
@@ -740,7 +746,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       });
       try {
         const now = AUTOSAVE_INTERVAL_MS + 1;
-        const result = tickAutosave(42, [], w, 0, now);
+        const result = await tickAutosave(42, [], w, 0, now);
         // Pre-#80 returned 0 (lastSaveMs unchanged) → next frame instantly
         // satisfied the elapsed check and stormed setItem at 60 FPS.
         // Post-fix advances to nowMs so retry waits a full interval.
@@ -749,18 +755,18 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         spy.mockRestore();
       }
     });
-    it('after setItem throw, the next call within the interval is a no-op (cooldown observed)', () => {
+    it('after setItem throw, the next call within the interval is a no-op (cooldown observed)', async () => {
       const w = createScenario(42);
       const spy = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
         throw new Error('quota');
       });
       try {
         const t1 = AUTOSAVE_INTERVAL_MS + 1;
-        const lastSaveMs = tickAutosave(42, [], w, 0, t1);
+        const lastSaveMs = await tickAutosave(42, [], w, 0, t1);
         expect(spy).toHaveBeenCalledTimes(1);
         // Half an interval later — cooldown should suppress the retry.
         const t2 = t1 + AUTOSAVE_INTERVAL_MS / 2;
-        const result = tickAutosave(42, [], w, lastSaveMs, t2);
+        const result = await tickAutosave(42, [], w, lastSaveMs, t2);
         expect(spy).toHaveBeenCalledTimes(1); // no second attempt
         expect(result).toBe(lastSaveMs);
       } finally {
@@ -770,12 +776,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   });
 
   describe('SCEN-06 replay truth — seed + inputLog reproduce snapshot', () => {
-    it('(a) seed round-trips', () => {
+    it('(a) seed round-trips', async () => {
       const w = createScenario(777);
-      tickAutosave(777, [], w, 0, AUTOSAVE_INTERVAL_MS + 1);
-      expect(loadSave()!.seed).toBe(777);
+      await tickAutosave(777, [], w, 0, AUTOSAVE_INTERVAL_MS + 1);
+      expect((await loadSave())!.seed).toBe(777);
     });
-    it('(b) inputLog round-trips', () => {
+    it('(b) inputLog round-trips', async () => {
       const w = createScenario(42);
       const log: SimCommand[] = [
         {
@@ -793,12 +799,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           issuedAtTick: 5,
         },
       ];
-      tickAutosave(42, log, w, 0, AUTOSAVE_INTERVAL_MS + 1);
-      const loaded = loadSave()!;
+      await tickAutosave(42, log, w, 0, AUTOSAVE_INTERVAL_MS + 1);
+      const loaded = (await loadSave())!;
       expect(loaded.inputLog.length).toBe(2);
       expect(loaded.inputLog[1]).toMatchObject({ tileX: 3, tileY: 3 });
     });
-    it('(c) queued unprocessed commands round-trip via snapshot.commandQueue', () => {
+    it('(c) queued unprocessed commands round-trip via snapshot.commandQueue', async () => {
       const w = createScenario(42);
       w.commandQueue.push({
         type: 'MarkDigTile',
@@ -807,22 +813,22 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         tileY: 9,
         issuedAtTick: 0,
       });
-      tickAutosave(42, [], w, 0, AUTOSAVE_INTERVAL_MS + 1);
-      const loaded = loadSave()!;
+      await tickAutosave(42, [], w, 0, AUTOSAVE_INTERVAL_MS + 1);
+      const loaded = (await loadSave())!;
       expect(loaded.snapshot.commandQueue.length).toBe(1);
       expect(loaded.snapshot.commandQueue[0]).toMatchObject({ tileX: 9, tileY: 9 });
     });
-    it('(d) loaded snapshot when re-serialized equals original (byte-for-byte)', () => {
+    it('(d) loaded snapshot when re-serialized equals original (byte-for-byte)', async () => {
       const w = createScenario(42);
       for (let t = 0; t < 25; t++) tick(w, []);
-      tickAutosave(42, [], w, 0, AUTOSAVE_INTERVAL_MS + 1);
-      const loaded = loadSave()!;
+      await tickAutosave(42, [], w, 0, AUTOSAVE_INTERVAL_MS + 1);
+      const loaded = (await loadSave())!;
       const rebuilt = deserializeWorldState(loaded.snapshot);
       expect(JSON.stringify(serializeWorldState(rebuilt))).toBe(
         JSON.stringify(serializeWorldState(w)),
       );
     });
-    it('(e) inputLog replay: createScenario(seed) + tick(cmds[t]) for each tick reproduces snapshot', () => {
+    it('(e) inputLog replay: createScenario(seed) + tick(cmds[t]) for each tick reproduces snapshot', async () => {
       // Build a reference world with a deterministic schedule
       const seed = 42;
       const schedule: SimCommand[][] = [];
@@ -846,8 +852,8 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       }
 
       // Save
-      tickAutosave(seed, inputLog, original, 0, AUTOSAVE_INTERVAL_MS + 1);
-      const loaded = loadSave()!;
+      await tickAutosave(seed, inputLog, original, 0, AUTOSAVE_INTERVAL_MS + 1);
+      const loaded = (await loadSave())!;
       expect(loaded.seed).toBe(seed);
 
       // Replay inputLog against a fresh scenario — use issuedAtTick to schedule
@@ -925,7 +931,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       localStorage.setItem(SAVE_KEY, JSON.stringify(file));
     }
 
-    it('post-Phase-10 entry without dig field passes through unchanged (including idle {0,0})', () => {
+    it('post-Phase-10 entry without dig field passes through unchanged (including idle {0,0})', async () => {
       const w = createScenario(42);
       const modernIdle: SimCommand = {
         type: 'SetBehaviorRatio',
@@ -939,7 +945,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         inputLog: [modernIdle],
         snapshot: serializeWorldState(w),
       });
-      const loaded = loadSave()!;
+      const loaded = (await loadSave())!;
       expect((loaded.inputLog[0] as { ratio: unknown }).ratio).toEqual({ forage: 0, fight: 0 });
     });
   });
@@ -1173,7 +1179,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       localStorage.setItem(SAVE_KEY, JSON.stringify(file));
     }
 
-    it('null ratio in inputLog: save still loads (command preserved verbatim)', () => {
+    it('null ratio in inputLog: save still loads (command preserved verbatim)', async () => {
       const w = createScenario(42);
       writeSave({
         version: SAVE_FORMAT_VERSION,
@@ -1183,12 +1189,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         ],
         snapshot: serializeWorldState(w),
       });
-      const loaded = loadSave();
+      const loaded = await loadSave();
       expect(loaded).not.toBeNull();
       expect(loaded!.inputLog.length).toBe(1);
       expect((loaded!.inputLog[0] as { ratio: unknown }).ratio).toBeNull();
     });
-    it('numeric ratio in inputLog: save still loads', () => {
+    it('numeric ratio in inputLog: save still loads', async () => {
       const w = createScenario(42);
       writeSave({
         version: SAVE_FORMAT_VERSION,
@@ -1198,9 +1204,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         ],
         snapshot: serializeWorldState(w),
       });
-      expect(loadSave()).not.toBeNull();
+      expect(await loadSave()).not.toBeNull();
     });
-    it('string ratio in inputLog: save still loads', () => {
+    it('string ratio in inputLog: save still loads', async () => {
       const w = createScenario(42);
       writeSave({
         version: SAVE_FORMAT_VERSION,
@@ -1210,7 +1216,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         ],
         snapshot: serializeWorldState(w),
       });
-      expect(loadSave()).not.toBeNull();
+      expect(await loadSave()).not.toBeNull();
     });
   });
 
@@ -1233,7 +1239,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     // -----------------------------------------------------------------------
     // #110 — envelope seed validation
     // -----------------------------------------------------------------------
-    it('#110 rejects envelope seed: string', () => {
+    it('#110 rejects envelope seed: string', async () => {
       const w = createScenario(42);
       writeSave({
         version: SAVE_FORMAT_VERSION,
@@ -1241,9 +1247,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         inputLog: [],
         snapshot: serializeWorldState(w),
       });
-      expect(loadSave()).toBeNull();
+      expect(await loadSave()).toBeNull();
     });
-    it('#110 rejects envelope seed: null', () => {
+    it('#110 rejects envelope seed: null', async () => {
       const w = createScenario(42);
       writeSave({
         version: SAVE_FORMAT_VERSION,
@@ -1251,15 +1257,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         inputLog: [],
         snapshot: serializeWorldState(w),
       });
-      expect(loadSave()).toBeNull();
+      expect(await loadSave()).toBeNull();
     });
-    it('#110 rejects envelope seed: missing', () => {
+    it('#110 rejects envelope seed: missing', async () => {
       const w = createScenario(42);
       const file = { version: SAVE_FORMAT_VERSION, inputLog: [], snapshot: serializeWorldState(w) };
       localStorage.setItem(SAVE_KEY, JSON.stringify(file));
-      expect(loadSave()).toBeNull();
+      expect(await loadSave()).toBeNull();
     });
-    it('#110 rejects envelope seed: non-integer', () => {
+    it('#110 rejects envelope seed: non-integer', async () => {
       const w = createScenario(42);
       writeSave({
         version: SAVE_FORMAT_VERSION,
@@ -1267,9 +1273,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         inputLog: [],
         snapshot: serializeWorldState(w),
       });
-      expect(loadSave()).toBeNull();
+      expect(await loadSave()).toBeNull();
     });
-    it('#110 rejects envelope seed: out of int32 range', () => {
+    it('#110 rejects envelope seed: out of int32 range', async () => {
       const w = createScenario(42);
       writeSave({
         version: SAVE_FORMAT_VERSION,
@@ -1277,9 +1283,9 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         inputLog: [],
         snapshot: serializeWorldState(w),
       });
-      expect(loadSave()).toBeNull();
+      expect(await loadSave()).toBeNull();
     });
-    it('#110 accepts envelope seed: int32 boundary values', () => {
+    it('#110 accepts envelope seed: int32 boundary values', async () => {
       const w = createScenario(42);
       writeSave({
         version: SAVE_FORMAT_VERSION,
@@ -1287,28 +1293,28 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         inputLog: [],
         snapshot: serializeWorldState(w),
       });
-      expect(loadSave()).not.toBeNull();
+      expect(await loadSave()).not.toBeNull();
       writeSave({
         version: SAVE_FORMAT_VERSION,
         seed: -0x80000000,
         inputLog: [],
         snapshot: serializeWorldState(w),
       });
-      expect(loadSave()).not.toBeNull();
+      expect(await loadSave()).not.toBeNull();
     });
 
     // -----------------------------------------------------------------------
     // #103 — non-array inputLog normalization (no soft-brick)
     // -----------------------------------------------------------------------
-    it('#103 normalizes missing inputLog to empty array', () => {
+    it('#103 normalizes missing inputLog to empty array', async () => {
       const w = createScenario(42);
       const file = { version: SAVE_FORMAT_VERSION, seed: 42, snapshot: serializeWorldState(w) };
       localStorage.setItem(SAVE_KEY, JSON.stringify(file));
-      const loaded = loadSave();
+      const loaded = await loadSave();
       expect(loaded).not.toBeNull();
       expect(loaded!.inputLog).toEqual([]);
     });
-    it('#103 normalizes null inputLog to empty array', () => {
+    it('#103 normalizes null inputLog to empty array', async () => {
       const w = createScenario(42);
       writeSave({
         version: SAVE_FORMAT_VERSION,
@@ -1316,11 +1322,11 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         inputLog: null,
         snapshot: serializeWorldState(w),
       });
-      const loaded = loadSave();
+      const loaded = await loadSave();
       expect(loaded).not.toBeNull();
       expect(loaded!.inputLog).toEqual([]);
     });
-    it('#103 normalizes string inputLog to empty array', () => {
+    it('#103 normalizes string inputLog to empty array', async () => {
       const w = createScenario(42);
       writeSave({
         version: SAVE_FORMAT_VERSION,
@@ -1328,7 +1334,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         inputLog: 'abc',
         snapshot: serializeWorldState(w),
       });
-      const loaded = loadSave();
+      const loaded = await loadSave();
       expect(loaded).not.toBeNull();
       expect(loaded!.inputLog).toEqual([]);
     });
@@ -1336,7 +1342,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     // -----------------------------------------------------------------------
     // #105 — null inputLog entry doesn't destroy the save
     // -----------------------------------------------------------------------
-    it('#105 null inputLog entry passes through migrateInputLogCommand without throwing', () => {
+    it('#105 null inputLog entry passes through migrateInputLogCommand without throwing', async () => {
       const w = createScenario(42);
       writeSave({
         version: SAVE_FORMAT_VERSION,
@@ -1346,7 +1352,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       });
       // Pre-fix: this returned null (loadSave swallowed the TypeError).
       // Post-fix: parseSaveFile completes; the null entry passes through.
-      const loaded = loadSave();
+      const loaded = await loadSave();
       expect(loaded).not.toBeNull();
       expect(loaded!.inputLog).toHaveLength(1);
       expect(loaded!.inputLog[0]).toBeNull();
@@ -1644,7 +1650,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(SAVE_KEY).toBe('subterrans:save:v3');
     });
 
-    it('rejects v2 envelopes with SaveVersionMismatchError', () => {
+    it('rejects v2 envelopes with SaveVersionMismatchError', async () => {
       const v2Envelope = JSON.stringify({
         version: 2,
         seed: 42,
@@ -1656,18 +1662,18 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       // future refactor that downgrades to a generic Error would slip past
       // the swallowed-error path otherwise.
       localStorage.setItem(SAVE_KEY, v2Envelope);
-      expect(hasSave()).toBe(false);
-      expect(loadSave()).toBeNull();
+      expect(await hasSave()).toBe(false);
+      expect(await loadSave()).toBeNull();
 
       // Direct production-path assertion — calls the module-exported
       // parseSaveFile, which is the function that actually decides to throw.
       expect(() => parseSaveFile(v2Envelope)).toThrow(SaveVersionMismatchError);
     });
 
-    it('purges legacy v2 keys on hasSave/loadSave', () => {
+    it('purges legacy v2 keys on hasSave/loadSave', async () => {
       localStorage.setItem('subterrans:save:v2', '{"version":2}');
       // Trigger the purge.
-      hasSave();
+      await hasSave();
       expect(localStorage.getItem('subterrans:save:v2')).toBeNull();
     });
 
@@ -1764,19 +1770,19 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
   // -------------------------------------------------------------------------
 
   describe('Issue #115 — manualSave', () => {
-    it('writes a parseable save under SAVE_KEY and returns true on success', () => {
+    it('writes a parseable save under SAVE_KEY and returns true on success', async () => {
       const world = createScenario(42);
-      const ok = manualSave(42, [], world);
+      const ok = await manualSave(42, [], world);
       expect(ok).toBe(true);
       expect(window.localStorage.getItem(SAVE_KEY)).not.toBeNull();
       // Round-trip via the public read path.
-      const loaded = loadSave();
+      const loaded = await loadSave();
       expect(loaded).not.toBeNull();
       expect(loaded!.seed).toBe(42);
       expect(loaded!.snapshot.tick).toBe(0);
     });
 
-    it('preserves the inputLog the caller supplies', () => {
+    it('preserves the inputLog the caller supplies', async () => {
       const world = createScenario(42);
       const log: SimCommand[] = [
         {
@@ -1786,57 +1792,57 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           issuedAtTick: 0,
         },
       ];
-      manualSave(42, log, world);
-      const loaded = loadSave();
+      await manualSave(42, log, world);
+      const loaded = await loadSave();
       expect(loaded!.inputLog).toHaveLength(1);
       expect(loaded!.inputLog[0]!.type).toBe('SetBehaviorRatio');
     });
 
-    it('returns false (does not throw) when localStorage.setItem rejects', () => {
+    it('returns false (does not throw) when localStorage.setItem rejects', async () => {
       const world = createScenario(42);
       const orig = window.localStorage.setItem;
       window.localStorage.setItem = vi.fn(() => {
         throw new Error('QuotaExceededError');
       });
       try {
-        const ok = manualSave(42, [], world);
+        const ok = await manualSave(42, [], world);
         expect(ok).toBe(false);
       } finally {
         window.localStorage.setItem = orig;
       }
     });
 
-    it('does NOT depend on or update the autosave timer (manual save is independent)', () => {
+    it('does NOT depend on or update the autosave timer (manual save is independent)', async () => {
       // tickAutosave returns the new lastSaveMs each call. A manual save in
       // between two autosave windows must not bump the autosave's clock —
       // they share the SAVE_KEY but track cadence independently.
       const world = createScenario(42);
       // First autosave at t=0 → writes, returns 0.
-      const t0 = tickAutosave(42, [], world, -AUTOSAVE_INTERVAL_MS, 0);
+      const t0 = await tickAutosave(42, [], world, -AUTOSAVE_INTERVAL_MS, 0);
       expect(t0).toBe(0);
       // Manual save at t=5000 — should write, but the autosave's lastSaveMs
       // is whatever the caller passes; manualSave doesn't see it. Verify by
       // calling tickAutosave again at t = AUTOSAVE_INTERVAL_MS-1 with the
       // unchanged lastSaveMs → still NOT due (cooldown not elapsed).
-      manualSave(42, [], world);
-      const t1 = tickAutosave(42, [], world, t0, AUTOSAVE_INTERVAL_MS - 1);
+      await manualSave(42, [], world);
+      const t1 = await tickAutosave(42, [], world, t0, AUTOSAVE_INTERVAL_MS - 1);
       expect(t1).toBe(t0); // still pre-cooldown — unchanged
     });
   });
 
   describe('Issue #115 — hasIncompatibleSave', () => {
-    it('returns false when localStorage is empty', () => {
-      expect(hasIncompatibleSave()).toBe(false);
+    it('returns false when localStorage is empty', async () => {
+      expect(await hasIncompatibleSave()).toBe(false);
     });
 
-    it('returns false for a freshly-written compatible save', () => {
-      manualSave(42, [], createScenario(42));
-      expect(hasIncompatibleSave()).toBe(false);
+    it('returns false for a freshly-written compatible save', async () => {
+      await manualSave(42, [], createScenario(42));
+      expect(await hasIncompatibleSave()).toBe(false);
       // hasSave is the symmetric positive case
-      expect(hasSave()).toBe(true);
+      expect(await hasSave()).toBe(true);
     });
 
-    it('returns true when SAVE_KEY holds a v2-shaped envelope (rejected by parseSaveFile)', () => {
+    it('returns true when SAVE_KEY holds a v2-shaped envelope (rejected by parseSaveFile)', async () => {
       // Stash a known-v2 envelope. parseSaveFile throws SaveVersionMismatchError
       // → hasIncompatibleSave returns true; hasSave returns false. The pair
       // lets the dialog distinguish "no save" from "save present, this build
@@ -1850,14 +1856,14 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: {},
         }),
       );
-      expect(hasIncompatibleSave()).toBe(true);
-      expect(hasSave()).toBe(false);
+      expect(await hasIncompatibleSave()).toBe(true);
+      expect(await hasSave()).toBe(false);
     });
 
-    it('returns true when SAVE_KEY holds completely malformed JSON', () => {
+    it('returns true when SAVE_KEY holds completely malformed JSON', async () => {
       window.localStorage.setItem(SAVE_KEY, '{not-json');
-      expect(hasIncompatibleSave()).toBe(true);
-      expect(hasSave()).toBe(false);
+      expect(await hasIncompatibleSave()).toBe(true);
+      expect(await hasSave()).toBe(false);
     });
 
     it('round-3 (Codex P2): returns true when snapshot.simVersion exceeds LATEST_SIM_VERSION (future-build save)', async () => {
@@ -1878,10 +1884,10 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         savedAtMs: Date.now(),
       };
       window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
-      expect(hasIncompatibleSave()).toBe(true);
+      expect(await hasIncompatibleSave()).toBe(true);
       // hasSave still returns true (envelope parses) — caller is expected
       // to gate on `hasSave() && !hasIncompatibleSave()` for "loadable".
-      expect(hasSave()).toBe(true);
+      expect(await hasSave()).toBe(true);
     });
 
     it('round-3: returns false when simVersion equals LATEST_SIM_VERSION (loadable)', async () => {
@@ -1897,8 +1903,8 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         savedAtMs: Date.now(),
       };
       window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
-      expect(hasIncompatibleSave()).toBe(false);
-      expect(hasSave()).toBe(true);
+      expect(await hasIncompatibleSave()).toBe(false);
+      expect(await hasSave()).toBe(true);
     });
 
     it('round-3: returns true when simVersion is omitted (old save below MIN_ACCEPTED — not loadable)', async () => {
@@ -1914,10 +1920,10 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         savedAtMs: Date.now(),
       };
       window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
-      expect(hasIncompatibleSave()).toBe(true);
+      expect(await hasIncompatibleSave()).toBe(true);
     });
 
-    it('Codex round-3 P1: returns true when snapshot is null (parseable envelope, garbage payload)', () => {
+    it('Codex round-3 P1: returns true when snapshot is null (parseable envelope, garbage payload)', async () => {
       // parseSaveFile only validates the envelope. A v3 envelope with
       // snapshot=null parses fine but reading snapshot.simVersion would
       // throw and crash the dialog. Treat as incompatible.
@@ -1930,10 +1936,10 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: null,
         }),
       );
-      expect(hasIncompatibleSave()).toBe(true);
+      expect(await hasIncompatibleSave()).toBe(true);
     });
 
-    it('Codex round-3 P1: returns true when snapshot is a non-object (string / number)', () => {
+    it('Codex round-3 P1: returns true when snapshot is a non-object (string / number)', async () => {
       window.localStorage.setItem(
         SAVE_KEY,
         JSON.stringify({
@@ -1943,7 +1949,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: 'not an object',
         }),
       );
-      expect(hasIncompatibleSave()).toBe(true);
+      expect(await hasIncompatibleSave()).toBe(true);
     });
 
     it('round-4 (Rob): returns true when snapshot is empty object (parseable but unloadable — Continue would lie)', async () => {
@@ -1961,7 +1967,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: {},
         }),
       );
-      expect(hasIncompatibleSave()).toBe(true);
+      expect(await hasIncompatibleSave()).toBe(true);
     });
 
     it('round-4 (Rob): returns true when simVersion is below LEGACY_SIM_VERSION (tampered down)', async () => {
@@ -1979,10 +1985,10 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           savedAtMs: Date.now(),
         }),
       );
-      expect(hasIncompatibleSave()).toBe(true);
+      expect(await hasIncompatibleSave()).toBe(true);
     });
 
-    it('round-4 (Rob): returns true when snapshot.colonies is missing (deserialize would throw)', () => {
+    it('round-4 (Rob): returns true when snapshot.colonies is missing (deserialize would throw)', async () => {
       window.localStorage.setItem(
         SAVE_KEY,
         JSON.stringify({
@@ -1992,7 +1998,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: { tick: 0, rngState: 0, nextEntityId: 0, commandQueue: [] },
         }),
       );
-      expect(hasIncompatibleSave()).toBe(true);
+      expect(await hasIncompatibleSave()).toBe(true);
     });
   });
 
@@ -2003,13 +2009,13 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
     // incompatible verdicts to a single boolean, so these tests are the only
     // direct guard that the future-vs-corrupt split is wired correctly — a
     // refactor that swapped the two branches would otherwise stay green.
-    it("returns 'none' when localStorage is empty", () => {
-      expect(classifySaveCompatibility()).toBe('none');
+    it("returns 'none' when localStorage is empty", async () => {
+      expect(await classifySaveCompatibility()).toBe('none');
     });
 
-    it("returns 'compatible' for a freshly-written current-format save", () => {
-      manualSave(42, [], createScenario(42));
-      expect(classifySaveCompatibility()).toBe('compatible');
+    it("returns 'compatible' for a freshly-written current-format save", async () => {
+      await manualSave(42, [], createScenario(42));
+      expect(await classifySaveCompatibility()).toBe('compatible');
     });
 
     it("returns 'incompatible-future' when simVersion exceeds LATEST (recoverable → suspend autosave)", async () => {
@@ -2020,7 +2026,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         SAVE_KEY,
         JSON.stringify({ version: SAVE_FORMAT_VERSION, seed: 7, inputLog: [], snapshot: snap }),
       );
-      expect(classifySaveCompatibility()).toBe('incompatible-future');
+      expect(await classifySaveCompatibility()).toBe('incompatible-future');
     });
 
     it("returns 'incompatible-corrupt' when simVersion is below MIN_ACCEPTED (tampered down → overwrite freely)", async () => {
@@ -2033,53 +2039,53 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         SAVE_KEY,
         JSON.stringify({ version: SAVE_FORMAT_VERSION, seed: 7, inputLog: [], snapshot: snap }),
       );
-      expect(classifySaveCompatibility()).toBe('incompatible-corrupt');
+      expect(await classifySaveCompatibility()).toBe('incompatible-corrupt');
     });
 
-    it("returns 'incompatible-corrupt' for a stale save-format envelope (parseSaveFile throws)", () => {
+    it("returns 'incompatible-corrupt' for a stale save-format envelope (parseSaveFile throws)", async () => {
       window.localStorage.setItem(
         SAVE_KEY,
         JSON.stringify({ version: 2, seed: 1, inputLog: [], snapshot: {} }),
       );
-      expect(classifySaveCompatibility()).toBe('incompatible-corrupt');
+      expect(await classifySaveCompatibility()).toBe('incompatible-corrupt');
     });
 
-    it("returns 'incompatible-corrupt' for malformed JSON", () => {
+    it("returns 'incompatible-corrupt' for malformed JSON", async () => {
       window.localStorage.setItem(SAVE_KEY, '{not-json');
-      expect(classifySaveCompatibility()).toBe('incompatible-corrupt');
+      expect(await classifySaveCompatibility()).toBe('incompatible-corrupt');
     });
 
-    it("returns 'incompatible-corrupt' when snapshot is null (parseable envelope, garbage payload)", () => {
+    it("returns 'incompatible-corrupt' when snapshot is null (parseable envelope, garbage payload)", async () => {
       window.localStorage.setItem(
         SAVE_KEY,
         JSON.stringify({ version: SAVE_FORMAT_VERSION, seed: 1, inputLog: [], snapshot: null }),
       );
-      expect(classifySaveCompatibility()).toBe('incompatible-corrupt');
+      expect(await classifySaveCompatibility()).toBe('incompatible-corrupt');
     });
 
-    it("returns 'incompatible-corrupt' when the snapshot deserialize throws (empty object, missing fields)", () => {
+    it("returns 'incompatible-corrupt' when the snapshot deserialize throws (empty object, missing fields)", async () => {
       window.localStorage.setItem(
         SAVE_KEY,
         JSON.stringify({ version: SAVE_FORMAT_VERSION, seed: 1, inputLog: [], snapshot: {} }),
       );
-      expect(classifySaveCompatibility()).toBe('incompatible-corrupt');
+      expect(await classifySaveCompatibility()).toBe('incompatible-corrupt');
     });
   });
 
   describe('Issue #115 — getSaveInfo', () => {
-    it('returns null when no save exists', () => {
-      expect(getSaveInfo()).toBeNull();
+    it('returns null when no save exists', async () => {
+      expect(await getSaveInfo()).toBeNull();
     });
 
-    it('returns null when the save is unreadable (would let the dialog show "incompatible save")', () => {
+    it('returns null when the save is unreadable (would let the dialog show "incompatible save")', async () => {
       window.localStorage.setItem(SAVE_KEY, '{not-json');
-      expect(getSaveInfo()).toBeNull();
+      expect(await getSaveInfo()).toBeNull();
     });
 
-    it('returns tick + player worker count + player food (human units) for a fresh save', () => {
+    it('returns tick + player worker count + player food (human units) for a fresh save', async () => {
       const world = createScenario(42);
-      manualSave(42, [], world);
-      const info = getSaveInfo();
+      await manualSave(42, [], world);
+      const info = await getSaveInfo();
       expect(info).not.toBeNull();
       expect(info!.tick).toBe(0);
       // Fresh scenario: queen alive; workerCount tracks living workers (no
@@ -2091,16 +2097,16 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(info!.playerFoodStored).toBe(playerColony.foodStored >> FP_SHIFT);
     });
 
-    it('returns the wall-clock savedAtMs from the envelope (issue #115)', () => {
+    it('returns the wall-clock savedAtMs from the envelope (issue #115)', async () => {
       const before = Date.now();
-      manualSave(42, [], createScenario(42));
+      await manualSave(42, [], createScenario(42));
       const after = Date.now();
-      const info = getSaveInfo();
+      const info = await getSaveInfo();
       expect(info!.savedAtMs).toBeGreaterThanOrEqual(before);
       expect(info!.savedAtMs).toBeLessThanOrEqual(after);
     });
 
-    it('returns savedAtMs=0 when the envelope omits the field (pre-issue-#115 saves)', () => {
+    it('returns savedAtMs=0 when the envelope omits the field (pre-issue-#115 saves)', async () => {
       // Simulate an older v3 envelope written before issue #115 added savedAtMs.
       // parseSaveFile must accept it (no version bump) and getSaveInfo falls
       // back to 0 ("unknown") rather than NaN or a 1970 stamp.
@@ -2112,12 +2118,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         // savedAtMs intentionally omitted
       };
       window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
-      const info = getSaveInfo();
+      const info = await getSaveInfo();
       expect(info).not.toBeNull();
       expect(info!.savedAtMs).toBe(0);
     });
 
-    it('returns savedAtMs=0 when the envelope field is malformed (negative or non-finite)', () => {
+    it('returns savedAtMs=0 when the envelope field is malformed (negative or non-finite)', async () => {
       const env = {
         version: SAVE_FORMAT_VERSION,
         seed: 1,
@@ -2126,19 +2132,19 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         savedAtMs: -1,
       };
       window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
-      const info = getSaveInfo();
+      const info = await getSaveInfo();
       expect(info!.savedAtMs).toBe(0);
     });
 
-    it('reflects updated tick count after the world advances', () => {
+    it('reflects updated tick count after the world advances', async () => {
       const world = createScenario(42);
       for (let i = 0; i < 5; i++) tick(world, []);
-      manualSave(42, [], world);
-      const info = getSaveInfo();
+      await manualSave(42, [], world);
+      const info = await getSaveInfo();
       expect(info!.tick).toBe(5);
     });
 
-    it('Codex round-3 P1: does NOT throw when snapshot is null (parseable envelope, garbage payload)', () => {
+    it('Codex round-3 P1: does NOT throw when snapshot is null (parseable envelope, garbage payload)', async () => {
       // The dialog opens by calling getSaveInfo + hasIncompatibleSave. Both
       // need to survive a parseable-but-garbage envelope so the user sees
       // the "incompatible" warning + can use Delete/New Game to recover.
@@ -2153,11 +2159,11 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: null,
         }),
       );
-      expect(() => getSaveInfo()).not.toThrow();
-      expect(getSaveInfo()).toBeNull();
+      await expect(getSaveInfo()).resolves.not.toThrow();
+      expect(await getSaveInfo()).toBeNull();
     });
 
-    it('Codex round-3 P1: does NOT throw when snapshot.colonies is missing', () => {
+    it('Codex round-3 P1: does NOT throw when snapshot.colonies is missing', async () => {
       // A snapshot with tick/rngState/etc. but no `colonies` field.
       // Pre-fix: dereferencing colonies[playerKey] would throw TypeError.
       window.localStorage.setItem(
@@ -2169,15 +2175,15 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: { tick: 5, rngState: 1, nextEntityId: 0 },
         }),
       );
-      expect(() => getSaveInfo()).not.toThrow();
-      const info = getSaveInfo();
+      await expect(getSaveInfo()).resolves.not.toThrow();
+      const info = await getSaveInfo();
       expect(info).not.toBeNull();
       expect(info!.tick).toBe(5);
       expect(info!.playerWorkers).toBe(0);
       expect(info!.playerFoodStored).toBe(0);
     });
 
-    it('Codex round-3 P1: returns 0 fields when snapshot.tick is missing/non-numeric', () => {
+    it('Codex round-3 P1: returns 0 fields when snapshot.tick is missing/non-numeric', async () => {
       window.localStorage.setItem(
         SAVE_KEY,
         JSON.stringify({
@@ -2187,12 +2193,12 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
           snapshot: { colonies: {} },
         }),
       );
-      const info = getSaveInfo();
+      const info = await getSaveInfo();
       expect(info).not.toBeNull();
       expect(info!.tick).toBe(0);
     });
 
-    it('returns 0 worker / 0 food when the player colony key is absent (defensive)', () => {
+    it('returns 0 worker / 0 food when the player colony key is absent (defensive)', async () => {
       // Hand-craft an envelope with a missing player colony record. This
       // should never happen in legitimate gameplay, but the dialog must not
       // crash if it does — surface zeros and let the player decide.
@@ -2235,7 +2241,7 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
         },
       };
       window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
-      const info = getSaveInfo();
+      const info = await getSaveInfo();
       expect(info).not.toBeNull();
       expect(info!.tick).toBe(7);
       expect(info!.playerWorkers).toBe(0);
@@ -2328,5 +2334,127 @@ describe('bakedSurfaceEffect serialization', () => {
         expect(sum).toBe(0);
       }
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #234 PR1 — the async StorageDriver seam. The 9 save.ts functions now route
+// every read/write through getStorageDriver() instead of touching the
+// `localStorage` global directly, so the whole save path can move to async,
+// evict-resistant backends (Capacitor / Tauri / IndexedDB / OPFS) later by
+// injecting a driver — without editing a single save.ts call site again.
+// These tests prove the async API round-trips through an INJECTED driver (not
+// localStorage) and that a driver whose get/set reject surfaces gracefully
+// through the existing try/catch in each save function.
+// ---------------------------------------------------------------------------
+describe('#234 StorageDriver seam', () => {
+  // Restore the process-default driver after every test so an injected fake
+  // never leaks into a later test (setStorageDriver mutates module state).
+  afterEach(() => {
+    setStorageDriver(new LocalStorageDriver());
+  });
+
+  /** In-memory, Map-backed driver — the canonical "not localStorage" backend. */
+  class FakeStorageDriver implements StorageDriver {
+    readonly store = new Map<string, string>();
+    get(key: string): Promise<string | null> {
+      return Promise.resolve(this.store.has(key) ? this.store.get(key)! : null);
+    }
+    set(key: string, value: string): Promise<void> {
+      this.store.set(key, value);
+      return Promise.resolve();
+    }
+    remove(key: string): Promise<void> {
+      this.store.delete(key);
+      return Promise.resolve();
+    }
+  }
+
+  it('round-trips a save through an injected in-memory driver (not localStorage)', async () => {
+    const fake = new FakeStorageDriver();
+    setStorageDriver(fake);
+    // Clear the real localStorage so a stale save there can't masquerade as a
+    // round-trip through the fake — the read MUST come from the injected driver.
+    window.localStorage.clear();
+    const world = createScenario(1234);
+
+    expect(await manualSave(1234, [], world)).toBe(true);
+    // Proof the write landed in the injected driver, not localStorage.
+    expect(fake.store.has(SAVE_KEY)).toBe(true);
+    expect(window.localStorage.getItem(SAVE_KEY)).toBeNull();
+
+    const loaded = await loadSave();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.seed).toBe(1234);
+    expect(loaded!.snapshot.tick).toBe(0);
+  });
+
+  it('manualSave + tickAutosave resolve gracefully when the driver.set rejects (no throw)', async () => {
+    class RejectingSetDriver implements StorageDriver {
+      get(): Promise<string | null> {
+        return Promise.resolve(null);
+      }
+      set(): Promise<void> {
+        return Promise.reject(new Error('quota'));
+      }
+      remove(): Promise<void> {
+        return Promise.resolve();
+      }
+    }
+    setStorageDriver(new RejectingSetDriver());
+    const world = createScenario(42);
+
+    // manualSave swallows the rejection and reports failure.
+    await expect(manualSave(42, [], world)).resolves.toBe(false);
+
+    // tickAutosave honors the #80 cooldown on a failed write: it advances to
+    // nowMs (not lastSaveMs) so a full-storage backend can't storm setItem at
+    // 60 FPS. The interval has elapsed here (nowMs - 0 > AUTOSAVE_INTERVAL_MS).
+    const nowMs = AUTOSAVE_INTERVAL_MS + 1;
+    await expect(tickAutosave(42, [], world, 0, nowMs)).resolves.toBe(nowMs);
+  });
+
+  it('hasSave + loadSave resolve to the empty-state values when the driver.get rejects (no throw)', async () => {
+    class RejectingGetDriver implements StorageDriver {
+      get(): Promise<string | null> {
+        return Promise.reject(new Error('storage blocked'));
+      }
+      set(): Promise<void> {
+        return Promise.resolve();
+      }
+      remove(): Promise<void> {
+        return Promise.resolve();
+      }
+    }
+    setStorageDriver(new RejectingGetDriver());
+
+    // The existing try/catch in each function swallows the rejection and
+    // returns the "no readable save" value rather than propagating.
+    await expect(hasSave()).resolves.toBe(false);
+    await expect(loadSave()).resolves.toBeNull();
+  });
+
+  it('the async save functions return Promises (Promise-returning signatures)', async () => {
+    // Inject a fake so the instanceof probe performs no real IO.
+    setStorageDriver(new FakeStorageDriver());
+    const world = createScenario(42);
+
+    const savePromise = manualSave(42, [], world);
+    expect(savePromise).toBeInstanceOf(Promise);
+    const hasPromise = hasSave();
+    expect(hasPromise).toBeInstanceOf(Promise);
+
+    // Settle both so neither floats as an unhandled promise.
+    await savePromise;
+    await hasPromise;
+  });
+
+  it('getStorageDriver returns the injected driver until it is replaced', () => {
+    const fake = new FakeStorageDriver();
+    setStorageDriver(fake);
+    expect(getStorageDriver()).toBe(fake);
+    const next = new LocalStorageDriver();
+    setStorageDriver(next);
+    expect(getStorageDriver()).toBe(next);
   });
 });

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -2426,12 +2426,31 @@ describe('#234 StorageDriver seam', () => {
         return Promise.resolve();
       }
     }
+    // Seed a REAL, valid save via the default driver first, then inject the
+    // rejecting driver. This makes the test bypass-sensitive: if the seam were
+    // bypassed and these functions read localStorage directly, they would find
+    // the seeded save and return true / non-null — the rejecting driver's get
+    // MUST be what drives them to the empty-state values.
+    window.localStorage.clear();
+    expect(await manualSave(7, [], createScenario(7))).toBe(true);
+    expect(window.localStorage.getItem(SAVE_KEY)).not.toBeNull();
     setStorageDriver(new RejectingGetDriver());
 
     // The existing try/catch in each function swallows the rejection and
     // returns the "no readable save" value rather than propagating.
     await expect(hasSave()).resolves.toBe(false);
     await expect(loadSave()).resolves.toBeNull();
+  });
+
+  it('LocalStorageDriver.set rejects (not throws) when the backing store throws', async () => {
+    const driver = new LocalStorageDriver();
+    const spy = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    // Pins the seam's core contract directly: a synchronous localStorage throw
+    // becomes a rejected promise (so awaiting call sites' try/catch still catch).
+    await expect(driver.set(SAVE_KEY, 'x')).rejects.toThrow('QuotaExceededError');
+    spy.mockRestore();
   });
 
   it('the async save functions return Promises (Promise-returning signatures)', async () => {

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -30,6 +30,7 @@ import { createColonyRecord } from '../sim/colony/colony-store.js';
 import type { NestEntrance } from '../sim/colony/entrance.js';
 import type { PendingChamber } from '../sim/colony/chamber.js';
 import type { SimCommand } from '../sim/commands.js';
+import { getStorageDriver } from './storage.js';
 import type { SurfaceGrid, UndergroundGrid } from '../sim/terrain.js';
 import { createSurfaceGrid, createUndergroundGrid } from '../sim/terrain.js';
 import type { PheromoneGrid } from '../sim/pheromone/pheromone-store.js';
@@ -1744,23 +1745,23 @@ export function parseSaveFile(raw: string): SaveFile {
  *
  * Issue #112 — added v2 to the purge list when SAVE_KEY moved to v3.
  */
-function purgeLegacySaves(): void {
+async function purgeLegacySaves(): Promise<void> {
   try {
-    localStorage.removeItem('subterrans:save:v1');
+    await getStorageDriver().remove('subterrans:save:v1');
   } catch {
     /* quota / private mode — silent: best-effort cleanup, no UX signal */
   }
   try {
-    localStorage.removeItem('subterrans:save:v2');
+    await getStorageDriver().remove('subterrans:save:v2');
   } catch {
     /* quota / private mode — silent: best-effort cleanup, no UX signal */
   }
 }
 
-export function hasSave(): boolean {
+export async function hasSave(): Promise<boolean> {
   try {
-    purgeLegacySaves();
-    const raw = localStorage.getItem(SAVE_KEY);
+    await purgeLegacySaves();
+    const raw = await getStorageDriver().get(SAVE_KEY);
     if (raw === null) return false;
     parseSaveFile(raw);
     return true;
@@ -1769,10 +1770,10 @@ export function hasSave(): boolean {
   }
 }
 
-export function loadSave(): SaveFile | null {
+export async function loadSave(): Promise<SaveFile | null> {
   try {
-    purgeLegacySaves();
-    const raw = localStorage.getItem(SAVE_KEY);
+    await purgeLegacySaves();
+    const raw = await getStorageDriver().get(SAVE_KEY);
     if (raw === null) return null;
     return parseSaveFile(raw);
   } catch {
@@ -1780,9 +1781,9 @@ export function loadSave(): SaveFile | null {
   }
 }
 
-export function deleteSave(): void {
+export async function deleteSave(): Promise<void> {
   try {
-    localStorage.removeItem(SAVE_KEY);
+    await getStorageDriver().remove(SAVE_KEY);
   } catch {
     // swallow — quota / private-mode errors are non-fatal for delete
   }
@@ -1812,14 +1813,14 @@ export function deleteSave(): void {
 /** Issue #115 — manual save. Returns true on successful write, false on
  *  quota / private-mode / blocked-storage failure. Does NOT touch the
  *  autosave timer; callers driving tickAutosave keep their own lastSaveMs. */
-export function manualSave(
+export async function manualSave(
   seed: number,
   inputLog: readonly SimCommand[],
   world: WorldState,
-): boolean {
+): Promise<boolean> {
   try {
     const envelope = buildSaveFile(seed, inputLog, world);
-    localStorage.setItem(SAVE_KEY, JSON.stringify(envelope));
+    await getStorageDriver().set(SAVE_KEY, JSON.stringify(envelope));
     return true;
   } catch {
     return false;
@@ -1852,11 +1853,11 @@ export type SaveCompatibility =
   | 'incompatible-future'
   | 'incompatible-corrupt';
 
-export function classifySaveCompatibility(): SaveCompatibility {
+export async function classifySaveCompatibility(): Promise<SaveCompatibility> {
   let raw: string | null;
   try {
-    purgeLegacySaves();
-    raw = localStorage.getItem(SAVE_KEY);
+    await purgeLegacySaves();
+    raw = await getStorageDriver().get(SAVE_KEY);
   } catch {
     return 'none';
   }
@@ -1906,7 +1907,7 @@ export function classifySaveCompatibility(): SaveCompatibility {
  *  Round-3 (Codex P2 follow-up): the simVersion check above replaces the
  *  prior "envelope-parse only" check that returned false for future-sim
  *  saves and enabled a Continue click that would silently lose the save. */
-export function hasIncompatibleSave(): boolean {
+export async function hasIncompatibleSave(): Promise<boolean> {
   // Issue #196 — delegate to the three-way classifier so this and the boot
   // path share one compatibility boundary. Both incompatible verdicts
   // (future + corrupt) mean Continue would not actually load the save, so
@@ -1915,7 +1916,7 @@ export function hasIncompatibleSave(): boolean {
   // Cost: one full WorldState allocation per call (the classifier's
   // deserialize). The dialog open path calls this once (cached for the
   // render); user-initiated, infrequent.
-  const verdict = classifySaveCompatibility();
+  const verdict = await classifySaveCompatibility();
   return verdict === 'incompatible-future' || verdict === 'incompatible-corrupt';
 }
 
@@ -1939,10 +1940,10 @@ export interface SaveInfo {
  *  deserialize. Returns null if no save exists or the envelope is unreadable.
  *  Player colony key is `String(PLAYER_COLONY_ID)` per the colonies map's
  *  stringified-int convention (ADR-0006). */
-export function getSaveInfo(): SaveInfo | null {
+export async function getSaveInfo(): Promise<SaveInfo | null> {
   let raw: string | null;
   try {
-    raw = localStorage.getItem(SAVE_KEY);
+    raw = await getStorageDriver().get(SAVE_KEY);
   } catch {
     return null;
   }
@@ -2016,17 +2017,17 @@ export function getSaveInfo(): SaveInfo | null {
  *
  * Caller reassigns: `lastSaveMs = tickAutosave(seed, inputLog, world, lastSaveMs, now);`
  */
-export function tickAutosave(
+export async function tickAutosave(
   seed: number,
   inputLog: readonly SimCommand[],
   world: WorldState,
   lastSaveMs: number,
   nowMs: number,
-): number {
+): Promise<number> {
   if (nowMs - lastSaveMs < AUTOSAVE_INTERVAL_MS) return lastSaveMs;
   try {
     const envelope = buildSaveFile(seed, inputLog, world);
-    localStorage.setItem(SAVE_KEY, JSON.stringify(envelope));
+    await getStorageDriver().set(SAVE_KEY, JSON.stringify(envelope));
     return nowMs;
   } catch {
     // Honor the cooldown on failure too — see #80 above.

--- a/src/platform/storage.ts
+++ b/src/platform/storage.ts
@@ -1,0 +1,57 @@
+// src/platform/storage.ts — async storage seam (#234 PR1).
+//
+// The save API historically called the `localStorage` global directly. This
+// module interposes an async `StorageDriver` so the whole save path can move to
+// async, evict-resistant backends (Capacitor Preferences, Tauri fs, IndexedDB,
+// OPFS — all async, all on the Phase 6 path) by injecting a driver, without
+// touching a single save.ts call site again.
+//
+// Platform layer — module-level mutable state is allowed here (the sim
+// no-singleton rule applies only under src/sim/).
+
+export interface StorageDriver {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+  remove(key: string): Promise<void>;
+}
+
+/**
+ * The default driver: a thin async wrapper over `localStorage`.
+ *
+ * The methods deliberately run the (synchronous) `localStorage` call inside
+ * `Promise.resolve().then(...)` rather than being `async` bodies. Both give the
+ * same important property — a synchronous throw (quota exceeded, storage
+ * disabled/evicted) surfaces as a REJECTED promise, so every save.ts call site's
+ * existing `try/catch` around an `await` keeps catching it unchanged. (A plain
+ * `async` body would do the same, but its no-`await` shape trips the
+ * type-aware `require-await` lint, whose disable directive the base auto-fixer
+ * then strips — so the `.then` form is the stable equivalent.)
+ */
+export class LocalStorageDriver implements StorageDriver {
+  get(key: string): Promise<string | null> {
+    return Promise.resolve().then(() => localStorage.getItem(key));
+  }
+
+  set(key: string, value: string): Promise<void> {
+    return Promise.resolve().then(() => {
+      localStorage.setItem(key, value);
+    });
+  }
+
+  remove(key: string): Promise<void> {
+    return Promise.resolve().then(() => {
+      localStorage.removeItem(key);
+    });
+  }
+}
+
+let active: StorageDriver = new LocalStorageDriver();
+
+export function getStorageDriver(): StorageDriver {
+  return active;
+}
+
+/** Inject a driver (tests, or a future Capacitor/Tauri/IndexedDB backend). */
+export function setStorageDriver(d: StorageDriver): void {
+  active = d;
+}

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -901,6 +901,16 @@ export class GameScene extends Phaser.Scene {
     // classifySaveCompatibility now hits the async storage driver (#234), so
     // create() can't await it — fire-and-forget. The overlay/fresh-boot dispatch
     // lands one microtask later (same frame under the sync-backed driver).
+    //
+    // Hold at SavePrompt synchronously first: update() early-returns on
+    // SavePrompt, so this closes the boot window in which it would otherwise
+    // tick an unbuilt world/gameLoop (gamePhase is field-initialised Playing).
+    // Both dispatch branches converge on SavePrompt anyway — the prompt branch
+    // sets it directly, the fresh branch via showDifficultySelectThenBoot — so
+    // this is a no-op under today's sync driver and hardens the seam for a
+    // future macrotask-resolving driver (Phase 6 IndexedDB/OPFS), which would
+    // otherwise have a pre-boot frame to crash on.
+    this.gamePhase = GamePhase.SavePrompt;
     void this.dispatchInitialBoot();
 
     // Lifecycle signal — preload assets are loaded (we're in create()), the

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -224,7 +224,7 @@ interface UIScenePhase9 {
   showSaveLoadDialogOverlay(callbacks: {
     onContinue: () => void;
     onNewGame: () => void;
-    onSaveNow: () => boolean;
+    onSaveNow: () => Promise<boolean>;
     onDelete: () => void;
     onBack: () => void;
   }): void;
@@ -379,6 +379,9 @@ export class GameScene extends Phaser.Scene {
    * Cleared on resetSessionState so an explicit restartGame re-enables it.
    */
   private autosaveSuspended: boolean = false;
+  // #234 — guards against overlapping fire-and-forget autosave writes (the async
+  // storage set can outlast the 30s interval); scene.update never awaits.
+  private autosaveInFlight: boolean = false;
   private resumedFromSave: boolean = false;
   private currentSeed: number = 0;
   // Issue #114 UAT — Settings sub-screen has a "Speed: N×" cycle row that
@@ -894,30 +897,11 @@ export class GameScene extends Phaser.Scene {
     // Cancel any in-flight gesture if the canvas loses focus (blur).
     this.game.events.on('blur', () => this.arbiter.cancelGesture());
 
-    // Phase 9 boot: classify any existing save ONCE. A loadable ('compatible')
-    // save shows the Continue/New Game SavePrompt. Everything else boots fresh —
-    // but a future-build save ('incompatible-future': simVersion > LATEST) is
-    // recoverable on a newer build, so the fresh boot must NOT let autosave /
-    // Save Now overwrite its bytes (issue #196). Corrupt / absent saves get no
-    // such protection — the new game's first autosave overwrites them freely.
-    const saveCompat = classifySaveCompatibility();
-    const bootMode = decideBootMode(() => saveCompat === 'compatible');
-    if (bootMode === 'prompt') {
-      this.gamePhase = GamePhase.SavePrompt;
-      const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
-      uiScene.showSavePromptOverlay({
-        onContinue: () => this.bootFromSave(),
-        onNewGame: () => {
-          deleteSave();
-          this.showDifficultySelectThenBoot();
-        },
-      });
-    } else {
-      // issue #196 — preserve a recoverable future-build save by suspending
-      // autosave after the fresh boot (mirrors bootFromSave's
-      // FutureSimVersionError catch on the Continue path).
-      this.showDifficultySelectThenBoot(saveCompat === 'incompatible-future');
-    }
+    // Phase 9 boot: classify any existing save and dispatch the right boot path.
+    // classifySaveCompatibility now hits the async storage driver (#234), so
+    // create() can't await it — fire-and-forget. The overlay/fresh-boot dispatch
+    // lands one microtask later (same frame under the sync-backed driver).
+    void this.dispatchInitialBoot();
 
     // Lifecycle signal — preload assets are loaded (we're in create()), the
     // scene graph is constructed, and the chosen boot path (fresh world or
@@ -937,6 +921,37 @@ export class GameScene extends Phaser.Scene {
   // ---------------------------------------------------------------------------
   // Boot helpers
   // ---------------------------------------------------------------------------
+
+  /**
+   * Phase 9 boot dispatch — classify any existing save ONCE and route to the
+   * right boot path. A loadable ('compatible') save shows the Continue/New Game
+   * SavePrompt; everything else boots fresh — but a future-build save
+   * ('incompatible-future': simVersion > LATEST) is recoverable on a newer build,
+   * so the fresh boot must NOT let autosave / Save Now overwrite its bytes
+   * (issue #196). Corrupt / absent saves get no such protection — the new game's
+   * first autosave overwrites them freely.
+   *
+   * Async because classifySaveCompatibility now awaits the storage driver (#234);
+   * create() fires this and returns (it can't await). Callbacks that touch async
+   * save fns fire-and-forget (`void`), preserving each fn's own try/catch.
+   */
+  private async dispatchInitialBoot(): Promise<void> {
+    const saveCompat = await classifySaveCompatibility();
+    const bootMode = decideBootMode(() => saveCompat === 'compatible');
+    if (bootMode === 'prompt') {
+      this.gamePhase = GamePhase.SavePrompt;
+      const uiScene = this.scene.get('UIScene') as unknown as UIScenePhase9;
+      uiScene.showSavePromptOverlay({
+        onContinue: () => void this.bootFromSave(),
+        onNewGame: () => {
+          void deleteSave();
+          this.showDifficultySelectThenBoot();
+        },
+      });
+    } else {
+      this.showDifficultySelectThenBoot(saveCompat === 'incompatible-future');
+    }
+  }
 
   /**
    * Clear every piece of per-session state that lives on the GameScene
@@ -1226,11 +1241,11 @@ export class GameScene extends Phaser.Scene {
     });
   }
 
-  private bootFromSave(): void {
-    const loaded = loadSave();
+  private async bootFromSave(): Promise<void> {
+    const loaded = await loadSave();
     if (loaded === null) {
       // Corrupt save: fall through to fresh (bootFresh runs its own reset)
-      deleteSave();
+      await deleteSave();
       this.bootFresh();
       return;
     }
@@ -1271,12 +1286,12 @@ export class GameScene extends Phaser.Scene {
       if (err instanceof OldSimVersionError) {
         // Pre-V22 save — no migration path; discard and start fresh.
         console.error(err.message);
-        deleteSave();
+        await deleteSave();
         this.bootFresh();
         return;
       }
       // Genuine corruption: discard so we don't loop the user.
-      deleteSave();
+      await deleteSave();
       this.bootFresh();
       return;
     }
@@ -1568,7 +1583,7 @@ export class GameScene extends Phaser.Scene {
   private retryGame(seed: number): void {
     const wasSuspended = this.autosaveSuspended;
     if (!wasSuspended) {
-      deleteSave();
+      void deleteSave();
     }
     this.currentOutcome = GameOutcome.None;
     this.currentCause = null;
@@ -1731,7 +1746,7 @@ export class GameScene extends Phaser.Scene {
         // gameLoop.resume(). We just need to flip out of Paused phase first
         // so finishBoot's `gamePhase = Playing` overwrite is consistent.
         this.gamePhase = GamePhase.Playing;
-        this.bootFromSave();
+        void this.bootFromSave();
       },
       onNewGame: () => {
         // restartGame deletes the existing save (preserving the issue #66
@@ -1741,7 +1756,7 @@ export class GameScene extends Phaser.Scene {
         this.gamePhase = GamePhase.Playing;
         this.restartGame();
       },
-      onSaveNow: () => {
+      onSaveNow: async () => {
         if (this.world === undefined) return false;
         // Round-5 P1 (Codex): bootFromSave sets autosaveSuspended = true when
         // it catches a FutureSimVersionError so the preserved newer-build
@@ -1753,7 +1768,7 @@ export class GameScene extends Phaser.Scene {
         // preserved bytes. Surface as a failed save so the player gets a
         // flash and can recover via Delete / a newer-build reload.
         if (this.autosaveSuspended) return false;
-        const ok = manualSave(this.currentSeed, this.inputLog, this.world);
+        const ok = await manualSave(this.currentSeed, this.inputLog, this.world);
         // Round-2 review: bump the autosave cooldown so the next autosave
         // window doesn't fire seconds later and overwrite the manual save's
         // timestamp. The dialog's "Saved 15:32" line otherwise jumps to
@@ -1794,7 +1809,7 @@ export class GameScene extends Phaser.Scene {
     //     that knows the simVersion).
     const wasSuspended = this.autosaveSuspended;
     if (!wasSuspended) {
-      deleteSave();
+      void deleteSave();
     }
     this.currentOutcome = GameOutcome.None;
     this.currentCause = null;
@@ -2106,14 +2121,19 @@ export class GameScene extends Phaser.Scene {
     // incompatible save is sitting in localStorage waiting for recovery
     // (issue #66: bootFromSave's deserialize-throw catch suspends autosave
     // so the preserved bytes aren't overwritten by this fresh session).
-    if (this.gamePhase === GamePhase.Playing && !this.autosaveSuspended) {
-      this.lastAutosaveMs = tickAutosave(
-        this.currentSeed,
-        this.inputLog,
-        this.world,
-        this.lastAutosaveMs,
-        time,
-      );
+    if (this.gamePhase === GamePhase.Playing && !this.autosaveSuspended && !this.autosaveInFlight) {
+      // Fire-and-forget (#234): scene.update never awaits — the async storage
+      // write must not block the frame. The in-flight guard prevents overlapping
+      // 30s writes; tickAutosave keeps its own interval gate, so a not-due call
+      // resolves immediately and just clears the guard the same microtask.
+      this.autosaveInFlight = true;
+      void tickAutosave(this.currentSeed, this.inputLog, this.world, this.lastAutosaveMs, time)
+        .then((next) => {
+          this.lastAutosaveMs = next;
+        })
+        .finally(() => {
+          this.autosaveInFlight = false;
+        });
     }
   }
 

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -300,7 +300,13 @@ const PAUSED_QUEUE_FULL_HINT_MS = 1500;
 const TOOLTIP_SHOW_DELAY_MS = 400;
 const TOOLTIP_HIDE_GRACE_MS = 1500;
 import { loadSettings, saveSettings } from '../platform/settings.js';
-import { hasSave, hasIncompatibleSave, getSaveInfo, deleteSave } from '../platform/save.js';
+import {
+  classifySaveCompatibility,
+  getSaveInfo,
+  deleteSave,
+  type SaveCompatibility,
+  type SaveInfo,
+} from '../platform/save.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
 import type { SetBehaviorRatioCommand, PlaceChamberCommand } from '../sim/commands.js';
 import { enqueueCommand } from '../input/command-queue.js';
@@ -351,7 +357,7 @@ export interface SaveLoadDialogCallbacks {
   /** Write the current world to localStorage via manualSave. Returns true on
    *  success, false on storage failure. The dialog re-renders afterward so
    *  the info line picks up the new saved tick. */
-  onSaveNow(): boolean;
+  onSaveNow(): Promise<boolean>;
   /** Issue #196 — the player committed Delete on the existing save. The dialog
    *  performs the actual `deleteSave()`; this notifies GameScene so it can
    *  release any autosave suspension armed to protect a future-build save (the
@@ -507,6 +513,11 @@ export class UIScene extends Phaser.Scene {
     delete: false,
     newGame: false,
   };
+  // #234 — prefetched storage state for the Save/Load dialog. Populated by the
+  // async refreshSaveDialogState() so renderSaveLoadDialog() stays synchronous
+  // (reads only these caches, never the async save API).
+  private saveDialogCompat: SaveCompatibility = 'none';
+  private saveDialogInfo: SaveInfo | null = null;
   // Issue #115 — Save Now feedback. After a manualSave call, the dialog
   // flashes a brief "Saved" / "Save failed" line above the regular info
   // text for SAVE_FLASH_MS so the player sees an explicit acknowledgement
@@ -2114,7 +2125,14 @@ export class UIScene extends Phaser.Scene {
     this.hideSaveLoadDialogOverlay(); // idempotent — clear any prior instance
     this.saveLoadDialogCallbacks = callbacks;
     this.saveLoadDialogConfirming = { delete: false, newGame: false };
+    // #234 — render immediately from the cached storage verdict (last-known
+    // across opens, or 'none' on the first open) so the dialog appears this
+    // frame — refreshSaveDialogState's own render is gated on
+    // isSaveLoadDialogVisible() (group non-empty), which only holds AFTER this
+    // first render. Then kick the async refresh to reconcile with a fresh
+    // storage read (it re-renders when the verdict/info lands).
     this.renderSaveLoadDialog();
+    void this.refreshSaveDialogState();
     this.recomputeActiveOverlay();
   }
 
@@ -2138,6 +2156,17 @@ export class UIScene extends Phaser.Scene {
     return this.saveLoadDialogGroup.length > 0;
   }
 
+  /** #234 — prefetch the dialog's storage state via the now-async save API,
+   *  cache it into saveDialogCompat / saveDialogInfo, then re-render from the
+   *  cache. Keeps renderSaveLoadDialog() synchronous. Called on dialog open and
+   *  after Save Now / Delete (the state-changing actions). */
+  private async refreshSaveDialogState(): Promise<void> {
+    const [compat, info] = await Promise.all([classifySaveCompatibility(), getSaveInfo()]);
+    this.saveDialogCompat = compat;
+    this.saveDialogInfo = info;
+    if (this.isSaveLoadDialogVisible()) this.renderSaveLoadDialog();
+  }
+
   /** Render (or re-render) the dialog in place. Called on show, on confirm
    *  flag flip, and after every state-changing action (Save Now, Delete) so
    *  the info line and button enable states stay current. */
@@ -2145,30 +2174,24 @@ export class UIScene extends Phaser.Scene {
     for (const obj of this.saveLoadDialogGroup) obj.destroy();
     this.saveLoadDialogGroup = [];
 
-    // Cache hasIncompatibleSave once per render — round-5 made it run a
-    // full deserialize, so calling it twice for the ctx fields below
-    // would deserialize the entire WorldState twice per frame.
-    const incompatible = hasIncompatibleSave();
+    // #234 — read the prefetched storage verdict from the cache
+    // (refreshSaveDialogState populated it via the async save API before this
+    // render; render itself stays synchronous). The classifier's 'compatible'
+    // verdict is exactly the old `hasSave() && !hasIncompatibleSave`: parseable
+    // envelope AND a successful deserialize. Both incompatible verdicts
+    // (future-sim / corrupt) mean Continue would silently fall through to
+    // bootFresh, so the dialog surfaces them identically. See save.ts.
+    const incompatible =
+      this.saveDialogCompat === 'incompatible-future' ||
+      this.saveDialogCompat === 'incompatible-corrupt';
     const ctx = {
-      // Round-3 (Codex P2): a future-sim save still passes parseSaveFile
-      // (so hasSave returns true) but bootFromSave would reject it via
-      // FutureSimVersionError. Treat the save as compatible only when
-      // BOTH envelope is parseable AND deserialize succeeds. The
-      // hasIncompatibleSave check covers parse-fails, future-sim, and
-      // (round-4) any other shape error that would make Continue a
-      // silent fall-through to bootFresh. See save.ts for the full
-      // classification.
-      //
-      // Round-5 (cache): hasIncompatibleSave now performs a full
-      // deserialize on the saved envelope. Local-cache the result so
-      // a single renderSaveLoadDialog() doesn't pay the cost twice.
-      hasCompatibleSave: hasSave() && !incompatible,
+      hasCompatibleSave: this.saveDialogCompat === 'compatible',
       hasIncompatibleSave: incompatible,
       confirming: { ...this.saveLoadDialogConfirming },
     };
     const items = saveLoadDialogItems(ctx, this.layout);
     this.saveLoadDialogVisibleItems = items;
-    const info = getSaveInfo();
+    const info = this.saveDialogInfo;
 
     // Background scrim — slightly darker than the pause menu so the layered
     // overlay reads as "deeper than the menu underneath."
@@ -2284,22 +2307,29 @@ export class UIScene extends Phaser.Scene {
         // toast — the flash plays the same role without a separate Phaser
         // tween / DOM-toast layer). Failure most often means quota /
         // private-mode; retry once or close other tabs.
-        const ok = cb?.onSaveNow() ?? false;
-        this.saveLoadDialogFlash = ok ? 'saved' : 'failed';
-        // Cancel any in-flight prior flash timer so a second Save Now in
-        // quick succession doesn't clear the new flash early.
-        if (this.saveLoadDialogFlashTimer !== null) {
-          this.saveLoadDialogFlashTimer.remove();
-        }
-        this.saveLoadDialogFlashTimer = this.time.delayedCall(SAVE_FLASH_MS, () => {
-          this.saveLoadDialogFlashTimer = null;
-          this.saveLoadDialogFlash = 'none';
-          // Guard: dialog may have closed between Save Now and the timer
-          // firing (e.g. player clicked Continue or Back). Re-render only
-          // if the dialog is still on screen.
-          if (this.isSaveLoadDialogVisible()) this.renderSaveLoadDialog();
-        });
-        this.renderSaveLoadDialog();
+        // #234 — onSaveNow is async now (storage seam). Fire-and-forget: the
+        // click dispatcher stays sync; the flash + info refresh land a microtask
+        // later (same frame under the sync-backed driver).
+        void (async () => {
+          const ok = (await cb?.onSaveNow()) ?? false;
+          this.saveLoadDialogFlash = ok ? 'saved' : 'failed';
+          // Cancel any in-flight prior flash timer so a second Save Now in
+          // quick succession doesn't clear the new flash early.
+          if (this.saveLoadDialogFlashTimer !== null) {
+            this.saveLoadDialogFlashTimer.remove();
+          }
+          this.saveLoadDialogFlashTimer = this.time.delayedCall(SAVE_FLASH_MS, () => {
+            this.saveLoadDialogFlashTimer = null;
+            this.saveLoadDialogFlash = 'none';
+            // Guard: dialog may have closed between Save Now and the timer
+            // firing (e.g. player clicked Continue or Back). Re-render only
+            // if the dialog is still on screen.
+            if (this.isSaveLoadDialogVisible()) this.renderSaveLoadDialog();
+          });
+          // Re-render from a fresh storage read (the manual save bumped the
+          // info line's timestamp / counts). refreshSaveDialogState renders.
+          await this.refreshSaveDialogState();
+        })();
         return;
       }
       case 'delete': {
@@ -2308,21 +2338,23 @@ export class UIScene extends Phaser.Scene {
           this.renderSaveLoadDialog();
           return;
         }
-        deleteSave();
-        // Issue #196 — releasing the save means any autosave suspension that
-        // was protecting a future-build save's bytes is no longer warranted
-        // (the bytes are gone). Notify GameScene so the running fresh session
-        // can save / autosave again instead of staying frozen until reload.
-        cb?.onDelete();
-        this.saveLoadDialogConfirming.delete = false;
-        this.renderSaveLoadDialog();
+        void (async () => {
+          await deleteSave();
+          // Issue #196 — releasing the save means any autosave suspension that
+          // was protecting a future-build save's bytes is no longer warranted
+          // (the bytes are gone). Notify GameScene so the running fresh session
+          // can save / autosave again instead of staying frozen until reload.
+          cb?.onDelete();
+          this.saveLoadDialogConfirming.delete = false;
+          await this.refreshSaveDialogState();
+        })();
         return;
       }
       case 'new-game': {
         // Confirm gate is only needed when a save exists — clicking New Game
         // with no save is just "restart the running scenario" and has no
         // hidden destructive consequence.
-        if (hasSave() && !this.saveLoadDialogConfirming.newGame) {
+        if (this.saveDialogCompat !== 'none' && !this.saveLoadDialogConfirming.newGame) {
           this.saveLoadDialogConfirming.newGame = true;
           this.renderSaveLoadDialog();
           return;


### PR DESCRIPTION
## #234 PR1 of 3 — async `StorageDriver` seam

C2·PR-7, first of the three independent PRs the #234 spec decomposes into (PR1 seam, PR2 autosave-failure caption, PR3 load-validation). **No on-disk format change, no simVersion/SAVE_FORMAT bump, no RNG or world-shape change** — the bytes written are identical (byte-gate verifies byte-identical vs `main`). This is purely the seam that lets Phase 6 inject Capacitor / Tauri / IndexedDB / OPFS (all async) without touching a save.ts call site again.

### What changed
- **New `src/platform/storage.ts`** — `StorageDriver` interface + `LocalStorageDriver` + `get/setStorageDriver`. The driver methods use `Promise.resolve().then(...)` (not an `async` body) so a synchronous `localStorage` throw (quota / disabled / evicted) surfaces as a **rejected promise**, preserving every call site's existing `try/catch`. (A plain `async` body gives the same semantics but trips the type-aware `require-await` lint, whose disable the base auto-fixer then strips — so `.then` is the stable equivalent.)
- **`save.ts`** — the 9 storage-touching functions (`hasSave`, `loadSave`, `deleteSave`, `manualSave`, `classifySaveCompatibility`, `hasIncompatibleSave`, `getSaveInfo`, `tickAutosave`, internal `purgeLegacySaves`) are now `async`, awaiting `getStorageDriver()`.
- **`game-scene.ts`** — boot classify extracted to `async dispatchInitialBoot()` (create() fires-and-returns); `bootFromSave` async; autosave **fire-and-forget + `autosaveInFlight` guard** (scene.update never awaits the write); `onSaveNow` async; best-effort `deleteSave()` calls voided.
- **`ui-scene.ts`** — the Save/Load dialog **prefetches** storage state via `async refreshSaveDialogState()` into `saveDialogCompat`/`saveDialogInfo` caches; `renderSaveLoadDialog` stays synchronous (reads only the caches).
- **`save.test.ts`** — 94 existing call sites awaited / `it()` callbacks made async; + a new `#234 StorageDriver seam` describe: FakeStorageDriver round-trip (proves the write lands in the injected driver, not localStorage), rejecting `set`/`get` degrade gracefully (false / cooldown-nowMs / null, no throw), Promise-returning signatures.

### One deliberate deviation from the spec (please scrutinize)
The spec's step 10 says showSaveLoadDialogOverlay should call `void refreshSaveDialogState()` *instead of* `renderSaveLoadDialog()`. But `refreshSaveDialogState` gates its own re-render on `isSaveLoadDialogVisible()` (= `saveLoadDialogGroup.length > 0`), which only becomes true **after** the first render — so the literal spec would leave the dialog blank on first open. I do **render-then-refresh**: render immediately from the cached verdict (last-known across opens, or `'none'` on first open), then kick the async refresh to reconcile. Under the sync-backed driver the refresh resolves the same frame, so no flicker.

### Staged non-goals (documented, not built here)
Compact/packed serialization, an IndexedDB/OPFS driver, and a save-size regression gate — batched with the next deliberate break / Phase 6.

### Verification
- `npm run verify`: **2761 passed | 1 skipped**, all guards/format/lint:types/cycles clean.
- Byte-gate capture-on-`main` / verify-on-branch: **byte-identical**.
- Cross-model reviewed by Fable (Codex over quota).

Part of #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Save and load actions now work with a more resilient background storage flow, improving compatibility across devices and platforms.
  * The save/load dialog now updates more intelligently, showing saved state and compatibility info more reliably.

* **Bug Fixes**
  * Improved handling of corrupted or malformed save data so it no longer causes unexpected errors.
  * Autosave and save/delete actions are more stable, reducing the chance of overlapping or failed save operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->