### PR TITLE
feat(platform): load-validation — colony scalars + ant SoA range checks (#234 PR3 of 3)

### DIFF
--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -233,6 +233,17 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       expect(() => deserializeWorldState(s)).not.toThrow();
       expect(deserializeWorldState(s).ants.hp[1]).toBe(-37);
     });
+
+    it('does NOT reject a valid save mid-spider-fight (combatOpponentId = -2 sentinel)', () => {
+      const w = createScenario(42);
+      // -2 is the sticky "paired with the spider" combat sentinel (combat.ts):
+      // set-if-not-already and read across ticks, so a save taken while an ant
+      // is engaging the spider legitimately carries it. ID_SENTINEL must allow it.
+      w.ants.combatOpponentId[1] = -2;
+      const s = serializeWorldState(w);
+      expect(() => deserializeWorldState(s)).not.toThrow();
+      expect(deserializeWorldState(s).ants.combatOpponentId[1]).toBe(-2);
+    });
   });
 
   describe('deserializeWorldState — round-trip', () => {

--- a/src/platform/save.test.ts
+++ b/src/platform/save.test.ts
@@ -34,6 +34,7 @@ import {
   ENEMY_COLONY_ID,
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
+  MAX_ENTITIES,
 } from '../sim/constants.js';
 import type { SimCommand } from '../sim/commands.js';
 import type { ColonyId } from '../sim/colony/colony-store.js';
@@ -145,6 +146,92 @@ describe('save.ts (SCEN-04 + SCEN-06)', () => {
       w.colonies[PLAYER_COLONY_ID]!.foodFlowFieldDirty = true;
       const s = serializeWorldState(w);
       expect(s.colonies[String(PLAYER_COLONY_ID)]!.foodFlowFieldDirty).toBe(true);
+    });
+  });
+
+  // #234 PR3 — load-validation asymmetry: colony scalars / brood-id-lists + the
+  // ant SoA now range-check on deserialize (previously verbatim). A tampered or
+  // corrupt save throws a plain Error → classifies 'incompatible-corrupt'. These
+  // pin one reject per rule class AND prove no VALID save (incl. dead-slot
+  // residue) is falsely rejected.
+  describe('#234 PR3 load-validation (deserialize range checks)', () => {
+    const PKEY = String(PLAYER_COLONY_ID);
+    // Serialize a valid world, mutate one field, expect deserialize to reject it.
+    function rejects(mutate: (s: ReturnType<typeof serializeWorldState>) => void): void {
+      const s = serializeWorldState(createScenario(42));
+      mutate(s);
+      expect(() => deserializeWorldState(s)).toThrow();
+    }
+
+    it('ant POS_FP: posX at the surface max (exclusive bound) is rejected', () => {
+      rejects((s) => {
+        s.ants.posX[0] = SURFACE_GRID_WIDTH << 8; // 32768 == POSMAX (exclusive)
+      });
+    });
+    it('ant ENUM: task outside [0,4] is rejected', () => {
+      rejects((s) => {
+        s.ants.task[0] = 5;
+      });
+    });
+    it('ant binary: zone not in {0,1} is rejected', () => {
+      rejects((s) => {
+        s.ants.zone[0] = 2;
+      });
+    });
+    it('ant TRI: searchHeadingX not in {-1,0,1} is rejected', () => {
+      rejects((s) => {
+        s.ants.searchHeadingX[0] = 2;
+      });
+    });
+    it('ant ID_SENTINEL: carriedBy >= capacity is rejected', () => {
+      rejects((s) => {
+        s.ants.carriedBy[0] = MAX_ENTITIES; // >= any load capacity
+      });
+    });
+    it('ant non-array column is rejected (previously a silent zero-fill)', () => {
+      rejects((s) => {
+        (s.ants as { zone: unknown }).zone = 5;
+      });
+    });
+    it('colony scalar: negative foodStored is rejected', () => {
+      rejects((s) => {
+        s.colonies[PKEY]!.foodStored = -1;
+      });
+    });
+    it('colony scalar: workerCount above MAX_ENTITIES is rejected', () => {
+      rejects((s) => {
+        s.colonies[PKEY]!.workerCount = MAX_ENTITIES + 1;
+      });
+    });
+    it('colony id-list: eggs containing a negative id is rejected', () => {
+      rejects((s) => {
+        s.colonies[PKEY]!.eggs = [-1];
+      });
+    });
+
+    it('a corrupt snapshot classifies as incompatible-corrupt end-to-end', async () => {
+      window.localStorage.clear();
+      setStorageDriver(new LocalStorageDriver());
+      expect(await manualSave(42, [], createScenario(42))).toBe(true); // valid save in storage
+      const env = JSON.parse(window.localStorage.getItem(SAVE_KEY)!) as {
+        snapshot: { ants: { task: number[] } };
+      };
+      env.snapshot.ants.task[0] = 99; // corrupt the snapshot, envelope stays valid
+      window.localStorage.setItem(SAVE_KEY, JSON.stringify(env));
+      await expect(classifySaveCompatibility()).resolves.toBe('incompatible-corrupt');
+    });
+
+    it('does NOT reject a valid save carrying dead-slot residue (combat-killed ant, negative hp)', () => {
+      const w = createScenario(42);
+      // A combat-killed ant leaves a dead-but-allocated slot with end-of-life
+      // residue; serializeAnts writes ALL slots, so a >=0 bound would wrongly
+      // reject this valid round-trip. FINITE_INT must allow it.
+      w.ants.alive[1] = 0;
+      w.ants.hp[1] = -37;
+      w.ants.attackCooldown[1] = -5;
+      const s = serializeWorldState(w);
+      expect(() => deserializeWorldState(s)).not.toThrow();
+      expect(deserializeWorldState(s).ants.hp[1]).toBe(-37);
     });
   });
 

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -1082,6 +1082,11 @@ function validateAntColumns(saved: SerializedAnts, capacity: number): void {
     v === -1 || (Number.isInteger(v) && v >= 0 && v < SURFACE_GRID_WIDTH);
   const idSentinel = (v: number): boolean =>
     v === -1 || (Number.isInteger(v) && v >= 0 && v < capacity);
+  // combatOpponentId additionally uses -2 as a sticky "paired with the spider"
+  // sentinel (combat.ts) — set-if-not-already and read across ticks, so a save
+  // taken mid-spider-fight legitimately carries it. Widen ID_SENTINEL for this
+  // one column so it is not falsely rejected.
+  const combatOppSentinel = (v: number): boolean => v === -2 || idSentinel(v);
   const byte = (v: number): boolean => Number.isInteger(v) && v >= 0 && v < 256;
   const enumMax =
     (max: number) =>
@@ -1124,7 +1129,7 @@ function validateAntColumns(saved: SerializedAnts, capacity: number): void {
     ['hp', saved.hp, finiteInt],
     ['homeGroundBonusHp', saved.homeGroundBonusHp, finiteInt],
     ['attackCooldown', saved.attackCooldown, finiteInt],
-    ['combatOpponentId', saved.combatOpponentId, idSentinel],
+    ['combatOpponentId', saved.combatOpponentId, combatOppSentinel],
   ];
 
   for (const [name, col, rule] of columns) {

--- a/src/platform/save.ts
+++ b/src/platform/save.ts
@@ -43,6 +43,7 @@ import {
   FOOD_PILE_INITIAL_PICKUPS_MAX,
   FOOD_PILE_SOFT_CEILING,
   FOOD_CHAMBER_CAPACITY,
+  BASE_FOOD_STORAGE_CAPACITY,
   SURFACE_GRID_WIDTH,
   SURFACE_GRID_HEIGHT,
   UNDERGROUND_GRID_WIDTH,
@@ -1059,11 +1060,95 @@ function copyIntoUint8(dst: Uint8Array, src: readonly number[]): void {
   for (let i = 0; i < n; i++) dst[i] = src[i]!;
 }
 
+// #234 PR3 — load-validation for the ant SoA. Historically every ant column
+// deserialized verbatim (in contrast to the heavily-validated chambers /
+// foodPiles), and a non-array column zero-filled silently. This range-checks
+// each serialized column BEFORE it reaches the runtime arrays: a tampered /
+// corrupt save throws a PLAIN Error (→ 'incompatible-corrupt' → bootFromSave
+// deletes + boots fresh, matching validateChamberRecord), never admitting an
+// out-of-range value or silently zero-filling.
+//
+// FINITE_INT columns are Number.isInteger-only with NO magnitude / >=0 bound:
+// dead-but-allocated slots retain end-of-life residue (a combat-killed ant keeps
+// a negative hp; serializeAnts writes ALL slots), so a tighter bound would reject
+// a valid round-trip. Positions use the SURFACE max on both axes so smaller
+// underground-zone values are never rejected.
+function validateAntColumns(saved: SerializedAnts, capacity: number): void {
+  const POSMAX = SURFACE_GRID_WIDTH << FP_SHIFT; // == SURFACE_GRID_HEIGHT << FP_SHIFT
+  const finiteInt = (v: number): boolean => Number.isInteger(v);
+  const posFp = (v: number): boolean => Number.isInteger(v) && v >= 0 && v < POSMAX;
+  const posFpSentinel = (v: number): boolean => v === -1 || posFp(v);
+  const tileSentinel = (v: number): boolean =>
+    v === -1 || (Number.isInteger(v) && v >= 0 && v < SURFACE_GRID_WIDTH);
+  const idSentinel = (v: number): boolean =>
+    v === -1 || (Number.isInteger(v) && v >= 0 && v < capacity);
+  const byte = (v: number): boolean => Number.isInteger(v) && v >= 0 && v < 256;
+  const enumMax =
+    (max: number) =>
+    (v: number): boolean =>
+      Number.isInteger(v) && v >= 0 && v <= max;
+  const binary = (v: number): boolean => v === 0 || v === 1;
+  const tri = (v: number): boolean => v === -1 || v === 0 || v === 1;
+
+  // Every deserialized column + its rule. recentTiles (unpackRecentTiles) and
+  // count (deserializeWorldState) are validated elsewhere and intentionally omitted.
+  const columns: ReadonlyArray<readonly [string, unknown, (v: number) => boolean]> = [
+    ['posX', saved.posX, posFp],
+    ['posY', saved.posY, posFp],
+    ['colonyId', saved.colonyId, byte],
+    ['task', saved.task, enumMax(4)],
+    ['subTask', saved.subTask, enumMax(2)],
+    ['speed', saved.speed, finiteInt],
+    ['foodCarrying', saved.foodCarrying, finiteInt],
+    ['starvationTimer', saved.starvationTimer, finiteInt],
+    ['age', saved.age, finiteInt],
+    ['alive', saved.alive, binary],
+    ['lifespan', saved.lifespan, finiteInt],
+    ['zone', saved.zone, binary],
+    ['digTileX', saved.digTileX, tileSentinel],
+    ['digTileY', saved.digTileY, tileSentinel],
+    ['digTicksRemaining', saved.digTicksRemaining, finiteInt],
+    ['targetPosX', saved.targetPosX, posFpSentinel],
+    ['targetPosY', saved.targetPosY, posFpSentinel],
+    ['searchWave', saved.searchWave, finiteInt],
+    ['searchHeadingX', saved.searchHeadingX, tri],
+    ['searchHeadingY', saved.searchHeadingY, tri],
+    ['searchHeadingTicks', saved.searchHeadingTicks, finiteInt],
+    ['searchPrevTileX', saved.searchPrevTileX, tileSentinel],
+    ['searchPrevTileY', saved.searchPrevTileY, tileSentinel],
+    ['currentGridColonyId', saved.currentGridColonyId, byte],
+    ['waitingDeposit', saved.waitingDeposit, binary],
+    ['searchPauseTicks', saved.searchPauseTicks, finiteInt],
+    ['carryingBroodId', saved.carryingBroodId, idSentinel],
+    ['carriedBy', saved.carriedBy, idSentinel],
+    ['hp', saved.hp, finiteInt],
+    ['homeGroundBonusHp', saved.homeGroundBonusHp, finiteInt],
+    ['attackCooldown', saved.attackCooldown, finiteInt],
+    ['combatOpponentId', saved.combatOpponentId, idSentinel],
+  ];
+
+  for (const [name, col, rule] of columns) {
+    if (!Array.isArray(col)) {
+      throw new Error(`Invalid ants.${name}: expected a number[]`);
+    }
+    // copyInto* is length-clamped to capacity, so values past it are never
+    // consumed — only validate what will actually be loaded.
+    const n = Math.min(col.length, capacity);
+    for (let i = 0; i < n; i++) {
+      const v = col[i] as unknown;
+      if (typeof v !== 'number' || !rule(v)) {
+        throw new Error(`Invalid ants.${name}[${i}]: ${String(v)}`);
+      }
+    }
+  }
+}
+
 function deserializeAnts(
   saved: SerializedAnts,
   capacity: number,
   nextEntityId: number,
 ): AntComponents {
+  validateAntColumns(saved, capacity);
   const a = createAntComponents(capacity);
   // createAntComponents pre-fills digTileX/digTileY/targetPosX/targetPosY with -1.
   // Overwrite with saved values (including -1 sentinels where appropriate).
@@ -1105,7 +1190,41 @@ function deserializeAnts(
   return a;
 }
 
+// #234 PR3 — range-check the colony scalars + brood/worker id-lists that
+// previously deserialized verbatim (unlike the validated chambers / foodPiles).
+// Runs BEFORE the `[...s.eggs]` spreads so a non-array id-list is caught with a
+// clean message rather than a raw TypeError from the spread. Plain Error →
+// 'incompatible-corrupt' → bootFromSave deletes + boots fresh. The ceilings are
+// structurally-unreachable tamper bounds, never a legitimate game state.
+function validateColonyScalars(s: SerializedColony): void {
+  const intIn = (v: number, lo: number, hi: number): boolean =>
+    Number.isInteger(v) && v >= lo && v <= hi;
+  // Entrance pool + every FoodStorage chamber maxed — a stockpile can't exceed this.
+  const FOOD_CEILING = BASE_FOOD_STORAGE_CAPACITY + MAX_ENTITIES * FOOD_CHAMBER_CAPACITY;
+  if (!intIn(s.foodStored, 0, FOOD_CEILING)) {
+    throw new Error(`Invalid colony.foodStored: ${String(s.foodStored)}`);
+  }
+  for (const key of ['workerCount', 'eggCount', 'larvaeCount', 'nurseCount'] as const) {
+    if (!intIn(s[key], 0, MAX_ENTITIES)) {
+      throw new Error(`Invalid colony.${key}: ${String(s[key])}`);
+    }
+  }
+  for (const key of ['eggs', 'larvae', 'workers'] as const) {
+    const list = s[key] as unknown;
+    if (!Array.isArray(list) || list.length > MAX_ENTITIES) {
+      throw new Error(`Invalid colony.${key}: not a number[] of length <= MAX_ENTITIES`);
+    }
+    for (let i = 0; i < list.length; i++) {
+      const v = list[i] as unknown;
+      if (typeof v !== 'number' || !intIn(v, 0, MAX_ENTITIES - 1)) {
+        throw new Error(`Invalid colony.${key}[${i}]: ${String(v)}`);
+      }
+    }
+  }
+}
+
 function deserializeColony(s: SerializedColony): ColonyRecord {
+  validateColonyScalars(s);
   const c = createColonyRecord(s.colonyId, s.queenEntityId);
   c.queenStarvationTimer = s.queenStarvationTimer;
   c.foodStored = s.foodStored;


### PR DESCRIPTION
Final PR of #234 (after the async seam #264 + autosave caption #266). **Validation tightening only** — no simVersion / SAVE_FORMAT / RNG / world-shape change; every save a real game produces still loads byte-identically.

### What
Closes the load-validation asymmetry the review flagged: colony scalars, brood/worker id-lists, and the ant SoA all deserialized **verbatim**, in contrast to the heavily-validated chambers/foodPiles. Now they range-check; a tampered/corrupt save throws a **plain Error** → classifies `incompatible-corrupt` → `bootFromSave` deletes + boots fresh (instead of silently zero-filling a non-array column or admitting out-of-range values).

- **`validateAntColumns`** — a data-driven `[column, rule]` table over all 32 deserialized ant columns, run before `copyInto*`. Rule classes: POS_FP / POS_FP_SENTINEL / TILE_SENTINEL / ID_SENTINEL / BYTE / ENUM / TRI / FINITE_INT. **FINITE_INT is `Number.isInteger`-only (NO `>=0` bound)** — dead-but-allocated slots retain end-of-life residue (a combat-killed ant keeps a negative `hp`; `serializeAnts` writes all slots), so a tighter bound would reject a valid round-trip. `pathErr` is a write-only zeros vestige (not a deserialized column) → no row (per the spec's #243-contingent note).
- **`validateColonyScalars`** — `foodStored` ≤ a structural ceiling; counts ≤ `MAX_ENTITIES`; `eggs`/`larvae`/`workers` are `number[]` of length ≤ `MAX_ENTITIES` with entries in `[0, MAX_ENTITIES)`. Runs **before** the `[...s.eggs]` spreads so a non-array id-list is caught with a clean message, not a raw `TypeError` from the spread.

### Tests
- One reject per rule class (POS_FP, ENUM, binary, TRI, ID_SENTINEL, non-array column, colony foodStored/workerCount/eggs) + end-to-end `incompatible-corrupt` classification.
- **No false-rejection:** the 189 existing round-trips still pass, plus a new positive pinning a dead-slot combat-killed ant (negative `hp`) round-tripping cleanly.

### Verification
- `npm run verify`: **2775 passed | 1 skipped**.
- Cross-model reviewed by Fable.

Closes #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)