### PR TITLE
refactor(render): finish + lock the LayoutContext seam (#238 PR2-5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check src/ eslint-rules/",
     "check:cycles": "node scripts/check-ant-cycles.mjs",
-    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run lint:types && bash scripts/check-sim-boundary.sh && bash scripts/check-asset-paths.sh && bash scripts/check-e2e-geometry.sh && npm run check:cycles && npm run test"
+    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run lint:types && bash scripts/check-sim-boundary.sh && bash scripts/check-asset-paths.sh && bash scripts/check-e2e-geometry.sh && bash scripts/check-layout-discipline.sh && npm run check:cycles && npm run test"
   },
   "dependencies": {
     "phaser": "^3.90.0"

--- a/scripts/check-layout-discipline.sh
+++ b/scripts/check-layout-discipline.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scripts/check-layout-discipline.sh
+# #238 LayoutContext discipline guard — the grep backstop that proves the
+# CANVAS_W/CANVAS_H drain (issue #238 PR2/PR3) stays drained. HUD / overlay /
+# camera geometry must be a pure function of a LayoutContext (see code/AGENTS.md
+# → "Layout discipline"), NOT of the fixed 800×592 canvas constants. This guard
+# fails if render/input code reintroduces either:
+#   1. a bare 800 / 592 canvas-size literal, or
+#   2. an `import … CANVAS_W/CANVAS_H` outside the sanctioned authority files.
+#
+# Mirrors check-sim-boundary.sh / check-asset-paths.sh: BSD-compatible ERE,
+# `set -euo pipefail`, `|| true` on the greps, an allowlist `grep -v` filter,
+# and a clear pass/fail echo. Comment lines (`//`, `/* … */`, ` * ` JSDoc) are
+# dropped first — a comment may legitimately reference the canonical 800×592
+# size or the CANVAS_W/H import while the surrounding code is discipline-clean
+# (mirrors the pure-comment drop in check-e2e-geometry.sh).
+#
+# Run via: bash scripts/check-layout-discipline.sh   (or npm run verify)
+# Exits 0 if clean; exits 1 with the offending lines otherwise.
+
+set -euo pipefail
+
+SCOPE=(src/render src/input)
+COMMENT_FILTER=':[[:space:]]*[/*]' # drop //, /*, and ` * ` JSDoc continuation lines
+
+# --- Check 1: no bare 800 / 592 canvas literal -----------------------------
+# File allowlist: sprites.ts (the CANVAS_W/H definitions) and layout.ts (the
+# default LayoutContext). PLUS one documented non-geometry literal: the
+# caption-hold tween duration `delay: 800` (ms) in ui-scene.ts — a timing value
+# that merely collides with the canvas width, not a geometry literal (#238).
+NUM_HITS=$( { grep -rnE '\b(800|592)\b' "${SCOPE[@]}" --include='*.ts' --exclude='*.test.ts' || true; } \
+  | grep -vE "$COMMENT_FILTER" \
+  | grep -vE '/(sprites|layout)\.ts:' \
+  | grep -vE 'delay: 800' \
+  || true )
+
+if [[ -n "$NUM_HITS" ]]; then
+  echo "Layout discipline (#238): bare 800/592 canvas literal in render/input code:"
+  echo "$NUM_HITS"
+  echo ""
+  echo "Derive canvas-relative geometry from a LayoutContext (layout.w / layout.h),"
+  echo "not the fixed 800×592 constants. The canvas-size defs live in sprites.ts."
+  exit 1
+fi
+echo "layout-discipline bare-800/592 guard: clean."
+
+# --- Check 2: no CANVAS_W/CANVAS_H import outside the authority files -------
+# File allowlist: sprites.ts (defines them), layout.ts (the default-context
+# seam), camera-adapter.ts (the screen↔world authority — AGENTS.md §"Layout
+# discipline" sanctions its canvas-size dependency), camera.ts (owns the
+# underground initial-center-Y = CANVAS_H/2 dependency; a candidate for a future
+# adapter-owned move, out of #238 PR2–5 scope), and src/main.ts (Phaser config).
+IMPORT_HITS=$( { grep -rnE 'import.*CANVAS_[WH]' "${SCOPE[@]}" --include='*.ts' --exclude='*.test.ts' || true; } \
+  | grep -vE "$COMMENT_FILTER" \
+  | grep -vE '/(sprites|layout|camera-adapter|camera|main)\.ts:' \
+  || true )
+
+if [[ -n "$IMPORT_HITS" ]]; then
+  echo "Layout discipline (#238): CANVAS_W/CANVAS_H imported outside the authority files:"
+  echo "$IMPORT_HITS"
+  echo ""
+  echo "Only sprites.ts / layout.ts / camera-adapter.ts / camera.ts / main.ts may import"
+  echo "CANVAS_W/CANVAS_H. Elsewhere, take a LayoutContext and derive from layout.w / layout.h."
+  exit 1
+fi
+echo "layout-discipline CANVAS-import guard: clean."
+
+echo "Layout-discipline guard: clean."

--- a/scripts/check-layout-discipline.sh
+++ b/scripts/check-layout-discipline.sh
@@ -44,25 +44,29 @@ if [[ -n "$NUM_HITS" ]]; then
 fi
 echo "layout-discipline bare-800/592 guard: clean."
 
-# --- Check 2: no CANVAS_W/CANVAS_H import outside the authority files -------
+# --- Check 2: no CANVAS_W/CANVAS_H USE outside the authority files ----------
+# Match any CANVAS_W/CANVAS_H *reference*, not just a single-line `import …`
+# statement (CodeRabbit #269): a multiline named-import member or a
+# `sprites.CANVAS_W` namespace access would evade an import-only pattern while
+# still coupling render/input geometry to the fixed canvas size.
 # File allowlist: sprites.ts (defines them), layout.ts (the default-context
 # seam), camera-adapter.ts (the screen↔world authority — AGENTS.md §"Layout
 # discipline" sanctions its canvas-size dependency), camera.ts (owns the
 # underground initial-center-Y = CANVAS_H/2 dependency; a candidate for a future
 # adapter-owned move, out of #238 PR2–5 scope), and src/main.ts (Phaser config).
-IMPORT_HITS=$( { grep -rnE 'import.*CANVAS_[WH]' "${SCOPE[@]}" --include='*.ts' --exclude='*.test.ts' || true; } \
+USE_HITS=$( { grep -rnE '\bCANVAS_[WH]\b' "${SCOPE[@]}" --include='*.ts' --exclude='*.test.ts' || true; } \
   | grep -vE "$COMMENT_FILTER" \
   | grep -vE '/(sprites|layout|camera-adapter|camera|main)\.ts:' \
   || true )
 
-if [[ -n "$IMPORT_HITS" ]]; then
-  echo "Layout discipline (#238): CANVAS_W/CANVAS_H imported outside the authority files:"
-  echo "$IMPORT_HITS"
+if [[ -n "$USE_HITS" ]]; then
+  echo "Layout discipline (#238): CANVAS_W/CANVAS_H used outside the authority files:"
+  echo "$USE_HITS"
   echo ""
-  echo "Only sprites.ts / layout.ts / camera-adapter.ts / camera.ts / main.ts may import"
+  echo "Only sprites.ts / layout.ts / camera-adapter.ts / camera.ts / main.ts may reference"
   echo "CANVAS_W/CANVAS_H. Elsewhere, take a LayoutContext and derive from layout.w / layout.h."
   exit 1
 fi
-echo "layout-discipline CANVAS-import guard: clean."
+echo "layout-discipline CANVAS-use guard: clean."
 
 echo "Layout-discipline guard: clean."

--- a/scripts/check-layout-discipline.sh
+++ b/scripts/check-layout-discipline.sh
@@ -21,7 +21,10 @@
 set -euo pipefail
 
 SCOPE=(src/render src/input)
-COMMENT_FILTER=':[[:space:]]*[/*]' # drop //, /*, and ` * ` JSDoc continuation lines
+# Drop FULL-LINE comments only (//, /*, ` * ` JSDoc), anchored to grep's
+# `path:line:` prefix so a mid-line comment (e.g. `x = 592 /* note */`) can't
+# hide a real violation on the same line (Codex #269 F2).
+COMMENT_FILTER='^[^:]*:[0-9]+:[[:space:]]*(//|/\*|\*)'
 
 # --- Check 1: no bare 800 / 592 canvas literal -----------------------------
 # File allowlist: sprites.ts (the CANVAS_W/H definitions) and layout.ts (the
@@ -31,7 +34,7 @@ COMMENT_FILTER=':[[:space:]]*[/*]' # drop //, /*, and ` * ` JSDoc continuation l
 NUM_HITS=$( { grep -rnE '\b(800|592)\b' "${SCOPE[@]}" --include='*.ts' --exclude='*.test.ts' || true; } \
   | grep -vE "$COMMENT_FILTER" \
   | grep -vE '/(sprites|layout)\.ts:' \
-  | grep -vE 'delay: 800' \
+  | grep -vE '/ui-scene\.ts:[0-9]+:[[:space:]]*delay: 800,' \
   || true )
 
 if [[ -n "$NUM_HITS" ]]; then
@@ -51,19 +54,19 @@ echo "layout-discipline bare-800/592 guard: clean."
 # still coupling render/input geometry to the fixed canvas size.
 # File allowlist: sprites.ts (defines them), layout.ts (the default-context
 # seam), camera-adapter.ts (the screen↔world authority — AGENTS.md §"Layout
-# discipline" sanctions its canvas-size dependency), camera.ts (owns the
-# underground initial-center-Y = CANVAS_H/2 dependency; a candidate for a future
-# adapter-owned move, out of #238 PR2–5 scope), and src/main.ts (Phaser config).
+# discipline" sanctions its canvas-size dependency), and camera.ts (owns the
+# underground initial-center-Y = CANVAS_H/2 dependency; deferred adapter-owned
+# move tracked in #270). src/main.ts is outside SCOPE (render/input), so no entry.
 USE_HITS=$( { grep -rnE '\bCANVAS_[WH]\b' "${SCOPE[@]}" --include='*.ts' --exclude='*.test.ts' || true; } \
   | grep -vE "$COMMENT_FILTER" \
-  | grep -vE '/(sprites|layout|camera-adapter|camera|main)\.ts:' \
+  | grep -vE '/(sprites|layout|camera-adapter|camera)\.ts:' \
   || true )
 
 if [[ -n "$USE_HITS" ]]; then
   echo "Layout discipline (#238): CANVAS_W/CANVAS_H used outside the authority files:"
   echo "$USE_HITS"
   echo ""
-  echo "Only sprites.ts / layout.ts / camera-adapter.ts / camera.ts / main.ts may reference"
+  echo "Only sprites.ts / layout.ts / camera-adapter.ts / camera.ts may reference"
   echo "CANVAS_W/CANVAS_H. Elsewhere, take a LayoutContext and derive from layout.w / layout.h."
   exit 1
 fi

--- a/src/render/camera-adapter.test.ts
+++ b/src/render/camera-adapter.test.ts
@@ -9,7 +9,7 @@
 //   - per-view settle (lerp cancel + clamp) and minimap-nav (underground preserves depth)
 //   - LOD hysteresis (0.55 / 0.65, band holds prior mode)
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { CANVAS_W, CANVAS_H, TILE_SIZE_PX } from './sprites.js';
 import {
   MIN_ZOOM,
@@ -22,6 +22,7 @@ import {
   makeCameraView,
   viewWorldWidth,
   viewWorldHeight,
+  setViewportSize,
   visibleWorldRect,
   screenToWorld,
   worldToScreen,
@@ -103,6 +104,49 @@ describe('screenToWorld / worldToScreen', () => {
     const a = screenToWorld(0, 0, v).worldX;
     const b = screenToWorld(1, 0, v).worldX;
     expect(b - a).toBeCloseTo(1 / 0.5, 9); // 2 world px per screen px at 0.5×
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setViewportSize — #238 PR3 module setter. A non-default logical canvas size
+// drives the projection (the mobile/responsive seam), NOT the fixed CANVAS_W/H.
+// Reset to CANVAS_W×CANVAS_H after each case so the rest of the suite keeps the
+// default viewport (the module state is a singleton).
+// ---------------------------------------------------------------------------
+
+describe('setViewportSize (#238 PR3 — non-default viewport)', () => {
+  afterEach(() => setViewportSize(CANVAS_W, CANVAS_H));
+
+  it('viewWorldWidth/Height are computed against the set size, not CANVAS_W/H', () => {
+    setViewportSize(360, 640);
+    expect(viewWorldWidth(1)).toBe(360);
+    expect(viewWorldHeight(1)).toBe(640);
+    expect(viewWorldWidth(0.5)).toBe(720); // 360 / 0.5 — still ÷zoom
+  });
+
+  it('the screen center of the new viewport maps to the camera center', () => {
+    setViewportSize(360, 640);
+    const v = view(1000, 500, 1);
+    const { worldX, worldY } = screenToWorld(180, 320, v); // (360/2, 640/2)
+    expect(worldX).toBeCloseTo(1000, 6);
+    expect(worldY).toBeCloseTo(500, 6);
+    const { screenX, screenY } = worldToScreen(1000, 500, v);
+    expect(screenX).toBeCloseTo(180, 6);
+    expect(screenY).toBeCloseTo(320, 6);
+  });
+
+  it('a screen corner projects using the new size (not the 800×592 default)', () => {
+    setViewportSize(360, 640);
+    const v = view(1000, 500, 1);
+    // top-left (0,0) → centerX − viewportW/2 = 1000 − 180 = 820 (would be 600 at 800w).
+    expect(screenToWorld(0, 0, v).worldX).toBeCloseTo(820, 6);
+    expect(screenToWorld(0, 0, v).worldY).toBeCloseTo(180, 6); // 500 − 640/2
+  });
+
+  it('afterEach restores the default CANVAS_W×CANVAS_H projection', () => {
+    // No setViewportSize here — the prior case's afterEach has reset it.
+    expect(viewWorldWidth(1)).toBe(CANVAS_W);
+    expect(viewWorldHeight(1)).toBe(CANVAS_H);
   });
 });
 

--- a/src/render/camera-adapter.test.ts
+++ b/src/render/camera-adapter.test.ts
@@ -143,6 +143,21 @@ describe('setViewportSize (#238 PR3 — non-default viewport)', () => {
     expect(screenToWorld(0, 0, v).worldY).toBeCloseTo(180, 6); // 500 − 640/2
   });
 
+  it('applyZoomAnchor keeps the anchored point under the cursor at the new viewport (#269 F5)', () => {
+    setViewportSize(360, 640);
+    const v = view(1000, 500, 1);
+    // Cursor at (300, 500): the zoom-anchor invariant only holds if applyZoomAnchor
+    // reads the 360×640 viewport, not the 800×592 default.
+    const anchor = beginWheelZoom(v, 1.8, 300, 500);
+    for (let i = 0; i < 20; i++) {
+      stepZoomLerp(v, 0.25);
+      applyZoomAnchor(v, anchor);
+      const back = screenToWorld(anchor.screenX, anchor.screenY, v);
+      expect(back.worldX).toBeCloseTo(anchor.worldX, 4);
+      expect(back.worldY).toBeCloseTo(anchor.worldY, 4);
+    }
+  });
+
   it('afterEach restores the default CANVAS_W×CANVAS_H projection', () => {
     // No setViewportSize here — the prior case's afterEach has reset it.
     expect(viewWorldWidth(1)).toBe(CANVAS_W);

--- a/src/render/camera-adapter.ts
+++ b/src/render/camera-adapter.ts
@@ -22,6 +22,29 @@
 import { CANVAS_W, CANVAS_H, TILE_SIZE_PX } from './sprites.js';
 
 // ---------------------------------------------------------------------------
+// Viewport size (#238 PR3)
+// ---------------------------------------------------------------------------
+
+// The logical viewport (screen) size the screen↔world projection is computed
+// against. Initialised to the fixed canvas size; UIScene/GameScene push their
+// LayoutContext size via setViewportSize() at boot. A module setter — NOT a
+// threaded {w,h} param — because these readers fan out through clampCameraView /
+// visibleWorldRect / screenToTileZoom / beginWheelZoom into dozens of call sites.
+// AGENTS.md §"Layout discipline" names camera-adapter the screen↔world authority
+// that owns the canvas-size dependency, so it keeps the CANVAS_W/CANVAS_H import
+// as the default init value (permanently on the PR5 guard's import allowlist).
+let viewportW = CANVAS_W;
+let viewportH = CANVAS_H;
+
+/** Set the logical viewport (screen) size the projection is computed against.
+ *  Byte-identical to CANVAS_W×CANVAS_H until a responsive layout passes a real
+ *  size. Idempotent; both scenes call it at boot. */
+export function setViewportSize(w: number, h: number): void {
+  viewportW = w;
+  viewportH = h;
+}
+
+// ---------------------------------------------------------------------------
 // Zoom limits
 // ---------------------------------------------------------------------------
 
@@ -114,14 +137,14 @@ export function makeCameraView(
 // Visible-window helpers
 // ---------------------------------------------------------------------------
 
-/** Width in world pixels of the visible window at a given zoom (CANVAS_W / zoom). */
+/** Width in world pixels of the visible window at a given zoom (viewportW / zoom). */
 export function viewWorldWidth(zoom: number): number {
-  return CANVAS_W / zoom;
+  return viewportW / zoom;
 }
 
-/** Height in world pixels of the visible window at a given zoom (CANVAS_H / zoom). */
+/** Height in world pixels of the visible window at a given zoom (viewportH / zoom). */
 export function viewWorldHeight(zoom: number): number {
-  return CANVAS_H / zoom;
+  return viewportH / zoom;
 }
 
 /**
@@ -150,9 +173,9 @@ export function visibleWorldRect(v: CameraView): WorldRect {
 // ---------------------------------------------------------------------------
 
 /**
- * screen→world (world pixels). Derivation: the visible window is CANVAS_W/zoom world px
+ * screen→world (world pixels). Derivation: the visible window is viewportW/zoom world px
  * wide, centered on centerX; a screen pixel sx maps linearly across it, so
- *   worldX = centerX + (sx − CANVAS_W/2) / zoom.
+ *   worldX = centerX + (sx − viewportW/2) / zoom.
  * This agrees with Phaser's render of camera.centerOn(centerX, centerY) at zoom, but is
  * computed without touching any Phaser matrix (no staleness after a zoom change).
  */
@@ -162,8 +185,8 @@ export function screenToWorld(
   v: CameraView,
 ): { worldX: number; worldY: number } {
   return {
-    worldX: v.centerX + (screenX - CANVAS_W / 2) / v.zoom,
-    worldY: v.centerY + (screenY - CANVAS_H / 2) / v.zoom,
+    worldX: v.centerX + (screenX - viewportW / 2) / v.zoom,
+    worldY: v.centerY + (screenY - viewportH / 2) / v.zoom,
   };
 }
 
@@ -174,8 +197,8 @@ export function worldToScreen(
   v: CameraView,
 ): { screenX: number; screenY: number } {
   return {
-    screenX: (worldX - v.centerX) * v.zoom + CANVAS_W / 2,
-    screenY: (worldY - v.centerY) * v.zoom + CANVAS_H / 2,
+    screenX: (worldX - v.centerX) * v.zoom + viewportW / 2,
+    screenY: (worldY - v.centerY) * v.zoom + viewportH / 2,
   };
 }
 
@@ -277,12 +300,12 @@ export function beginWheelZoom(
 /**
  * Re-anchor the camera center so the anchor's world point sits under its screen point at
  * the current zoom. Solving screenToWorld(screenX) == worldX for centerX:
- *   worldX = centerX + (screenX − CANVAS_W/2)/zoom  ⇒  centerX = worldX − (screenX − CANVAS_W/2)/zoom.
+ *   worldX = centerX + (screenX − viewportW/2)/zoom  ⇒  centerX = worldX − (screenX − viewportW/2)/zoom.
  * Mutates v. Call AFTER each zoom-lerp step, then clamp.
  */
 export function applyZoomAnchor(v: CameraView, anchor: ZoomAnchor): void {
-  v.centerX = anchor.worldX - (anchor.screenX - CANVAS_W / 2) / v.zoom;
-  v.centerY = anchor.worldY - (anchor.screenY - CANVAS_H / 2) / v.zoom;
+  v.centerX = anchor.worldX - (anchor.screenX - viewportW / 2) / v.zoom;
+  v.centerY = anchor.worldY - (anchor.screenY - viewportH / 2) / v.zoom;
 }
 
 /** Smallest zoom delta treated as "arrived" — snaps to target and ends the lerp. */

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -18,7 +18,9 @@
 //            manual screen offsets in the draw modules, and do NOT setScrollFactor(0) on
 //            world objects (that cancels scroll but NOT zoom — see screen-effects).
 // Pitfall 2: Keyboard registration is GameScene-only — UIScene must NOT call createCursorKeys().
-// Pitfall 3: scale.mode = NONE, fixed 800x592 — no DPR scaling.
+// Pitfall 3: logical resolution is fixed at CANVAS_W×CANVAS_H; Phaser.Scale.FIT (see
+//            main.ts scale config) scales only the canvas's CSS box to fit the parent
+//            while preserving aspect ratio, so game pixels are never DPR-distorted.
 // Pitfall 4: NEVER use .keys()/.entries()/.get() on world.colonies — it is a PLAIN OBJECT (ADR-0006).
 // Pitfall 5: No setMsPerTick(Infinity) for pause — use gameLoop.pause()/resume() (Plan 06 Task 1).
 // Pitfall 6: Pause is opened via Esc (issue #116) and routed through the UIScene pause-menu
@@ -76,6 +78,7 @@ import {
   clampCameraView,
   screenToTileZoom,
   resolveDotMode,
+  setViewportSize,
 } from './camera-adapter.js';
 import { CameraController, WHEEL_ZOOM_STEP, WHEEL_NOTCH_PX } from './camera-controller.js';
 import {
@@ -194,7 +197,6 @@ import {
   type FlashDirection,
 } from './screen-effects.js';
 import { ChamberType } from '../sim/enums.js';
-import { CANVAS_W, CANVAS_H } from './sprites.js';
 import { DEFAULT_LAYOUT } from './layout.js';
 import { buildHudLayout } from './hud-layout.js';
 // UIScenePhase9 — subset of UIScene public API added in Plan 06 Task 3.
@@ -547,6 +549,10 @@ export class GameScene extends Phaser.Scene {
   }
 
   create() {
+    // #238 PR3 — publish this scene's logical canvas size to the camera-adapter
+    // projection before any camera/projection math runs this frame. Byte-identical
+    // to CANVAS_W×CANVAS_H today; both scenes set it at boot (idempotent).
+    setViewportSize(this.layout.w, this.layout.h);
     this.viewState = createViewState(PLAYER_START_X, PLAYER_START_Y);
     this.gfx = this.add.graphics();
     this.overlayGfx = this.add.graphics();
@@ -1122,7 +1128,7 @@ export class GameScene extends Phaser.Scene {
         if (captionText && uiScene) {
           uiScene.showCaption(
             captionText,
-            CANVAS_W / 2,
+            this.layout.w / 2,
             60,
             oneShotKeyForEvent(ev.type) ?? undefined,
           );
@@ -1136,7 +1142,7 @@ export class GameScene extends Phaser.Scene {
         // mentions tunnels. No one-shot key — recurring captions never dedup.
         const captionText = captionForEvent(ev.type);
         if (captionText && uiScene) {
-          uiScene.showCaption(captionText, CANVAS_W / 2, 60);
+          uiScene.showCaption(captionText, this.layout.w / 2, 60);
         }
       }
 
@@ -1149,7 +1155,7 @@ export class GameScene extends Phaser.Scene {
         const captionText = checkAndTrigger('aiInvading');
         if (captionText) {
           uiScene?.triggerScreenEdgeFlash('right');
-          if (uiScene) uiScene.showCaption(captionText, CANVAS_W / 2, 60, 'aiInvading');
+          if (uiScene) uiScene.showCaption(captionText, this.layout.w / 2, 60, 'aiInvading');
         }
       }
     }
@@ -1182,7 +1188,7 @@ export class GameScene extends Phaser.Scene {
       // Caption #9: first queen damage.
       const captionText = checkAndTrigger('queenDamage');
       if (captionText && uiScene) {
-        uiScene.showCaption(captionText, CANVAS_W / 2, CANVAS_H / 2 - 40, 'queenDamage');
+        uiScene.showCaption(captionText, this.layout.w / 2, this.layout.h / 2 - 40, 'queenDamage');
       }
     }
     this.prevQueenCombinedHp = combinedHp;
@@ -1200,7 +1206,12 @@ export class GameScene extends Phaser.Scene {
       // Caption #10: queen starvation onset.
       const captionText = checkAndTrigger('queenStarvation');
       if (captionText && uiScene) {
-        uiScene.showCaption(captionText, CANVAS_W / 2, CANVAS_H / 2 - 40, 'queenStarvation');
+        uiScene.showCaption(
+          captionText,
+          this.layout.w / 2,
+          this.layout.h / 2 - 40,
+          'queenStarvation',
+        );
       }
     }
 
@@ -1211,13 +1222,13 @@ export class GameScene extends Phaser.Scene {
     if (spiderState === 'Hunting' || spiderState === 'Striking') {
       const captionText = checkAndTrigger('spider');
       if (captionText && uiScene) {
-        uiScene.showCaption(captionText, CANVAS_W / 2, 60, 'spider');
+        uiScene.showCaption(captionText, this.layout.w / 2, 60, 'spider');
       }
     }
     if (this.world.spiderPriorityColonyId !== null) {
       const captionText = checkAndTrigger('spiderPriority');
       if (captionText && uiScene) {
-        uiScene.showCaption(captionText, CANVAS_W / 2, 60, 'spiderPriority');
+        uiScene.showCaption(captionText, this.layout.w / 2, 60, 'spiderPriority');
       }
     }
   }
@@ -1374,7 +1385,8 @@ export class GameScene extends Phaser.Scene {
           if ('colonyId' in cmd && cmd.colonyId !== PLAYER_COLONY_ID) continue;
           if (cmd.type === 'MarkDigTile') {
             const text = checkAndTrigger('dig');
-            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80, 'dig');
+            if (text && uiScene)
+              uiScene.showCaption(text, this.layout.w / 2, this.layout.h - 80, 'dig');
           } else if (cmd.type === 'PlaceChamber') {
             const chamberTypeLabel: Record<number, string> = {
               [ChamberType.Queen]: 'Queen',
@@ -1384,13 +1396,16 @@ export class GameScene extends Phaser.Scene {
             const chamberTypeName =
               chamberTypeLabel[cmd.chamberType] ?? `chamber type ${cmd.chamberType}`;
             const text = checkAndTrigger('chamber', chamberTypeName);
-            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80, 'chamber');
+            if (text && uiScene)
+              uiScene.showCaption(text, this.layout.w / 2, this.layout.h - 80, 'chamber');
           } else if (cmd.type === 'MarkFoodPile') {
             const text = checkAndTrigger('foodMark');
-            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80, 'foodMark');
+            if (text && uiScene)
+              uiScene.showCaption(text, this.layout.w / 2, this.layout.h - 80, 'foodMark');
           } else if (cmd.type === 'SetRallyPoint') {
             const text = checkAndTrigger('rally');
-            if (text && uiScene) uiScene.showCaption(text, CANVAS_W / 2, CANVAS_H - 80, 'rally');
+            if (text && uiScene)
+              uiScene.showCaption(text, this.layout.w / 2, this.layout.h - 80, 'rally');
           }
         }
       },
@@ -2180,7 +2195,7 @@ export class GameScene extends Phaser.Scene {
     const text = checkAndTrigger('autosaveFailed');
     if (text === null) return;
     const ui = this.scene.get('UIScene') as unknown as UIScenePhase9;
-    ui.showCaption(text, CANVAS_W / 2, 60, 'autosaveFailed');
+    ui.showCaption(text, this.layout.w / 2, 60, 'autosaveFailed');
   }
 
   /**

--- a/src/render/pause-menu-layout.test.ts
+++ b/src/render/pause-menu-layout.test.ts
@@ -9,6 +9,7 @@ import {
   PAUSE_MENU_BUTTON_GAP,
   type PauseMenuPage,
   type PauseMenuRenderContext,
+  type MenuItemRect,
 } from './pause-menu-layout.js';
 import { DEFAULT_LAYOUT, createLayoutContext } from './layout.js';
 import { CANVAS_W, CANVAS_H } from './sprites.js';
@@ -220,4 +221,54 @@ describe('pauseMenuItems — LayoutContext seam (issue #213)', () => {
     const taller = pauseMenuItemsAt('main', ctx, tall);
     expect(taller[0]!.rect.y).toBeGreaterThan(def[0]!.rect.y);
   });
+});
+
+// ---------------------------------------------------------------------------
+// Small-context regression fixtures (#238 PR4). Guard the PR1–3 LayoutContext
+// reflow + the Phase 6 mobile work: at a phone-portrait 360×640 context every
+// clickable rect must stay on-screen and none may overlap. These PASS today
+// (verified in #238) — they exist to fail loudly if a future reflow regresses.
+//
+// Heights below ~490 need genuine reflow (scroll / re-order), NOT proportional
+// row compression (which fails its own no-overlap test at real phone heights —
+// see #238). That reflow is owned by Phase 6.
+// ---------------------------------------------------------------------------
+
+/** True iff rect r lies fully inside the 0..w × 0..h canvas. */
+function within(r: MenuItemRect, w: number, h: number): boolean {
+  return r.x >= 0 && r.y >= 0 && r.x + r.w <= w && r.y + r.h <= h;
+}
+
+/** True iff any two rects overlap (strict — touching edges do not count). */
+function anyOverlap(rects: readonly MenuItemRect[]): boolean {
+  for (let i = 0; i < rects.length; i++) {
+    for (let j = i + 1; j < rects.length; j++) {
+      const a = rects[i]!;
+      const b = rects[j]!;
+      if (a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h) return true;
+    }
+  }
+  return false;
+}
+
+describe('pause menu — small-context regression (#238 PR4, 360×640)', () => {
+  const phone = createLayoutContext(360, 640);
+  // The tallest stacks the layout produces: main (4), main + Quit (5), settings (5).
+  const cases: Array<[string, MenuItemRect[]]> = [
+    ['main', pauseMenuItemsAt('main', ctx, phone).map((i) => i.rect)],
+    [
+      'main+quit',
+      pauseMenuItemsAt('main', { ...ctx, quitAndSurveyEnabled: true }, phone).map((i) => i.rect),
+    ],
+    ['settings', pauseMenuItemsAt('settings', ctx, phone).map((i) => i.rect)],
+  ];
+
+  for (const [name, rects] of cases) {
+    it(`${name}: every interactive rect is within the 360×640 canvas`, () => {
+      for (const r of rects) expect(within(r, 360, 640)).toBe(true);
+    });
+    it(`${name}: no interactive rects overlap`, () => {
+      expect(anyOverlap(rects)).toBe(false);
+    });
+  }
 });

--- a/src/render/save-load-dialog-layout.test.ts
+++ b/src/render/save-load-dialog-layout.test.ts
@@ -10,6 +10,7 @@ import {
   DIALOG_BUTTON_H,
   DIALOG_BUTTON_GAP,
   type SaveLoadDialogContext,
+  type DialogItemRect,
 } from './save-load-dialog-layout.js';
 import { DEFAULT_LAYOUT, createLayoutContext } from './layout.js';
 import { CANVAS_W } from './sprites.js';
@@ -232,5 +233,46 @@ describe('itemAt', () => {
     const items = saveLoadDialogItems(baseCtx); // Continue and Delete disabled
     const continueItem = items.find((i) => i.id === 'continue')!;
     expect(itemAt(items, continueItem.rect.x + 5, continueItem.rect.y + 5)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Small-context regression fixtures (#238 PR4). Guard the PR1–3 LayoutContext
+// reflow + the Phase 6 mobile work: at a phone-portrait 360×640 context every
+// clickable rect must stay on-screen and none may overlap. These PASS today
+// (verified in #238) — they exist to fail loudly if a future reflow regresses.
+//
+// Heights below ~490 need genuine reflow (scroll / re-order), NOT proportional
+// row compression (which fails its own no-overlap test at real phone heights —
+// see #238). That reflow is owned by Phase 6.
+// ---------------------------------------------------------------------------
+
+/** True iff rect r lies fully inside the 0..w × 0..h canvas. */
+function within(r: DialogItemRect, w: number, h: number): boolean {
+  return r.x >= 0 && r.y >= 0 && r.x + r.w <= w && r.y + r.h <= h;
+}
+
+/** True iff any two rects overlap (strict — touching edges do not count). */
+function anyOverlap(rects: readonly DialogItemRect[]): boolean {
+  for (let i = 0; i < rects.length; i++) {
+    for (let j = i + 1; j < rects.length; j++) {
+      const a = rects[i]!;
+      const b = rects[j]!;
+      if (a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h) return true;
+    }
+  }
+  return false;
+}
+
+describe('save/load dialog — small-context regression (#238 PR4, 360×640)', () => {
+  const phone = createLayoutContext(360, 640);
+  const rects = saveLoadDialogItemsAt(baseCtx, phone).map((i) => i.rect);
+
+  it('every interactive rect is within the 360×640 canvas', () => {
+    for (const r of rects) expect(within(r, 360, 640)).toBe(true);
+  });
+
+  it('no interactive rects overlap', () => {
+    expect(anyOverlap(rects)).toBe(false);
   });
 });

--- a/src/render/survey-overlay-layout.test.ts
+++ b/src/render/survey-overlay-layout.test.ts
@@ -13,9 +13,12 @@ import {
   surveySubmitButtonRect,
   surveySkipButtonRect,
   surveyFreeTextRect,
+  surveyBrokenRowHitRect,
+  surveyUploadRowHitRect,
   SURVEY_BROKEN_CHECKBOX_RECT,
   SURVEY_UPLOAD_CHECKBOX_RECT,
   SURVEY_CONSENT_DISCLOSURE,
+  type SurveyRect,
 } from './survey-overlay-layout.js';
 import { DEFAULT_LAYOUT, createLayoutContext } from './layout.js';
 
@@ -151,5 +154,55 @@ describe('survey layout — LayoutContext seam (issue #213)', () => {
   it('spans the free-text + row-hit width across the layout (inset 80px each side)', () => {
     const wide = createLayoutContext(1000, 700);
     expect(surveyFreeTextRect(wide).w).toBe(wide.w - 160);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Small-context regression fixtures (#238 PR4). Guard the PR1–3 LayoutContext
+// reflow + the Phase 6 mobile work: at a phone-portrait 360×640 context every
+// clickable rect must stay on-screen and none may overlap. These PASS today
+// (verified in #238) — they exist to fail loudly if a future reflow regresses.
+// The clickable set is the checkbox ROW-hit rects (not the narrow visible
+// squares), the free-text affordance, the five rating buttons, and Submit/Skip.
+//
+// Heights below ~490 need genuine reflow (scroll / re-order), NOT proportional
+// row compression (which fails its own no-overlap test at real phone heights —
+// see #238). That reflow is owned by Phase 6.
+// ---------------------------------------------------------------------------
+
+/** True iff rect r lies fully inside the 0..w × 0..h canvas. */
+function within(r: SurveyRect, w: number, h: number): boolean {
+  return r.x >= 0 && r.y >= 0 && r.x + r.w <= w && r.y + r.h <= h;
+}
+
+/** True iff any two rects overlap (strict — touching edges do not count). */
+function anyOverlap(rects: readonly SurveyRect[]): boolean {
+  for (let i = 0; i < rects.length; i++) {
+    for (let j = i + 1; j < rects.length; j++) {
+      const a = rects[i]!;
+      const b = rects[j]!;
+      if (a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h) return true;
+    }
+  }
+  return false;
+}
+
+describe('survey overlay — small-context regression (#238 PR4, 360×640)', () => {
+  const phone = createLayoutContext(360, 640);
+  const rects: SurveyRect[] = [
+    ...surveyRatingButtonsAt(phone).map((b) => b.rect),
+    surveyFreeTextRect(phone),
+    surveyBrokenRowHitRect(phone),
+    surveyUploadRowHitRect(phone),
+    surveySubmitButtonRect(phone),
+    surveySkipButtonRect(phone),
+  ];
+
+  it('every interactive rect is within the 360×640 canvas', () => {
+    for (const r of rects) expect(within(r, 360, 640)).toBe(true);
+  });
+
+  it('no interactive rects overlap', () => {
+    expect(anyOverlap(rects)).toBe(false);
   });
 });

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -36,7 +36,6 @@ import {
   triggerScreenEdgeFlash as drawScreenEdgeFlash,
   type FlashDirection,
 } from './screen-effects.js';
-import { CANVAS_W, CANVAS_H } from './sprites.js';
 
 // Re-export pure helpers for Plan 07 and external consumers
 export { formatOutcomeTitle, formatKillStatsSubtitle, formatCauseSubtitle, type QueenDeathCause };
@@ -240,6 +239,7 @@ import {
 } from './tooltips.js';
 import { DEFAULT_LAYOUT, type LayoutContext } from './layout.js';
 import { buildHudLayout, type HudLayout } from './hud-layout.js';
+import { setViewportSize } from './camera-adapter.js';
 import {
   pauseMenuItems,
   pageTitle,
@@ -570,6 +570,10 @@ export class UIScene extends Phaser.Scene {
   }
 
   create() {
+    // #238 PR3 — publish this scene's logical canvas size to the camera-adapter
+    // projection (the screen↔world authority). Byte-identical to CANVAS_W×CANVAS_H
+    // today; both scenes set it at boot (idempotent — they share DEFAULT_LAYOUT).
+    setViewportSize(this.layout.w, this.layout.h);
     this.gfx = this.add.graphics();
     this.dragState = createSliderDragState();
     // Stage 3b (#2): seed the in-mem hint-strip visibility from persisted
@@ -1394,7 +1398,7 @@ export class UIScene extends Phaser.Scene {
    * (beginCaption), never at enqueue — a dropped/coalesced hint re-triggers later.
    */
   public showFirstUseHint(id: HintFirstUseId, text: string): void {
-    this.enqueueCaption({ text, x: CANVAS_W / 2, y: 60, source: 'first-use', hintId: id });
+    this.enqueueCaption({ text, x: this.layout.w / 2, y: 60, source: 'first-use', hintId: id });
   }
 
   /** Admit a caption through the shared policy; begin it now if the queue was
@@ -1557,9 +1561,12 @@ export class UIScene extends Phaser.Scene {
     const pad = 6;
     const w = t.width;
     const h = t.height;
-    const tx = Math.max(2, Math.min(a.x + a.w / 2 - w / 2, CANVAS_W - w - 2));
-    const below = a.y < CANVAS_H / 2;
-    const ty = Math.max(2, Math.min(below ? a.y + a.h + pad : a.y - h - pad, CANVAS_H - h - 2));
+    const tx = Math.max(2, Math.min(a.x + a.w / 2 - w / 2, this.layout.w - w - 2));
+    const below = a.y < this.layout.h / 2;
+    const ty = Math.max(
+      2,
+      Math.min(below ? a.y + a.h + pad : a.y - h - pad, this.layout.h - h - 2),
+    );
     t.setPosition(tx, ty);
     this.tooltipText = t;
   }
@@ -1612,7 +1619,7 @@ export class UIScene extends Phaser.Scene {
   // scrolls, so the fixed-canvas edge strips land correctly. Delegates the draw
   // to the pure screen-effects helper with `this` = UIScene.
   public triggerScreenEdgeFlash(direction: FlashDirection): void {
-    drawScreenEdgeFlash(this, direction, CANVAS_W, CANVAS_H);
+    drawScreenEdgeFlash(this, direction, this.layout.w, this.layout.h);
   }
 
   public hideGameOverOverlay(): void {


### PR DESCRIPTION
Completes #238 (after PR1 #268). Bundles the spec's PR2-5 — all render/test-only, **byte-identical** at 800×592 (`this.layout.w/h` === `CANVAS_W/H` today; `verify` + the hud-layout deep-equality gate prove zero geometry drift). Bundled deliberately: PR5's discipline guard fails `verify` on any residual CANVAS ref, so it must land atomically with the PR2/PR3 drain it enforces.

- **PR2 — residual CANVAS_W/H drain:** ui-scene (caption x / tooltip clamp / screen-edge flash) + game-scene captions → `this.layout.w/h`; both `CANVAS_W/H` imports deleted; stale `game-scene.ts:21` `scale.mode` comment fixed (real: `Phaser.Scale.FIT`).
- **PR3 — camera-adapter viewport setter:** `viewportW/H` module state + `setViewportSize()`; the 5 projection fns read it; UIScene/GameScene call `setViewportSize(this.layout.w, this.layout.h)` at boot. Adapter **keeps** its `CANVAS_W/H` import (default init + sanctioned screen↔world authority). Adapter test gains a `setViewportSize(360,640)` case + `afterEach` reset.
- **PR4 — small-context fixtures:** `within` + `anyOverlap` helpers + a `createLayoutContext(360,640)` block in the pause-menu / save-load / survey layout tests. They **pass today** — a regression guard for the Phase-6 reflow. No proportional compression (the spec proved it fails its own no-overlap test at real phone heights).
- **PR5 — discipline guard:** `scripts/check-layout-discipline.sh` fails on a bare `800/592` or a `CANVAS_W/H` import in `src/render|input` outside the authority allowlist; wired into `verify`. **Proven to have teeth** (planted a bare literal + an import → both caught).

### Two documented allowlist entries (please sanity-check)
- `delay: 800` — a caption-hold tween duration (ms), not a canvas dimension.
- `camera.ts`'s `CANVAS_H` import — `UNDERGROUND_INITIAL_CENTER_Y_PX = CANVAS_H/2`, a genuine canvas dependency; moving that derivation into the adapter (which owns viewport) is **out of this bundle's scope** → allowlisted with a follow-up note.

### Verification
- `npm run verify`: **2792 passed | 1 skipped**, all guards clean (incl. layout-discipline); `tsc` clean.
- Cross-model reviewed by Fable.

Closes #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)