### PR TITLE
feat(input): #237 PR1 — two-pointer arbiter state machine (touch readiness)

### DIFF
--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -959,4 +959,67 @@ describe('#237 PR1 — two-pointer transition table', () => {
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // survivor up → back to idle
     expect(h.arbiter.hasPendingGesture()).toBe(false);
   });
+
+  // --- Codex-review regressions (abandon paths must reset the two-pointer
+  // bookkeeping, or the NEXT down mis-routes; the invariant is
+  // `mode==='single' ⇒ single!==null`). ------------------------------------
+
+  it('reconcileContext during a pinch abandons it: the fingers lift with no tap, then a fresh tap works once (F1)', () => {
+    const h = makeHarness('surface', 'command');
+    const f1 = tileCenter(6, 1, h.vs);
+    const f2 = tileCenter(10, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // → pinch
+    // A keyboard tool switch lands mid-pinch; the per-frame reconcile aborts it.
+    h.vs.activeTool = 'dig';
+    h.arbiter.reconcileContext();
+    const before = h.world.commandQueue.length;
+    // Teeth: lifting one finger must NOT re-arm the survivor as a single. Pre-fix
+    // the reconcile stranded mode='pinch' with both pointers, so this up re-armed
+    // finger 2 (hasPendingGesture → true) and its later lift could tap. Post-fix
+    // the pinch is fully reset, so the lift is a no-op against an idle arbiter.
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    expect(h.arbiter.hasPendingGesture()).toBe(false); // survivor NOT re-armed
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f2.x, f2.y, 2));
+    expect(h.world.commandQueue.length).toBe(before); // neither lift emitted a tap
+    // Settle the context back and prove a fresh single taps exactly once.
+    h.vs.activeTool = 'command';
+    h.arbiter.reconcileContext();
+    const tap = tileCenter(7, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, tap.x, tap.y, 1));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, tap.x, tap.y, 1));
+    expect(h.world.commandQueue.filter((c) => c.type === 'SetRallyPoint')).toHaveLength(1);
+  });
+
+  it('cancelGesture during a single (matching pointerup LOST), then a fresh same-finger tap fires once — not swallowed (F2)', () => {
+    const h = makeHarness('surface', 'command');
+    const f1 = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    // A blur / tool-select cancels the gesture; the matching pointerup never arrives.
+    h.arbiter.cancelGesture();
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+    // A fresh press of the SAME pointerId must arm a NEW single (idle→single), not
+    // fall through the stale mode==='single' path into the 2nd-finger pinch branch.
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    expect(h.arbiter.hasPendingGesture()).toBe(true);
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    expect(h.world.commandQueue.filter((c) => c.type === 'SetRallyPoint')).toHaveLength(1);
+  });
+
+  it('a mid-drag pan-bail (canPan→false) resets tracking so a later fresh tap fires once (F2)', () => {
+    const h = makeHarness('surface', 'command');
+    const start = tileCenter(6, 4, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y, 1));
+    h.canPan.value = false; // the pan gate flips off before the drag classifies
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y, 1)); // classify=pan → bail
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+    expect(panInputState.isPanning).toBe(false); // never claimed
+    // The bail must have reset the two-pointer bookkeeping to idle; a fresh press
+    // (same id) therefore arms a clean single and taps once.
+    h.canPan.value = true;
+    const tap = tileCenter(7, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, tap.x, tap.y, 1));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, tap.x, tap.y, 1));
+    expect(h.world.commandQueue.filter((c) => c.type === 'SetRallyPoint')).toHaveLength(1);
+  });
 });

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -848,3 +848,115 @@ describe('canEditWorld / canPan split', () => {
     expect(h.arbiter.isPainting()).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #237 PR1 — two-pointer transition table
+//
+// The arbiter tracks up to two button-0 (touch) pointers through an
+// idle → single → pinch → single state machine. PR1 only wires the state
+// bookkeeping (which finger owns the gesture, when a tap is / isn't emitted,
+// and the load-bearing pan-ownership handoff); the actual pinch-zoom camera
+// math lands in PR2. These tests pin the transitions by their OBSERVABLE
+// effects — hasPendingGesture() (a single is armed), panInputState.isPanning
+// (pan ownership), and world.commandQueue (a tap fired) — since mode/pointers
+// are private. Two fingers are distinct pointerIds on the same LEFT_BUTTON.
+// ---------------------------------------------------------------------------
+
+describe('#237 PR1 — two-pointer transition table', () => {
+  it('idle→single→pinch→single: a 2nd finger clears the single; lifting one re-arms the survivor', () => {
+    const h = makeHarness('surface', 'command');
+    const f1 = tileCenter(6, 1, h.vs);
+    const f2 = tileCenter(10, 1, h.vs);
+    // idle → single
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    expect(h.arbiter.hasPendingGesture()).toBe(true);
+    // single → pinch: the single snapshot is cleared (no pending tap while pinching)
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f2.x, f2.y, 2));
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+    // pinch → single: lifting finger 1 re-snapshots the survivor (finger 2)
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    expect(h.arbiter.hasPendingGesture()).toBe(true);
+  });
+
+  it('a re-down of the SAME finger while single does NOT enter pinch', () => {
+    const h = makeHarness('surface', 'command');
+    const f1 = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    // Same pointerId down again → ignored; still a live single (not pinch).
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    expect(h.arbiter.hasPendingGesture()).toBe(true);
+    // Lifting it taps (proves it stayed 'single', not 'pinch' which emits no tap).
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    expect(h.world.commandQueue.some((c) => c.type === 'SetRallyPoint')).toBe(true);
+  });
+
+  it('lifting a pinch finger emits NO tap (pinch fingers are not taps)', () => {
+    const h = makeHarness('surface', 'command'); // a surface tap would enqueue SetRallyPoint
+    const f1 = tileCenter(6, 1, h.vs);
+    const f2 = tileCenter(10, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // → pinch
+    const before = h.world.commandQueue.length;
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f1.x, f1.y, 1)); // lift a pinch finger
+    expect(h.world.commandQueue.length).toBe(before); // no tap enqueued
+  });
+
+  it('entering pinch from a live left-drag pan RELEASES the pan claim (#85 ownership protocol)', () => {
+    const h = makeHarness('surface', 'command');
+    const f1 = tileCenter(6, 4, h.vs);
+    const f2 = tileCenter(12, 4, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, f1.x + 40, f1.y, 1)); // cross threshold → pan
+    expect(panInputState.isPanning).toBe(true);
+    // 2nd finger → pinch. The handoff MUST go through cancelGesture (ownership-gated)
+    // so the live pan's isPanning claim is dropped — else keyboard pan stays locked.
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f2.x, f2.y, 2));
+    expect(panInputState.isPanning).toBe(false);
+  });
+
+  it('a 3rd finger during pinch is ignored and does not disturb the two tracked fingers', () => {
+    const h = makeHarness('surface', 'command');
+    const f1 = tileCenter(6, 1, h.vs);
+    const f2 = tileCenter(10, 1, h.vs);
+    const f3 = tileCenter(14, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // → pinch
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f3.x, f3.y, 3)); // 3rd → ignored (untracked)
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f3.x, f3.y, 3)); // untracked up → ignored
+    expect(h.arbiter.hasPendingGesture()).toBe(false); // still pinch, undisturbed
+    // Lifting a REAL pinch finger still re-arms the survivor → proves f1/f2 intact.
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f2.x, f2.y, 2));
+    expect(h.arbiter.hasPendingGesture()).toBe(true);
+  });
+
+  it('onPointerUpOutside abandons a pinch: releases the pan claim, clears pointers, re-idles', () => {
+    const h = makeHarness('surface', 'command');
+    const f1 = tileCenter(6, 4, h.vs);
+    const f2 = tileCenter(12, 4, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, f1.x + 40, f1.y, 1)); // pan
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // → pinch (releases pan)
+    h.arbiter.onPointerUpOutside();
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+    expect(panInputState.isPanning).toBe(false);
+    // A fresh single works after the reset — the arbiter is not stranded in 'pinch'.
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    expect(h.arbiter.hasPendingGesture()).toBe(true);
+  });
+
+  it('a full two-finger pinch that lifts BOTH fingers returns to idle (no residual tap)', () => {
+    const h = makeHarness('surface', 'command');
+    const f1 = tileCenter(6, 1, h.vs);
+    const f2 = tileCenter(10, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // → pinch
+    const before = h.world.commandQueue.length;
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f1.x, f1.y, 1)); // → survivor f2 single (no tap)
+    // Lifting the survivor with no intervening move IS a tap on its snapshot tile —
+    // that's the survivor behaving as a real single, which is correct. Assert only
+    // that the FIRST lift (the pinch finger) emitted nothing.
+    expect(h.world.commandQueue.length).toBe(before);
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // survivor up → back to idle
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+  });
+});

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -1022,4 +1022,35 @@ describe('#237 PR1 — two-pointer transition table', () => {
     h.arbiter.onPointerUp(ev(LEFT_BUTTON, tap.x, tap.y, 1));
     expect(h.world.commandQueue.filter((c) => c.type === 'SetRallyPoint')).toHaveLength(1);
   });
+
+  it('a mid-drag paint-bail (canEditWorld→false) resets tracking so a later fresh dig tap marks once (F2 paint twin)', () => {
+    const h = makeHarness('underground', 'dig'); // underground+Dig → a drag classifies as paint
+    h.canEditWorld.value = false;
+    const start = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y, 1));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 40, start.y, 1)); // classify=paint → bail
+    expect(h.arbiter.hasPendingGesture()).toBe(false);
+    expect(h.arbiter.isPainting()).toBe(false);
+    // The bail reset the two-pointer bookkeeping; a fresh dig tap now marks once.
+    h.canEditWorld.value = true;
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y, 1));
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, start.x, start.y, 1));
+    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(1);
+  });
+
+  it('a pinch survivor over the HUD is NOT re-armed as a world tap (idle guards re-applied on re-snapshot) (Codex #271)', () => {
+    const h = makeHarness('surface', 'command');
+    const worldPt = tileCenter(6, 1, h.vs);
+    const hudPt = { x: 4, y: 4 };
+    // Only finger 2's location reads as HUD. The 2nd-finger→pinch handoff does NOT
+    // HUD-guard, so finger 2 is tracked; the guard must bite on the survivor lift.
+    h.setHudHit((x, y) => x === hudPt.x && y === hudPt.y);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, worldPt.x, worldPt.y, 1)); // finger 1: world single
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, hudPt.x, hudPt.y, 2)); // finger 2 on HUD → pinch
+    const before = h.world.commandQueue.length;
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, worldPt.x, worldPt.y, 1)); // lift world finger → survivor = HUD finger
+    expect(h.arbiter.hasPendingGesture()).toBe(false); // survivor over HUD → dropped, not re-armed
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, hudPt.x, hudPt.y, 2)); // lift the HUD finger
+    expect(h.world.commandQueue.length).toBe(before); // no world tap from HUD coordinates
+  });
 });

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -433,17 +433,9 @@ export class GestureArbiter {
       return;
     }
 
-    // mode === 'idle' — arm a single from the first pointer if the guards pass.
-    // While the chamber context menu is up (or about to (dis)appear), a left press
-    // is a menu select/dismiss owned by UIScene's pointerdown — don't arm, or the
-    // same click would also fire a world tap. Mirrors the retired underground guard.
-    if (this.deps.isContextMenuActive()) return;
-    // Arm if EITHER a pan or a world edit could result; the per-mode gate is
-    // re-checked when the gesture resolves (canPan in the move→pan branch,
-    // canEditWorld at paint-begin / tap dispatch). Gating the whole press on
-    // canEditWorld here would kill left-drag pan while user-paused.
-    if (!this.deps.canPan() && !this.deps.canEditWorld()) return;
-    if (this.deps.isPointerOverHUD(ev.x, ev.y)) return;
+    // mode === 'idle' — arm a single from the first pointer if the admission
+    // guards pass (context-menu / pan-or-edit / HUD; see canArmSingleAt).
+    if (!this.canArmSingleAt(ev.x, ev.y)) return;
     if (!this.armSingle(ev.pointerId, ev.x, ev.y)) return; // world unavailable
     this.mode = 'single';
     this.pointers.set(ev.pointerId, { pointerId: ev.pointerId, x: ev.x, y: ev.y });
@@ -456,12 +448,37 @@ export class GestureArbiter {
   }
 
   /**
+   * canArmSingleAt — the idle-down ADMISSION guards for arming a single (tap/drag)
+   * at a screen point. Applied both to a fresh first-pointer down AND to the
+   * survivor re-snapshot when one pinch finger lifts. The survivor re-check is
+   * load-bearing (Codex #271): the 2nd-finger→pinch handoff does NOT HUD-guard its
+   * pointer, so without re-checking here a finger placed on the HUD could outlive
+   * the pinch and dispatch a world tap from HUD coordinates.
+   *
+   *  - isContextMenuActive: while the chamber menu is up (or about to (dis)appear)
+   *    a left press is a menu select/dismiss owned by UIScene's pointerdown — don't
+   *    arm, or the same click would also fire a world tap.
+   *  - canPan || canEditWorld: arm if EITHER a pan or a world edit could result;
+   *    the per-mode gate is re-checked when the gesture resolves (canPan in the
+   *    move→pan branch, canEditWorld at paint-begin / tap dispatch). Gating the
+   *    whole press on canEditWorld would kill left-drag pan while user-paused.
+   *  - isPointerOverHUD: a press on a HUD zone belongs to the HUD, not the world.
+   */
+  private canArmSingleAt(x: number, y: number): boolean {
+    if (this.deps.isContextMenuActive()) return false;
+    if (!this.deps.canPan() && !this.deps.canEditWorld()) return false;
+    if (this.deps.isPointerOverHUD(x, y)) return false;
+    return true;
+  }
+
+  /**
    * armSingle — capture a fresh single (tap/drag) snapshot at a screen position.
    * Shared by a first left/touch down and by the survivor re-snapshot when one
    * pinch finger lifts (#237 PR1). Returns false (nothing armed) when the world is
-   * unavailable. The tap acts on the SNAPSHOTTED tile/tool/view, not live state (a
-   * later keyboard change can't retarget it; reconcileContext cancels on such
-   * changes).
+   * unavailable. Callers gate on canArmSingleAt FIRST (HUD/menu/edit admission);
+   * this only fails on an unavailable world. The tap acts on the SNAPSHOTTED
+   * tile/tool/view, not live state (a later keyboard change can't retarget it;
+   * reconcileContext cancels on such changes).
    *
    * Paint note: the underground-Dig stroke is NOT begun here — it is armed lazily
    * on the first move classified as paint (see onPointerMove), so a release before
@@ -595,13 +612,18 @@ export class GestureArbiter {
       if (!this.pointers.has(ev.pointerId)) return; // untracked 3rd-finger up — ignore
       this.pointers.delete(ev.pointerId);
       const survivor = [...this.pointers.values()][0];
-      if (survivor !== undefined && this.armSingle(survivor.pointerId, survivor.x, survivor.y)) {
+      // Re-apply the idle-down admission guards before re-arming (Codex #271): a
+      // survivor now over the HUD / under an open menu / with the world gone must
+      // NOT become a tap. If it can't arm, cancelGesture drops everything → idle
+      // (the still-down finger then no-ops until it lifts and a fresh press starts).
+      if (
+        survivor !== undefined &&
+        this.canArmSingleAt(survivor.x, survivor.y) &&
+        this.armSingle(survivor.pointerId, survivor.x, survivor.y)
+      ) {
         this.mode = 'single';
       } else {
-        this.pointers.clear();
-        this.single = null;
-        this.dragMode = null;
-        this.mode = 'idle';
+        this.cancelGesture();
       }
       // PR2 clears pinch state (pinch = null) here.
       return;

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -100,6 +100,12 @@ export interface ArbiterPointerEvent {
   x: number;
   /** Screen Y in pixels. */
   y: number;
+  /**
+   * #237 — Phaser `pointer.wasTouch`: true when this event came from touch. The
+   * stable boolean to gate touch-only behavior (pinch entry / long-press / hover
+   * preview). Optional so existing unit tests need not set it (mouse paths).
+   */
+  wasTouch?: boolean;
 }
 
 /** Snapshot taken at left pointer-down; the tap acts on these, not live state. */
@@ -217,8 +223,17 @@ export class GestureArbiter {
   private readonly deps: GestureArbiterDeps;
   private readonly paintStroke: PaintStrokeState = createPaintStrokeState();
 
-  /** Snapshot of the active left press, or null when no left gesture is pending. */
-  private snapshot: GestureSnapshot | null = null;
+  /**
+   * #237 PR1 — two-pointer state. `mode` gates the handlers; `pointers` tracks
+   * every down button-0/touch pointer's live position (the source for a pinch's
+   * midpoint/distance in PR2, and for re-snapshotting the survivor when one pinch
+   * finger lifts). `single` is the tap/drag gesture (the former `snapshot`). The
+   * pinch camera state (`PinchState` + begin/applyPinch) arrives in PR2.
+   */
+  private mode: 'idle' | 'single' | 'pinch' = 'idle';
+  private pointers = new Map<number, { pointerId: number; x: number; y: number }>();
+  /** Snapshot of the active single (tap/drag) press, or null when none is pending. */
+  private single: GestureSnapshot | null = null;
   /** Once the threshold is crossed, the resolved drag mode ('paint' | 'pan'); null while still a tap. */
   private dragMode: 'paint' | 'pan' | null = null;
   /** Last pointer position seen during a pan drag (for incremental camera delta). */
@@ -245,9 +260,9 @@ export class GestureArbiter {
     return this.dragMode === 'paint' && this.paintStroke.active;
   }
 
-  /** True while a left gesture is pending (down seen, up not yet). */
+  /** True while a single (tap/drag) gesture is pending (down seen, up not yet). */
   hasPendingGesture(): boolean {
-    return this.snapshot !== null;
+    return this.single !== null;
   }
 
   /**
@@ -298,7 +313,7 @@ export class GestureArbiter {
    * release anyway.
    */
   private clearLeftGesture(): void {
-    this.snapshot = null;
+    this.single = null;
     this.dragMode = null;
     resetPaintStrokeState(this.paintStroke);
   }
@@ -349,32 +364,73 @@ export class GestureArbiter {
       return;
     }
     if (ev.button !== LEFT_BUTTON) return;
-    // While the chamber context menu is up (or about to (dis)appear), a left
-    // press is a menu select/dismiss owned by UIScene's pointerdown — don't arm
-    // a snapshot, or the same click would also fire a world tap (re-open the
-    // menu / mark a dig). Mirrors the retired underground-input guard.
+
+    // #237 PR1 — two-pointer transitions (button-0 / touch). `pointers` tracks
+    // every down button-0 pointer; `mode` gates the handlers.
+    if (this.mode === 'pinch') {
+      // A 3rd+ finger while pinching → ignore (not tracked).
+      return;
+    }
+    if (this.mode === 'single') {
+      // A 2nd distinct pointer while a single gesture is live → enter pinch.
+      if (this.single !== null && ev.pointerId === this.single.pointerId) return; // same id re-down
+      // Hand off via cancelGesture (NOT clearLeftGesture) so a live left-drag pan
+      // releases its panInputState.isPanning claim — the load-bearing pan-ownership
+      // protocol (see cancelGesture / issue #85 / Fix 2). It clears single/dragMode/
+      // paint but LEAVES `pointers` intact (finger 1 stays tracked).
+      this.cancelGesture();
+      this.pointers.set(ev.pointerId, { pointerId: ev.pointerId, x: ev.x, y: ev.y });
+      this.mode = 'pinch';
+      // PR2 wires beginPinch(...) here from the two tracked pointers.
+      return;
+    }
+
+    // mode === 'idle' — arm a single from the first pointer if the guards pass.
+    // While the chamber context menu is up (or about to (dis)appear), a left press
+    // is a menu select/dismiss owned by UIScene's pointerdown — don't arm, or the
+    // same click would also fire a world tap. Mirrors the retired underground guard.
     if (this.deps.isContextMenuActive()) return;
-    // Arm a snapshot if EITHER a pan or a world edit could result; the per-mode
-    // gate is re-checked when the gesture resolves (canPan in the move→pan
-    // branch, canEditWorld at paint-begin / tap dispatch). Gating the whole
-    // press on canEditWorld here would kill left-drag pan while user-paused.
+    // Arm if EITHER a pan or a world edit could result; the per-mode gate is
+    // re-checked when the gesture resolves (canPan in the move→pan branch,
+    // canEditWorld at paint-begin / tap dispatch). Gating the whole press on
+    // canEditWorld here would kill left-drag pan while user-paused.
     if (!this.deps.canPan() && !this.deps.canEditWorld()) return;
     if (this.deps.isPointerOverHUD(ev.x, ev.y)) return;
+    if (!this.armSingle(ev.pointerId, ev.x, ev.y)) return; // world unavailable
+    this.mode = 'single';
+    this.pointers.set(ev.pointerId, { pointerId: ev.pointerId, x: ev.x, y: ev.y });
 
+    // Stage 3b (#3): a world gesture has begun. Signal it so GameScene can evaluate
+    // the proactive [Tab] first-use nudge on the player's first world input of the
+    // session (the nudge gate reads view/undergroundVisited, which a pan/dig press
+    // does not change, so firing at press-time is safe).
+    this.deps.onWorldInput?.();
+  }
+
+  /**
+   * armSingle — capture a fresh single (tap/drag) snapshot at a screen position.
+   * Shared by a first left/touch down and by the survivor re-snapshot when one
+   * pinch finger lifts (#237 PR1). Returns false (nothing armed) when the world is
+   * unavailable. The tap acts on the SNAPSHOTTED tile/tool/view, not live state (a
+   * later keyboard change can't retarget it; reconcileContext cancels on such
+   * changes).
+   *
+   * Paint note: the underground-Dig stroke is NOT begun here — it is armed lazily
+   * on the first move classified as paint (see onPointerMove), so a release before
+   * the threshold is a single-tile Dig tap (onPointerUp) and cannot double-emit.
+   */
+  private armSingle(pointerId: number, x: number, y: number): boolean {
     const world = this.deps.getWorld();
-    if (!world) return;
+    if (!world) return false;
     const vs = this.deps.viewState;
     const cam = activeCamera(vs);
-    const { tileX, tileY } = screenToTileZoom(ev.x, ev.y, cam);
+    const { tileX, tileY } = screenToTileZoom(x, y, cam);
     const spiderHit =
-      vs.activeView === 'surface'
-        ? isSpiderHit(world, vs, ev.x, ev.y, this.deps.getPrevWorld())
-        : false;
-
-    this.snapshot = {
-      pointerId: ev.pointerId,
-      downX: ev.x,
-      downY: ev.y,
+      vs.activeView === 'surface' ? isSpiderHit(world, vs, x, y, this.deps.getPrevWorld()) : false;
+    this.single = {
+      pointerId,
+      downX: x,
+      downY: y,
       tileX,
       tileY,
       spiderHit,
@@ -383,26 +439,33 @@ export class GestureArbiter {
       undergroundColonyId: vs.activeUndergroundColonyId,
     };
     this.dragMode = null;
-    this.panLastX = ev.x;
-    this.panLastY = ev.y;
-
-    // Stage 3b (#3): a world gesture has begun. Signal it so GameScene can
-    // evaluate the proactive [Tab] first-use nudge on the player's first world
-    // input of the session (the nudge gate reads view/undergroundVisited, which
-    // a pan/dig press does not change, so firing at press-time is safe).
-    this.deps.onWorldInput?.();
-
-    // Eagerly begin a paint stroke for underground-Dig so the down-tile mark
-    // fires immediately (matching the prior click-then-drag behavior). The
-    // stroke only PAINTS once the threshold is crossed; a release before then
-    // is a single-tile Dig tap (handled in onPointerUp), so we must not let the
-    // eager begin double-emit. We therefore arm the stroke lazily on the first
-    // move classified as paint instead — see onPointerMove.
+    this.panLastX = x;
+    this.panLastY = y;
+    return true;
   }
 
   onPointerMove(ev: ArbiterPointerEvent): void {
-    const snap = this.snapshot;
+    // #237 PR1 — pinch: track each finger's live position (PR2 recomputes the
+    // midpoint/distance from `pointers` and applies the zoom here).
+    if (this.mode === 'pinch') {
+      const p = this.pointers.get(ev.pointerId);
+      if (p !== undefined) {
+        p.x = ev.x;
+        p.y = ev.y;
+      }
+      return;
+    }
+    if (this.mode !== 'single') return; // idle — no gesture pending
+
+    const snap = this.single;
     if (snap === null || ev.pointerId !== snap.pointerId) return;
+    // Keep the tracked position current so a 2nd finger's pinch begins from this
+    // pointer's live (moved) position, not its stale down position.
+    const tracked = this.pointers.get(ev.pointerId);
+    if (tracked !== undefined) {
+      tracked.x = ev.x;
+      tracked.y = ev.y;
+    }
 
     // Classify on first crossing of the threshold.
     if (this.dragMode === null) {
@@ -469,7 +532,39 @@ export class GestureArbiter {
   }
 
   onPointerUp(ev: ArbiterPointerEvent): void {
-    const snap = this.snapshot;
+    // #237 PR1 — a pinch finger lifted: NO tap. Drop it and re-snapshot the
+    // survivor as a fresh single (so lifting it later taps, moving it pans/paints).
+    if (this.mode === 'pinch') {
+      if (!this.pointers.has(ev.pointerId)) return; // untracked 3rd-finger up — ignore
+      this.pointers.delete(ev.pointerId);
+      const survivor = [...this.pointers.values()][0];
+      if (survivor !== undefined && this.armSingle(survivor.pointerId, survivor.x, survivor.y)) {
+        this.mode = 'single';
+      } else {
+        this.pointers.clear();
+        this.single = null;
+        this.dragMode = null;
+        this.mode = 'idle';
+      }
+      // PR2 clears pinch state (pinch = null) here.
+      return;
+    }
+    if (this.mode !== 'single') return; // idle — nothing pending
+
+    // Remove this pointer up-front so every exit path of the single-up teardown
+    // leaves `pointers` correct; then run today's single-gesture up handling.
+    this.pointers.delete(ev.pointerId);
+    this.handleSingleUp(ev);
+    if (this.pointers.size === 0) this.mode = 'idle';
+  }
+
+  /**
+   * handleSingleUp — today's single-pointer up handling (drag-end / menu-swallow /
+   * TAP). Operates on `this.single`; onPointerUp above owns the two-pointer
+   * bookkeeping. Extracted verbatim in #237 PR1.
+   */
+  private handleSingleUp(ev: ArbiterPointerEvent): void {
+    const snap = this.single;
     if (snap === null || ev.pointerId !== snap.pointerId) {
       // A left-up with no matching snapshot: the arbiter has no pending left
       // gesture, so it does NOT own panInputState.isPanning here. Leave the flag
@@ -521,9 +616,14 @@ export class GestureArbiter {
     this.cancelGesture();
   }
 
-  /** pointerupoutside / blur — abandon whatever was pending. */
+  /** pointerupoutside / blur — abandon everything pending. */
   onPointerUpOutside(): void {
+    // Release the single gesture (dropping pan iff owned), then clear all tracked
+    // pointers + any pinch so a stray finger can't strand the arbiter in 'pinch'.
     this.cancelGesture();
+    this.pointers.clear();
+    this.mode = 'idle';
+    // PR2 clears pinch state here.
   }
 
   // --- internals -----------------------------------------------------------
@@ -708,6 +808,7 @@ export function registerGestureArbiter(
       button: pointer.button,
       x: pointer.x,
       y: pointer.y,
+      wasTouch: pointer.wasTouch,
     });
   });
   scene.input.on('pointermove', (pointer: import('phaser').Input.Pointer) => {
@@ -719,6 +820,7 @@ export function registerGestureArbiter(
       button: pointer.button,
       x: pointer.x,
       y: pointer.y,
+      wasTouch: pointer.wasTouch,
     });
   });
   scene.input.on('pointerup', (pointer: import('phaser').Input.Pointer) => {
@@ -727,6 +829,7 @@ export function registerGestureArbiter(
       button: pointer.button,
       x: pointer.x,
       y: pointer.y,
+      wasTouch: pointer.wasTouch,
     });
   });
   scene.input.on('pointerupoutside', () => {

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -266,12 +266,39 @@ export class GestureArbiter {
   }
 
   /**
-   * cancelGesture — synchronously abandon any in-flight left gesture: clear the
-   * pending tap (snapshot), the paint stroke, the pan/drag state, AND
-   * panInputState.isPanning IFF the arbiter currently owns the pan (a left-drag
-   * pan, dragMode==='pan'). Idempotent; safe to call when nothing is pending.
+   * cancelGesture — FULLY abandon any in-flight gesture: release the single
+   * (tap/drag) snapshot + paint stroke, drop panInputState.isPanning IFF the
+   * arbiter owns the pan (dragMode==='pan'), AND reset the two-pointer
+   * bookkeeping (mode→idle, every tracked pointer forgotten). Idempotent; safe
+   * when nothing is pending.
    *
-   * The isPanning clear is guarded on ownership because that flag is a shared
+   * This is the "abandon everything" primitive every abort caller wants —
+   * reconcileContext (tool/view/colony change), selectTool, blur, the RIGHT
+   * button, and the pan/menu/tap teardowns in handleSingleUp. The two-pointer
+   * reset (#237 PR1) is load-bearing: a keyboard-driven cancel DURING a pinch
+   * must not strand mode='pinch' with live `pointers`, or a later finger-lift
+   * would re-arm a stray single / emit a tap under the changed context (Codex
+   * F1). Likewise it guarantees the invariant `mode==='single' ⇒ single!==null`:
+   * a cancel can never leave mode='single' with a null snapshot for the next
+   * down to mis-route into the 2nd-finger (pinch) branch (Codex F2).
+   *
+   * The single→pinch handoff (onPointerDown) deliberately does NOT use this — it
+   * needs the ownership-gated release WITHOUT the pointer reset (finger 1 stays
+   * tracked for the pinch), so it calls releaseSingle directly.
+   */
+  cancelGesture(): void {
+    this.releaseSingle();
+    this.resetPointerTracking();
+  }
+
+  /**
+   * releaseSingle — ownership-gated teardown of the single (tap/drag) gesture:
+   * clear its snapshot + paint stroke, and drop panInputState.isPanning IFF this
+   * gesture owned the pan (dragMode==='pan'). Does NOT touch the two-pointer
+   * bookkeeping — cancelGesture layers resetPointerTracking on top; the
+   * single→pinch handoff calls this ALONE so finger 1 stays tracked.
+   *
+   * The isPanning clear is ownership-guarded because that flag is a shared
    * singleton: registerDragPan claims it for a MIDDLE-button drag-pan. Callers
    * such as reconcileContext (tool/view/colony change) and selectTool fire on the
    * frame a hotkey lands, which can be DURING a live middle-drag; an unconditional
@@ -280,18 +307,33 @@ export class GestureArbiter {
    * pointerdown, never on move). When dragMode!=='pan' the arbiter does not own
    * isPanning, so it leaves the flag to whoever does.
    *
-   * Fix 2 — cancelGesture (NOT clearLeftGesture) is what the RIGHT-button branch
-   * uses, so a right-click DURING an active left-drag pan (dragMode==='pan')
-   * releases the pan claim: right-click has no registerDragPan release handler, so
-   * without this the flag would stay set and keyboard pan would remain suppressed
-   * (the #85 lock) until another full pan or a session reset. The ownership guard
-   * keeps it safe when the left gesture was NOT panning (dragMode null → a foreign
-   * isPanning, e.g. set by some other owner, is left intact).
+   * Fix 2 — cancelGesture (via releaseSingle, NOT clearLeftGesture) is what the
+   * RIGHT-button branch uses, so a right-click DURING an active left-drag pan
+   * (dragMode==='pan') releases the pan claim: right-click has no registerDragPan
+   * release handler, so without this the flag would stay set and keyboard pan
+   * would remain suppressed (the #85 lock) until another full pan or a session
+   * reset. The ownership guard keeps it safe when the left gesture was NOT panning
+   * (dragMode null → a foreign isPanning, e.g. set by some other owner, is left
+   * intact).
    */
-  cancelGesture(): void {
+  private releaseSingle(): void {
     const ownsPan = this.dragMode === 'pan';
     this.clearLeftGesture();
     if (ownsPan) panInputState.isPanning = false;
+  }
+
+  /**
+   * resetPointerTracking — return the two-pointer state machine to idle: forget
+   * every tracked pointer and set mode='idle'. Paired with releaseSingle by
+   * cancelGesture, and with clearLeftGesture by the mid-drag paint/pan bails and
+   * the secondary-button branch — i.e. anywhere a gesture is abandoned WITHOUT a
+   * matching pointerup. Keeping it out of those paths would let mode='single'
+   * linger with a null single (or mode='pinch' linger with dead pointers), which
+   * mis-routes the next down (Codex F1/F2).
+   */
+  private resetPointerTracking(): void {
+    this.pointers.clear();
+    this.mode = 'idle';
   }
 
   /**
@@ -359,7 +401,12 @@ export class GestureArbiter {
         this.cancelGesture();
         this.handleRightClick(ev);
       } else {
+        // MIDDLE: clearLeftGesture leaves isPanning ALONE (registerDragPan just
+        // claimed it for the middle drag); resetPointerTracking still abandons the
+        // left gesture's two-pointer bookkeeping so a stale mode/pointer can't
+        // outlive it (without touching isPanning).
         this.clearLeftGesture();
+        this.resetPointerTracking();
       }
       return;
     }
@@ -374,11 +421,12 @@ export class GestureArbiter {
     if (this.mode === 'single') {
       // A 2nd distinct pointer while a single gesture is live → enter pinch.
       if (this.single !== null && ev.pointerId === this.single.pointerId) return; // same id re-down
-      // Hand off via cancelGesture (NOT clearLeftGesture) so a live left-drag pan
-      // releases its panInputState.isPanning claim — the load-bearing pan-ownership
-      // protocol (see cancelGesture / issue #85 / Fix 2). It clears single/dragMode/
-      // paint but LEAVES `pointers` intact (finger 1 stays tracked).
-      this.cancelGesture();
+      // Hand off via releaseSingle (NOT cancelGesture) so a live left-drag pan
+      // releases its panInputState.isPanning claim through the load-bearing
+      // ownership protocol (see releaseSingle / issue #85 / Fix 2) while finger 1
+      // stays tracked in `pointers` — cancelGesture would additionally reset the
+      // very bookkeeping we are about to build the pinch from.
+      this.releaseSingle();
       this.pointers.set(ev.pointerId, { pointerId: ev.pointerId, x: ev.x, y: ev.y });
       this.mode = 'pinch';
       // PR2 wires beginPinch(...) here from the two tracked pointers.
@@ -479,7 +527,11 @@ export class GestureArbiter {
         // Use clearLeftGesture (not cancelGesture): no pan was claimed here, so
         // we must not touch panInputState.isPanning a concurrent owner may hold.
         if (!this.deps.canEditWorld()) {
+          // Abandon the whole gesture: clearLeftGesture (no isPanning to release —
+          // paint never claimed it) + resetPointerTracking so mode/pointers don't
+          // linger as a stale 'single' the next down would mis-route (Codex F2).
           this.clearLeftGesture();
+          this.resetPointerTracking();
           return;
         }
         const world = this.deps.getWorld();
@@ -507,7 +559,12 @@ export class GestureArbiter {
         // it yet on this path — the claim below is the only setter — and a
         // concurrent middle-drag may own it).
         if (!this.deps.canPan()) {
+          // Abandon before claiming the camera: clearLeftGesture leaves isPanning
+          // untouched (we never set it on this path; a concurrent middle-drag may
+          // own it) and resets dragMode→null; resetPointerTracking clears the stale
+          // 'single' bookkeeping so the next down isn't mis-routed (Codex F2).
           this.clearLeftGesture();
+          this.resetPointerTracking();
           return;
         }
         // Claim the camera so keyboard pan is suppressed for the duration.
@@ -618,11 +675,10 @@ export class GestureArbiter {
 
   /** pointerupoutside / blur — abandon everything pending. */
   onPointerUpOutside(): void {
-    // Release the single gesture (dropping pan iff owned), then clear all tracked
-    // pointers + any pinch so a stray finger can't strand the arbiter in 'pinch'.
+    // cancelGesture now fully resets: releases the single (dropping pan iff owned)
+    // AND clears the two-pointer bookkeeping (mode→idle, pointers cleared), so a
+    // stray finger can't strand the arbiter in 'pinch'.
     this.cancelGesture();
-    this.pointers.clear();
-    this.mode = 'idle';
     // PR2 clears pinch state here.
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,6 +121,10 @@ export function mount(target: HTMLElement, options?: MountOptions): MountedGame 
       width: CANVAS_W,
       height: CANVAS_H,
     },
+    // #237 — Phaser's default gives ONE active touch pointer, so a 2nd finger is
+    // invisible. Allow 3 (two fingers for pinch + headroom) so the arbiter's
+    // two-pointer tracking sees the second touch.
+    input: { activePointers: 3 },
     scene: [GameScene, UIScene],
     callbacks: {
       // preBoot fires before any scene is added or starts preload(), so the


### PR DESCRIPTION
**#237 PR1 of 5** — touch-input readiness. This PR wires the multi-pointer *plumbing* the rest of #237 builds on; it is state bookkeeping **only**, no behavior change on the desktop/single-pointer path.

## What & why
Phaser's default surfaces one active touch pointer, so a second finger is invisible. This PR:
- **`main.ts`**: `input.activePointers = 3` (two fingers for pinch + headroom).
- **`gesture-arbiter.ts`**: replaces the single `snapshot` field with a two-pointer state machine — `mode` (`idle|single|pinch`), a `pointers` map of live positions, and `single` (the renamed tap/drag snapshot). Adds `wasTouch?` to `ArbiterPointerEvent` (plumbed now, consumed by PR3).

## Transition table (onPointerDown/Move/Up)
- 2nd distinct pointer during a `single` → hand off to `pinch`
- 3rd finger while pinching → ignored
- lift one pinch finger → re-snapshot the survivor as a fresh `single` (**no tap**)
- lifting a pinch finger **never** taps
- `onPointerUpOutside` abandons a pinch so a stray finger can't strand the arbiter

## The load-bearing bit
The `single → pinch` handoff goes through `cancelGesture` (ownership-gated), so a live left-drag **pan releases its `panInputState.isPanning` claim** — preserving the #85 pan-ownership protocol. `armSingle` factors the arm body (shared by first-down and survivor re-snapshot); `handleSingleUp` extracts today's single-pointer up handling verbatim.

## Scope boundary
Pinch-zoom **camera math** (`PinchState` + `begin/applyPinch`) is deferred to **PR2**. Entering pinch here tracks the second finger but does **not** zoom.

## Verification
- `npm run verify` green — **2800 passed** | 1 skipped.
- All **44 existing** arbiter tests pass unchanged (single-pointer behavior preserved).
- **+7 transition-table tests**: idle→single→pinch→single, same-finger re-down stays single, no-tap-on-pinch-lift, pan-claim-released-on-single→pinch, 3rd-finger-ignore, upoutside-reset, both-fingers-up→idle.

Render-layer only — no `src/sim/` imports, no `WorldState` mutation, no `simVersion` touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved two-finger gesture handling, including pinch detection alongside single-finger input.
  * Increased touch tracking so a second finger is recognized reliably during gameplay.

* **Bug Fixes**
  * Fixed cases where pinch gestures could interfere with taps or leave the app in a stuck gesture state.
  * Improved recovery when fingers are lifted in different orders or moved outside the active area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->