### PR TITLE
feat(input): #237 PR2 — pinch zoom (touch)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,11 +21,32 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
+      // Exclude the touch-only specs (#237) — they need hasTouch and run in the
+      // chromium-touch project below. Anchored to a basename starting with
+      // `touch-` (leading slash) so a hypothetical `retouch-*.spec.ts` can't
+      // sneak in, while future `touch-<feature>.spec.ts` (PR4 long-press, PR5
+      // hover) match without a config change.
+      testIgnore: /[\\/]touch-[^\\/]*\.spec\.ts$/,
       use: {
         ...devices['Desktop Chrome'],
         // --disable-gpu prevents WebGL framebuffer errors in headless Chromium
         // (Phaser falls back to Canvas renderer cleanly without this flag causing
         //  "Framebuffer status: Framebuffer Unsupported" console errors).
+        launchOptions: {
+          args: ['--disable-gpu'],
+        },
+      },
+    },
+    {
+      // #237 PR2 — touch project: same Chrome, but hasTouch so page.touchscreen /
+      // CDP Input.dispatchTouchEvent deliver real touch pointers (activePointers:3
+      // in main.ts then surfaces the 2nd finger to the arbiter). Same testMatch
+      // anchor as the chromium testIgnore above, kept in sync deliberately.
+      name: 'chromium-touch',
+      testMatch: /[\\/]touch-[^\\/]*\.spec\.ts$/,
+      use: {
+        ...devices['Desktop Chrome'],
+        hasTouch: true,
         launchOptions: {
           args: ['--disable-gpu'],
         },

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -1074,6 +1074,20 @@ describe('#237 PR2 — pinch zoom drive', () => {
     expect(cam.zoom).toBe(cam.targetZoom); // zoom===targetZoom → tickZoomLerp is a no-op
   });
 
+  it('entering pinch cancels an in-flight wheel-zoom lerp so a stationary hold does not drift (Codex PR2)', () => {
+    const h = makeHarness('surface', 'command');
+    const cam = h.vs.surfaceCamera;
+    // Simulate a wheel zoom mid-lerp: zoom lags behind a larger targetZoom.
+    cam.zoom = 1;
+    cam.targetZoom = 1.8;
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, 350, 300, 1));
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, 450, 300, 2)); // enter pinch — must seize zoom now
+    // No pinch move yet. targetZoom must have snapped to zoom, or the per-frame
+    // tickZoomLerp would keep zooming toward 1.8 under stationary fingers.
+    expect(cam.targetZoom).toBe(cam.zoom);
+    expect(cam.zoom).toBe(1); // and the current zoom is untouched (no jump on entry)
+  });
+
   it('a two-finger drag ending at the same spread pans the camera (net zoom unchanged, center shifts)', () => {
     const h = makeHarness('surface', 'command');
     const cam = h.vs.surfaceCamera;

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -944,20 +944,45 @@ describe('#237 PR1 — two-pointer transition table', () => {
     expect(h.arbiter.hasPendingGesture()).toBe(true);
   });
 
-  it('a full two-finger pinch that lifts BOTH fingers returns to idle (no residual tap)', () => {
+  it('a full two-finger pinch that lifts BOTH fingers returns to idle with NO tap (Codex #272)', () => {
     const h = makeHarness('surface', 'command');
     const f1 = tileCenter(6, 1, h.vs);
     const f2 = tileCenter(10, 1, h.vs);
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
     h.arbiter.onPointerDown(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // → pinch
     const before = h.world.commandQueue.length;
-    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f1.x, f1.y, 1)); // → survivor f2 single (no tap)
-    // Lifting the survivor with no intervening move IS a tap on its snapshot tile —
-    // that's the survivor behaving as a real single, which is correct. Assert only
-    // that the FIRST lift (the pinch finger) emitted nothing.
-    expect(h.world.commandQueue.length).toBe(before);
-    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // survivor up → back to idle
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f1.x, f1.y, 1)); // lift finger 1 → survivor f2 re-armed
+    // The survivor is a pinch CONTINUATION, not a fresh press: lifting it with no
+    // intervening move is the pinch's paired release, so it must NOT tap — else a
+    // pinch-zoom release would drop a rally point / mark a dig tile.
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // lift finger 2 → end the pinch
+    expect(h.world.commandQueue.length).toBe(before); // neither lift enqueued anything
     expect(h.arbiter.hasPendingGesture()).toBe(false);
+  });
+
+  it('ending an underground-Dig pinch by lifting both fingers marks NO tile (Codex #272)', () => {
+    const h = makeHarness('underground', 'dig'); // a stray tap here would MarkDigTile
+    const f1 = tileCenter(5, 8, h.vs);
+    const f2 = tileCenter(9, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // → pinch
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f1.x, f1.y, 1)); // survivor re-armed
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // paired release
+    expect(h.world.commandQueue.filter((c) => c.type === 'MarkDigTile')).toHaveLength(0);
+  });
+
+  it('a pinch survivor that CONTINUES as a one-finger drag still pans (fix suppresses only the no-move tap)', () => {
+    const h = makeHarness('surface', 'command');
+    const f1 = tileCenter(6, 1, h.vs);
+    const f2 = tileCenter(10, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f1.x, f1.y, 1));
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // → pinch
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f2.x, f2.y, 2)); // lift f2 → survivor = f1
+    // Survivor moves > threshold → it's a real one-finger pan, unaffected by the tap guard.
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, f1.x + 40, f1.y, 1));
+    expect(panInputState.isPanning).toBe(true);
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, f1.x + 40, f1.y, 1));
+    expect(panInputState.isPanning).toBe(false); // pan ended cleanly, still no tap
   });
 
   // --- Codex-review regressions (abandon paths must reset the two-pointer

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -1054,3 +1054,56 @@ describe('#237 PR1 — two-pointer transition table', () => {
     expect(h.world.commandQueue.length).toBe(before); // no world tap from HUD coordinates
   });
 });
+
+// ---------------------------------------------------------------------------
+// #237 PR2 — the arbiter drives the pinch zoom on the active camera. (The pinch
+// math itself is unit-tested in camera-adapter.test.ts; here we assert the
+// arbiter wires two-finger geometry into beginPinch/applyPinch + clears it.)
+// ---------------------------------------------------------------------------
+
+describe('#237 PR2 — pinch zoom drive', () => {
+  it('spreading two fingers apart zooms the active camera IN, driving zoom directly (no lerp)', () => {
+    const h = makeHarness('surface', 'command');
+    const cam = h.vs.surfaceCamera;
+    cam.zoom = cam.targetZoom = 1; // known mid-range start
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, 350, 300, 1));
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, 450, 300, 2)); // enter pinch (dist 100)
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, 300, 300, 1)); // dist 150
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, 500, 300, 2)); // dist 200 → 2×
+    expect(cam.zoom).toBeGreaterThan(1);
+    expect(cam.zoom).toBe(cam.targetZoom); // zoom===targetZoom → tickZoomLerp is a no-op
+  });
+
+  it('a two-finger drag ending at the same spread pans the camera (net zoom unchanged, center shifts)', () => {
+    const h = makeHarness('surface', 'command');
+    const cam = h.vs.surfaceCamera;
+    // Seat the camera well inside the world so clampCameraView is a no-op and the
+    // raw pan shift is observable (the default harness center hugs an edge).
+    cam.zoom = cam.targetZoom = 1;
+    cam.centerX = 1000;
+    cam.centerY = 500;
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, 350, 300, 1));
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, 450, 300, 2)); // dist 100
+    // Slide both fingers +60px right (final spread back to 100) → net pan, no net zoom.
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, 410, 300, 1));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, 510, 300, 2));
+    expect(cam.zoom).toBeCloseTo(1, 6); // final spread == start spread → no net zoom
+    expect(cam.centerX).toBeCloseTo(940, 6); // 1000 − 60: content followed the fingers
+  });
+
+  it('lifting one pinch finger ends the zoom drive — a later single-finger move pans, not zooms', () => {
+    const h = makeHarness('surface', 'command');
+    const cam = h.vs.surfaceCamera;
+    cam.zoom = cam.targetZoom = 1;
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, 350, 300, 1));
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, 450, 300, 2)); // pinch
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, 300, 300, 1)); // zoom in
+    const zoomedIn = cam.zoom;
+    expect(zoomedIn).toBeGreaterThan(1);
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, 450, 300, 2)); // lift finger 2 → survivor finger 1 becomes a single
+    // A single-finger drag now pans; it must NOT keep driving the (ended) pinch zoom.
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, 340, 300, 1)); // 40px from re-snapshot (300) → crosses threshold → pan
+    expect(cam.zoom).toBe(zoomedIn); // zoom frozen at the pinch's last value
+    expect(panInputState.isPanning).toBe(true); // it resolved as a pan
+  });
+});

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -63,6 +63,7 @@ import {
   type PinchState,
   beginPinch,
   applyPinch,
+  cancelZoomLerp,
   clampCameraView,
   screenToTileZoom,
   panByScreenDelta,
@@ -438,8 +439,14 @@ export class GestureArbiter {
       // #237 PR2 — capture the pinch anchor from the two tracked fingers. Math.max
       // (dist, 1) guards a zero startDist (two touches reported at the same point)
       // so applyPinch's distance ratio stays finite.
+      const cam = activeCamera(this.deps.viewState);
+      // The pinch takes over the zoom NOW: cancel any in-flight wheel-zoom lerp
+      // (targetZoom≠zoom) so a STATIONARY two-finger hold can't keep lerping toward
+      // a stale targetZoom under the fingers before the first pinch move (Codex
+      // PR2). applyPinch then drives zoom===targetZoom directly.
+      cancelZoomLerp(cam);
       const { midX, midY, dist } = this.twoPointerMidDist();
-      this.pinch = beginPinch(activeCamera(this.deps.viewState), midX, midY, Math.max(dist, 1));
+      this.pinch = beginPinch(cam, midX, midY, Math.max(dist, 1));
       return;
     }
 

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -60,6 +60,9 @@ import type { ViewState, ToolId } from '../render/camera.js';
 import { TILE_SIZE_PX } from '../render/sprites.js';
 import {
   type CameraView,
+  type PinchState,
+  beginPinch,
+  applyPinch,
   clampCameraView,
   screenToTileZoom,
   panByScreenDelta,
@@ -224,16 +227,18 @@ export class GestureArbiter {
   private readonly paintStroke: PaintStrokeState = createPaintStrokeState();
 
   /**
-   * #237 PR1 — two-pointer state. `mode` gates the handlers; `pointers` tracks
-   * every down button-0/touch pointer's live position (the source for a pinch's
-   * midpoint/distance in PR2, and for re-snapshotting the survivor when one pinch
-   * finger lifts). `single` is the tap/drag gesture (the former `snapshot`). The
-   * pinch camera state (`PinchState` + begin/applyPinch) arrives in PR2.
+   * #237 two-pointer state. `mode` gates the handlers; `pointers` tracks every
+   * down button-0/touch pointer's live position (the source for a pinch's
+   * midpoint/distance, and for re-snapshotting the survivor when one pinch finger
+   * lifts). `single` is the tap/drag gesture (the former `snapshot`). `pinch`
+   * (PR2) is the captured pinch-start state; non-null iff `mode === 'pinch'`.
    */
   private mode: 'idle' | 'single' | 'pinch' = 'idle';
   private pointers = new Map<number, { pointerId: number; x: number; y: number }>();
   /** Snapshot of the active single (tap/drag) press, or null when none is pending. */
   private single: GestureSnapshot | null = null;
+  /** #237 PR2 — captured pinch-start (zoom/dist/anchor); non-null iff mode==='pinch'. */
+  private pinch: PinchState | null = null;
   /** Once the threshold is crossed, the resolved drag mode ('paint' | 'pan'); null while still a tap. */
   private dragMode: 'paint' | 'pan' | null = null;
   /** Last pointer position seen during a pan drag (for incremental camera delta). */
@@ -334,6 +339,7 @@ export class GestureArbiter {
   private resetPointerTracking(): void {
     this.pointers.clear();
     this.mode = 'idle';
+    this.pinch = null; // #237 PR2 — pinch state lives only while mode==='pinch'
   }
 
   /**
@@ -429,7 +435,11 @@ export class GestureArbiter {
       this.releaseSingle();
       this.pointers.set(ev.pointerId, { pointerId: ev.pointerId, x: ev.x, y: ev.y });
       this.mode = 'pinch';
-      // PR2 wires beginPinch(...) here from the two tracked pointers.
+      // #237 PR2 — capture the pinch anchor from the two tracked fingers. Math.max
+      // (dist, 1) guards a zero startDist (two touches reported at the same point)
+      // so applyPinch's distance ratio stays finite.
+      const { midX, midY, dist } = this.twoPointerMidDist();
+      this.pinch = beginPinch(activeCamera(this.deps.viewState), midX, midY, Math.max(dist, 1));
       return;
     }
 
@@ -509,14 +519,37 @@ export class GestureArbiter {
     return true;
   }
 
+  /**
+   * twoPointerMidDist — the midpoint and finger-distance of the two tracked pinch
+   * pointers (#237 PR2), the source for beginPinch/applyPinch. Only called while
+   * pinching (exactly two tracked fingers); the undefined-guard satisfies
+   * noUncheckedIndexedAccess and degrades to a no-op zoom (dist=1) if ever reached
+   * with fewer.
+   */
+  private twoPointerMidDist(): { midX: number; midY: number; dist: number } {
+    const [a, b] = [...this.pointers.values()];
+    if (a === undefined || b === undefined) {
+      return { midX: a?.x ?? b?.x ?? 0, midY: a?.y ?? b?.y ?? 0, dist: 1 };
+    }
+    return { midX: (a.x + b.x) / 2, midY: (a.y + b.y) / 2, dist: Math.hypot(a.x - b.x, a.y - b.y) };
+  }
+
   onPointerMove(ev: ArbiterPointerEvent): void {
-    // #237 PR1 — pinch: track each finger's live position (PR2 recomputes the
-    // midpoint/distance from `pointers` and applies the zoom here).
+    // #237 pinch: track each tracked finger's live position, then recompute the
+    // midpoint/distance and drive the anchored zoom (PR2).
     if (this.mode === 'pinch') {
       const p = this.pointers.get(ev.pointerId);
-      if (p !== undefined) {
-        p.x = ev.x;
-        p.y = ev.y;
+      if (p === undefined) return; // untracked 3rd finger — its moves don't drive the pinch
+      p.x = ev.x;
+      p.y = ev.y;
+      if (this.pinch !== null) {
+        const vs = this.deps.viewState;
+        const cam = activeCamera(vs);
+        const { midX, midY, dist } = this.twoPointerMidDist();
+        // Anchored zoom about the CURRENT midpoint folds the two-finger pan in.
+        applyPinch(cam, this.pinch, midX, midY, dist);
+        const [worldW, worldH] = worldDimensions(vs);
+        clampCameraView(cam, worldW, worldH);
       }
       return;
     }
@@ -622,10 +655,10 @@ export class GestureArbiter {
         this.armSingle(survivor.pointerId, survivor.x, survivor.y)
       ) {
         this.mode = 'single';
+        this.pinch = null; // #237 PR2 — pinch ended; the survivor is a plain single now
       } else {
-        this.cancelGesture();
+        this.cancelGesture(); // drops pinch via resetPointerTracking
       }
-      // PR2 clears pinch state (pinch = null) here.
       return;
     }
     if (this.mode !== 'single') return; // idle — nothing pending
@@ -697,11 +730,10 @@ export class GestureArbiter {
 
   /** pointerupoutside / blur — abandon everything pending. */
   onPointerUpOutside(): void {
-    // cancelGesture now fully resets: releases the single (dropping pan iff owned)
-    // AND clears the two-pointer bookkeeping (mode→idle, pointers cleared), so a
-    // stray finger can't strand the arbiter in 'pinch'.
+    // cancelGesture fully resets: releases the single (dropping pan iff owned) AND
+    // clears the two-pointer bookkeeping via resetPointerTracking (mode→idle,
+    // pointers cleared, pinch=null), so a stray finger can't strand the arbiter.
     this.cancelGesture();
-    // PR2 clears pinch state here.
   }
 
   // --- internals -----------------------------------------------------------

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -240,6 +240,14 @@ export class GestureArbiter {
   private single: GestureSnapshot | null = null;
   /** #237 PR2 — captured pinch-start (zoom/dist/anchor); non-null iff mode==='pinch'. */
   private pinch: PinchState | null = null;
+  /**
+   * #237 — true when `single` was re-armed from a pinch SURVIVOR (one finger of a
+   * two-finger pinch lifted while the other stayed down). Such a single may still
+   * pan/paint if it MOVES, but a lift with no intervening move is the paired
+   * release of the pinch (both fingers up ~together), NOT a one-finger tap — so it
+   * must not dispatch a tap (Codex #272 P1). Reset on every fresh arm / abandon.
+   */
+  private singleFromPinch = false;
   /** Once the threshold is crossed, the resolved drag mode ('paint' | 'pan'); null while still a tap. */
   private dragMode: 'paint' | 'pan' | null = null;
   /** Last pointer position seen during a pan drag (for incremental camera delta). */
@@ -364,6 +372,7 @@ export class GestureArbiter {
   private clearLeftGesture(): void {
     this.single = null;
     this.dragMode = null;
+    this.singleFromPinch = false;
     resetPaintStrokeState(this.paintStroke);
   }
 
@@ -521,6 +530,7 @@ export class GestureArbiter {
       undergroundColonyId: vs.activeUndergroundColonyId,
     };
     this.dragMode = null;
+    this.singleFromPinch = false; // fresh arm; the survivor re-arm re-sets this true
     this.panLastX = x;
     this.panLastY = y;
     return true;
@@ -663,6 +673,9 @@ export class GestureArbiter {
       ) {
         this.mode = 'single';
         this.pinch = null; // #237 PR2 — pinch ended; the survivor is a plain single now
+        // Mark it pinch-derived: it can pan/paint if it MOVES, but a lift with no
+        // move is the pinch's paired release, not a tap (suppressed in handleSingleUp).
+        this.singleFromPinch = true;
       } else {
         this.cancelGesture(); // drops pinch via resetPointerTracking
       }
@@ -721,6 +734,16 @@ export class GestureArbiter {
     // or mark a dig at the menu-anchor tile. (onPointerDown already blocks NEW
     // presses while the menu is active; this covers the in-flight case.)
     if (this.deps.isContextMenuActive()) {
+      this.cancelGesture();
+      return;
+    }
+
+    // A pinch SURVIVOR that never moved is the paired release of the two-finger
+    // pinch (both fingers lift ~together), NOT a one-finger tap — suppress it so a
+    // pinch-zoom release can't move the rally point / mark a dig tile (Codex #272
+    // P1). A survivor that MOVED took the dragMode!==null path above (pan/paint),
+    // so this only gates the no-move release; a genuine tap needs a fresh press.
+    if (this.singleFromPinch) {
       this.cancelGesture();
       return;
     }

--- a/src/render/camera-adapter.test.ts
+++ b/src/render/camera-adapter.test.ts
@@ -30,6 +30,8 @@ import {
   clampCameraView,
   beginWheelZoom,
   applyZoomAnchor,
+  beginPinch,
+  applyPinch,
   stepZoomLerp,
   cancelZoomLerp,
   panByScreenDelta,
@@ -267,6 +269,61 @@ describe('cursor-anchored zoom (no drift across lerp)', () => {
     v.targetZoom = 1.9;
     cancelZoomLerp(v);
     expect(v.targetZoom).toBe(0.7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pinch zoom (touch — #237 PR2)
+// ---------------------------------------------------------------------------
+
+describe('pinch zoom (#237 PR2)', () => {
+  it('beginPinch captures startZoom + the world point under the start midpoint, and does not mutate v', () => {
+    const v = view(1000, 500, 1.3);
+    const before = { ...v };
+    const p = beginPinch(v, 350, 275, 90);
+    expect(p.startZoom).toBe(1.3);
+    expect(p.startDist).toBe(90);
+    const w = screenToWorld(350, 275, v);
+    expect(p.anchorWorldX).toBeCloseTo(w.worldX, 6);
+    expect(p.anchorWorldY).toBeCloseTo(w.worldY, 6);
+    expect(v).toEqual(before); // begin is read-only
+  });
+
+  it('applyPinch scales zoom by the live finger-distance ratio, driving zoom directly (no lerp)', () => {
+    const v = view(1000, 500, 1);
+    const p = beginPinch(v, 400, 300, 100);
+    applyPinch(v, p, 400, 300, 150); // 1.5× the start distance, stays within [MIN,MAX]
+    expect(v.zoom).toBeCloseTo(1.5, 6);
+    expect(v.targetZoom).toBe(v.zoom); // zoom===targetZoom → tickZoomLerp is a no-op
+  });
+
+  it('clamps zoom to [MIN_ZOOM, MAX_ZOOM] at extreme distance ratios', () => {
+    const vIn = view(1000, 500, 1);
+    applyPinch(vIn, beginPinch(vIn, 400, 300, 10), 400, 300, 10000); // huge ratio
+    expect(vIn.zoom).toBe(MAX_ZOOM);
+    const vOut = view(1000, 500, 1);
+    applyPinch(vOut, beginPinch(vOut, 400, 300, 10000), 400, 300, 10); // tiny ratio
+    expect(vOut.zoom).toBe(MIN_ZOOM);
+  });
+
+  it('keeps the start-midpoint world point under the CURRENT (moved) midpoint — folds the two-finger pan in', () => {
+    const v = view(1000, 500, 0.8);
+    const p = beginPinch(v, 300, 250, 120);
+    // Move the midpoint AND change the distance in one update.
+    applyPinch(v, p, 500, 420, 240);
+    const under = screenToWorld(500, 420, v);
+    expect(under.worldX).toBeCloseTo(p.anchorWorldX, 4);
+    expect(under.worldY).toBeCloseTo(p.anchorWorldY, 4);
+  });
+
+  it('a pure two-finger pan (same distance, moved midpoint) zooms not at all but shifts the center', () => {
+    const v = view(1000, 500, 1);
+    const p = beginPinch(v, 400, 300, 150);
+    applyPinch(v, p, 460, 300, 150); // midpoint slid +60px right, distance unchanged
+    expect(v.zoom).toBeCloseTo(1, 6); // ratio 1 → no zoom
+    // Content follows the fingers: center shifts −60/zoom world px (like panByScreenDelta).
+    expect(v.centerX).toBeCloseTo(1000 - 60, 6);
+    expect(v.centerY).toBeCloseTo(500, 6);
   });
 });
 

--- a/src/render/camera-adapter.ts
+++ b/src/render/camera-adapter.ts
@@ -334,6 +334,66 @@ export function cancelZoomLerp(v: CameraView): void {
 }
 
 // ---------------------------------------------------------------------------
+// Pinch zoom (touch — #237 PR2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Captured at pinch-start: the zoom and finger-distance the gesture began at, plus
+ * the world point under the START midpoint. applyPinch scales zoom by the live
+ * distance ratio and re-anchors so that world point stays under the CURRENT
+ * midpoint — which folds the two-finger pan into the same operation (no separate
+ * pan term). The wheel-zoom analog is ZoomAnchor; pinch differs in that it drives
+ * zoom DIRECTLY (both zoom and targetZoom), bypassing the per-frame lerp — the
+ * fingers ARE the animation, so a lerp would only add lag.
+ */
+export interface PinchState {
+  startZoom: number;
+  startDist: number;
+  anchorWorldX: number;
+  anchorWorldY: number;
+}
+
+/**
+ * Begin a pinch. Captures the current zoom + the world point under the start
+ * midpoint (screenToWorld at the current view). Does NOT mutate v. Callers pass a
+ * strictly-positive startDist (guard Math.max(dist, 1)) so applyPinch's ratio is
+ * finite.
+ */
+export function beginPinch(
+  v: CameraView,
+  midX: number,
+  midY: number,
+  startDist: number,
+): PinchState {
+  const { worldX, worldY } = screenToWorld(midX, midY, v);
+  return { startZoom: v.zoom, startDist, anchorWorldX: worldX, anchorWorldY: worldY };
+}
+
+/**
+ * Apply a pinch update. Scales zoom by the live finger-distance ratio (clamped),
+ * then re-anchors the center so the start-midpoint world point sits under the
+ * CURRENT midpoint at the new zoom — same center-solve as applyZoomAnchor
+ * (centerX = worldX − (screenX − viewportW/2)/zoom), evaluated at the moved
+ * midpoint so a two-finger drag pans for free. Sets zoom === targetZoom so the
+ * per-frame tickZoomLerp is a no-op and cameraController.apply just pushes this
+ * view. Mutates v (matches applyZoomAnchor / panByScreenDelta). Caller clamps to
+ * world bounds afterward (clampCameraView).
+ */
+export function applyPinch(
+  v: CameraView,
+  p: PinchState,
+  midX: number,
+  midY: number,
+  curDist: number,
+): void {
+  const z = clampZoom((p.startZoom * curDist) / p.startDist);
+  v.zoom = z;
+  v.targetZoom = z;
+  v.centerX = p.anchorWorldX - (midX - viewportW / 2) / z;
+  v.centerY = p.anchorWorldY - (midY - viewportH / 2) / z;
+}
+
+// ---------------------------------------------------------------------------
 // Pan (PLAN §D15)
 // ---------------------------------------------------------------------------
 

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -292,6 +292,11 @@ declare global {
        *  sim state, crossing the sim/render boundary). Empty until the first
        *  frame renders. Issue #193. */
       getDrawOrder(): string[];
+      /** Return the ACTIVE camera's current zoom (surface or underground per the
+       *  active view). Render-side observability for the #237 pinch-zoom e2e
+       *  (touch-smoke.spec.ts): reads viewState, mutates nothing, crosses no
+       *  sim/render boundary. Dev-build only. */
+      getActiveZoom(): number;
     };
   }
 }
@@ -482,6 +487,11 @@ export class GameScene extends Phaser.Scene {
     if (!import.meta.env.DEV || typeof window === 'undefined') return;
     window.__phase9_test = {
       getDrawOrder: (): string[] => [...this.drawOrder],
+      getActiveZoom: (): number =>
+        (this.viewState.activeView === 'surface'
+          ? this.viewState.surfaceCamera
+          : this.viewState.undergroundCamera
+        ).zoom,
     };
   }
 

--- a/tests/touch-smoke.spec.ts
+++ b/tests/touch-smoke.spec.ts
@@ -1,0 +1,118 @@
+// touch-smoke.spec.ts — #237 PR2 end-to-end touch smoke (chromium-touch project).
+//
+// Proves the touch plumbing works through the real stack: main.ts's
+// input.activePointers:3 surfaces a 2nd finger, Phaser forwards both pointers to
+// the GestureArbiter, and a two-finger spread drives beginPinch/applyPinch on the
+// active camera. The pinch MATH is unit-tested in camera-adapter.test.ts and the
+// arbiter WIRING in gesture-arbiter.test.ts; this only guards the browser-level
+// touch → Phaser → arbiter path that unit tests can't reach.
+//
+// Runs ONLY in the `chromium-touch` project (hasTouch:true) — see
+// playwright.config.ts. Reads zoom via the dev-only window.__phase9_test
+// observability hook (getActiveZoom); it mutates nothing and crosses no
+// sim/render boundary.
+
+import { test, expect, type Page } from '@playwright/test';
+import { DIFFICULTY_NORMAL_RECT, centerOf } from './helpers/geometry.js';
+
+/** The active camera's live zoom, via the dev-build observability hook. */
+async function getZoom(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const t = (window as unknown as { __phase9_test?: { getActiveZoom?: () => number } })
+      .__phase9_test;
+    if (!t?.getActiveZoom) throw new Error('__phase9_test.getActiveZoom not installed');
+    return t.getActiveZoom();
+  });
+}
+
+async function activeOverlay(page: Page): Promise<string> {
+  return await page.evaluate(
+    () =>
+      (window as unknown as { __phase9_ui?: { activeOverlay?: string } }).__phase9_ui
+        ?.activeOverlay ?? '<undefined>',
+  );
+}
+
+/** Boot to a clean Playing state (mirrors menu-and-dialog.spec.ts's bootGame). */
+async function bootToPlaying(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.locator('canvas').first().waitFor({ state: 'attached' });
+  await page.waitForFunction(
+    () => typeof (window as { __phase9_ui?: unknown }).__phase9_ui !== 'undefined',
+  );
+  await page.evaluate(() => localStorage.removeItem('subterrans:save:v3'));
+  await page.reload();
+  await page.locator('canvas').first().waitFor({ state: 'attached' });
+  // Poll-click "Normal" until the Choose-Difficulty overlay clears to Playing.
+  const box = await page.locator('canvas').first().boundingBox();
+  if (!box) throw new Error('canvas has no bounding box');
+  const norm = centerOf(DIFFICULTY_NORMAL_RECT);
+  await expect
+    .poll(
+      async () => {
+        if ((await activeOverlay(page)) === 'none') return 'none';
+        await page.mouse.click(box.x + norm.x, box.y + norm.y);
+        return activeOverlay(page);
+      },
+      { timeout: 15_000 },
+    )
+    .toBe('none');
+}
+
+test('two-finger spread pinch-zooms the camera in', async ({ page }) => {
+  await bootToPlaying(page);
+  const box = await page.locator('canvas').first().boundingBox();
+  if (!box) throw new Error('canvas has no bounding box');
+  // Midpoint at the canvas center (world region — the HUD lives at the edges).
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+
+  const z0 = await getZoom(page);
+  expect(z0).toBeCloseTo(1, 5); // fresh game boots at DEFAULT_ZOOM
+
+  const client = await page.context().newCDPSession(page);
+  // Two fingers start 60px apart on a horizontal line through the midpoint...
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [
+      { x: cx - 30, y: cy },
+      { x: cx + 30, y: cy },
+    ],
+  });
+  // ...then spread apart in steps (dist 60 → ~460, a >3× ratio → clamps toward MAX_ZOOM).
+  for (let s = 1; s <= 5; s++) {
+    const half = 30 + s * 40; // 70, 110, 150, 190, 230
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [
+        { x: cx - half, y: cy },
+        { x: cx + half, y: cy },
+      ],
+    });
+  }
+
+  // Phaser processes the queued touches on its rAF loop, then the arbiter drives
+  // applyPinch — poll until the zoom reflects the spread.
+  await expect.poll(async () => getZoom(page), { timeout: 5_000 }).toBeGreaterThan(z0 + 0.1);
+
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchEnd',
+    touchPoints: [{ x: cx + 230, y: cy }],
+  });
+  await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+});
+
+test('a single-finger tap does not pinch-zoom (single-pointer path intact)', async ({ page }) => {
+  await bootToPlaying(page);
+  const box = await page.locator('canvas').first().boundingBox();
+  if (!box) throw new Error('canvas has no bounding box');
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+
+  const z0 = await getZoom(page);
+  await page.touchscreen.tap(cx, cy);
+  // Give Phaser a few frames to process the tap, then assert it neither zoomed
+  // nor left the Playing state (a lone finger must never enter pinch).
+  await expect.poll(async () => activeOverlay(page), { timeout: 5_000 }).toBe('none');
+  expect(await getZoom(page)).toBeCloseTo(z0, 5);
+});

--- a/tests/touch-smoke.spec.ts
+++ b/tests/touch-smoke.spec.ts
@@ -95,10 +95,11 @@ test('two-finger spread pinch-zooms the camera in', async ({ page }) => {
   // applyPinch — poll until the zoom reflects the spread.
   await expect.poll(async () => getZoom(page), { timeout: 5_000 }).toBeGreaterThan(z0 + 0.1);
 
-  await client.send('Input.dispatchTouchEvent', {
-    type: 'touchEnd',
-    touchPoints: [{ x: cx + 230, y: cy }],
-  });
+  // Release the gesture. CDP requires touchEnd/touchCancel to carry NO points —
+  // it ends ALL active touches at once (a partial one-finger release is not
+  // expressible via Input.dispatchTouchEvent, and the survivor→single path is
+  // covered in gesture-arbiter.test.ts). A non-empty touchEnd is a protocol
+  // violation Chrome may reject.
   await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
 });
 


### PR DESCRIPTION
**#237 PR2 of 5** — pinch zoom. Two fingers zoom the camera about their midpoint, building on PR1's two-pointer state machine. Pure camera math + arbiter wiring + a real touch e2e. Input/render only — no `simVersion`, no `WorldState` mutation.

## Camera math (`camera-adapter.ts`)
New pure `PinchState` + `beginPinch`/`applyPinch`, mirroring `beginWheelZoom`/`applyZoomAnchor`:
- `beginPinch` captures `startZoom` + the world point under the **start** midpoint.
- `applyPinch` scales zoom by the live finger-distance ratio (clamped), then re-anchors the center so that world point stays under the **current** midpoint — which **folds the two-finger pan in** (no separate pan term). Drives `zoom === targetZoom` directly, so the per-frame `tickZoomLerp` is a no-op and `cameraController.apply` just pushes the pinched view.

## Arbiter wiring (`gesture-arbiter.ts`)
- `pinch: PinchState | null` (non-null **iff** `mode === 'pinch'`) + `twoPointerMidDist()`.
- single→pinch handoff calls `beginPinch` from the two tracked fingers (`Math.max(dist, 1)` guards a zero `startDist`); each pinch-move recomputes mid/dist → `applyPinch` + `clampCameraView`.
- `pinch` cleared on the survivor re-arm **and** via `resetPointerTracking` (every abandon path) — the PR1 invariant now reads `pinch !== null ⟺ mode === 'pinch'`.

## Touch e2e — and a gate fix
- `game-scene.ts`: dev-only `__phase9_test.getActiveZoom()` observability hook (reads the active camera's zoom; mutates nothing, crosses no sim/render boundary).
- `playwright.config.ts`: new **`chromium-touch`** project (`hasTouch`) + `testIgnore` on `chromium`. **Both anchor the touch specs by a basename starting with `touch-`** (`/[\\/]touch-[^\\/]*\.spec\.ts$/`) — this fixes the design doc's `/touch\.spec\.ts/`, which matched **zero** files (`touch-smoke.spec.ts` doesn't contain `touch.spec.ts`) → a silently-vacuous gate. Future PR4/PR5 touch specs (`touch-longpress`, `touch-hover`) match without a config change.
- `tests/touch-smoke.spec.ts`: CDP `Input.dispatchTouchEvent` two-finger spread → asserts `getActiveZoom` increased; a lone `touchscreen.tap` neither zooms nor leaves Playing.

## Verification
- `npm run verify` green — **2813 passed** (+5 camera-adapter pinch cases: ratio/clamp/anchor-under-moved-midpoint; +3 arbiter drive cases: spread→zoom-in, same-spread→pan, survivor-ends-drive).
- **`chromium-touch` e2e green** (2 passed) — real touch → Phaser → arbiter → zoom.
- `chromium` project excludes the touch spec (27 tests, unchanged) — verified via `--list`.

Scope note: pinch is intentionally **not** HUD-guarded on move (a two-finger gesture is unambiguously a zoom); the survivor-becomes-single path **is** HUD-guarded (PR1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two-finger pinch zoom support on touch-enabled devices.
  * Camera zoom now follows finger spread smoothly while keeping the zoom focus anchored under the pinch midpoint.
  * Touch interactions now distinguish between pinch zooming and simple one-finger panning/tapping.
* **Bug Fixes**
  * Improved handling when switching between pinch gestures and other camera movements, reducing unexpected zoom drift.
* **Tests**
  * Added end-to-end coverage for touch pinch zoom and single-tap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->