### PR TITLE
refactor(render): HUD anchor table → buildHudLayout(LayoutContext) (#238 PR1 of 5)

### DIFF
--- a/src/input/camera-input.test.ts
+++ b/src/input/camera-input.test.ts
@@ -34,11 +34,17 @@ beforeEach(() => {
 import type { ViewState } from '../render/camera.js';
 import { SURFACE_WORLD_PX_W } from '../render/camera.js';
 import { makeCameraView, KEYBOARD_PAN_SPEED_PX_PER_SEC } from '../render/camera-adapter.js';
-import { HUD, CANVAS_W } from '../render/sprites.js';
+import { CANVAS_W } from '../render/sprites.js';
+import { buildHudLayout } from '../render/hud-layout.js';
+import { DEFAULT_LAYOUT } from '../render/layout.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
 import { hintStripState, resetHintStripState } from '../render/hint-strip-state.js';
 
-// Stage 3b: the hint-strip visibility singleton gates HUD.HINTS masking. Reset
+// #238: isPointerOverHUD / registerDragPan now take the built HUD layout; at the
+// default 800×592 layout hud.* == the former HUD table.
+const hud = buildHudLayout(DEFAULT_LAYOUT);
+
+// Stage 3b: the hint-strip visibility singleton gates hud.HINTS masking. Reset
 // it after each test so a hidden-legend case doesn't leak into its neighbors.
 afterEach(() => {
   resetHintStripState();
@@ -124,52 +130,52 @@ function center(rect: { x: number; y: number; w: number; h: number }): [number, 
 describe('isPointerOverHUD', () => {
   it('masks STATS / TRIANGLE / MINIMAP / VIEW_TOGGLE', () => {
     const vs = makeViewState('surface');
-    for (const rect of [HUD.STATS, HUD.TRIANGLE, HUD.MINIMAP, HUD.VIEW_TOGGLE]) {
+    for (const rect of [hud.STATS, hud.TRIANGLE, hud.MINIMAP, hud.VIEW_TOGGLE]) {
       const [x, y] = center(rect);
-      expect(isPointerOverHUD(x, y, vs)).toBe(true);
+      expect(isPointerOverHUD(x, y, hud, vs)).toBe(true);
     }
   });
 
   it('masks the Stage 1 interactive zones: TOOLS, HINTS, and SPEED', () => {
     const vs = makeViewState('surface');
-    for (const rect of [HUD.TOOLS, HUD.HINTS, HUD.SPEED]) {
+    for (const rect of [hud.TOOLS, hud.HINTS, hud.SPEED]) {
       const [x, y] = center(rect);
-      expect(isPointerOverHUD(x, y, vs)).toBe(true);
+      expect(isPointerOverHUD(x, y, hud, vs)).toBe(true);
     }
   });
 
-  it('Stage 3b: drops HUD.HINTS from the mask when the legend is hidden, keeps TOOLS/SPEED', () => {
+  it('Stage 3b: drops hud.HINTS from the mask when the legend is hidden, keeps TOOLS/SPEED', () => {
     const vs = makeViewState('surface');
     hintStripState.visible = false;
-    const [hx, hy] = center(HUD.HINTS);
+    const [hx, hy] = center(hud.HINTS);
     // The freed legend band is no longer a dead input zone…
-    expect(isPointerOverHUD(hx, hy, vs)).toBe(false);
+    expect(isPointerOverHUD(hx, hy, hud, vs)).toBe(false);
     // …but the other interactive widgets stay masked.
-    for (const rect of [HUD.TOOLS, HUD.SPEED]) {
+    for (const rect of [hud.TOOLS, hud.SPEED]) {
       const [x, y] = center(rect);
-      expect(isPointerOverHUD(x, y, vs)).toBe(true);
+      expect(isPointerOverHUD(x, y, hud, vs)).toBe(true);
     }
   });
 
   it('returns false for a clearly-empty world point', () => {
     const vs = makeViewState('surface');
     // A point in the mid-canvas play area clear of every rect.
-    expect(isPointerOverHUD(400, 300, vs)).toBe(false);
+    expect(isPointerOverHUD(400, 300, hud, vs)).toBe(false);
   });
 
   it('uses a half-open inclusion rule [x, x+w) × [y, y+h)', () => {
     const vs = makeViewState('surface');
     // Top-left corner is inside.
-    expect(isPointerOverHUD(HUD.TOOLS.x, HUD.TOOLS.y, vs)).toBe(true);
+    expect(isPointerOverHUD(hud.TOOLS.x, hud.TOOLS.y, hud, vs)).toBe(true);
     // The exclusive right/bottom edge is outside.
-    expect(isPointerOverHUD(HUD.TOOLS.x + HUD.TOOLS.w, HUD.TOOLS.y, vs)).toBe(false);
-    expect(isPointerOverHUD(HUD.TOOLS.x, HUD.TOOLS.y + HUD.TOOLS.h, vs)).toBe(false);
+    expect(isPointerOverHUD(hud.TOOLS.x + hud.TOOLS.w, hud.TOOLS.y, hud, vs)).toBe(false);
+    expect(isPointerOverHUD(hud.TOOLS.x, hud.TOOLS.y + hud.TOOLS.h, hud, vs)).toBe(false);
   });
 
   it('masks UNDERGROUND_COLONY_TOGGLE only on the underground view', () => {
-    const [x, y] = center(HUD.UNDERGROUND_COLONY_TOGGLE);
-    expect(isPointerOverHUD(x, y, makeViewState('surface'))).toBe(false);
-    expect(isPointerOverHUD(x, y, makeViewState('underground'))).toBe(true);
+    const [x, y] = center(hud.UNDERGROUND_COLONY_TOGGLE);
+    expect(isPointerOverHUD(x, y, hud, makeViewState('surface'))).toBe(false);
+    expect(isPointerOverHUD(x, y, hud, makeViewState('underground'))).toBe(true);
   });
 });
 
@@ -267,7 +273,7 @@ describe('registerDragPan (middle-button)', () => {
     // Center clear of the clamp edges so the pan delta isn't masked by clamping.
     const vs = makeViewState('surface', 1000, 1000);
     const { scene, emit } = makeFakeScene();
-    registerDragPan(scene, vs);
+    registerDragPan(scene, vs, hud);
     // Non-HUD points (mid play-area, clear of every HUD rect).
     emit('pointerdown', middlePointer(400, 300));
     expect(panInputState.isPanning).toBe(true);
@@ -287,7 +293,7 @@ describe('registerDragPan (middle-button)', () => {
     const vs = makeViewState('surface', 1000, 1000);
     const { scene, emit } = makeFakeScene();
     const blocked = { value: false };
-    registerDragPan(scene, vs, () => blocked.value);
+    registerDragPan(scene, vs, hud, () => blocked.value);
 
     // Drag starts and pans while unblocked.
     emit('pointerdown', middlePointer(400, 300));

--- a/src/input/camera-input.ts
+++ b/src/input/camera-input.ts
@@ -24,7 +24,7 @@
 // type` only so this file is testable without Phaser.
 
 import type * as Phaser from 'phaser';
-import { HUD } from '../render/sprites.js';
+import type { HudLayout } from '../render/hud-layout.js';
 import { antActivityPanelState } from '../render/ant-activity-panel-state.js';
 import { hintStripState } from '../render/hint-strip-state.js';
 import { type ViewState, worldPxDimensions } from '../render/camera.js';
@@ -87,9 +87,17 @@ export function resetDragState(dragState: DragState): void {
  * Used by drag-pan, the gesture arbiter, and the wheel-zoom handler to suppress
  * pointer/wheel events that land on HUD widgets.
  *
+ * Zones come from the passed `hud` (buildHudLayout output) so this reflows with
+ * the layout instead of reading a fixed table.
+ *
  * Inclusion rule: x in [rect.x, rect.x + rect.w) and y in [rect.y, rect.y + rect.h).
  */
-export function isPointerOverHUD(px: number, py: number, viewState?: ViewState): boolean {
+export function isPointerOverHUD(
+  px: number,
+  py: number,
+  hud: HudLayout,
+  viewState?: ViewState,
+): boolean {
   // Ant-activity popup full-canvas mask — while the panel is visible OR already
   // dismissing (pendingHide), treat every screen pixel as HUD (Phaser does not
   // guarantee cross-scene dispatch order, so masking the whole canvas closes both
@@ -99,25 +107,25 @@ export function isPointerOverHUD(px: number, py: number, viewState?: ViewState):
   }
 
   const zones: Array<{ x: number; y: number; w: number; h: number }> = [
-    HUD.STATS,
-    HUD.TRIANGLE,
-    HUD.SPEED,
-    HUD.TOOLS,
-    HUD.MINIMAP,
-    HUD.VIEW_TOGGLE,
+    hud.STATS,
+    hud.TRIANGLE,
+    hud.SPEED,
+    hud.TOOLS,
+    hud.MINIMAP,
+    hud.VIEW_TOGGLE,
   ];
   // Stage 3b (issue #18, Codex R1#2) — the hint strip masks world input ONLY
   // while its legend is visible. When the player hides the legend (settings
-  // toggle → hintStripState.visible=false), drop HUD.HINTS so the freed band is
+  // toggle → hintStripState.visible=false), drop hud.HINTS so the freed band is
   // not a dead input zone. Default visible → the band stays masked as before.
   if (hintStripState.visible) {
-    zones.push(HUD.HINTS);
+    zones.push(hud.HINTS);
   }
   // Issue #14 — colony toggle is rendered ONLY on the underground view. Mask the
   // click zone only when it's actually visible. Callers without a ViewState
   // (legacy/test) pass undefined and the toggle stays unmasked.
   if (viewState !== undefined && viewState.activeView === 'underground') {
-    zones.push(HUD.UNDERGROUND_COLONY_TOGGLE);
+    zones.push(hud.UNDERGROUND_COLONY_TOGGLE);
   }
   for (const zone of zones) {
     if (px >= zone.x && px < zone.x + zone.w && py >= zone.y && py < zone.y + zone.h) {
@@ -243,12 +251,14 @@ export interface DragState {
  * inside a HUD widget never pans, and a mid-drag HUD crossing doesn't jump the
  * camera. Stage 2: pan delta goes through panByScreenDelta (÷ zoom).
  *
+ * `hud` is the built HUD layout, threaded into the isPointerOverHUD masks.
  * Returns the shared dragState object. `isBlocked` lets GameScene suspend pan
  * during GameOver.
  */
 export function registerDragPan(
   scene: Phaser.Scene,
   viewState: ViewState,
+  hud: HudLayout,
   isBlocked?: () => boolean,
 ): DragState {
   const dragState: DragState = {
@@ -261,7 +271,7 @@ export function registerDragPan(
   scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
     if (isBlocked?.()) return;
     if (!pointer.middleButtonDown()) return;
-    if (isPointerOverHUD(pointer.x, pointer.y, viewState)) return;
+    if (isPointerOverHUD(pointer.x, pointer.y, hud, viewState)) return;
     dragState.active = true;
     dragState.lastX = pointer.x;
     dragState.lastY = pointer.y;
@@ -285,7 +295,7 @@ export function registerDragPan(
     if (!pointer.middleButtonDown()) return;
     // Issue #73 — over a HUD widget mid-drag, suppress the camera delta but
     // still track lastX/lastY so the next non-HUD move is incremental.
-    if (isPointerOverHUD(pointer.x, pointer.y, viewState)) {
+    if (isPointerOverHUD(pointer.x, pointer.y, hud, viewState)) {
       dragState.lastX = pointer.x;
       dragState.lastY = pointer.y;
       return;

--- a/src/render/ant-activity.test.ts
+++ b/src/render/ant-activity.test.ts
@@ -3,7 +3,13 @@
 // semantics, and formatted output stability.
 
 import { describe, it, expect } from 'vitest';
-import { computeAntActivity, formatAntActivityLines, ANT_ACTIVITY_PANEL } from './ant-activity.js';
+import {
+  computeAntActivity,
+  formatAntActivityLines,
+  antActivityPanelRect,
+} from './ant-activity.js';
+import { buildHudLayout } from './hud-layout.js';
+import { DEFAULT_LAYOUT } from './layout.js';
 import { createWorldState, allocateEntityId } from '../sim/types.js';
 import type { WorldState } from '../sim/types.js';
 import { initAnt, killAnt } from '../sim/ant/ant-store.js';
@@ -187,12 +193,13 @@ describe('formatAntActivityLines', () => {
   });
 });
 
-describe('ANT_ACTIVITY_PANEL layout', () => {
-  it('anchors below HUD.STATS and fits within the 800x592 canvas', () => {
-    expect(ANT_ACTIVITY_PANEL.x).toBeGreaterThanOrEqual(0);
-    expect(ANT_ACTIVITY_PANEL.y).toBeGreaterThan(8 + 24); // below HUD.STATS
-    expect(ANT_ACTIVITY_PANEL.x + ANT_ACTIVITY_PANEL.w).toBeLessThanOrEqual(800);
-    expect(ANT_ACTIVITY_PANEL.y + ANT_ACTIVITY_PANEL.h).toBeLessThanOrEqual(592);
+describe('antActivityPanelRect layout', () => {
+  it('anchors below the stats bar and fits within the 800x592 canvas', () => {
+    const panel = antActivityPanelRect(buildHudLayout(DEFAULT_LAYOUT).STATS);
+    expect(panel.x).toBeGreaterThanOrEqual(0);
+    expect(panel.y).toBeGreaterThan(8 + 24); // below the stats bar (y=8, h=24)
+    expect(panel.x + panel.w).toBeLessThanOrEqual(800);
+    expect(panel.y + panel.h).toBeLessThanOrEqual(592);
   });
 });
 

--- a/src/render/ant-activity.ts
+++ b/src/render/ant-activity.ts
@@ -35,7 +35,7 @@ import type { WorldState } from '../sim/types.js';
 import type { ColonyRecord } from '../sim/colony/colony-store.js';
 import { isAlive } from '../sim/ant/ant-store.js';
 import { AntTask, ForagingSubState, DiggingSubState } from '../sim/enums.js';
-import { HUD } from './sprites.js';
+import type { HudRect } from './hud-layout.js';
 
 export interface ForagingBreakdown {
   searching: number;
@@ -163,21 +163,24 @@ export function formatAntActivityLines(a: AntActivity): string[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Fixed screen rect the popup renders into. Anchored just below HUD.STATS
- * (top-left), wide enough to hold the longest formatted line without clipping
- * (`  carrying:  NN` at 10px monospace), tall enough for the 19 lines in
- * `formatAntActivityLines` plus padding.
+ * Fixed screen rect the popup renders into, derived from the passed stats rect
+ * (hud.STATS). Anchored just below the stats bar (top-left), wide enough to hold
+ * the longest formatted line without clipping (`  carrying:  NN` at 10px
+ * monospace), tall enough for the 19 lines in `formatAntActivityLines` plus
+ * padding. At the default 800×592 layout (stats = {x:8, y:8, w:200, h:24}) this
+ * yields the former `ANT_ACTIVITY_PANEL` constant: {x:8, y:36, w:220, h:264}.
  *
- * Exported so `isPointerOverHUD` (camera-input) can include this rect when
- * the panel is visible — otherwise clicks inside the panel would fall
- * through to the world.
+ * Used by `isPointerOverHUD` (camera-input) so clicks inside the panel don't
+ * fall through to the world while it is visible.
  */
-export const ANT_ACTIVITY_PANEL = {
-  x: HUD.STATS.x,
-  y: HUD.STATS.y + HUD.STATS.h + 4,
-  w: 220,
-  h: 264,
-} as const;
+export function antActivityPanelRect(stats: HudRect): HudRect {
+  return {
+    x: stats.x,
+    y: stats.y + stats.h + 4,
+    w: 220,
+    h: 264,
+  };
+}
 
 export const ANT_ACTIVITY_PANEL_COLORS = {
   background: 0x000000,

--- a/src/render/boot-overlay-layout.test.ts
+++ b/src/render/boot-overlay-layout.test.ts
@@ -20,7 +20,7 @@ import {
 import { DEFAULT_LAYOUT } from './layout.js';
 import { pauseMenuItems, type PauseMenuRenderContext } from './pause-menu-layout.js';
 import { saveLoadDialogItems, type SaveLoadDialogContext } from './save-load-dialog-layout.js';
-import { HUD } from './sprites.js';
+import { buildHudLayout } from './hud-layout.js';
 
 // Same contexts tests/helpers/geometry.ts uses (playtrace off → 4-row main menu).
 const MAIN: PauseMenuRenderContext = {
@@ -67,6 +67,6 @@ describe('#240 layout functions equal the specs’ former inline literals', () =
   });
 
   it('HUD view-toggle button', () => {
-    expect(HUD.VIEW_TOGGLE).toEqual({ x: 632, y: 396, w: 80, h: 24 });
+    expect(buildHudLayout(DEFAULT_LAYOUT).VIEW_TOGGLE).toEqual({ x: 632, y: 396, w: 80, h: 24 });
   });
 });

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -195,6 +195,8 @@ import {
 } from './screen-effects.js';
 import { ChamberType } from '../sim/enums.js';
 import { CANVAS_W, CANVAS_H } from './sprites.js';
+import { DEFAULT_LAYOUT } from './layout.js';
+import { buildHudLayout } from './hud-layout.js';
 // UIScenePhase9 — subset of UIScene public API added in Plan 06 Task 3.
 // Typed here to avoid circular imports; UIScene implements these methods.
 interface UIScenePhase9 {
@@ -296,6 +298,13 @@ export class GameScene extends Phaser.Scene {
   private world!: WorldState;
   private prevState!: WorldState;
   private viewState!: ViewState;
+  // Issue #213 / #238 — the LayoutContext seam + its built HUD anchor table.
+  // Fixed at the canvas size today (DEFAULT_LAYOUT = 800×592); the eventual
+  // responsive work recomputes `layout` from the real canvas and rebuilds `hud`.
+  // `hud` is threaded into isPointerOverHUD / registerDragPan so the pan/zoom
+  // masks read the same zone rects the HUD draws.
+  private layout = DEFAULT_LAYOUT;
+  private hud = buildHudLayout(this.layout);
   private gameLoop!: GameLoop;
   private gfx!: Phaser.GameObjects.Graphics;
   // Overlay layer for world-space primitives that must render above the sprite
@@ -616,7 +625,7 @@ export class GameScene extends Phaser.Scene {
     // mid middle-drag suspends the camera move and it doesn't persist after
     // Resume (Codex P2). A bare user-pause (Space) is NOT modal, so middle-pan
     // still works while paused — intended.
-    this.dragState = registerDragPan(this, this.viewState, () => this.isModalOpen());
+    this.dragState = registerDragPan(this, this.viewState, this.hud, () => this.isModalOpen());
 
     // Stage 2 (issue #18): mouse-wheel zoom. Gated exactly like world pan — ignored
     // over HUD zones and whenever a modal / menu / game-over owns input
@@ -627,7 +636,7 @@ export class GameScene extends Phaser.Scene {
       'wheel',
       (pointer: Phaser.Input.Pointer, _over: unknown, _dx: number, dy: number) => {
         if (!this.canAcceptWorldHotkey()) return;
-        if (isPointerOverHUD(pointer.x, pointer.y, this.viewState)) return;
+        if (isPointerOverHUD(pointer.x, pointer.y, this.hud, this.viewState)) return;
         const native = pointer.event as WheelEvent | undefined;
         if (native?.ctrlKey || native?.metaKey) return;
         if (dy === 0) return;
@@ -831,7 +840,7 @@ export class GameScene extends Phaser.Scene {
       // computeUndergroundDigHover's outcome() — willTakeEffect never touches its memo.
       getFeedforward: () => this.feedforward,
       viewState: this.viewState,
-      isPointerOverHUD: (x, y) => isPointerOverHUD(x, y, this.viewState),
+      isPointerOverHUD: (x, y) => isPointerOverHUD(x, y, this.hud, this.viewState),
       isPaused: () => isPausedByAny(this.pauseReasons),
       // World edits (tap / paint / chamber) are allowed whenever no modal is up —
       // crucially that INCLUDES a bare user-pause, so a click/dig-paint while
@@ -2177,7 +2186,7 @@ export class GameScene extends Phaser.Scene {
   /**
    * Compute the entrance hover outline for the current frame, or null when it
    * should not show. Shown only for Dig + surface, with the pointer on canvas
-   * and not over HUD. The tile + validity are recomputed here every frame from
+   * and not over a HUD zone. The tile + validity are recomputed here every frame from
    * the LIVE camera so the outline tracks the pointer even under a moving camera.
    */
   private computeEntranceHover(
@@ -2187,7 +2196,8 @@ export class GameScene extends Phaser.Scene {
     if (this.viewState.activeView !== 'surface') return null;
     if (this.viewState.activeTool !== 'dig') return null;
     if (this.hoverScreenX === null || this.hoverScreenY === null) return null;
-    if (isPointerOverHUD(this.hoverScreenX, this.hoverScreenY, this.viewState)) return null;
+    if (isPointerOverHUD(this.hoverScreenX, this.hoverScreenY, this.hud, this.viewState))
+      return null;
     if (this.world === undefined) return null;
     const { tileX, tileY } = screenToTileZoom(this.hoverScreenX, this.hoverScreenY, cam);
     // Reject off-grid tiles on BOTH axes. Zoomed out, the visible world rect can extend
@@ -2237,7 +2247,8 @@ export class GameScene extends Phaser.Scene {
     if (this.arbiter.isPainting()) return null;
     if (this.viewState.activeUndergroundColonyId !== PLAYER_COLONY_ID) return null;
     if (this.hoverScreenX === null || this.hoverScreenY === null) return null;
-    if (isPointerOverHUD(this.hoverScreenX, this.hoverScreenY, this.viewState)) return null;
+    if (isPointerOverHUD(this.hoverScreenX, this.hoverScreenY, this.hud, this.viewState))
+      return null;
     if (this.world === undefined) return null;
     const grid = this.world.undergroundGrids[PLAYER_COLONY_ID];
     const projGrid = projected.undergroundGrids[PLAYER_COLONY_ID];
@@ -2364,7 +2375,7 @@ export class GameScene extends Phaser.Scene {
     const overHud =
       this.hoverScreenX !== null &&
       this.hoverScreenY !== null &&
-      isPointerOverHUD(this.hoverScreenX, this.hoverScreenY, this.viewState);
+      isPointerOverHUD(this.hoverScreenX, this.hoverScreenY, this.hud, this.viewState);
     const effectiveTool: CursorTool = resolveCursorTool({
       activeTool: this.viewState.activeTool,
       activeView: this.viewState.activeView,

--- a/src/render/hint-strip-state.ts
+++ b/src/render/hint-strip-state.ts
@@ -6,7 +6,7 @@
 // versa):
 //   - UIScene.renderHintStrip() gates ONLY the static legend on it (the paused-
 //     queue-full warning + caption-yield stay visible regardless — Codex R1#3).
-//   - isPointerOverHUD() drops HUD.HINTS from the world-input mask when the
+//   - isPointerOverHUD() drops hud.HINTS from the world-input mask when the
 //     legend is hidden, so a hidden strip leaves no dead input zone (Codex R1#2).
 //
 // Authoritative in-memory truth (like ViewState.showPheromoneOverlay): the

--- a/src/render/hud-controls.test.ts
+++ b/src/render/hud-controls.test.ts
@@ -14,57 +14,70 @@ import {
   PAUSED_QUEUE_FULL_HINT,
   RUNNING_QUEUE_FULL_HINT,
 } from './hud-controls.js';
-import { HUD } from './sprites.js';
+import { buildHudLayout } from './hud-layout.js';
+import { DEFAULT_LAYOUT } from './layout.js';
+
+// #238: hud-controls.ts now takes the tools/speed rects; at the default 800×592
+// layout hud.TOOLS / hud.SPEED == the former HUD-table TOOLS / SPEED.
+const hud = buildHudLayout(DEFAULT_LAYOUT);
 
 function center(r: { x: number; y: number; w: number; h: number }): [number, number] {
   return [r.x + r.w / 2, r.y + r.h / 2];
 }
 
 describe('tool palette geometry + hit-testing', () => {
-  it('lays out 3 buttons inside HUD.TOOLS, left → right', () => {
+  it('lays out 3 buttons inside hud.TOOLS, left → right', () => {
     expect(TOOL_ORDER).toEqual(['command', 'dig', 'chamber']);
-    const r0 = toolButtonRect(0);
-    const r2 = toolButtonRect(2);
-    expect(r0.x).toBe(HUD.TOOLS.x);
-    expect(r2.x + r2.w).toBeLessThanOrEqual(HUD.TOOLS.x + HUD.TOOLS.w);
+    const r0 = toolButtonRect(0, hud.TOOLS);
+    const r2 = toolButtonRect(2, hud.TOOLS);
+    expect(r0.x).toBe(hud.TOOLS.x);
+    expect(r2.x + r2.w).toBeLessThanOrEqual(hud.TOOLS.x + hud.TOOLS.w);
   });
 
   it('hits each tool by its button center', () => {
-    expect(toolButtonAt(...center(toolButtonRect(0)), 'underground')).toBe('command');
-    expect(toolButtonAt(...center(toolButtonRect(1)), 'underground')).toBe('dig');
-    expect(toolButtonAt(...center(toolButtonRect(2)), 'underground')).toBe('chamber');
+    expect(toolButtonAt(...center(toolButtonRect(0, hud.TOOLS)), 'underground', hud.TOOLS)).toBe(
+      'command',
+    );
+    expect(toolButtonAt(...center(toolButtonRect(1, hud.TOOLS)), 'underground', hud.TOOLS)).toBe(
+      'dig',
+    );
+    expect(toolButtonAt(...center(toolButtonRect(2, hud.TOOLS)), 'underground', hud.TOOLS)).toBe(
+      'chamber',
+    );
   });
 
   it('Chamber is inert on the surface (returns null there)', () => {
-    expect(toolButtonAt(...center(toolButtonRect(2)), 'surface')).toBeNull();
+    expect(toolButtonAt(...center(toolButtonRect(2, hud.TOOLS)), 'surface', hud.TOOLS)).toBeNull();
     // Command/Dig still hittable on the surface.
-    expect(toolButtonAt(...center(toolButtonRect(0)), 'surface')).toBe('command');
+    expect(toolButtonAt(...center(toolButtonRect(0, hud.TOOLS)), 'surface', hud.TOOLS)).toBe(
+      'command',
+    );
   });
 
   it('returns null outside every button', () => {
-    expect(toolButtonAt(0, 0, 'underground')).toBeNull();
+    expect(toolButtonAt(0, 0, 'underground', hud.TOOLS)).toBeNull();
   });
 });
 
 describe('speed widget geometry + hit-testing', () => {
-  it('lays out ⏸ + three presets inside HUD.SPEED', () => {
+  it('lays out ⏸ + three presets inside hud.SPEED', () => {
     expect(SPEED_CONTROL_ORDER).toEqual(['pause', 1, 2, 4]);
-    const rPause = speedControlRect(0);
-    expect(rPause.x).toBe(HUD.SPEED.x);
-    expect(rPause.w).toBe(HUD.SPEED.PAUSE_BUTTON_W);
-    const rLast = speedControlRect(3);
-    expect(rLast.x + rLast.w).toBeLessThanOrEqual(HUD.SPEED.x + HUD.SPEED.w);
+    const rPause = speedControlRect(0, hud.SPEED);
+    expect(rPause.x).toBe(hud.SPEED.x);
+    expect(rPause.w).toBe(hud.SPEED.PAUSE_BUTTON_W);
+    const rLast = speedControlRect(3, hud.SPEED);
+    expect(rLast.x + rLast.w).toBeLessThanOrEqual(hud.SPEED.x + hud.SPEED.w);
   });
 
   it('hits ⏸ / 1× / 2× / 4× by their centers', () => {
-    expect(speedControlAt(...center(speedControlRect(0)))).toBe('pause');
-    expect(speedControlAt(...center(speedControlRect(1)))).toBe(1);
-    expect(speedControlAt(...center(speedControlRect(2)))).toBe(2);
-    expect(speedControlAt(...center(speedControlRect(3)))).toBe(4);
+    expect(speedControlAt(...center(speedControlRect(0, hud.SPEED)), hud.SPEED)).toBe('pause');
+    expect(speedControlAt(...center(speedControlRect(1, hud.SPEED)), hud.SPEED)).toBe(1);
+    expect(speedControlAt(...center(speedControlRect(2, hud.SPEED)), hud.SPEED)).toBe(2);
+    expect(speedControlAt(...center(speedControlRect(3, hud.SPEED)), hud.SPEED)).toBe(4);
   });
 
   it('returns null outside the widget', () => {
-    expect(speedControlAt(0, 0)).toBeNull();
+    expect(speedControlAt(0, 0, hud.SPEED)).toBeNull();
   });
 });
 

--- a/src/render/hud-controls.ts
+++ b/src/render/hud-controls.ts
@@ -2,17 +2,17 @@
 // testing for the new interactive HUD widgets (tool palette, speed widget) and
 // the static per-tool/per-view hint strip text.
 //
-// No Phaser, no DOM — pure functions over the locked HUD rects in sprites.ts, so
-// they are unit-testable. UIScene draws using these positions and routes clicks
-// through these hit-tests; the gesture arbiter / camera-input mask the same rects
-// via isPointerOverHUD.
+// No Phaser, no DOM — pure functions over HUD rects passed in by the caller
+// (built via buildHudLayout in hud-layout.ts), so they are unit-testable. UIScene
+// draws using these positions and routes clicks through these hit-tests; the
+// gesture arbiter / camera-input mask the same rects via isPointerOverHUD.
 
-import { HUD } from './sprites.js';
 import type { ToolId } from './camera.js';
+import type { HudLayout } from './hud-layout.js';
 import { glyphFor } from './input-glyphs.js';
 
 // ---------------------------------------------------------------------------
-// Tool palette (HUD.TOOLS) — 3 buttons: Command / Dig / Chamber
+// Tool palette (hud.TOOLS) — 3 buttons: Command / Dig / Chamber
 // ---------------------------------------------------------------------------
 
 /** The three tools in palette order (left → right). */
@@ -25,10 +25,13 @@ export const TOOL_LABEL: Record<ToolId, string> = {
   chamber: 'Chmb',
 };
 
-/** Screen rect of the i-th tool button (0..2) within HUD.TOOLS. */
-export function toolButtonRect(index: number): { x: number; y: number; w: number; h: number } {
-  const x = HUD.TOOLS.x + index * (HUD.TOOLS.BUTTON_W + HUD.TOOLS.GAP);
-  return { x, y: HUD.TOOLS.y, w: HUD.TOOLS.BUTTON_W, h: HUD.TOOLS.h };
+/** Screen rect of the i-th tool button (0..2) within the tools rect (hud.TOOLS). */
+export function toolButtonRect(
+  index: number,
+  tools: HudLayout['TOOLS'],
+): { x: number; y: number; w: number; h: number } {
+  const x = tools.x + index * (tools.BUTTON_W + tools.GAP);
+  return { x, y: tools.y, w: tools.BUTTON_W, h: tools.h };
 }
 
 /**
@@ -41,18 +44,19 @@ export function toolButtonAt(
   px: number,
   py: number,
   view: 'surface' | 'underground',
+  tools: HudLayout['TOOLS'],
 ): ToolId | null {
   for (let i = 0; i < TOOL_ORDER.length; i++) {
     const tool = TOOL_ORDER[i]!;
     if (tool === 'chamber' && view === 'surface') continue; // greyed on surface
-    const r = toolButtonRect(i);
+    const r = toolButtonRect(i, tools);
     if (px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h) return tool;
   }
   return null;
 }
 
 // ---------------------------------------------------------------------------
-// Speed widget (HUD.SPEED) — ⏸ / 1× / 2× / 4×
+// Speed widget (hud.SPEED) — ⏸ / 1× / 2× / 4×
 // ---------------------------------------------------------------------------
 
 /** A speed-widget control: the pause toggle or a multiplier preset. */
@@ -61,23 +65,30 @@ export type SpeedControl = 'pause' | 1 | 2 | 4;
 /** The four speed-widget controls in left → right order. */
 export const SPEED_CONTROL_ORDER: readonly SpeedControl[] = ['pause', 1, 2, 4];
 
-/** Screen rect of the i-th speed control (0=⏸, 1=1×, 2=2×, 3=4×) within HUD.SPEED. */
-export function speedControlRect(index: number): { x: number; y: number; w: number; h: number } {
+/** Screen rect of the i-th speed control (0=⏸, 1=1×, 2=2×, 3=4×) within the speed rect (hud.SPEED). */
+export function speedControlRect(
+  index: number,
+  speed: HudLayout['SPEED'],
+): { x: number; y: number; w: number; h: number } {
   // ⏸ button is PAUSE_BUTTON_W wide; each multiplier is SPEED_BUTTON_W wide.
   if (index <= 0) {
-    return { x: HUD.SPEED.x, y: HUD.SPEED.y, w: HUD.SPEED.PAUSE_BUTTON_W, h: HUD.SPEED.h };
+    return { x: speed.x, y: speed.y, w: speed.PAUSE_BUTTON_W, h: speed.h };
   }
-  const x = HUD.SPEED.x + HUD.SPEED.PAUSE_BUTTON_W + (index - 1) * HUD.SPEED.SPEED_BUTTON_W;
-  return { x, y: HUD.SPEED.y, w: HUD.SPEED.SPEED_BUTTON_W, h: HUD.SPEED.h };
+  const x = speed.x + speed.PAUSE_BUTTON_W + (index - 1) * speed.SPEED_BUTTON_W;
+  return { x, y: speed.y, w: speed.SPEED_BUTTON_W, h: speed.h };
 }
 
 /**
  * Hit-test the speed widget. Returns the control at (px, py): 'pause' for the ⏸
  * button, or 1/2/4 for the multiplier presets; null if outside.
  */
-export function speedControlAt(px: number, py: number): SpeedControl | null {
+export function speedControlAt(
+  px: number,
+  py: number,
+  speed: HudLayout['SPEED'],
+): SpeedControl | null {
   for (let i = 0; i < SPEED_CONTROL_ORDER.length; i++) {
-    const r = speedControlRect(i);
+    const r = speedControlRect(i, speed);
     if (px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h) {
       return SPEED_CONTROL_ORDER[i]!;
     }
@@ -86,7 +97,7 @@ export function speedControlAt(px: number, py: number): SpeedControl | null {
 }
 
 // ---------------------------------------------------------------------------
-// Hint strip (HUD.HINTS) — static per-tool / per-view legend
+// Hint strip (hud.HINTS) — static per-tool / per-view legend
 // ---------------------------------------------------------------------------
 
 /**
@@ -135,10 +146,11 @@ export function toolButtonVisualAt(
   px: number,
   py: number,
   view: 'surface' | 'underground',
+  tools: HudLayout['TOOLS'],
 ): { tool: ToolId; enabled: boolean } | null {
   for (let i = 0; i < TOOL_ORDER.length; i++) {
     const tool = TOOL_ORDER[i]!;
-    const r = toolButtonRect(i);
+    const r = toolButtonRect(i, tools);
     if (px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h) {
       return { tool, enabled: !(tool === 'chamber' && view === 'surface') };
     }

--- a/src/render/hud-layout.test.ts
+++ b/src/render/hud-layout.test.ts
@@ -1,0 +1,39 @@
+// src/render/hud-layout.test.ts — #238 PR1 acceptance gate.
+//
+// The deep-equality snapshot below is the load-bearing test: it pins
+// buildHudLayout(DEFAULT_LAYOUT) to the exact values the former sprites.ts `HUD`
+// constant held at 800×592, so the LayoutContext conversion provably changed
+// zero geometry at the default size.
+
+import { describe, it, expect } from 'vitest';
+import { buildHudLayout } from './hud-layout.js';
+import { DEFAULT_LAYOUT, createLayoutContext } from './layout.js';
+
+describe('buildHudLayout', () => {
+  it('is byte-identical to the legacy HUD table at the default 800×592 layout', () => {
+    // Verbatim from the former sprites.ts HUD block (lines 150-208).
+    const EXPECTED = {
+      STATS: { x: 8, y: 8, w: 200, h: 24 },
+      TRIANGLE: { x: 8, y: 532, w: 120, h: 44 },
+      SPEED: { x: 320, y: 552, w: 160, h: 32, PAUSE_BUTTON_W: 40, SPEED_BUTTON_W: 32 },
+      HINTS: { x: 8, y: 508, w: 616, h: 18 },
+      TOOLS: { x: 632, y: 36, w: 128, h: 40, BUTTON_W: 40, GAP: 4 },
+      MINIMAP: { x: 632, y: 424, w: 160, h: 160 },
+      VIEW_TOGGLE: { x: 632, y: 396, w: 80, h: 24 },
+      UNDERGROUND_COLONY_TOGGLE: { x: 632, y: 372, w: 112, h: 22 },
+      SAVE_ICON: { x: 772, y: 8, w: 20, h: 20 },
+    };
+    expect(buildHudLayout(DEFAULT_LAYOUT)).toEqual(EXPECTED);
+  });
+
+  it('reflows right/bottom-anchored zones with the layout size', () => {
+    const hud = buildHudLayout(createLayoutContext(1000, 700));
+    expect(hud.MINIMAP.x).toBe(832); // 1000 - 168
+    expect(hud.MINIMAP.y).toBe(532); // 700 - 168
+    expect(hud.SAVE_ICON.x).toBe(972); // 1000 - 28
+    expect(hud.SPEED.x).toBe(420); // 1000/2 - 80
+    expect(hud.TRIANGLE.y).toBe(640); // 700 - 60
+    // Top-left-anchored zones are size-independent.
+    expect(hud.STATS).toEqual({ x: 8, y: 8, w: 200, h: 24 });
+  });
+});

--- a/src/render/hud-layout.ts
+++ b/src/render/hud-layout.ts
@@ -1,0 +1,51 @@
+// src/render/hud-layout.ts — #238 PR1: the HUD anchor table as a pure function
+// of LayoutContext (phase 2 of the layout seam; follow-up to #213).
+//
+// buildHudLayout(DEFAULT_LAYOUT) is byte-identical to the former `HUD` constant
+// that lived in sprites.ts at 800×592 — locked by the deep-equality snapshot in
+// hud-layout.test.ts. Anchors are expressed relative to layout.w / layout.h so
+// the HUD reflows on resize (the Phase-6 mobile goal). Intentionally does NOT
+// import CANVAS_W/H — geometry derives from the passed LayoutContext (PR5's
+// discipline guard enforces this).
+
+import type { LayoutContext } from './layout.js';
+
+export interface HudRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface HudLayout {
+  STATS: HudRect;
+  TRIANGLE: HudRect;
+  SPEED: HudRect & { PAUSE_BUTTON_W: number; SPEED_BUTTON_W: number };
+  HINTS: HudRect;
+  TOOLS: HudRect & { BUTTON_W: number; GAP: number };
+  MINIMAP: HudRect;
+  VIEW_TOGGLE: HudRect;
+  UNDERGROUND_COLONY_TOGGLE: HudRect;
+  SAVE_ICON: HudRect;
+}
+
+/**
+ * Build the HUD anchor table for a given layout. Every anchor evaluates to the
+ * former sprites.ts `HUD` constant at 800×592 (deep-equality-gated). Anchor
+ * rationale (TRIANGLE h≥44 invariant, TOOLS band placement, colony-toggle
+ * width, etc.) is unchanged — see PRD §6b and the prior HUD block's comments.
+ */
+export function buildHudLayout(layout: LayoutContext): HudLayout {
+  const { w, h } = layout;
+  return {
+    STATS: { x: 8, y: 8, w: 200, h: 24 },
+    TRIANGLE: { x: 8, y: h - 60, w: 120, h: 44 },
+    SPEED: { x: w / 2 - 80, y: h - 40, w: 160, h: 32, PAUSE_BUTTON_W: 40, SPEED_BUTTON_W: 32 },
+    HINTS: { x: 8, y: h - 84, w: w - 184, h: 18 },
+    TOOLS: { x: w - 168, y: 36, w: 128, h: 40, BUTTON_W: 40, GAP: 4 },
+    MINIMAP: { x: w - 168, y: h - 168, w: 160, h: 160 },
+    VIEW_TOGGLE: { x: w - 168, y: h - 196, w: 80, h: 24 },
+    UNDERGROUND_COLONY_TOGGLE: { x: w - 168, y: h - 220, w: 112, h: 22 },
+    SAVE_ICON: { x: w - 28, y: 8, w: 20, h: 20 },
+  };
+}

--- a/src/render/hud-stats.test.ts
+++ b/src/render/hud-stats.test.ts
@@ -250,17 +250,17 @@ describe('queenHealthBarFillWidth', () => {
 });
 
 describe('queenBarRect', () => {
-  it('right-anchors the bar inside the 200x24 HUD.STATS rect', () => {
+  it('right-anchors the bar inside the 200x24 hud.STATS rect', () => {
     const rect = queenBarRect({ x: 8, y: 8, w: 200, h: 24 });
     const { w, h, yOffset, rightInset } = HUD_STATS_LAYOUT.queenBar;
     expect(rect.w).toBe(w);
     expect(rect.h).toBe(h);
     expect(rect.y).toBe(8 + yOffset);
     expect(rect.x).toBe(8 + 200 - rightInset - w);
-    // stays inside HUD.STATS horizontally
+    // stays inside hud.STATS horizontally
     expect(rect.x).toBeGreaterThanOrEqual(8);
     expect(rect.x + rect.w).toBeLessThanOrEqual(8 + 200);
-    // stays inside HUD.STATS vertically
+    // stays inside hud.STATS vertically
     expect(rect.y).toBeGreaterThanOrEqual(8);
     expect(rect.y + rect.h).toBeLessThanOrEqual(8 + 24);
   });
@@ -284,7 +284,7 @@ describe('queenLabelRect (09 HUD clarity pass — two-row layout)', () => {
     expect(label.x + label.w).toBeLessThan(bar.x);
   });
 
-  it('stays inside HUD.STATS both horizontally and vertically', () => {
+  it('stays inside hud.STATS both horizontally and vertically', () => {
     const stats = { x: 8, y: 8, w: 200, h: 24 };
     const label = queenLabelRect(stats);
     expect(label.x).toBeGreaterThanOrEqual(stats.x);
@@ -329,7 +329,7 @@ describe('two-row stats layout (09 HUD clarity pass)', () => {
     expect(label.x + label.w).toBeLessThanOrEqual(bar.x);
   });
 
-  it('both rows remain inside the HUD.STATS rect vertically', () => {
+  it('both rows remain inside the hud.STATS rect vertically', () => {
     // Approximate rendered height of a 10px monospace Text widget.
     const TEXT_HEIGHT = 12;
     const row1Top = stats.y + HUD_STATS_LAYOUT.row1YOffset;

--- a/src/render/hud-stats.ts
+++ b/src/render/hud-stats.ts
@@ -61,9 +61,9 @@ export const HUD_STATS_COLORS = {
 } as const;
 
 export const HUD_STATS_LAYOUT = {
-  // Two-row micro-layout inside HUD.STATS (200×24 at y=8). Row 1 carries
-  // Ants+Food; row 2 carries the Queen label + health bar. yOffsets are
-  // relative to HUD.STATS.y and chosen so the 10px Text widgets + the 6px
+  // Two-row micro-layout inside the stats rect (hud.STATS; 200×24 at y=8). Row 1
+  // carries Ants+Food; row 2 carries the Queen label + health bar. yOffsets are
+  // relative to the stats rect's y and chosen so the 10px Text widgets + the 6px
   // bar all sit inside the 24px rect.
   row1YOffset: 1, // canvas y = 9
   row2YOffset: 13, // canvas y = 21

--- a/src/render/minimap.test.ts
+++ b/src/render/minimap.test.ts
@@ -4,7 +4,9 @@
 // Runs under Node with no Phaser.
 
 import { describe, it, expect } from 'vitest';
-import { HUD, TILE_SIZE_PX } from './sprites.js';
+import { TILE_SIZE_PX } from './sprites.js';
+import { buildHudLayout } from './hud-layout.js';
+import { DEFAULT_LAYOUT } from './layout.js';
 import { COLOR_BARREN_EARTH, COLOR_BARREN_EARTH_DARK } from './terrain-atlas.js';
 import { createViewState } from './camera.js';
 import {
@@ -24,6 +26,10 @@ import {
   SURFACE_GRID_HEIGHT,
 } from '../sim/constants.js';
 import { SurfaceTileState, sgSet } from '../sim/terrain.js';
+
+// #238: minimap.ts now takes the built HUD layout; at the default 800×592 layout
+// hud.MINIMAP == the former hud.MINIMAP, so these tests stay byte-identical.
+const hud = buildHudLayout(DEFAULT_LAYOUT);
 
 // ---------------------------------------------------------------------------
 // MockGfx — records calls, does not render anything
@@ -121,31 +127,31 @@ function makeMinimalWorld(overrides?: {
 
 describe('minimapClickToTile', () => {
   it('top-left corner of minimap returns tileX=0, tileY=0', () => {
-    const result = minimapClickToTile(HUD.MINIMAP.x, HUD.MINIMAP.y);
+    const result = minimapClickToTile(hud.MINIMAP.x, hud.MINIMAP.y, hud);
     expect(result).not.toBeNull();
     expect(result!.tileX).toBeCloseTo(0, 5);
     expect(result!.tileY).toBeCloseTo(0, 5);
   });
 
   it('center of minimap returns tileX=64, tileY=64', () => {
-    const cx = HUD.MINIMAP.x + HUD.MINIMAP.w / 2;
-    const cy = HUD.MINIMAP.y + HUD.MINIMAP.h / 2;
-    const result = minimapClickToTile(cx, cy);
+    const cx = hud.MINIMAP.x + hud.MINIMAP.w / 2;
+    const cy = hud.MINIMAP.y + hud.MINIMAP.h / 2;
+    const result = minimapClickToTile(cx, cy, hud);
     expect(result).not.toBeNull();
     expect(result!.tileX).toBeCloseTo(64, 5);
     expect(result!.tileY).toBeCloseTo(64, 5);
   });
 
   it('point (0, 0) far outside minimap returns null', () => {
-    expect(minimapClickToTile(0, 0)).toBeNull();
+    expect(minimapClickToTile(0, 0, hud)).toBeNull();
   });
 
   it('x just outside right edge returns null', () => {
-    expect(minimapClickToTile(HUD.MINIMAP.x + HUD.MINIMAP.w, HUD.MINIMAP.y)).toBeNull();
+    expect(minimapClickToTile(hud.MINIMAP.x + hud.MINIMAP.w, hud.MINIMAP.y, hud)).toBeNull();
   });
 
   it('y just outside bottom edge returns null', () => {
-    expect(minimapClickToTile(HUD.MINIMAP.x, HUD.MINIMAP.y + HUD.MINIMAP.h)).toBeNull();
+    expect(minimapClickToTile(hud.MINIMAP.x, hud.MINIMAP.y + hud.MINIMAP.h, hud)).toBeNull();
   });
 });
 
@@ -156,9 +162,9 @@ describe('minimapClickToTile', () => {
 describe('applyMinimapClick', () => {
   it('click at center sets surfaceCamera center to world px (1024, 1024) and returns true', () => {
     const vs = createViewState(PLAYER_START_X, PLAYER_START_Y);
-    const cx = HUD.MINIMAP.x + HUD.MINIMAP.w / 2;
-    const cy = HUD.MINIMAP.y + HUD.MINIMAP.h / 2;
-    const result = applyMinimapClick(vs, cx, cy);
+    const cx = hud.MINIMAP.x + hud.MINIMAP.w / 2;
+    const cy = hud.MINIMAP.y + hud.MINIMAP.h / 2;
+    const result = applyMinimapClick(vs, cx, cy, hud);
     expect(result).toBe(true);
     // Minimap center → tile (64, 64) → world px (64×16, 64×16) = (1024, 1024).
     // At zoom 1 the surface clamp ([400,1648]×[296,1752]) leaves both untouched.
@@ -173,7 +179,7 @@ describe('applyMinimapClick', () => {
     const vs = createViewState(PLAYER_START_X, PLAYER_START_Y);
     const origX = vs.surfaceCamera.centerX;
     const origY = vs.surfaceCamera.centerY;
-    const result = applyMinimapClick(vs, 0, 0);
+    const result = applyMinimapClick(vs, 0, 0, hud);
     expect(result).toBe(false);
     expect(vs.surfaceCamera.centerX).toBe(origX);
     expect(vs.surfaceCamera.centerY).toBe(origY);
@@ -187,9 +193,9 @@ describe('applyMinimapClick', () => {
     // depth-preservation assertion tests preservation, not the clamp. §A6.
     const depthY = 500;
     vs.undergroundCamera.centerY = depthY;
-    const cx = HUD.MINIMAP.x + HUD.MINIMAP.w / 2;
-    const cy = HUD.MINIMAP.y + HUD.MINIMAP.h / 2;
-    applyMinimapClick(vs, cx, cy);
+    const cx = hud.MINIMAP.x + hud.MINIMAP.w / 2;
+    const cy = hud.MINIMAP.y + hud.MINIMAP.h / 2;
+    applyMinimapClick(vs, cx, cy, hud);
     // X should be X-linked to the surface camera's clamped center X.
     expect(vs.undergroundCamera.centerX).toBe(vs.surfaceCamera.centerX);
     // centerY (depth) must be UNCHANGED — underground depth is independent (§A6).
@@ -199,9 +205,9 @@ describe('applyMinimapClick', () => {
   it('when activeView=surface, click does NOT touch undergroundCamera.centerX', () => {
     const vs = createViewState(PLAYER_START_X, PLAYER_START_Y);
     const origUnderX = vs.undergroundCamera.centerX;
-    const cx = HUD.MINIMAP.x + HUD.MINIMAP.w / 2;
-    const cy = HUD.MINIMAP.y + HUD.MINIMAP.h / 2;
-    applyMinimapClick(vs, cx, cy);
+    const cx = hud.MINIMAP.x + hud.MINIMAP.w / 2;
+    const cy = hud.MINIMAP.y + hud.MINIMAP.h / 2;
+    applyMinimapClick(vs, cx, cy, hud);
     // undergroundCamera.centerX should NOT change when in surface view
     expect(vs.undergroundCamera.centerX).toBe(origUnderX);
   });
@@ -262,7 +268,7 @@ describe('drawMinimap smoke test', () => {
     const gfx = new MockGfx();
     const world = makeMinimalWorld({ foodPiles: stubFoodPiles, colonies: stubColonies });
     const vs = createViewState(PLAYER_START_X, PLAYER_START_Y);
-    drawMinimap(gfx, world, vs);
+    drawMinimap(gfx, world, vs, hud);
 
     const fillRects = gfx.callsOf('fillRect');
     // Should have at least: 1 background + 1 food pile + 1 colony + 4 viewport outline = 7
@@ -270,10 +276,10 @@ describe('drawMinimap smoke test', () => {
 
     // First fillRect is the grass background covering the full minimap
     const bg = fillRects[0]!;
-    expect(bg.args[0]).toBe(HUD.MINIMAP.x);
-    expect(bg.args[1]).toBe(HUD.MINIMAP.y);
-    expect(bg.args[2]).toBe(HUD.MINIMAP.w);
-    expect(bg.args[3]).toBe(HUD.MINIMAP.h);
+    expect(bg.args[0]).toBe(hud.MINIMAP.x);
+    expect(bg.args[1]).toBe(hud.MINIMAP.y);
+    expect(bg.args[2]).toBe(hud.MINIMAP.w);
+    expect(bg.args[3]).toBe(hud.MINIMAP.h);
   });
 
   it('MINIMAP_SCALE_X and MINIMAP_SCALE_Y equal 1.25 for 128-tile world', () => {
@@ -293,7 +299,7 @@ describe('drawMinimap smoke test', () => {
 
     const world = makeMinimalWorld({ foodPiles: [], colonies: stubColonies });
     const vs = createViewState(PLAYER_START_X, PLAYER_START_Y);
-    drawMinimap(gfx, world, vs);
+    drawMinimap(gfx, world, vs, hud);
 
     const styles = gfx.callsOf('fillStyle');
     // No black background anywhere.

--- a/src/render/minimap.ts
+++ b/src/render/minimap.ts
@@ -1,21 +1,22 @@
 // minimap.ts — Phase 8 minimap pure draw + click-to-pan helpers.
 //
-// Renders the surface overview (160x160 at HUD.MINIMAP) onto a GfxLike.
+// Renders the surface overview (160x160 at hud.MINIMAP) onto a GfxLike.
 // The minimap always shows the surface view regardless of activeView per PRD §7a.
 //
 // Exports:
-//   drawMinimap(gfx, world, viewState) — called per frame from UIScene.update()
-//   minimapClickToTile(px, py) — converts screen pixel to tile coord, returns null if outside
-//   applyMinimapClick(viewState, px, py) — pan surface camera + X-link underground camera
-//   MINIMAP_SCALE_X, MINIMAP_SCALE_Y — pixel-to-tile scale factors
+//   drawMinimap(gfx, world, viewState, hud) — called per frame from UIScene.update()
+//   minimapClickToTile(px, py, hud) — converts screen pixel to tile coord, returns null if outside
+//   applyMinimapClick(viewState, px, py, hud) — pan surface camera + X-link underground camera
+//   MINIMAP_SCALE_X, MINIMAP_SCALE_Y — default-layout pixel-to-tile scale factors
 
 import {
-  HUD,
   TILE_SIZE_PX,
   COLOR_PLAYER_COLONY,
   COLOR_ENEMY_COLONY,
   COLOR_FOOD_PILE_NORMAL,
 } from './sprites.js';
+import { buildHudLayout, type HudLayout } from './hud-layout.js';
+import { DEFAULT_LAYOUT } from './layout.js';
 import { COLOR_BARREN_EARTH, COLOR_BARREN_EARTH_DARK } from './terrain-atlas.js';
 import {
   SURFACE_GRID_WIDTH,
@@ -38,8 +39,13 @@ import {
 import { clampCameraView, minimapNavTargets, visibleWorldRect } from './camera-adapter.js';
 import type { GfxLike } from './draw-surface.js';
 
-export const MINIMAP_SCALE_X = HUD.MINIMAP.w / SURFACE_GRID_WIDTH; // 160 / 128 = 1.25
-export const MINIMAP_SCALE_Y = HUD.MINIMAP.h / SURFACE_GRID_HEIGHT; // 1.25
+// Exported for tests + external consumers. Derived from the default 800×592
+// layout's minimap rect so they stay byte-identical to the pre-#238 values
+// (160/128 = 1.25). Consumers inside this module derive the scale from the
+// passed `hud` instead so the minimap reflows with the layout.
+const DEFAULT_MINIMAP = buildHudLayout(DEFAULT_LAYOUT).MINIMAP;
+export const MINIMAP_SCALE_X = DEFAULT_MINIMAP.w / SURFACE_GRID_WIDTH; // 160 / 128 = 1.25
+export const MINIMAP_SCALE_Y = DEFAULT_MINIMAP.h / SURFACE_GRID_HEIGHT; // 1.25
 
 // Issue #76 — memorial marker color/size for fully-dead colonies (queen
 // dead AND no live entrances). Distinct dark gray (not a darkened
@@ -53,7 +59,19 @@ function clamp(v: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, v));
 }
 
-export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewState): void {
+export function drawMinimap(
+  gfx: GfxLike,
+  world: WorldState,
+  viewState: ViewState,
+  hud: HudLayout,
+): void {
+  // Scale + anchor derive from the passed layout's minimap rect so the minimap
+  // reflows on resize; at the default 800×592 layout these equal the exported
+  // MINIMAP_SCALE_X/Y (1.25) and the former HUD-table MINIMAP anchor.
+  const mm = hud.MINIMAP;
+  const sx = mm.w / SURFACE_GRID_WIDTH;
+  const sy = mm.h / SURFACE_GRID_HEIGHT;
+
   // Surface terrain (issue #40 reframe — barren-earth-default). Base layer
   // is the warm tan barren-earth color used by the surface render; a sparse
   // darker-earth dapple gives the minimap a textured "ant scale" feel
@@ -65,17 +83,17 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
   // The intent is "you are looking at a faraway ground", not "every blade
   // of grass and pebble visible".
   gfx.fillStyle(COLOR_BARREN_EARTH, 1);
-  gfx.fillRect(HUD.MINIMAP.x, HUD.MINIMAP.y, HUD.MINIMAP.w, HUD.MINIMAP.h);
+  gfx.fillRect(mm.x, mm.y, mm.w, mm.h);
 
   const surface = world.surface;
   if (surface !== undefined) {
     // Sparse darker-earth dapple — ~12% of tiles, deterministic per (tx, ty).
     // Codex P2 fix from PR #41 review (which got squash-merged before this
     // commit landed): each dapple is a 1×1 pixel dot, NOT a `ceil(scale)+1`
-    // sized cell. With MINIMAP_SCALE_X = 1.25, drawing 3×3 cells caused
-    // each dapple to overlap ~2 neighboring cells, so 12% of tiles ended
-    // up covering ~50% of the minimap area — darkening the whole map and
-    // making colony / food markers harder to read.
+    // sized cell. With sx = 1.25, drawing 3×3 cells caused each dapple to
+    // overlap ~2 neighboring cells, so 12% of tiles ended up covering ~50%
+    // of the minimap area — darkening the whole map and making colony /
+    // food markers harder to read.
     gfx.fillStyle(COLOR_BARREN_EARTH_DARK, 0.7);
     const SALT_MINIMAP_DAPPLE = 901;
     for (let ty = 0; ty < surface.height; ty++) {
@@ -88,8 +106,8 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
         if ((h & 0xff) >= 32) continue; // ~12% coverage
         // Floor to integer pixel for crisp rendering — avoids sub-pixel
         // sampling artifacts on Phaser's WebGL pipeline.
-        const px = (HUD.MINIMAP.x + tx * MINIMAP_SCALE_X) | 0;
-        const py = (HUD.MINIMAP.y + ty * MINIMAP_SCALE_Y) | 0;
+        const px = (mm.x + tx * sx) | 0;
+        const py = (mm.y + ty * sy) | 0;
         gfx.fillRect(px, py, 1, 1);
       }
     }
@@ -97,8 +115,8 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
 
   // Food piles (2x2 pixels per pile)
   for (const pile of world.foodPiles) {
-    const px = HUD.MINIMAP.x + pile.tileX * MINIMAP_SCALE_X;
-    const py = HUD.MINIMAP.y + pile.tileY * MINIMAP_SCALE_Y;
+    const px = mm.x + pile.tileX * sx;
+    const py = mm.y + pile.tileY * sy;
     gfx.fillStyle(COLOR_FOOD_PILE_NORMAL, 1);
     gfx.fillRect(px - 1, py - 1, 2, 2);
   }
@@ -159,8 +177,8 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
       halfOffset = 1;
     }
 
-    const px = HUD.MINIMAP.x + tileX * MINIMAP_SCALE_X;
-    const py = HUD.MINIMAP.y + tileY * MINIMAP_SCALE_Y;
+    const px = mm.x + tileX * sx;
+    const py = mm.y + tileY * sy;
     gfx.fillStyle(color, 1);
     gfx.fillRect(px - halfOffset, py - halfOffset, size, size);
   }
@@ -173,15 +191,15 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
   // world window can exceed the world/minimap extent (e.g. at MIN_ZOOM the rect
   // is ~312px wide vs the 160px minimap, and a centered camera pushes its left
   // edge negative), so the unclamped outline would spill outside the 160×160 box
-  // onto neighboring HUD. Clamp each edge to [HUD.MINIMAP.x .. x+w] / [.y .. y+h].
-  const minX = HUD.MINIMAP.x;
-  const maxX = HUD.MINIMAP.x + HUD.MINIMAP.w;
-  const minY = HUD.MINIMAP.y;
-  const maxY = HUD.MINIMAP.y + HUD.MINIMAP.h;
-  const rx = clamp(HUD.MINIMAP.x + (rect.left / TILE_SIZE_PX) * MINIMAP_SCALE_X, minX, maxX);
-  const ry = clamp(HUD.MINIMAP.y + (rect.top / TILE_SIZE_PX) * MINIMAP_SCALE_Y, minY, maxY);
-  const rRight = clamp(HUD.MINIMAP.x + (rect.right / TILE_SIZE_PX) * MINIMAP_SCALE_X, minX, maxX);
-  const rBottom = clamp(HUD.MINIMAP.y + (rect.bottom / TILE_SIZE_PX) * MINIMAP_SCALE_Y, minY, maxY);
+  // onto neighboring HUD zones. Clamp each edge to [mm.x .. x+w] / [.y .. y+h].
+  const minX = mm.x;
+  const maxX = mm.x + mm.w;
+  const minY = mm.y;
+  const maxY = mm.y + mm.h;
+  const rx = clamp(mm.x + (rect.left / TILE_SIZE_PX) * sx, minX, maxX);
+  const ry = clamp(mm.y + (rect.top / TILE_SIZE_PX) * sy, minY, maxY);
+  const rRight = clamp(mm.x + (rect.right / TILE_SIZE_PX) * sx, minX, maxX);
+  const rBottom = clamp(mm.y + (rect.bottom / TILE_SIZE_PX) * sy, minY, maxY);
   const rw = rRight - rx;
   const rh = rBottom - ry;
 
@@ -196,17 +214,26 @@ export function drawMinimap(gfx: GfxLike, world: WorldState, viewState: ViewStat
 export function minimapClickToTile(
   px: number,
   py: number,
+  hud: HudLayout,
 ): { tileX: number; tileY: number } | null {
-  if (px < HUD.MINIMAP.x || px >= HUD.MINIMAP.x + HUD.MINIMAP.w) return null;
-  if (py < HUD.MINIMAP.y || py >= HUD.MINIMAP.y + HUD.MINIMAP.h) return null;
+  const mm = hud.MINIMAP;
+  const sx = mm.w / SURFACE_GRID_WIDTH;
+  const sy = mm.h / SURFACE_GRID_HEIGHT;
+  if (px < mm.x || px >= mm.x + mm.w) return null;
+  if (py < mm.y || py >= mm.y + mm.h) return null;
   return {
-    tileX: (px - HUD.MINIMAP.x) / MINIMAP_SCALE_X,
-    tileY: (py - HUD.MINIMAP.y) / MINIMAP_SCALE_Y,
+    tileX: (px - mm.x) / sx,
+    tileY: (py - mm.y) / sy,
   };
 }
 
-export function applyMinimapClick(viewState: ViewState, px: number, py: number): boolean {
-  const tile = minimapClickToTile(px, py);
+export function applyMinimapClick(
+  viewState: ViewState,
+  px: number,
+  py: number,
+  hud: HudLayout,
+): boolean {
+  const tile = minimapClickToTile(px, py, hud);
   if (!tile) return false;
   // Click tile (fractional) → world px. minimapNavTargets sets the SURFACE center to
   // the click and X-links the underground center while PRESERVING its depth (PLAN

--- a/src/render/sprites.test.ts
+++ b/src/render/sprites.test.ts
@@ -8,7 +8,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   CANVAS_W,
-  HUD,
   lerpColor,
   COLOR_SURFACE_GRASS_PRIMARY,
   COLOR_SURFACE_GRASS_DARK,
@@ -39,6 +38,14 @@ import {
   COLOR_PHEROMONE_DANGER_STRONG,
   COLOR_RALLY_POINT,
 } from './sprites.js';
+import { buildHudLayout } from './hud-layout.js';
+import { DEFAULT_LAYOUT } from './layout.js';
+
+// #238: the HUD anchor table moved to hud-layout.ts. These structural/relational
+// sanity checks now run against buildHudLayout(DEFAULT_LAYOUT); at 800×592 it's
+// byte-identical to the former sprites.ts HUD const (deep-equality-gated in
+// hud-layout.test.ts).
+const hud = buildHudLayout(DEFAULT_LAYOUT);
 
 // ---------------------------------------------------------------------------
 // lerpColor
@@ -85,47 +92,47 @@ describe('HUD zone layout', () => {
     // STATS starts at y=8, h=24 → bottom edge = y+h = 32
     // The plan spec says y+h ≤ 24 as a sanity check that it's at the top region
     // Actual spec: STATS.y = 8, so it's clearly at the top
-    expect(HUD.STATS.y).toBe(8);
-    expect(HUD.STATS.y + HUD.STATS.h).toBeLessThanOrEqual(48); // top zone
+    expect(hud.STATS.y).toBe(8);
+    expect(hud.STATS.y + hud.STATS.h).toBeLessThanOrEqual(48); // top zone
   });
 
   it('MINIMAP is on the right side (x=632 ≥ CANVAS_W/2)', () => {
-    expect(HUD.MINIMAP.x).toBeGreaterThanOrEqual(CANVAS_W / 2);
+    expect(hud.MINIMAP.x).toBeGreaterThanOrEqual(CANVAS_W / 2);
   });
 
   it('TRIANGLE is on the left side (x + w ≤ 128)', () => {
-    expect(HUD.TRIANGLE.x + HUD.TRIANGLE.w).toBeLessThanOrEqual(128);
+    expect(hud.TRIANGLE.x + hud.TRIANGLE.w).toBeLessThanOrEqual(128);
   });
 
   it('HUD zone exact coordinates match PRD §6b', () => {
-    expect(HUD.STATS).toMatchObject({ x: 8, y: 8, w: 200, h: 24 });
+    expect(hud.STATS).toMatchObject({ x: 8, y: 8, w: 200, h: 24 });
     // Phase 10 / issue #13 follow-up: TRIANGLE shrunk from 120×120 to 120×44
     // when the widget collapsed from a 3-vertex triangle to a 1-D slider.
     // Bottom edge (y + h = 576) is unchanged so neighbouring HUD zones'
     // pixel anchors are undisturbed.
-    expect(HUD.TRIANGLE).toMatchObject({ x: 8, y: 532, w: 120, h: 44 });
-    expect(HUD.MINIMAP).toMatchObject({ x: 632, y: 424, w: 160, h: 160 });
-    expect(HUD.VIEW_TOGGLE).toMatchObject({ x: 632, y: 396, w: 80, h: 24 });
+    expect(hud.TRIANGLE).toMatchObject({ x: 8, y: 532, w: 120, h: 44 });
+    expect(hud.MINIMAP).toMatchObject({ x: 632, y: 424, w: 160, h: 160 });
+    expect(hud.VIEW_TOGGLE).toMatchObject({ x: 632, y: 396, w: 80, h: 24 });
     // Issue #14: colony-toggle button stacked just above VIEW_TOGGLE.
-    expect(HUD.UNDERGROUND_COLONY_TOGGLE).toMatchObject({ x: 632, y: 372, w: 112, h: 22 });
-    expect(HUD.SPEED).toMatchObject({ x: 320, y: 552, w: 160, h: 32 });
-    expect(HUD.SAVE_ICON).toMatchObject({ x: 772, y: 8, w: 20, h: 20 });
+    expect(hud.UNDERGROUND_COLONY_TOGGLE).toMatchObject({ x: 632, y: 372, w: 112, h: 22 });
+    expect(hud.SPEED).toMatchObject({ x: 320, y: 552, w: 160, h: 32 });
+    expect(hud.SAVE_ICON).toMatchObject({ x: 772, y: 8, w: 20, h: 20 });
   });
 
   it('STATS and TRIANGLE do not overlap vertically', () => {
-    const statsBottom = HUD.STATS.y + HUD.STATS.h;
-    expect(statsBottom).toBeLessThanOrEqual(HUD.TRIANGLE.y);
+    const statsBottom = hud.STATS.y + hud.STATS.h;
+    expect(statsBottom).toBeLessThanOrEqual(hud.TRIANGLE.y);
   });
 
   it('VIEW_TOGGLE is directly above MINIMAP', () => {
-    expect(HUD.VIEW_TOGGLE.x).toBe(HUD.MINIMAP.x);
-    expect(HUD.VIEW_TOGGLE.y + HUD.VIEW_TOGGLE.h).toBeLessThanOrEqual(HUD.MINIMAP.y);
+    expect(hud.VIEW_TOGGLE.x).toBe(hud.MINIMAP.x);
+    expect(hud.VIEW_TOGGLE.y + hud.VIEW_TOGGLE.h).toBeLessThanOrEqual(hud.MINIMAP.y);
   });
 
   it('UNDERGROUND_COLONY_TOGGLE sits directly above VIEW_TOGGLE without overlap (issue #14)', () => {
-    expect(HUD.UNDERGROUND_COLONY_TOGGLE.x).toBe(HUD.VIEW_TOGGLE.x);
-    expect(HUD.UNDERGROUND_COLONY_TOGGLE.y + HUD.UNDERGROUND_COLONY_TOGGLE.h).toBeLessThanOrEqual(
-      HUD.VIEW_TOGGLE.y,
+    expect(hud.UNDERGROUND_COLONY_TOGGLE.x).toBe(hud.VIEW_TOGGLE.x);
+    expect(hud.UNDERGROUND_COLONY_TOGGLE.y + hud.UNDERGROUND_COLONY_TOGGLE.h).toBeLessThanOrEqual(
+      hud.VIEW_TOGGLE.y,
     );
   });
 });

--- a/src/render/sprites.ts
+++ b/src/render/sprites.ts
@@ -1,7 +1,7 @@
-// sprites.ts — Phase 8 render-layer color palette, canvas dimensions, HUD zone layout, and color utilities.
+// sprites.ts — Phase 8 render-layer color palette, canvas dimensions, and color utilities.
 //
-// Source: PRD §7g (03-PRD-world-interaction.md) for color constants,
-//         PRD §6b (04-PRD-playable-game-loop.md) for HUD zone layout.
+// Source: PRD §7g (03-PRD-world-interaction.md) for color constants.
+// (The HUD anchor table moved to hud-layout.ts — #238; buildHudLayout(layout).)
 //
 // This file is in src/render/ — ESLint simSafetyConfig does NOT apply here.
 // Float arithmetic is permitted in the render layer per ARCHITECTURE.md Principle 6.
@@ -130,83 +130,6 @@ export const COLOR_PHEROMONE_DANGER_FAINT = 0x400000;
 
 /** PRD §7g — Danger-trail pheromone (high intensity) color. */
 export const COLOR_PHEROMONE_DANGER_STRONG = 0xff4000;
-
-// ---------------------------------------------------------------------------
-// HUD zone layout — PRD §6b normative pixel coordinates for 800×592 canvas
-// ---------------------------------------------------------------------------
-
-/**
- * HUD zone rectangles.
- *
- * All coordinates are screen pixels for the 800×592 canvas.
- *
- * SPEED and SAVE_ICON are Phase 9 layout reservations — coordinates are defined here
- * so Phase 9 has stable pixel targets, but Phase 8 draws NOTHING in these zones.
- *
- * Source: PRD §6b (04-PRD-playable-game-loop.md)
- */
-export const HUD = {
-  /** Colony stats bar: ant count, food stored, queen health. */
-  STATS: { x: 8, y: 8, w: 200, h: 24 },
-  /**
-   * Behavior allocation slider widget. Field name retained from the Phase 8
-   * 3-vertex triangle to minimize diff churn; Phase 10 / D-01 collapsed the
-   * widget to a 1-D Forage↔Fight slider, so the box no longer needs to be a
-   * 120×120 square. Issue #13 follow-up: shrunk to 120×44 to hug the slider
-   * track + extreme-icon labels and avoid the unsightly empty square that
-   * the original triangle bounding box left behind.
-   *
-   * Geometry is sized to keep `trackY = y + h/2` valid given the 22px label
-   * gap (`trackY - 22 == y` ⇒ labels render flush with the box top edge).
-   * h must stay ≥ 44 for that invariant to hold without re-deriving the
-   * track formula. Bottom edge (y + h = 576) is unchanged from the prior
-   * 120×120 layout so HUD-anchor pixel positions of neighboring zones are
-   * not disturbed.
-   */
-  TRIANGLE: { x: 8, y: 532, w: 120, h: 44 },
-  /**
-   * Speed controls zone.
-   * Phase 9 layout reservation — Phase 8 draws nothing here.
-   * Phase 9 wires 1×/2×/4× speed buttons and pause button.
-   */
-  SPEED: { x: 320, y: 552, w: 160, h: 32, PAUSE_BUTTON_W: 40, SPEED_BUTTON_W: 32 },
-  /**
-   * Stage 1 controls rework (issue #18) — tool palette (Command/Dig/Chamber).
-   * Top-right band, clear of STATS (top-left), the ant-activity panel
-   * (8,36,220,264), SAVE_ICON (772,8), and the y≥372 toggles/minimap. Three
-   * 40×40 buttons at x = 632 / 676 / 720 (BUTTON_W 40, GAP 4).
-   */
-  TOOLS: { x: 632, y: 36, w: 128, h: 40, BUTTON_W: 40, GAP: 4 },
-  /**
-   * Stage 1 controls rework (issue #18) — context hint strip (static per-tool/
-   * per-view legend). Lower band: above TRIANGLE/SPEED (y≥532), left of MINIMAP
-   * (x≥632), below the ant-activity panel (y≤300).
-   */
-  HINTS: { x: 8, y: 508, w: 616, h: 18 },
-  /** Minimap: full surface overview with colony positions and food sources. */
-  MINIMAP: { x: 632, y: 424, w: 160, h: 160 },
-  /** View toggle button: switches between surface and underground views. */
-  VIEW_TOGGLE: { x: 632, y: 396, w: 80, h: 24 },
-  /**
-   * Issue #14 — colony toggle button (underground view only). Flips the
-   * underground render between PLAYER and ENEMY grids; equivalent to the
-   * X keybind. Visible only while activeView === 'underground'. Sits just
-   * above VIEW_TOGGLE so the underground HUD chrome stacks vertically.
-   *
-   * Width 112 fits "Enemy Colony (X)" at fontSize 12 with breathing room
-   * (~6 px/char × 16 chars + 8 px padding ≈ 104 px). 100 px was the
-   * original sizing and clipped right against the rightmost glyph; 112
-   * gives a comfortable margin without crowding the canvas-right edge
-   * (canvas width 800; toggle right edge 744 leaves 56 px for SAVE_ICON).
-   */
-  UNDERGROUND_COLONY_TOGGLE: { x: 632, y: 372, w: 112, h: 22 },
-  /**
-   * Save icon zone.
-   * Phase 9 layout reservation — Phase 8 draws nothing here.
-   * Phase 9 wires autosave indicator rendering.
-   */
-  SAVE_ICON: { x: 772, y: 8, w: 20, h: 20 },
-} as const;
 
 // ---------------------------------------------------------------------------
 // Color interpolation utility

--- a/src/render/tooltips.test.ts
+++ b/src/render/tooltips.test.ts
@@ -2,7 +2,6 @@
 // Chamber-on-surface) and ≤150-char copy.
 
 import { describe, it, expect } from 'vitest';
-import { HUD } from './sprites.js';
 import { toolButtonRect, speedControlRect } from './hud-controls.js';
 import {
   tooltipTargetAt,
@@ -10,6 +9,12 @@ import {
   sameTooltipTarget,
   type TooltipTarget,
 } from './tooltips.js';
+import { buildHudLayout } from './hud-layout.js';
+import { DEFAULT_LAYOUT } from './layout.js';
+
+// #238: tooltips.ts + hud-controls.ts now take the built HUD layout / its rects;
+// at the default 800×592 layout hud.* == the former HUD table.
+const hud = buildHudLayout(DEFAULT_LAYOUT);
 
 const center = (r: { x: number; y: number; w: number; h: number }) => ({
   x: r.x + r.w / 2,
@@ -17,73 +22,76 @@ const center = (r: { x: number; y: number; w: number; h: number }) => ({
 });
 
 describe('tooltipTargetAt', () => {
-  it('hits HUD.STATS', () => {
-    const c = center(HUD.STATS);
-    expect(tooltipTargetAt(c.x, c.y, 'surface')?.kind).toBe('stats');
+  it('hits the stats bar', () => {
+    const c = center(hud.STATS);
+    expect(tooltipTargetAt(c.x, c.y, 'surface', hud)?.kind).toBe('stats');
   });
 
   it('hits the view toggle', () => {
-    const c = center(HUD.VIEW_TOGGLE);
-    expect(tooltipTargetAt(c.x, c.y, 'surface')?.kind).toBe('view-toggle');
+    const c = center(hud.VIEW_TOGGLE);
+    expect(tooltipTargetAt(c.x, c.y, 'surface', hud)?.kind).toBe('view-toggle');
   });
 
   it('hits the colony toggle ONLY on the underground view', () => {
-    const c = center(HUD.UNDERGROUND_COLONY_TOGGLE);
-    expect(tooltipTargetAt(c.x, c.y, 'underground')?.kind).toBe('colony-toggle');
+    const c = center(hud.UNDERGROUND_COLONY_TOGGLE);
+    expect(tooltipTargetAt(c.x, c.y, 'underground', hud)?.kind).toBe('colony-toggle');
     // On the surface the toggle isn't rendered, so its rect is not a tooltip
     // target (and nothing else lives there).
-    expect(tooltipTargetAt(c.x, c.y, 'surface')).toBeNull();
+    expect(tooltipTargetAt(c.x, c.y, 'surface', hud)).toBeNull();
   });
 
   it('hits an enabled tool button', () => {
-    const c = center(toolButtonRect(1)); // Dig
-    const t = tooltipTargetAt(c.x, c.y, 'underground');
-    expect(t).toEqual({ kind: 'tool', tool: 'dig', enabled: true, anchor: HUD.TOOLS });
+    const c = center(toolButtonRect(1, hud.TOOLS)); // Dig
+    const t = tooltipTargetAt(c.x, c.y, 'underground', hud);
+    expect(t).toEqual({ kind: 'tool', tool: 'dig', enabled: true, anchor: hud.TOOLS });
   });
 
   it('STILL hits the DISABLED Chamber button on the surface (enabled:false)', () => {
-    const c = center(toolButtonRect(2)); // Chamber
-    const t = tooltipTargetAt(c.x, c.y, 'surface');
-    expect(t).toEqual({ kind: 'tool', tool: 'chamber', enabled: false, anchor: HUD.TOOLS });
+    const c = center(toolButtonRect(2, hud.TOOLS)); // Chamber
+    const t = tooltipTargetAt(c.x, c.y, 'surface', hud);
+    expect(t).toEqual({ kind: 'tool', tool: 'chamber', enabled: false, anchor: hud.TOOLS });
     // …and it's enabled underground.
-    const u = tooltipTargetAt(c.x, c.y, 'underground');
+    const u = tooltipTargetAt(c.x, c.y, 'underground', hud);
     expect(u).toMatchObject({ kind: 'tool', tool: 'chamber', enabled: true });
   });
 
   it('hits the speed widget (pause + a preset)', () => {
-    const pause = center(speedControlRect(0));
-    expect(tooltipTargetAt(pause.x, pause.y, 'surface')).toMatchObject({
+    const pause = center(speedControlRect(0, hud.SPEED));
+    expect(tooltipTargetAt(pause.x, pause.y, 'surface', hud)).toMatchObject({
       kind: 'speed',
       control: 'pause',
     });
-    const two = center(speedControlRect(2)); // 2×
-    expect(tooltipTargetAt(two.x, two.y, 'surface')).toMatchObject({ kind: 'speed', control: 2 });
+    const two = center(speedControlRect(2, hud.SPEED)); // 2×
+    expect(tooltipTargetAt(two.x, two.y, 'surface', hud)).toMatchObject({
+      kind: 'speed',
+      control: 2,
+    });
   });
 
   it('hits the Forage↔Fight slider', () => {
-    const c = center(HUD.TRIANGLE);
-    expect(tooltipTargetAt(c.x, c.y, 'surface')?.kind).toBe('slider');
+    const c = center(hud.TRIANGLE);
+    expect(tooltipTargetAt(c.x, c.y, 'surface', hud)?.kind).toBe('slider');
   });
 
   it('returns null over open world / the minimap (excluded)', () => {
-    expect(tooltipTargetAt(400, 300, 'surface')).toBeNull();
-    const m = center(HUD.MINIMAP);
-    expect(tooltipTargetAt(m.x, m.y, 'underground')).toBeNull();
+    expect(tooltipTargetAt(400, 300, 'surface', hud)).toBeNull();
+    const m = center(hud.MINIMAP);
+    expect(tooltipTargetAt(m.x, m.y, 'underground', hud)).toBeNull();
   });
 });
 
 describe('tooltipTextFor', () => {
   const all: TooltipTarget[] = [
-    { kind: 'tool', tool: 'command', enabled: true, anchor: HUD.TOOLS },
-    { kind: 'tool', tool: 'dig', enabled: true, anchor: HUD.TOOLS },
-    { kind: 'tool', tool: 'chamber', enabled: true, anchor: HUD.TOOLS },
-    { kind: 'tool', tool: 'chamber', enabled: false, anchor: HUD.TOOLS },
-    { kind: 'speed', control: 'pause', anchor: HUD.SPEED },
-    { kind: 'speed', control: 2, anchor: HUD.SPEED },
-    { kind: 'view-toggle', anchor: HUD.VIEW_TOGGLE },
-    { kind: 'colony-toggle', anchor: HUD.UNDERGROUND_COLONY_TOGGLE },
-    { kind: 'slider', anchor: HUD.TRIANGLE },
-    { kind: 'stats', anchor: HUD.STATS },
+    { kind: 'tool', tool: 'command', enabled: true, anchor: hud.TOOLS },
+    { kind: 'tool', tool: 'dig', enabled: true, anchor: hud.TOOLS },
+    { kind: 'tool', tool: 'chamber', enabled: true, anchor: hud.TOOLS },
+    { kind: 'tool', tool: 'chamber', enabled: false, anchor: hud.TOOLS },
+    { kind: 'speed', control: 'pause', anchor: hud.SPEED },
+    { kind: 'speed', control: 2, anchor: hud.SPEED },
+    { kind: 'view-toggle', anchor: hud.VIEW_TOGGLE },
+    { kind: 'colony-toggle', anchor: hud.UNDERGROUND_COLONY_TOGGLE },
+    { kind: 'slider', anchor: hud.TRIANGLE },
+    { kind: 'stats', anchor: hud.STATS },
   ];
 
   it('every tooltip is non-empty and ≤150 chars', () => {
@@ -96,32 +104,32 @@ describe('tooltipTextFor', () => {
 
   it('the disabled Chamber explains WHY it is inert', () => {
     expect(
-      tooltipTextFor({ kind: 'tool', tool: 'chamber', enabled: false, anchor: HUD.TOOLS }),
+      tooltipTextFor({ kind: 'tool', tool: 'chamber', enabled: false, anchor: hud.TOOLS }),
     ).toBe('Chamber — underground only');
   });
 
   it('STATS teaches the non-obvious ant-activity click', () => {
-    expect(tooltipTextFor({ kind: 'stats', anchor: HUD.STATS }).toLowerCase()).toContain(
+    expect(tooltipTextFor({ kind: 'stats', anchor: hud.STATS }).toLowerCase()).toContain(
       'ant-activity',
     );
   });
 
   it('includes the keyboard glyph where a key exists', () => {
-    expect(tooltipTextFor({ kind: 'view-toggle', anchor: HUD.VIEW_TOGGLE })).toContain('[Tab]');
+    expect(tooltipTextFor({ kind: 'view-toggle', anchor: hud.VIEW_TOGGLE })).toContain('[Tab]');
   });
 });
 
 describe('sameTooltipTarget', () => {
   it('distinguishes different tools and matches same tool', () => {
-    const dig: TooltipTarget = { kind: 'tool', tool: 'dig', enabled: true, anchor: HUD.TOOLS };
-    const dig2: TooltipTarget = { kind: 'tool', tool: 'dig', enabled: true, anchor: HUD.TOOLS };
-    const cmd: TooltipTarget = { kind: 'tool', tool: 'command', enabled: true, anchor: HUD.TOOLS };
+    const dig: TooltipTarget = { kind: 'tool', tool: 'dig', enabled: true, anchor: hud.TOOLS };
+    const dig2: TooltipTarget = { kind: 'tool', tool: 'dig', enabled: true, anchor: hud.TOOLS };
+    const cmd: TooltipTarget = { kind: 'tool', tool: 'command', enabled: true, anchor: hud.TOOLS };
     expect(sameTooltipTarget(dig, dig2)).toBe(true);
     expect(sameTooltipTarget(dig, cmd)).toBe(false);
   });
 
   it('null handling', () => {
     expect(sameTooltipTarget(null, null)).toBe(true);
-    expect(sameTooltipTarget(null, { kind: 'stats', anchor: HUD.STATS })).toBe(false);
+    expect(sameTooltipTarget(null, { kind: 'stats', anchor: hud.STATS })).toBe(false);
   });
 });

--- a/src/render/tooltips.ts
+++ b/src/render/tooltips.ts
@@ -2,9 +2,9 @@
 //
 // Pure hit-test + copy for on-hover tooltips over the HUD CONTROL widgets: the
 // tool palette, speed widget, view toggle, colony toggle, the Forage↔Fight
-// slider, and HUD.STATS (whose tooltip teaches the non-obvious "click for ant
-// activity"). EXCLUDED: the minimap (hover vs click-nav ambiguity) and the
-// ant-activity panel popup (Codex R1#6/R2).
+// slider, and the stats bar (hud.STATS, whose tooltip teaches the non-obvious
+// "click for ant activity"). EXCLUDED: the minimap (hover vs click-nav
+// ambiguity) and the ant-activity panel popup (Codex R1#6/R2).
 //
 // Phaser-free: UIScene owns the hover-state machine, the delay timers, the
 // modal/teardown lifecycle, and the Text object; this module owns only the
@@ -12,8 +12,8 @@
 // so it is unit-testable. The tool hit-test uses toolButtonVisualAt so the
 // DISABLED Chamber-on-surface still tooltips (Codex R1#7).
 
-import { HUD } from './sprites.js';
 import type { ToolId } from './camera.js';
+import type { HudLayout } from './hud-layout.js';
 import { toolButtonVisualAt, speedControlAt, type SpeedControl } from './hud-controls.js';
 import { isInsideSlider } from './triangle-widget.js';
 import { glyphFor } from './input-glyphs.js';
@@ -50,20 +50,21 @@ export function tooltipTargetAt(
   px: number,
   py: number,
   view: 'surface' | 'underground',
+  hud: HudLayout,
 ): TooltipTarget | null {
-  if (inRect(px, py, HUD.STATS)) return { kind: 'stats', anchor: HUD.STATS };
-  if (inRect(px, py, HUD.VIEW_TOGGLE)) return { kind: 'view-toggle', anchor: HUD.VIEW_TOGGLE };
-  if (view === 'underground' && inRect(px, py, HUD.UNDERGROUND_COLONY_TOGGLE)) {
-    return { kind: 'colony-toggle', anchor: HUD.UNDERGROUND_COLONY_TOGGLE };
+  if (inRect(px, py, hud.STATS)) return { kind: 'stats', anchor: hud.STATS };
+  if (inRect(px, py, hud.VIEW_TOGGLE)) return { kind: 'view-toggle', anchor: hud.VIEW_TOGGLE };
+  if (view === 'underground' && inRect(px, py, hud.UNDERGROUND_COLONY_TOGGLE)) {
+    return { kind: 'colony-toggle', anchor: hud.UNDERGROUND_COLONY_TOGGLE };
   }
-  const toolHit = toolButtonVisualAt(px, py, view);
+  const toolHit = toolButtonVisualAt(px, py, view, hud.TOOLS);
   if (toolHit !== null) {
-    return { kind: 'tool', tool: toolHit.tool, enabled: toolHit.enabled, anchor: HUD.TOOLS };
+    return { kind: 'tool', tool: toolHit.tool, enabled: toolHit.enabled, anchor: hud.TOOLS };
   }
-  const speedHit = speedControlAt(px, py);
-  if (speedHit !== null) return { kind: 'speed', control: speedHit, anchor: HUD.SPEED };
-  // The slider lives inside the HUD.TRIANGLE box (legacy field name).
-  if (isInsideSlider(px, py)) return { kind: 'slider', anchor: HUD.TRIANGLE };
+  const speedHit = speedControlAt(px, py, hud.SPEED);
+  if (speedHit !== null) return { kind: 'speed', control: speedHit, anchor: hud.SPEED };
+  // The slider lives inside the hud.TRIANGLE box (legacy field name).
+  if (isInsideSlider(px, py, hud.TRIANGLE)) return { kind: 'slider', anchor: hud.TRIANGLE };
   return null;
 }
 

--- a/src/render/triangle-widget.test.ts
+++ b/src/render/triangle-widget.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-  SLIDER_GEOMETRY,
+  sliderGeometry,
   screenToSliderRatio,
   ratioToSliderPos,
   isInsideSlider,
@@ -17,7 +17,16 @@ import {
   createSliderDragState,
 } from './triangle-widget.js';
 import type { GfxLike } from './draw-surface.js';
-import { HUD, COLOR_PLAYER_COLONY } from './sprites.js';
+import { COLOR_PLAYER_COLONY } from './sprites.js';
+import { buildHudLayout } from './hud-layout.js';
+import { DEFAULT_LAYOUT } from './layout.js';
+
+// #238: triangle-widget.ts now takes the slider-zone rect (the hud.TRIANGLE box)
+// as a parameter. At the default 800×592 layout `tri` == the former HUD-table TRIANGLE
+// and `SG` == the former SLIDER_GEOMETRY constant, so these tests stay
+// byte-identical.
+const tri = buildHudLayout(DEFAULT_LAYOUT).TRIANGLE;
+const SG = sliderGeometry(tri);
 
 // ---------------------------------------------------------------------------
 // MockGfx — spy recorder implementing GfxLike (matches draw-surface.test.ts pattern)
@@ -66,28 +75,28 @@ class MockGfx implements GfxLike {
 }
 
 // ---------------------------------------------------------------------------
-// SLIDER_GEOMETRY sanity (locked to HUD.TRIANGLE — single source of truth)
+// sliderGeometry sanity (locked to the hud.TRIANGLE rect — single source of truth)
 // ---------------------------------------------------------------------------
 
-describe('SLIDER_GEOMETRY', () => {
-  it('trackLeft = HUD.TRIANGLE.x + 16', () => {
-    expect(SLIDER_GEOMETRY.trackLeft).toBe(HUD.TRIANGLE.x + 16);
+describe('sliderGeometry', () => {
+  it('trackLeft = tri.x + 16', () => {
+    expect(SG.trackLeft).toBe(tri.x + 16);
   });
 
-  it('trackRight = HUD.TRIANGLE.x + HUD.TRIANGLE.w - 16', () => {
-    expect(SLIDER_GEOMETRY.trackRight).toBe(HUD.TRIANGLE.x + HUD.TRIANGLE.w - 16);
+  it('trackRight = tri.x + tri.w - 16', () => {
+    expect(SG.trackRight).toBe(tri.x + tri.w - 16);
   });
 
-  it('trackY at the vertical midpoint of HUD.TRIANGLE', () => {
-    expect(SLIDER_GEOMETRY.trackY).toBe(HUD.TRIANGLE.y + HUD.TRIANGLE.h / 2);
+  it('trackY at the vertical midpoint of tri', () => {
+    expect(SG.trackY).toBe(tri.y + tri.h / 2);
   });
 
   it('trackLen = trackRight - trackLeft', () => {
-    expect(SLIDER_GEOMETRY.trackLen).toBe(SLIDER_GEOMETRY.trackRight - SLIDER_GEOMETRY.trackLeft);
+    expect(SG.trackLen).toBe(SG.trackRight - SG.trackLeft);
   });
 
   it('trackLen is positive (geometry sane)', () => {
-    expect(SLIDER_GEOMETRY.trackLen).toBeGreaterThan(0);
+    expect(SG.trackLen).toBeGreaterThan(0);
   });
 });
 
@@ -97,43 +106,43 @@ describe('SLIDER_GEOMETRY', () => {
 
 describe('screenToSliderRatio — extremes', () => {
   it('left edge of track returns full forage', () => {
-    expect(screenToSliderRatio(SLIDER_GEOMETRY.trackLeft)).toEqual({ forage: 10, fight: 0 });
+    expect(screenToSliderRatio(SG.trackLeft, tri)).toEqual({ forage: 10, fight: 0 });
   });
 
   it('right edge of track returns full fight', () => {
-    expect(screenToSliderRatio(SLIDER_GEOMETRY.trackRight)).toEqual({ forage: 0, fight: 10 });
+    expect(screenToSliderRatio(SG.trackRight, tri)).toEqual({ forage: 0, fight: 10 });
   });
 
   it('exact center returns balanced 5/5', () => {
-    const center = (SLIDER_GEOMETRY.trackLeft + SLIDER_GEOMETRY.trackRight) / 2;
-    expect(screenToSliderRatio(center)).toEqual({ forage: 5, fight: 5 });
+    const center = (SG.trackLeft + SG.trackRight) / 2;
+    expect(screenToSliderRatio(center, tri)).toEqual({ forage: 5, fight: 5 });
   });
 });
 
 describe('screenToSliderRatio — clamping', () => {
   it('px far left of track clamps to forage:10', () => {
-    expect(screenToSliderRatio(SLIDER_GEOMETRY.trackLeft - 100)).toEqual({ forage: 10, fight: 0 });
+    expect(screenToSliderRatio(SG.trackLeft - 100, tri)).toEqual({ forage: 10, fight: 0 });
   });
 
   it('px far right of track clamps to fight:10', () => {
-    expect(screenToSliderRatio(SLIDER_GEOMETRY.trackRight + 100)).toEqual({ forage: 0, fight: 10 });
+    expect(screenToSliderRatio(SG.trackRight + 100, tri)).toEqual({ forage: 0, fight: 10 });
   });
 
   it('px = 0 (canvas left edge) clamps to forage:10', () => {
-    expect(screenToSliderRatio(0)).toEqual({ forage: 10, fight: 0 });
+    expect(screenToSliderRatio(0, tri)).toEqual({ forage: 10, fight: 0 });
   });
 
   it('px = 1000 (canvas-right-extreme) clamps to fight:10', () => {
-    expect(screenToSliderRatio(1000)).toEqual({ forage: 0, fight: 10 });
+    expect(screenToSliderRatio(1000, tri)).toEqual({ forage: 0, fight: 10 });
   });
 });
 
 describe('screenToSliderRatio — sum invariant', () => {
   // Cover all 11 discrete steps along the track.
   for (let step = 0; step <= 10; step++) {
-    const px = SLIDER_GEOMETRY.trackLeft + (step / 10) * SLIDER_GEOMETRY.trackLen;
+    const px = SG.trackLeft + (step / 10) * SG.trackLen;
     it(`step ${step}: forage + fight === 10 at px=${px}`, () => {
-      const r = screenToSliderRatio(px);
+      const r = screenToSliderRatio(px, tri);
       expect(r.forage + r.fight).toBe(10);
       expect(r.forage).toBeGreaterThanOrEqual(0);
       expect(r.fight).toBeGreaterThanOrEqual(0);
@@ -147,27 +156,27 @@ describe('screenToSliderRatio — sum invariant', () => {
 
 describe('ratioToSliderPos — extremes', () => {
   it('forage=10, fight=0 returns track-left x', () => {
-    const pos = ratioToSliderPos({ forage: 10, fight: 0 });
-    expect(pos.x).toBe(SLIDER_GEOMETRY.trackLeft);
-    expect(pos.y).toBe(SLIDER_GEOMETRY.trackY);
+    const pos = ratioToSliderPos({ forage: 10, fight: 0 }, tri);
+    expect(pos.x).toBe(SG.trackLeft);
+    expect(pos.y).toBe(SG.trackY);
   });
 
   it('forage=0, fight=10 returns track-right x', () => {
-    const pos = ratioToSliderPos({ forage: 0, fight: 10 });
-    expect(pos.x).toBe(SLIDER_GEOMETRY.trackRight);
-    expect(pos.y).toBe(SLIDER_GEOMETRY.trackY);
+    const pos = ratioToSliderPos({ forage: 0, fight: 10 }, tri);
+    expect(pos.x).toBe(SG.trackRight);
+    expect(pos.y).toBe(SG.trackY);
   });
 
   it('forage=5, fight=5 returns track midpoint', () => {
-    const pos = ratioToSliderPos({ forage: 5, fight: 5 });
-    expect(pos.x).toBe(SLIDER_GEOMETRY.trackLeft + SLIDER_GEOMETRY.trackLen / 2);
-    expect(pos.y).toBe(SLIDER_GEOMETRY.trackY);
+    const pos = ratioToSliderPos({ forage: 5, fight: 5 }, tri);
+    expect(pos.x).toBe(SG.trackLeft + SG.trackLen / 2);
+    expect(pos.y).toBe(SG.trackY);
   });
 
   it('forage=0, fight=0 (degenerate) pins to track center', () => {
-    const pos = ratioToSliderPos({ forage: 0, fight: 0 });
-    expect(pos.x).toBe(SLIDER_GEOMETRY.trackLeft + SLIDER_GEOMETRY.trackLen / 2);
-    expect(pos.y).toBe(SLIDER_GEOMETRY.trackY);
+    const pos = ratioToSliderPos({ forage: 0, fight: 0 }, tri);
+    expect(pos.x).toBe(SG.trackLeft + SG.trackLen / 2);
+    expect(pos.y).toBe(SG.trackY);
   });
 });
 
@@ -177,10 +186,10 @@ describe('ratioToSliderPos — extremes', () => {
 
 describe('round-trip: pixel → ratio → pixel snaps to nearest step', () => {
   it('all integer px in [trackLeft, trackRight] round-trip within ½ step (~4.4px)', () => {
-    const stepPx = SLIDER_GEOMETRY.trackLen / 10;
-    for (let px = SLIDER_GEOMETRY.trackLeft; px <= SLIDER_GEOMETRY.trackRight; px++) {
-      const r = screenToSliderRatio(px);
-      const back = ratioToSliderPos(r);
+    const stepPx = SG.trackLen / 10;
+    for (let px = SG.trackLeft; px <= SG.trackRight; px++) {
+      const r = screenToSliderRatio(px, tri);
+      const back = ratioToSliderPos(r, tri);
       // After Math.round in screenToSliderRatio, px snaps to its nearest discrete
       // step pixel. Tolerance is half-a-step + 1 (rounding slack).
       expect(Math.abs(back.x - px)).toBeLessThanOrEqual(stepPx / 2 + 1);
@@ -189,36 +198,36 @@ describe('round-trip: pixel → ratio → pixel snaps to nearest step', () => {
 });
 
 // ---------------------------------------------------------------------------
-// isInsideSlider — hit-test against HUD.TRIANGLE zone
+// isInsideSlider — hit-test against the hud.TRIANGLE zone
 // ---------------------------------------------------------------------------
 
 describe('isInsideSlider', () => {
-  it('returns true for a point inside HUD.TRIANGLE', () => {
-    expect(isInsideSlider(HUD.TRIANGLE.x + 10, HUD.TRIANGLE.y + 10)).toBe(true);
+  it('returns true for a point inside tri', () => {
+    expect(isInsideSlider(tri.x + 10, tri.y + 10, tri)).toBe(true);
   });
 
   it('returns true for the track centerline', () => {
-    expect(isInsideSlider(SLIDER_GEOMETRY.trackLeft + 1, SLIDER_GEOMETRY.trackY)).toBe(true);
+    expect(isInsideSlider(SG.trackLeft + 1, SG.trackY, tri)).toBe(true);
   });
 
   it('returns false for a point left of the zone', () => {
-    expect(isInsideSlider(HUD.TRIANGLE.x - 1, HUD.TRIANGLE.y + 10)).toBe(false);
+    expect(isInsideSlider(tri.x - 1, tri.y + 10, tri)).toBe(false);
   });
 
   it('returns false for a point above the zone', () => {
-    expect(isInsideSlider(HUD.TRIANGLE.x + 10, HUD.TRIANGLE.y - 1)).toBe(false);
+    expect(isInsideSlider(tri.x + 10, tri.y - 1, tri)).toBe(false);
   });
 
   it('returns false for a point right of the zone', () => {
-    expect(isInsideSlider(HUD.TRIANGLE.x + HUD.TRIANGLE.w, HUD.TRIANGLE.y + 10)).toBe(false);
+    expect(isInsideSlider(tri.x + tri.w, tri.y + 10, tri)).toBe(false);
   });
 
   it('returns false for a point below the zone', () => {
-    expect(isInsideSlider(HUD.TRIANGLE.x + 10, HUD.TRIANGLE.y + HUD.TRIANGLE.h)).toBe(false);
+    expect(isInsideSlider(tri.x + 10, tri.y + tri.h, tri)).toBe(false);
   });
 
   it('top-left corner is inside (inclusive)', () => {
-    expect(isInsideSlider(HUD.TRIANGLE.x, HUD.TRIANGLE.y)).toBe(true);
+    expect(isInsideSlider(tri.x, tri.y, tri)).toBe(true);
   });
 });
 
@@ -229,7 +238,7 @@ describe('isInsideSlider', () => {
 describe('drawSlider', () => {
   it('emits exactly the expected GfxLike methods (no Image / Sprite calls)', () => {
     const gfx = new MockGfx();
-    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 10, fight: 0 });
+    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 10, fight: 0 }, tri);
     const allowedMethods = new Set([
       'fillStyle',
       'lineStyle',
@@ -244,7 +253,7 @@ describe('drawSlider', () => {
 
   it('emits ≥ 8 GfxLike calls (background + track + 2 icons + 2 markers + style)', () => {
     const gfx = new MockGfx();
-    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 10, fight: 0 });
+    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 10, fight: 0 }, tri);
     // 4× fillRect (zone bg, track, forage icon, fight icon)
     // 1× fillCircle (current marker)
     // 1× strokeCircle (target marker)
@@ -254,37 +263,32 @@ describe('drawSlider', () => {
 
   it('emits exactly four fillRect calls (background, track, forage icon, fight icon)', () => {
     const gfx = new MockGfx();
-    drawSlider(gfx, { forage: 5, fight: 5 }, { forage: 5, fight: 5 });
+    drawSlider(gfx, { forage: 5, fight: 5 }, { forage: 5, fight: 5 }, tri);
     expect(gfx.callsOf('fillRect').length).toBe(4);
   });
 
-  it('first fillRect is the zone background filling HUD.TRIANGLE exactly', () => {
+  it('first fillRect is the zone background filling tri exactly', () => {
     const gfx = new MockGfx();
-    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 10, fight: 0 });
+    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 10, fight: 0 }, tri);
     const firstFillRect = gfx.callsOf('fillRect')[0]!;
-    expect(firstFillRect.args).toEqual([
-      HUD.TRIANGLE.x,
-      HUD.TRIANGLE.y,
-      HUD.TRIANGLE.w,
-      HUD.TRIANGLE.h,
-    ]);
+    expect(firstFillRect.args).toEqual([tri.x, tri.y, tri.w, tri.h]);
   });
 
   it('emits exactly one fillCircle (current marker)', () => {
     const gfx = new MockGfx();
-    drawSlider(gfx, { forage: 7, fight: 3 }, { forage: 5, fight: 5 });
+    drawSlider(gfx, { forage: 7, fight: 3 }, { forage: 5, fight: 5 }, tri);
     expect(gfx.callsOf('fillCircle').length).toBe(1);
   });
 
   it('emits exactly one strokeCircle (target marker)', () => {
     const gfx = new MockGfx();
-    drawSlider(gfx, { forage: 7, fight: 3 }, { forage: 5, fight: 5 });
+    drawSlider(gfx, { forage: 7, fight: 3 }, { forage: 5, fight: 5 }, tri);
     expect(gfx.callsOf('strokeCircle').length).toBe(1);
   });
 
   it('current marker uses COLOR_PLAYER_COLONY', () => {
     const gfx = new MockGfx();
-    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 0, fight: 10 });
+    drawSlider(gfx, { forage: 10, fight: 0 }, { forage: 0, fight: 10 }, tri);
     // Find the fillStyle call immediately preceding the fillCircle call.
     const fillCircleIdx = gfx.calls.findIndex((c) => c.method === 'fillCircle');
     expect(fillCircleIdx).toBeGreaterThan(0);
@@ -301,18 +305,18 @@ describe('drawSlider', () => {
 
   it('current marker position tracks currentRatio', () => {
     const gfx = new MockGfx();
-    drawSlider(gfx, { forage: 0, fight: 10 }, { forage: 10, fight: 0 });
+    drawSlider(gfx, { forage: 0, fight: 10 }, { forage: 10, fight: 0 }, tri);
     const fillCircle = gfx.callsOf('fillCircle')[0]!;
     const [cx] = fillCircle.args as [number, number, number];
-    expect(cx).toBe(SLIDER_GEOMETRY.trackRight);
+    expect(cx).toBe(SG.trackRight);
   });
 
   it('target marker position tracks targetRatio independently of currentRatio', () => {
     const gfx = new MockGfx();
-    drawSlider(gfx, { forage: 0, fight: 10 }, { forage: 10, fight: 0 });
+    drawSlider(gfx, { forage: 0, fight: 10 }, { forage: 10, fight: 0 }, tri);
     const strokeCircle = gfx.callsOf('strokeCircle')[0]!;
     const [tx] = strokeCircle.args as [number, number, number];
-    expect(tx).toBe(SLIDER_GEOMETRY.trackLeft);
+    expect(tx).toBe(SG.trackLeft);
   });
 });
 

--- a/src/render/triangle-widget.ts
+++ b/src/render/triangle-widget.ts
@@ -11,28 +11,40 @@
 //
 // This file has no Phaser imports — only GfxLike from draw-surface.ts.
 
-import { HUD, COLOR_PLAYER_COLONY } from './sprites.js';
+import { COLOR_PLAYER_COLONY } from './sprites.js';
+import type { HudRect } from './hud-layout.js';
 import type { GfxLike } from './draw-surface.js';
 
 // ---------------------------------------------------------------------------
-// Slider track geometry inside HUD.TRIANGLE zone (x:[8,128), y:[532,576))
+// Slider track geometry inside the slider zone rect `t` (the hud.TRIANGLE box)
 //
 // Track centerline at the vertical midpoint of the zone. Track length spans
 // from a 16px inset on the left to a 16px inset on the right of the zone,
-// giving an 88-pixel-wide horizontal track. 4-pixel-thick rendered track.
+// giving an 88-pixel-wide horizontal track at the default 120-wide box.
+// 4-pixel-thick rendered track.
 // ---------------------------------------------------------------------------
 
-const TRACK_LEFT = HUD.TRIANGLE.x + 16; // 24
-const TRACK_RIGHT = HUD.TRIANGLE.x + HUD.TRIANGLE.w - 16; // 112
-const TRACK_Y = HUD.TRIANGLE.y + HUD.TRIANGLE.h / 2; // 554
-const TRACK_LEN = TRACK_RIGHT - TRACK_LEFT; // 88
-
-export const SLIDER_GEOMETRY = {
-  trackLeft: TRACK_LEFT,
-  trackRight: TRACK_RIGHT,
-  trackY: TRACK_Y,
-  trackLen: TRACK_LEN,
-} as const;
+/**
+ * Track geometry derived from the slider zone rect `t` (the hud.TRIANGLE box).
+ * At the default 800×592 layout (t = {x:8, y:532, w:120, h:44}) this yields the
+ * former `SLIDER_GEOMETRY` constant exactly: trackLeft 24, trackRight 112,
+ * trackY 554, trackLen 88.
+ */
+export function sliderGeometry(t: HudRect): {
+  trackLeft: number;
+  trackRight: number;
+  trackY: number;
+  trackLen: number;
+} {
+  const trackLeft = t.x + 16;
+  const trackRight = t.x + t.w - 16;
+  return {
+    trackLeft,
+    trackRight,
+    trackY: t.y + t.h / 2,
+    trackLen: trackRight - trackLeft,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // SliderDragState — mutable drag tracking (owned by UIScene)
@@ -56,17 +68,18 @@ export function createSliderDragState(): SliderDragState {
 // y is intentionally ignored — slider is 1-D.
 // ---------------------------------------------------------------------------
 
-export function screenToSliderRatio(px: number): { forage: number; fight: number } {
-  // WR-05: defensive guard against degenerate track geometry (TRACK_LEN <= 0).
-  // The test suite asserts `SLIDER_GEOMETRY.trackLen > 0` so this branch is
-  // currently unreachable in production, but a future HUD constants change
-  // could silently zero the denominator — `(px - TRACK_LEFT) / 0` is +/-Inf
-  // or NaN, `Math.max(0, Math.min(1, NaN)) === NaN`, and the function would
-  // return `{forage: NaN, fight: NaN}`, corrupting colony.targetRatio. Fall
-  // back to the safe default rather than poisoning state.
-  if (TRACK_LEN <= 0) return { forage: 10, fight: 0 };
-  const t = (px - TRACK_LEFT) / TRACK_LEN; // float in [0,1] (clamped below)
-  const tc = Math.max(0, Math.min(1, t));
+export function screenToSliderRatio(px: number, t: HudRect): { forage: number; fight: number } {
+  const { trackLeft, trackLen } = sliderGeometry(t);
+  // WR-05: defensive guard against degenerate track geometry (trackLen <= 0).
+  // The test suite asserts `sliderGeometry(t).trackLen > 0` so this branch is
+  // currently unreachable in production, but a future layout change could
+  // silently zero the denominator — `(px - trackLeft) / 0` is +/-Inf or NaN,
+  // `Math.max(0, Math.min(1, NaN)) === NaN`, and the function would return
+  // `{forage: NaN, fight: NaN}`, corrupting colony.targetRatio. Fall back to
+  // the safe default rather than poisoning state.
+  if (trackLen <= 0) return { forage: 10, fight: 0 };
+  const ratio = (px - trackLeft) / trackLen; // float in [0,1] (clamped below)
+  const tc = Math.max(0, Math.min(1, ratio));
   // 11 discrete steps: 0,1,...,10. fight gets `Math.round(tc * 10)`; forage = 10 - fight.
   const fight = Math.round(tc * 10);
   const forage = 10 - fight;
@@ -80,31 +93,30 @@ export function screenToSliderRatio(px: number): { forage: number; fight: number
 // are zero (degenerate save-migration edge case), pins to the track center.
 // ---------------------------------------------------------------------------
 
-export function ratioToSliderPos(ratio: { forage: number; fight: number }): {
+export function ratioToSliderPos(
+  ratio: { forage: number; fight: number },
+  t: HudRect,
+): {
   x: number;
   y: number;
 } {
+  const { trackLeft, trackLen, trackY } = sliderGeometry(t);
   const total = ratio.forage + ratio.fight;
   // Degenerate: pin to center if both are 0.
-  const t = total === 0 ? 0.5 : ratio.fight / total;
-  return { x: TRACK_LEFT + t * TRACK_LEN, y: TRACK_Y };
+  const frac = total === 0 ? 0.5 : ratio.fight / total;
+  return { x: trackLeft + frac * trackLen, y: trackY };
 }
 
 // ---------------------------------------------------------------------------
-// isInsideSlider — hit-test against the full HUD.TRIANGLE zone
+// isInsideSlider — hit-test against the full slider zone rect `t` (hud.TRIANGLE)
 //
 // Uses the full HUD slot (not just the visible track) so vertical slop on
 // click/drag still registers as a slider gesture. Matches the prior triangle
 // widget's hit zone for input continuity.
 // ---------------------------------------------------------------------------
 
-export function isInsideSlider(px: number, py: number): boolean {
-  return (
-    px >= HUD.TRIANGLE.x &&
-    px < HUD.TRIANGLE.x + HUD.TRIANGLE.w &&
-    py >= HUD.TRIANGLE.y &&
-    py < HUD.TRIANGLE.y + HUD.TRIANGLE.h
-  );
+export function isInsideSlider(px: number, py: number, t: HudRect): boolean {
+  return px >= t.x && px < t.x + t.w && py >= t.y && py < t.y + t.h;
 }
 
 // ---------------------------------------------------------------------------
@@ -123,26 +135,28 @@ export function drawSlider(
   gfx: GfxLike,
   currentRatio: { forage: number; fight: number },
   targetRatio: { forage: number; fight: number },
+  t: HudRect,
 ): void {
+  const { trackLeft, trackY, trackLen } = sliderGeometry(t);
   // Zone background — semi-transparent dark fill behind the slider so labels
   // and markers stay readable against the surface beneath.
   gfx.fillStyle(0x222222, 0.9);
-  gfx.fillRect(HUD.TRIANGLE.x, HUD.TRIANGLE.y, HUD.TRIANGLE.w, HUD.TRIANGLE.h);
+  gfx.fillRect(t.x, t.y, t.w, t.h);
   // Track line (4px thick, mid-gray).
   gfx.fillStyle(0x666666, 1);
-  gfx.fillRect(TRACK_LEFT, TRACK_Y - 2, TRACK_LEN, 4);
+  gfx.fillRect(trackLeft, trackY - 2, trackLen, 4);
   // Forage icon (left extreme): 12x12 green programmer-art square.
   gfx.fillStyle(0x66cc66, 1);
-  gfx.fillRect(HUD.TRIANGLE.x + 4, TRACK_Y - 6, 12, 12);
+  gfx.fillRect(t.x + 4, trackY - 6, 12, 12);
   // Fight icon (right extreme): 12x12 red programmer-art square.
   gfx.fillStyle(0xcc6666, 1);
-  gfx.fillRect(HUD.TRIANGLE.x + HUD.TRIANGLE.w - 16, TRACK_Y - 6, 12, 12);
+  gfx.fillRect(t.x + t.w - 16, trackY - 6, 12, 12);
   // Current marker (filled circle — current task census).
-  const cur = ratioToSliderPos(currentRatio);
+  const cur = ratioToSliderPos(currentRatio, t);
   gfx.fillStyle(COLOR_PLAYER_COLONY, 1);
   gfx.fillCircle(cur.x, cur.y, 6);
   // Target marker (outline circle — player-set target / drag preview).
-  const tgt = ratioToSliderPos(targetRatio);
+  const tgt = ratioToSliderPos(targetRatio, t);
   gfx.lineStyle(2, 0xffffff, 1);
   gfx.strokeCircle(tgt.x, tgt.y, 6);
 }

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -24,7 +24,6 @@ import type { ViewState, ToolId } from './camera.js';
 import { toggleView, toggleUndergroundColony } from './camera.js';
 import type { SpeedControl } from './hud-controls.js';
 import type { WorldState } from '../sim/types.js';
-import { HUD } from './sprites.js';
 import { GameOutcome } from '../sim/game-over.js';
 import {
   formatOutcomeTitle,
@@ -60,7 +59,7 @@ export type ActiveOverlay =
 
 // Phase 09.1 Chunk 2 — enemy underground observability. Exposed via the same
 // __phase9_ui global so Playwright can read which colony the underground view
-// is currently scoped to without OCR against the canvas-drawn HUD.
+// is currently scoped to without OCR against the canvas-drawn HUD text.
 export type ActiveUndergroundLabel = 'Your Colony' | 'Enemy Colony';
 
 // Distinguishes the two boot overlays that both report activeOverlay
@@ -161,7 +160,7 @@ import {
   drawSlider,
   screenToSliderRatio,
   isInsideSlider,
-  SLIDER_GEOMETRY,
+  sliderGeometry,
   type SliderDragState,
 } from './triangle-widget.js';
 import { drawMinimap, applyMinimapClick } from './minimap.js';
@@ -207,7 +206,7 @@ import {
 import {
   computeAntActivity,
   formatAntActivityLines,
-  ANT_ACTIVITY_PANEL,
+  antActivityPanelRect,
   ANT_ACTIVITY_PANEL_COLORS,
 } from './ant-activity.js';
 import {
@@ -240,6 +239,7 @@ import {
   type TooltipTarget,
 } from './tooltips.js';
 import { DEFAULT_LAYOUT, type LayoutContext } from './layout.js';
+import { buildHudLayout, type HudLayout } from './hud-layout.js';
 import {
   pauseMenuItems,
   pageTitle,
@@ -368,7 +368,7 @@ export interface SaveLoadDialogCallbacks {
   onBack(): void;
 }
 
-// HUD-02 stats row lives entirely inside the 200x24 HUD.STATS rect so
+// HUD-02 stats row lives entirely inside the 200x24 hud.STATS rect so
 // isPointerOverHUD() correctly masks world-input click-through. Per PRD §6c
 // + 09 HUD clarity pass:
 //   - Semi-transparent dark background (0x000000, α=0.6) fills the full rect.
@@ -380,9 +380,13 @@ export interface SaveLoadDialogCallbacks {
 //     completes and capacity grows.
 //   - Queen label restored to "Queen" from the prior single-char 'Q' — the
 //     bar color alone was not enough for players to tell what it measured.
-const STATS_ROW1_Y = HUD.STATS.y + HUD_STATS_LAYOUT.row1YOffset;
-const STATS_ROW2_Y = HUD.STATS.y + HUD_STATS_LAYOUT.row2YOffset;
-const STATS_TEXT_X = HUD.STATS.x + HUD_STATS_LAYOUT.leftTextInset;
+// Module-scope, so derived from the fixed default layout's STATS rect (these
+// text anchors can't read the per-instance `this.hud`). Byte-identical to the
+// former hud.STATS-based values at 800×592.
+const DEFAULT_STATS = buildHudLayout(DEFAULT_LAYOUT).STATS;
+const STATS_ROW1_Y = DEFAULT_STATS.y + HUD_STATS_LAYOUT.row1YOffset;
+const STATS_ROW2_Y = DEFAULT_STATS.y + HUD_STATS_LAYOUT.row2YOffset;
+const STATS_TEXT_X = DEFAULT_STATS.x + HUD_STATS_LAYOUT.leftTextInset;
 
 export class UIScene extends Phaser.Scene {
   /**
@@ -392,6 +396,14 @@ export class UIScene extends Phaser.Scene {
    * work recomputes it from the real canvas and reflows on resize.
    */
   private layout: LayoutContext = DEFAULT_LAYOUT;
+
+  /**
+   * Issue #238 — the HUD anchor table for this scene, built from `layout`. Every
+   * HUD zone rect (`this.hud.STATS`, `this.hud.MINIMAP`, …) comes from here
+   * rather than a fixed table, so a future resize rebuilds it from the new
+   * layout. Declared right after `layout` so its field initializer sees it.
+   */
+  private hud: HudLayout = buildHudLayout(this.layout);
 
   private viewState!: ViewState;
   // Lazy accessor — returns the live WorldState or undefined pre-boot.
@@ -564,7 +576,7 @@ export class UIScene extends Phaser.Scene {
     // settings so a returning player's "hide legend" choice is honored on boot.
     hintStripState.visible = loadSettings().hintStripVisible;
 
-    // HUD-02 stats row — three Texts confined to the 200x24 HUD.STATS rect,
+    // HUD-02 stats row — three Texts confined to the 200x24 hud.STATS rect,
     // two-row layout. Row 1: antsText (white, left) + foodText (green, right-
     // anchored). Row 2: queenLabelText (white, left) + queen health bar
     // (drawn in update() via gfx so its color can change per frame without
@@ -598,17 +610,18 @@ export class UIScene extends Phaser.Scene {
     // Field name `triangleLabels` retained to minimize diff churn — a future
     // cleanup may rename to `sliderLabels` alongside the file rename.
     //
-    // Phase 8.5 invariant preserved: labels render INSIDE HUD.TRIANGLE zone
+    // Phase 8.5 invariant preserved: labels render INSIDE the hud.TRIANGLE zone
     // (x: [8,128), y: [532,576)) so pointer clicks on the visible text don't
     // fall through to world input. After issue #13's slider-zone shrink the
-    // label sits flush at the top edge — trackY=554 - 22 = 532 = HUD.TRIANGLE.y,
+    // label sits flush at the top edge — trackY=554 - 22 = 532 = hud.TRIANGLE.y,
     // and the 10px label text occupies y:[532,542], inside the zone.
+    const sliderTrackY = sliderGeometry(this.hud.TRIANGLE).trackY;
     this.triangleLabels = [
-      this.add.text(HUD.TRIANGLE.x + 4, SLIDER_GEOMETRY.trackY - 22, 'Forage', {
+      this.add.text(this.hud.TRIANGLE.x + 4, sliderTrackY - 22, 'Forage', {
         color: '#ffffff',
         fontSize: '10px',
       }),
-      this.add.text(HUD.TRIANGLE.x + HUD.TRIANGLE.w - 28, SLIDER_GEOMETRY.trackY - 22, 'Fight', {
+      this.add.text(this.hud.TRIANGLE.x + this.hud.TRIANGLE.w - 28, sliderTrackY - 22, 'Fight', {
         color: '#ffffff',
         fontSize: '10px',
       }),
@@ -619,8 +632,8 @@ export class UIScene extends Phaser.Scene {
 
     // View toggle button label — text updated per-frame.
     this.viewToggleText = this.add.text(
-      HUD.VIEW_TOGGLE.x + 4,
-      HUD.VIEW_TOGGLE.y + 6,
+      this.hud.VIEW_TOGGLE.x + 4,
+      this.hud.VIEW_TOGGLE.y + 6,
       'Underground >',
       { color: '#ffffff', fontSize: '12px', backgroundColor: '#333333' },
     );
@@ -628,7 +641,7 @@ export class UIScene extends Phaser.Scene {
     this.viewToggleText.setScrollFactor(0);
 
     // Phase 09.1 Chunk 2 + issue #14 — underground colony toggle button.
-    // Sits above VIEW_TOGGLE (HUD.UNDERGROUND_COLONY_TOGGLE) so the two
+    // Sits above VIEW_TOGGLE (hud.UNDERGROUND_COLONY_TOGGLE) so the two
     // underground-only HUD elements stack vertically. Visibility is bound
     // to activeView === 'underground' in update(); text follows
     // activeUndergroundColonyId (binary toggle).
@@ -639,20 +652,20 @@ export class UIScene extends Phaser.Scene {
     // for keyboard players. Background matches VIEW_TOGGLE styling so the
     // two read as a stacked pair of toggle buttons.
     this.undergroundLabelText = this.add.text(
-      HUD.UNDERGROUND_COLONY_TOGGLE.x + 4,
-      HUD.UNDERGROUND_COLONY_TOGGLE.y + 4,
+      this.hud.UNDERGROUND_COLONY_TOGGLE.x + 4,
+      this.hud.UNDERGROUND_COLONY_TOGGLE.y + 4,
       'Your Colony (X)',
       { color: '#ffffff', fontSize: '12px' },
     );
     this.undergroundLabelText.setScrollFactor(0);
     this.undergroundLabelText.setVisible(false);
 
-    // Stage 1 controls rework (issue #18) — tool palette (HUD.TOOLS), hint strip
-    // (HUD.HINTS), and speed widget (HUD.SPEED). Backgrounds + active-tool
+    // Stage 1 controls rework (issue #18) — tool palette (hud.TOOLS), hint strip
+    // (hud.HINTS), and speed widget (hud.SPEED). Backgrounds + active-tool
     // highlight are drawn in update() via gfx; these Text objects carry the
-    // labels. All scroll-locked so they stay pinned to the HUD.
+    // labels. All scroll-locked so they stay pinned to the HUD region.
     this.toolButtonTexts = TOOL_ORDER.map((tool, i) => {
-      const r = toolButtonRect(i);
+      const r = toolButtonRect(i, this.hud.TOOLS);
       const t = this.add.text(r.x + 4, r.y + r.h / 2 - 6, TOOL_LABEL[tool], {
         color: '#ffffff',
         fontSize: '11px',
@@ -662,7 +675,7 @@ export class UIScene extends Phaser.Scene {
       t.setDepth(5);
       return t;
     });
-    this.hintText = this.add.text(HUD.HINTS.x + 2, HUD.HINTS.y + 2, '', {
+    this.hintText = this.add.text(this.hud.HINTS.x + 2, this.hud.HINTS.y + 2, '', {
       color: '#cfd8dc',
       fontSize: '11px',
       fontFamily: 'monospace',
@@ -670,7 +683,7 @@ export class UIScene extends Phaser.Scene {
     this.hintText.setScrollFactor(0);
     this.hintText.setDepth(5);
     this.speedControlTexts = SPEED_CONTROL_ORDER.map((control, i) => {
-      const r = speedControlRect(i);
+      const r = speedControlRect(i, this.hud.SPEED);
       const label = control === 'pause' ? '||' : `${control}x`;
       const t = this.add.text(r.x + 4, r.y + r.h / 2 - 7, label, {
         color: '#ffffff',
@@ -698,9 +711,10 @@ export class UIScene extends Phaser.Scene {
     });
 
     // Ant-activity popup body — single multi-line Text widget anchored to the
-    // top-left of ANT_ACTIVITY_PANEL. Created once, shown/hidden and retargeted
-    // per frame in update() based on antActivityPanelState.visible.
-    this.antActivityText = this.add.text(ANT_ACTIVITY_PANEL.x + 8, ANT_ACTIVITY_PANEL.y + 8, '', {
+    // top-left of the ant-activity panel rect. Created once, shown/hidden and
+    // retargeted per frame in update() based on antActivityPanelState.visible.
+    const antActivityPanel = antActivityPanelRect(this.hud.STATS);
+    this.antActivityText = this.add.text(antActivityPanel.x + 8, antActivityPanel.y + 8, '', {
       color: ANT_ACTIVITY_PANEL_COLORS.textCss,
       fontSize: '11px',
       fontFamily: 'monospace',
@@ -866,7 +880,7 @@ export class UIScene extends Phaser.Scene {
       // Ant-activity popup — STATS rect click toggles the panel open/closed.
       // Checked before other HUD zones so a click on the stats row can never
       // fall through to world input regardless of panel state.
-      if (this.isInsideRect(pointer.x, pointer.y, HUD.STATS)) {
+      if (this.isInsideRect(pointer.x, pointer.y, this.hud.STATS)) {
         // The panel-open transition bypasses recomputeActiveOverlay (and the ant
         // panel isn't part of anyOverlayOpen), so a tooltip shown by hovering
         // STATS would linger over the freshly-opened popup until the next
@@ -889,25 +903,25 @@ export class UIScene extends Phaser.Scene {
       //     marking. applyPendingAntActivityPanelHide commits the flip at
       //     the top of the next UIScene.update frame.
       if (antActivityPanelState.visible) {
-        if (this.isInsideRect(pointer.x, pointer.y, ANT_ACTIVITY_PANEL)) {
+        if (this.isInsideRect(pointer.x, pointer.y, antActivityPanelRect(this.hud.STATS))) {
           return;
         }
         const overHud =
-          this.isInsideRect(pointer.x, pointer.y, HUD.TRIANGLE) ||
-          this.isInsideRect(pointer.x, pointer.y, HUD.MINIMAP) ||
-          this.isInsideRect(pointer.x, pointer.y, HUD.VIEW_TOGGLE) ||
+          this.isInsideRect(pointer.x, pointer.y, this.hud.TRIANGLE) ||
+          this.isInsideRect(pointer.x, pointer.y, this.hud.MINIMAP) ||
+          this.isInsideRect(pointer.x, pointer.y, this.hud.VIEW_TOGGLE) ||
           // Issue #14 — colony-toggle button. Without this entry, a click
           // on the new toggle while the ant-activity panel is up would
           // be classified as "world click", dismissing the panel and
           // dropping the toggle dispatch.
-          this.isInsideRect(pointer.x, pointer.y, HUD.UNDERGROUND_COLONY_TOGGLE) ||
+          this.isInsideRect(pointer.x, pointer.y, this.hud.UNDERGROUND_COLONY_TOGGLE) ||
           // Stage 1 controls rework (issue #18) — the new interactive HUD zones
           // (tool palette, hint strip, speed widget) must be on the ant-panel
           // allow-list too, else a click on them while the panel is up dismisses
           // the panel and drops the palette/speed dispatch.
-          this.isInsideRect(pointer.x, pointer.y, HUD.TOOLS) ||
-          this.isInsideRect(pointer.x, pointer.y, HUD.HINTS) ||
-          this.isInsideRect(pointer.x, pointer.y, HUD.SPEED);
+          this.isInsideRect(pointer.x, pointer.y, this.hud.TOOLS) ||
+          this.isInsideRect(pointer.x, pointer.y, this.hud.HINTS) ||
+          this.isInsideRect(pointer.x, pointer.y, this.hud.SPEED);
         if (!overHud) {
           // Click on the world — dismiss and consume. `return` prevents
           // any further UIScene handling; the deferred hide prevents the
@@ -923,7 +937,7 @@ export class UIScene extends Phaser.Scene {
       }
 
       // View toggle button
-      if (this.isInsideRect(pointer.x, pointer.y, HUD.VIEW_TOGGLE)) {
+      if (this.isInsideRect(pointer.x, pointer.y, this.hud.VIEW_TOGGLE)) {
         toggleView(this.viewState);
         return;
       }
@@ -933,7 +947,7 @@ export class UIScene extends Phaser.Scene {
       // invisible) doesn't flip the underground colony invisibly.
       if (
         this.viewState.activeView === 'underground' &&
-        this.isInsideRect(pointer.x, pointer.y, HUD.UNDERGROUND_COLONY_TOGGLE)
+        this.isInsideRect(pointer.x, pointer.y, this.hud.UNDERGROUND_COLONY_TOGGLE)
       ) {
         toggleUndergroundColony(this.viewState);
         return;
@@ -942,14 +956,14 @@ export class UIScene extends Phaser.Scene {
       // the GameScene-owned, gated selectTool so a palette pick obeys the same
       // gate as the 1/2/3 hotkeys (and the Chamber-on-surface no-op). Consume the
       // click so it never falls through to the world arbiter.
-      const toolHit = toolButtonAt(pointer.x, pointer.y, this.viewState.activeView);
+      const toolHit = toolButtonAt(pointer.x, pointer.y, this.viewState.activeView, this.hud.TOOLS);
       if (toolHit !== null) {
         this.onSelectTool?.(toolHit);
         return;
       }
       // Speed widget click — ⏸ toggles the 'user' pause; 1×/2×/4× set the
       // multiplier (without changing pause reasons). Both via GameScene.
-      const speedHit = speedControlAt(pointer.x, pointer.y);
+      const speedHit = speedControlAt(pointer.x, pointer.y, this.hud.SPEED);
       if (speedHit !== null) {
         this.onSpeedControl?.(speedHit);
         return;
@@ -958,14 +972,14 @@ export class UIScene extends Phaser.Scene {
       // any in-flight wheel zoom-lerp/anchor on the active camera — otherwise the
       // next tickZoomLerp re-anchors from the fixed cursor point and overrides the
       // minimap nav (same class of bug the keyboard/drag-pan cancel prevents).
-      if (applyMinimapClick(this.viewState, pointer.x, pointer.y)) {
+      if (applyMinimapClick(this.viewState, pointer.x, pointer.y, this.hud)) {
         this.onMinimapNav?.();
         return;
       }
       // Behavior slider drag start (Phase 10 / D-01 — 1-D Forage↔Fight axis)
-      if (isInsideSlider(pointer.x, pointer.y)) {
+      if (isInsideSlider(pointer.x, pointer.y, this.hud.TRIANGLE)) {
         this.dragState.isDragging = true;
-        this.dragState.targetRatio = screenToSliderRatio(pointer.x);
+        this.dragState.targetRatio = screenToSliderRatio(pointer.x, this.hud.TRIANGLE);
         return;
       }
     });
@@ -977,7 +991,7 @@ export class UIScene extends Phaser.Scene {
       if (!this.dragState.isDragging) return;
       if (!pointer.isDown) return;
       // 1-D slider: only x is consulted; pointer y is ignored within drag.
-      this.dragState.targetRatio = screenToSliderRatio(pointer.x);
+      this.dragState.targetRatio = screenToSliderRatio(pointer.x, this.hud.TRIANGLE);
     });
 
     // Stage 3b (#5): the cursor leaving the canvas hides any tooltip + cancels a
@@ -1078,7 +1092,7 @@ export class UIScene extends Phaser.Scene {
     //   - "Ants: N" white text, "Food: N" green-tinted text, "Queen:" label
     //   - visual queen-health bar right-anchored inside the rect, color by pct
     this.gfx.fillStyle(HUD_STATS_COLORS.background, HUD_STATS_COLORS.backgroundAlpha);
-    this.gfx.fillRect(HUD.STATS.x, HUD.STATS.y, HUD.STATS.w, HUD.STATS.h);
+    this.gfx.fillRect(this.hud.STATS.x, this.hud.STATS.y, this.hud.STATS.w, this.hud.STATS.h);
 
     if (colony) {
       const s = computeHudStats(world, colony);
@@ -1090,11 +1104,11 @@ export class UIScene extends Phaser.Scene {
       // small inset). Row 2: "Queen" left-anchored, queen health bar right-
       // anchored. Rows are disjoint so "Food: C/M" can grow without fighting
       // the queen label for horizontal budget.
-      const bar = queenBarRect(HUD.STATS);
-      const label = queenLabelRect(HUD.STATS);
+      const bar = queenBarRect(this.hud.STATS);
+      const label = queenLabelRect(this.hud.STATS);
       this.queenLabelText.setPosition(label.x, label.y);
       const FOOD_RIGHT_INSET = 6;
-      const foodX = HUD.STATS.x + HUD.STATS.w - FOOD_RIGHT_INSET - this.foodText.width;
+      const foodX = this.hud.STATS.x + this.hud.STATS.w - FOOD_RIGHT_INSET - this.foodText.width;
       this.foodText.setPosition(foodX, STATS_ROW1_Y);
 
       // Queen health bar — track + proportional fill.
@@ -1146,15 +1160,26 @@ export class UIScene extends Phaser.Scene {
         this.gfx as unknown as import('./draw-surface.js').GfxLike,
         currentRatio,
         targetRatio,
+        this.hud.TRIANGLE,
       );
     }
 
     // Minimap
-    drawMinimap(this.gfx as unknown as import('./draw-surface.js').GfxLike, world, this.viewState);
+    drawMinimap(
+      this.gfx as unknown as import('./draw-surface.js').GfxLike,
+      world,
+      this.viewState,
+      this.hud,
+    );
 
     // View toggle button background
     this.gfx.fillStyle(0x333333, 1);
-    this.gfx.fillRect(HUD.VIEW_TOGGLE.x, HUD.VIEW_TOGGLE.y, HUD.VIEW_TOGGLE.w, HUD.VIEW_TOGGLE.h);
+    this.gfx.fillRect(
+      this.hud.VIEW_TOGGLE.x,
+      this.hud.VIEW_TOGGLE.y,
+      this.hud.VIEW_TOGGLE.w,
+      this.hud.VIEW_TOGGLE.h,
+    );
     this.viewToggleText.setText(
       this.viewState.activeView === 'surface' ? 'Underground >' : '< Surface',
     );
@@ -1173,10 +1198,10 @@ export class UIScene extends Phaser.Scene {
       // pattern below) so the click zone reads as a button.
       this.gfx.fillStyle(0x333333, 1);
       this.gfx.fillRect(
-        HUD.UNDERGROUND_COLONY_TOGGLE.x,
-        HUD.UNDERGROUND_COLONY_TOGGLE.y,
-        HUD.UNDERGROUND_COLONY_TOGGLE.w,
-        HUD.UNDERGROUND_COLONY_TOGGLE.h,
+        this.hud.UNDERGROUND_COLONY_TOGGLE.x,
+        this.hud.UNDERGROUND_COLONY_TOGGLE.y,
+        this.hud.UNDERGROUND_COLONY_TOGGLE.w,
+        this.hud.UNDERGROUND_COLONY_TOGGLE.h,
       );
     }
     this.undergroundLabelText.setText(`${undergroundLabel} (X)`);
@@ -1200,23 +1225,14 @@ export class UIScene extends Phaser.Scene {
       this.antActivityText.setText(body);
       this.antActivityText.setVisible(true);
 
+      const panel = antActivityPanelRect(this.hud.STATS);
       this.gfx.fillStyle(
         ANT_ACTIVITY_PANEL_COLORS.background,
         ANT_ACTIVITY_PANEL_COLORS.backgroundAlpha,
       );
-      this.gfx.fillRect(
-        ANT_ACTIVITY_PANEL.x,
-        ANT_ACTIVITY_PANEL.y,
-        ANT_ACTIVITY_PANEL.w,
-        ANT_ACTIVITY_PANEL.h,
-      );
+      this.gfx.fillRect(panel.x, panel.y, panel.w, panel.h);
       this.gfx.lineStyle(1, ANT_ACTIVITY_PANEL_COLORS.border, 1);
-      this.gfx.strokeRect(
-        ANT_ACTIVITY_PANEL.x,
-        ANT_ACTIVITY_PANEL.y,
-        ANT_ACTIVITY_PANEL.w,
-        ANT_ACTIVITY_PANEL.h,
-      );
+      this.gfx.strokeRect(panel.x, panel.y, panel.w, panel.h);
     } else {
       this.antActivityText.setVisible(false);
     }
@@ -1397,11 +1413,12 @@ export class UIScene extends Phaser.Scene {
     if (req.source === 'first-use' && req.hintId !== undefined) {
       markFirstUseHintShown(req.hintId as HintFirstUseId);
     }
-    // Stage 1 (Codex R4-1): a caption whose vertical band overlaps the HUD.HINTS
-    // strip yields (hides) the strip for its lifetime so the two don't collide.
+    // Stage 1 (Codex R4-1): a caption whose vertical band overlaps the hint
+    // strip (hud.HINTS) yields (hides) the strip for its lifetime so the two
+    // don't collide.
     const capTop = req.y - 14;
     const capBottom = req.y + 14;
-    if (capTop < HUD.HINTS.y + HUD.HINTS.h && capBottom > HUD.HINTS.y) {
+    if (capTop < this.hud.HINTS.y + this.hud.HINTS.h && capBottom > this.hud.HINTS.y) {
       this.hintYieldUntilMs = this.time.now + CAPTION_TOTAL_MS;
     }
     const captionText = this.add.text(req.x, req.y, req.text, {
@@ -1491,7 +1508,7 @@ export class UIScene extends Phaser.Scene {
       this.cancelTooltip();
       return;
     }
-    const target = tooltipTargetAt(pointer.x, pointer.y, this.viewState.activeView);
+    const target = tooltipTargetAt(pointer.x, pointer.y, this.viewState.activeView, this.hud);
     if (sameTooltipTarget(target, this.hoverTarget)) return; // unchanged — let timers run
     this.hoverTarget = target;
     this.clearTooltipShowTimer();
@@ -1622,7 +1639,7 @@ export class UIScene extends Phaser.Scene {
     const active = this.viewState.activeTool;
     for (let i = 0; i < TOOL_ORDER.length; i++) {
       const tool = TOOL_ORDER[i]!;
-      const r = toolButtonRect(i);
+      const r = toolButtonRect(i, this.hud.TOOLS);
       const greyed = tool === 'chamber' && surface;
       const isActive = tool === active && !greyed;
       // Background: brighter when active, dim when greyed.
@@ -1659,7 +1676,7 @@ export class UIScene extends Phaser.Scene {
     }
     // Stage 3b (#2, Codex R1#3): the visibility toggle gates ONLY the static
     // legend — the caption-yield (above) and the queue-full warning (above) stay
-    // visible. A hidden legend also frees HUD.HINTS from the input mask
+    // visible. A hidden legend also frees hud.HINTS from the input mask
     // (camera-input reads the same hintStripState).
     if (!hintStripState.visible) {
       this.hintText.setVisible(false);
@@ -1676,7 +1693,7 @@ export class UIScene extends Phaser.Scene {
     const speed = this.getSpeedMultiplierFn ? this.getSpeedMultiplierFn() : 1;
     for (let i = 0; i < SPEED_CONTROL_ORDER.length; i++) {
       const control = SPEED_CONTROL_ORDER[i]!;
-      const r = speedControlRect(i);
+      const r = speedControlRect(i, this.hud.SPEED);
       const isActive = control === 'pause' ? paused : control === speed;
       this.gfx.fillStyle(isActive ? 0x2a6cc0 : 0x444444, 1);
       this.gfx.fillRect(r.x, r.y, r.w, r.h);

--- a/tests/helpers/geometry.ts
+++ b/tests/helpers/geometry.ts
@@ -7,14 +7,15 @@
 // Importing ui-scene.ts (Phaser) would crash the Node runner, but these modules
 // don't touch Phaser: layout.ts→sprites.ts (zero imports), pause-menu-layout.ts /
 // save-load-dialog-layout.ts (type-only cross-imports), boot-overlay-layout.ts and
-// sprites.ts (zero imports).
+// sprites.ts (zero imports), and hud-layout.ts (#238 — type-only import of
+// LayoutContext; the VIEW_TOGGLE rect now comes from buildHudLayout).
 import { DEFAULT_LAYOUT } from '../../src/render/layout.js';
 import { pauseMenuItems, type PauseMenuRenderContext } from '../../src/render/pause-menu-layout.js';
 import {
   saveLoadDialogItems,
   type SaveLoadDialogContext,
 } from '../../src/render/save-load-dialog-layout.js';
-import { HUD } from '../../src/render/sprites.js';
+import { buildHudLayout } from '../../src/render/hud-layout.js';
 
 export interface Rect {
   x: number;
@@ -61,7 +62,7 @@ export const DIALOG_SAVE_NOW_RECT: Rect = dialogItems[1]!.rect;
 export const DIALOG_DELETE_RECT: Rect = dialogItems[2]!.rect;
 
 /** HUD view-toggle button (surface ↔ underground). */
-export const VIEW_TOGGLE_RECT: Rect = HUD.VIEW_TOGGLE;
+export const VIEW_TOGGLE_RECT: Rect = buildHudLayout(DEFAULT_LAYOUT).VIEW_TOGGLE;
 
 // Boot-overlay rects re-exported from the Phaser-free module (the same source
 // ui-scene.ts uses), so specs import their click targets from one place.


### PR DESCRIPTION
First of #238's five render-only PRs (LayoutContext phase 2). **Byte-identical** — `buildHudLayout(DEFAULT_LAYOUT)` equals the former `HUD` const's values at 800×592, locked by a deep-equality acceptance test. No sim / simVersion change.

### What
- **New `src/render/hud-layout.ts`** — `HudRect` / `HudLayout` + `buildHudLayout(layout)`. The 9 HUD zones are now expressed relative to `layout.w`/`layout.h` (so the HUD reflows on resize — the Phase-6 goal), each anchor evaluating to today's constant at 800×592.
- **Deleted the `HUD` const from `sprites.ts`** (kept `CANVAS_W/H`, `TILE_SIZE_PX`, `COLOR_*`, `lerpColor`).
- **Threaded the built layout / its rects through every consumer**: `hud-controls`, `triangle-widget` (`SLIDER_GEOMETRY` → `sliderGeometry(t)`), `tooltips`, `minimap` (`MINIMAP_SCALE_X/Y` derived from `buildHudLayout(DEFAULT_LAYOUT).MINIMAP`), `ant-activity` (`ANT_ACTIVITY_PANEL` → `antActivityPanelRect(stats)`), `camera-input` (`isPointerOverHUD`/`registerDragPan` gain a `hud` param), `ui-scene` (`private hud = buildHudLayout(this.layout)`; every `HUD.X` → `this.hud.X`), `game-scene`.
- Consumer tests thread `buildHudLayout(DEFAULT_LAYOUT)`; **assertions unchanged** (byte-identity holds).

### Acceptance gate
`hud-layout.test.ts` deep-equality-snapshots `buildHudLayout(DEFAULT_LAYOUT)` against the verbatim former `HUD` values (+ a reflow assertion at 1000×700). This is the proof of zero geometry drift.

### Verification
- `npm run verify`: **2778 passed | 1 skipped**; `grep HUD.` empty; all render-consumer tests green at unchanged assertions.
- Cross-model reviewed by Fable.

Follow-ons (this PR only does PR1): PR2 residual CANVAS_W/H drain · PR3 camera-adapter viewport setter · PR4 small-context fixtures · PR5 discipline guard.

Part of #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HUD elements now adapt to the current screen layout, keeping controls, minimap, tooltips, and sliders aligned across resolutions.
  * Hover and click interactions now respect the active HUD visibility, improving consistency for surface and underground views.

* **Bug Fixes**
  * Fixed input blocking around HUD areas so camera panning, zooming, and drag interactions are suppressed more reliably.
  * Updated tooltip and minimap interactions to use the correct on-screen positions, reducing misfires near UI edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->