### PR TITLE
feat(input): #237 PR3 — scale-tuned drag threshold (touch)

### DIFF
--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -171,8 +171,14 @@ function makeHarness(
   };
 }
 
-function ev(button: number, x: number, y: number, pointerId = 1): ArbiterPointerEvent {
-  return { pointerId, button, x, y };
+function ev(
+  button: number,
+  x: number,
+  y: number,
+  pointerId = 1,
+  wasTouch = false,
+): ArbiterPointerEvent {
+  return { pointerId, button, x, y, wasTouch };
 }
 
 beforeEach(() => {
@@ -1156,26 +1162,39 @@ describe('#237 PR2 — pinch zoom drive', () => {
 // #237 PR3 — scale-tuned drag threshold (getDragThreshold dep)
 // ---------------------------------------------------------------------------
 
-describe('#237 PR3 — injected drag threshold', () => {
-  it('defers pan classification until the move crosses the LARGER injected threshold', () => {
+describe('#237 PR3 — injected drag threshold (touch-gated)', () => {
+  // Touch events carry wasTouch=true (the 5th ev() arg), so the injected 20px
+  // threshold applies; mouse events (default false) keep the fixed DRAG_THRESHOLD_PX.
+  const touch = (button: number, x: number, y: number, id = 1) => ev(button, x, y, id, true);
+
+  it('TOUCH: defers pan classification until the move crosses the LARGER injected threshold', () => {
     const h = makeHarness('surface', 'command', 20); // touch-scale threshold, not the 6px default
     const start = tileCenter(6, 4, h.vs);
-    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, start.x, start.y));
     // 10px crosses the fixed 6px default but NOT the injected 20px → still a tap.
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 10, start.y));
+    h.arbiter.onPointerMove(touch(LEFT_BUTTON, start.x + 10, start.y));
     expect(panInputState.isPanning).toBe(false);
     // Past 20px → now classified as a pan.
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 25, start.y));
+    h.arbiter.onPointerMove(touch(LEFT_BUTTON, start.x + 25, start.y));
     expect(panInputState.isPanning).toBe(true);
   });
 
-  it('a tap within the injected threshold still taps (no drag misclassification)', () => {
+  it('TOUCH: a tap within the injected threshold still taps (no drag misclassification)', () => {
     const h = makeHarness('surface', 'command', 20);
     const p = tileCenter(6, 1, h.vs);
-    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
-    h.arbiter.onPointerMove(ev(LEFT_BUTTON, p.x + 15, p.y)); // 15px < 20 → under threshold
-    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x + 15, p.y));
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerMove(touch(LEFT_BUTTON, p.x + 15, p.y)); // 15px < 20 → under threshold
+    h.arbiter.onPointerUp(touch(LEFT_BUTTON, p.x + 15, p.y));
     expect(panInputState.isPanning).toBe(false);
     expect(h.world.commandQueue.some((c) => c.type === 'SetRallyPoint')).toBe(true); // acted as a tap
+  });
+
+  it('MOUSE: ignores the injected touch threshold — a 10px drag still pans at the fixed 6px (F1)', () => {
+    const h = makeHarness('surface', 'command', 20); // touch threshold injected...
+    const start = tileCenter(6, 4, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y)); // ...but this is a MOUSE press (wasTouch=false)
+    // 10px crosses the fixed 6px default; the 20px touch threshold must NOT apply.
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 10, start.y));
+    expect(panInputState.isPanning).toBe(true); // mouse desktop feel unchanged
   });
 });

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -1197,4 +1197,16 @@ describe('#237 PR3 — injected drag threshold (touch-gated)', () => {
     h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 10, start.y));
     expect(panInputState.isPanning).toBe(true); // mouse desktop feel unchanged
   });
+
+  it('a mixed mouse+touch pinch leaves the survivor on its OWN device threshold (F2)', () => {
+    const h = makeHarness('surface', 'command', 20); // touch threshold injected
+    const start = tileCenter(6, 4, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y, 1, false)); // MOUSE finger 1
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x + 60, start.y, 2, true)); // TOUCH finger 2 → pinch
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, start.x + 60, start.y, 2, true)); // lift TOUCH → survivor = MOUSE finger 1
+    // The survivor carries the mouse's wasTouch=false, so a 10px drag pans at the
+    // fixed 6px, NOT the injected 20px touch threshold (a hardcoded `true` would defer).
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 10, start.y, 1, false));
+    expect(panInputState.isPanning).toBe(true);
+  });
 });

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -113,6 +113,10 @@ interface Harness {
 function makeHarness(
   view: 'surface' | 'underground',
   tool: 'command' | 'dig' | 'chamber',
+  // #237 PR3 — inject a scale-tuned drag threshold. OMITTED by default so the
+  // arbiter exercises its `?? DRAG_THRESHOLD_PX` fallback (as in production before
+  // GameScene wires the dep, and every pre-PR3 test).
+  dragThreshold?: number,
 ): Harness {
   const world = makeWorld();
   const vs = makeViewState(view, tool);
@@ -147,6 +151,7 @@ function makeHarness(
       queueFullPaused.push(p);
     },
   };
+  if (dragThreshold !== undefined) deps.getDragThreshold = () => dragThreshold;
   const arbiter = new GestureArbiter(deps);
   return {
     arbiter,
@@ -1144,5 +1149,33 @@ describe('#237 PR2 — pinch zoom drive', () => {
     h.arbiter.onPointerMove(ev(LEFT_BUTTON, 340, 300, 1)); // 40px from re-snapshot (300) → crosses threshold → pan
     expect(cam.zoom).toBe(zoomedIn); // zoom frozen at the pinch's last value
     expect(panInputState.isPanning).toBe(true); // it resolved as a pan
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #237 PR3 — scale-tuned drag threshold (getDragThreshold dep)
+// ---------------------------------------------------------------------------
+
+describe('#237 PR3 — injected drag threshold', () => {
+  it('defers pan classification until the move crosses the LARGER injected threshold', () => {
+    const h = makeHarness('surface', 'command', 20); // touch-scale threshold, not the 6px default
+    const start = tileCenter(6, 4, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y));
+    // 10px crosses the fixed 6px default but NOT the injected 20px → still a tap.
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 10, start.y));
+    expect(panInputState.isPanning).toBe(false);
+    // Past 20px → now classified as a pan.
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 25, start.y));
+    expect(panInputState.isPanning).toBe(true);
+  });
+
+  it('a tap within the injected threshold still taps (no drag misclassification)', () => {
+    const h = makeHarness('surface', 'command', 20);
+    const p = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, p.x + 15, p.y)); // 15px < 20 → under threshold
+    h.arbiter.onPointerUp(ev(LEFT_BUTTON, p.x + 15, p.y));
+    expect(panInputState.isPanning).toBe(false);
+    expect(h.world.commandQueue.some((c) => c.type === 'SetRallyPoint')).toBe(true); // acted as a tap
   });
 });

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -1209,4 +1209,14 @@ describe('#237 PR3 — injected drag threshold (touch-gated)', () => {
     h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 10, start.y, 1, false));
     expect(panInputState.isPanning).toBe(true);
   });
+
+  it('TOUCH with getDragThreshold OMITTED falls back to the fixed DRAG_THRESHOLD_PX', () => {
+    const h = makeHarness('surface', 'command'); // no 3rd arg → dep omitted (as in production before wiring)
+    const start = tileCenter(6, 4, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, start.x, start.y, 1, true)); // TOUCH press
+    // Even a touch gesture uses the fixed 6px when no threshold dep is provided;
+    // a 10px move therefore crosses it and pans.
+    h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 10, start.y, 1, true));
+    expect(panInputState.isPanning).toBe(true);
+  });
 });

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -205,6 +205,14 @@ export interface GestureArbiterDeps {
   /** A world gesture began (a left press that armed a snapshot) — the signal
    *  GameScene uses to evaluate the proactive [Tab] nudge on first world input. */
   onWorldInput?: () => void;
+  /**
+   * #237 PR3 — the drag threshold in LOGICAL pixels, scale-tuned for the current
+   * display (see gesture.thresholdLogicalPx). GameScene computes it from the
+   * canvas's CSS width at boot and on resize; the arbiter reads it per move.
+   * Optional: omitted callers (and every existing unit test) fall back to the
+   * fixed DRAG_THRESHOLD_PX, so desktop behavior is unchanged.
+   */
+  getDragThreshold?: () => number;
 }
 
 /** Return the active CameraView for the current view. */
@@ -582,9 +590,11 @@ export class GestureArbiter {
       tracked.y = ev.y;
     }
 
-    // Classify on first crossing of the threshold.
+    // Classify on first crossing of the threshold (#237 PR3: scale-tuned in
+    // logical px when GameScene provides it; fixed DRAG_THRESHOLD_PX otherwise).
     if (this.dragMode === null) {
-      if (!hasCrossedDragThreshold(snap.downX, snap.downY, ev.x, ev.y, DRAG_THRESHOLD_PX)) {
+      const threshold = this.deps.getDragThreshold?.() ?? DRAG_THRESHOLD_PX;
+      if (!hasCrossedDragThreshold(snap.downX, snap.downY, ev.x, ev.y, threshold)) {
         return; // still a potential tap
       }
       this.dragMode = classifyDragMode(snap.tool, snap.view);

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -248,7 +248,10 @@ export class GestureArbiter {
    * (PR2) is the captured pinch-start state; non-null iff `mode === 'pinch'`.
    */
   private mode: 'idle' | 'single' | 'pinch' = 'idle';
-  private pointers = new Map<number, { pointerId: number; x: number; y: number }>();
+  private pointers = new Map<
+    number,
+    { pointerId: number; x: number; y: number; wasTouch: boolean }
+  >();
   /** Snapshot of the active single (tap/drag) press, or null when none is pending. */
   private single: GestureSnapshot | null = null;
   /** #237 PR2 — captured pinch-start (zoom/dist/anchor); non-null iff mode==='pinch'. */
@@ -456,7 +459,12 @@ export class GestureArbiter {
       // stays tracked in `pointers` — cancelGesture would additionally reset the
       // very bookkeeping we are about to build the pinch from.
       this.releaseSingle();
-      this.pointers.set(ev.pointerId, { pointerId: ev.pointerId, x: ev.x, y: ev.y });
+      this.pointers.set(ev.pointerId, {
+        pointerId: ev.pointerId,
+        x: ev.x,
+        y: ev.y,
+        wasTouch: ev.wasTouch ?? false,
+      });
       this.mode = 'pinch';
       // #237 PR2 — capture the pinch anchor from the two tracked fingers. Math.max
       // (dist, 1) guards a zero startDist (two touches reported at the same point)
@@ -477,7 +485,12 @@ export class GestureArbiter {
     if (!this.canArmSingleAt(ev.x, ev.y)) return;
     if (!this.armSingle(ev.pointerId, ev.x, ev.y, ev.wasTouch ?? false)) return; // world unavailable
     this.mode = 'single';
-    this.pointers.set(ev.pointerId, { pointerId: ev.pointerId, x: ev.x, y: ev.y });
+    this.pointers.set(ev.pointerId, {
+      pointerId: ev.pointerId,
+      x: ev.x,
+      y: ev.y,
+      wasTouch: ev.wasTouch ?? false,
+    });
 
     // Stage 3b (#3): a world gesture has begun. Signal it so GameScene can evaluate
     // the proactive [Tab] first-use nudge on the player's first world input of the
@@ -690,8 +703,10 @@ export class GestureArbiter {
       if (
         survivor !== undefined &&
         this.canArmSingleAt(survivor.x, survivor.y) &&
-        // A pinch is touch-only (two fingers), so the survivor is a touch gesture.
-        this.armSingle(survivor.pointerId, survivor.x, survivor.y, true)
+        // Carry the survivor's OWN wasTouch (usually a touch pinch finger, but a
+        // mixed mouse+touch pinch can leave the mouse as survivor) so its drag
+        // threshold matches its real device (Fable #273 F2).
+        this.armSingle(survivor.pointerId, survivor.x, survivor.y, survivor.wasTouch)
       ) {
         this.mode = 'single';
         this.pinch = null; // #237 PR2 — pinch ended; the survivor is a plain single now

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -123,6 +123,9 @@ interface GestureSnapshot {
   tool: ToolId;
   view: 'surface' | 'underground';
   undergroundColonyId: ViewState['activeUndergroundColonyId'];
+  /** #237 PR3 — was this gesture started by a touch pointer? Only touch gets the
+   *  scale-tuned drag threshold; mouse/trackpad keeps the fixed DRAG_THRESHOLD_PX. */
+  wasTouch: boolean;
 }
 
 /**
@@ -206,11 +209,13 @@ export interface GestureArbiterDeps {
    *  GameScene uses to evaluate the proactive [Tab] nudge on first world input. */
   onWorldInput?: () => void;
   /**
-   * #237 PR3 — the drag threshold in LOGICAL pixels, scale-tuned for the current
-   * display (see gesture.thresholdLogicalPx). GameScene computes it from the
-   * canvas's CSS width at boot and on resize; the arbiter reads it per move.
-   * Optional: omitted callers (and every existing unit test) fall back to the
-   * fixed DRAG_THRESHOLD_PX, so desktop behavior is unchanged.
+   * #237 PR3 — the TOUCH drag threshold in LOGICAL pixels, scale-tuned for the
+   * current display (see gesture.thresholdLogicalPx). GameScene computes it from
+   * the canvas's CSS width at boot and on resize; the arbiter reads it per move
+   * but applies it ONLY to touch gestures (snap.wasTouch). Mouse/trackpad always
+   * uses the fixed, UAT-tuned DRAG_THRESHOLD_PX, so desktop click-vs-drag is
+   * unchanged regardless of this value. Optional: omitted (as in every existing
+   * unit test) → even touch falls back to DRAG_THRESHOLD_PX.
    */
   getDragThreshold?: () => number;
 }
@@ -470,7 +475,7 @@ export class GestureArbiter {
     // mode === 'idle' — arm a single from the first pointer if the admission
     // guards pass (context-menu / pan-or-edit / HUD; see canArmSingleAt).
     if (!this.canArmSingleAt(ev.x, ev.y)) return;
-    if (!this.armSingle(ev.pointerId, ev.x, ev.y)) return; // world unavailable
+    if (!this.armSingle(ev.pointerId, ev.x, ev.y, ev.wasTouch ?? false)) return; // world unavailable
     this.mode = 'single';
     this.pointers.set(ev.pointerId, { pointerId: ev.pointerId, x: ev.x, y: ev.y });
 
@@ -518,7 +523,7 @@ export class GestureArbiter {
    * on the first move classified as paint (see onPointerMove), so a release before
    * the threshold is a single-tile Dig tap (onPointerUp) and cannot double-emit.
    */
-  private armSingle(pointerId: number, x: number, y: number): boolean {
+  private armSingle(pointerId: number, x: number, y: number, wasTouch: boolean): boolean {
     const world = this.deps.getWorld();
     if (!world) return false;
     const vs = this.deps.viewState;
@@ -536,6 +541,7 @@ export class GestureArbiter {
       tool: vs.activeTool,
       view: vs.activeView,
       undergroundColonyId: vs.activeUndergroundColonyId,
+      wasTouch,
     };
     this.dragMode = null;
     this.singleFromPinch = false; // fresh arm; the survivor re-arm re-sets this true
@@ -590,10 +596,15 @@ export class GestureArbiter {
       tracked.y = ev.y;
     }
 
-    // Classify on first crossing of the threshold (#237 PR3: scale-tuned in
-    // logical px when GameScene provides it; fixed DRAG_THRESHOLD_PX otherwise).
+    // Classify on first crossing of the threshold. #237 PR3: TOUCH uses the
+    // scale-tuned threshold (finger jitter grows in logical px as the FIT-scaled
+    // canvas shrinks) when GameScene provides it; mouse/trackpad keeps the fixed,
+    // UAT-tuned DRAG_THRESHOLD_PX so desktop click-vs-drag is unchanged.
     if (this.dragMode === null) {
-      const threshold = this.deps.getDragThreshold?.() ?? DRAG_THRESHOLD_PX;
+      const threshold =
+        snap.wasTouch && this.deps.getDragThreshold !== undefined
+          ? this.deps.getDragThreshold()
+          : DRAG_THRESHOLD_PX;
       if (!hasCrossedDragThreshold(snap.downX, snap.downY, ev.x, ev.y, threshold)) {
         return; // still a potential tap
       }
@@ -679,7 +690,8 @@ export class GestureArbiter {
       if (
         survivor !== undefined &&
         this.canArmSingleAt(survivor.x, survivor.y) &&
-        this.armSingle(survivor.pointerId, survivor.x, survivor.y)
+        // A pinch is touch-only (two fingers), so the survivor is a touch gesture.
+        this.armSingle(survivor.pointerId, survivor.x, survivor.y, true)
       ) {
         this.mode = 'single';
         this.pinch = null; // #237 PR2 — pinch ended; the survivor is a plain single now

--- a/src/input/gesture.test.ts
+++ b/src/input/gesture.test.ts
@@ -1,7 +1,12 @@
 // gesture.test.ts — Vitest unit tests for the pure gesture classifier (issue #18).
 
 import { describe, it, expect } from 'vitest';
-import { hasCrossedDragThreshold, classifyDragMode, DRAG_THRESHOLD_PX } from './gesture.js';
+import {
+  hasCrossedDragThreshold,
+  classifyDragMode,
+  thresholdLogicalPx,
+  DRAG_THRESHOLD_PX,
+} from './gesture.js';
 
 describe('hasCrossedDragThreshold', () => {
   it('false for zero movement and for movement at the threshold', () => {
@@ -40,5 +45,26 @@ describe('classifyDragMode (the view×tool drag matrix)', () => {
     expect(classifyDragMode('command', 'underground')).toBe('pan');
     expect(classifyDragMode('dig', 'surface')).toBe('pan');
     expect(classifyDragMode('chamber', 'underground')).toBe('pan');
+  });
+});
+
+describe('thresholdLogicalPx (#237 PR3 — scale-tuned drag threshold)', () => {
+  it('maps ~10px physical jitter to logical px by the inverse of cssScale', () => {
+    expect(thresholdLogicalPx(1)).toBe(10); // 1:1 display → ceil(10/1) = 10
+    expect(thresholdLogicalPx(0.5)).toBe(20); // canvas shrunk to half → ceil(10/0.5) = 20
+    expect(thresholdLogicalPx(2)).toBe(6); // enlarged 2× → ceil(5) = 5 → clamped up to the 6 floor
+  });
+
+  it('clamps to [6, 24]', () => {
+    expect(thresholdLogicalPx(3)).toBe(6); // ceil(10/3) = 4 → 6 floor
+    expect(thresholdLogicalPx(10)).toBe(6); // tiny logical jitter → 6 floor
+    expect(thresholdLogicalPx(0.25)).toBe(24); // ceil(40) = 40 → 24 ceiling
+    expect(thresholdLogicalPx(0.1)).toBe(24); // extreme shrink → 24 ceiling
+  });
+
+  it('is never looser than the fixed desktop DRAG_THRESHOLD_PX floor at any scale', () => {
+    for (const s of [0.1, 0.5, 1, 1.5, 2, 3, 10]) {
+      expect(thresholdLogicalPx(s)).toBeGreaterThanOrEqual(DRAG_THRESHOLD_PX);
+    }
   });
 });

--- a/src/input/gesture.ts
+++ b/src/input/gesture.ts
@@ -24,20 +24,24 @@ import type { ToolId } from '../render/camera.js';
 export const DRAG_THRESHOLD_PX = 6;
 
 /**
- * thresholdLogicalPx — the drag threshold (in LOGICAL/game pixels) tuned for the
- * current display scale (#237 PR3). The arbiter classifies in logical pixels
- * (Phaser.Scale.FIT maps the CSS-displayed canvas back to the fixed logical
- * canvas), so a fixed physical finger jitter maps to MORE logical pixels the
- * smaller the canvas is displayed.
+ * thresholdLogicalPx — the TOUCH drag threshold (in LOGICAL/game pixels) tuned for
+ * the current display scale (#237 PR3). The arbiter applies this ONLY to touch
+ * gestures; mouse/trackpad keeps the fixed DRAG_THRESHOLD_PX above (unchanged).
+ *
+ * The arbiter classifies in logical pixels (Phaser.Scale.FIT maps the CSS-
+ * displayed canvas back to the fixed logical canvas), so a fixed physical finger
+ * jitter maps to MORE logical pixels the smaller the canvas is displayed.
  *
  * `cssScale` = displayed CSS width / logical width (see layout.cssScaleX). A
- * ~10px physical jitter is therefore `10 / cssScale` logical px:
+ * ~10px physical finger jitter is therefore `ceil(10 / cssScale)` logical px:
  *   - phone, canvas shrunk (cssScale 0.5) → 20 logical px of jitter → threshold 20
  *   - 1:1 display (cssScale 1)            → 10
- *   - canvas enlarged (cssScale 3)        → ~3 → clamped up to the 6px floor
- * Clamped to [6, 24]: the 6px floor keeps trackpad clicks from registering as
- * drags on large displays (the original DRAG_THRESHOLD_PX intent); the 24px
- * ceiling stops a pathologically tiny canvas from swallowing real short drags.
+ *   - canvas enlarged (cssScale 3)        → ceil(3.33) = 4 → clamped up to the 6 floor
+ * Clamped to [6, 24]: the 6px floor keeps a big-display touch from being twitchier
+ * than the desktop default; the 24px ceiling stops a pathologically tiny canvas
+ * from swallowing real short drags. A degenerate cssScale ≤ 0 yields +Infinity or a
+ * negative and clamps to 24 / 6 respectively (no throw); callers still guard a
+ * zero canvas width so this isn't reached in practice.
  */
 export function thresholdLogicalPx(cssScale: number): number {
   return Math.max(6, Math.min(24, Math.ceil(10 / cssScale)));

--- a/src/input/gesture.ts
+++ b/src/input/gesture.ts
@@ -23,6 +23,26 @@ import type { ToolId } from '../render/camera.js';
  */
 export const DRAG_THRESHOLD_PX = 6;
 
+/**
+ * thresholdLogicalPx — the drag threshold (in LOGICAL/game pixels) tuned for the
+ * current display scale (#237 PR3). The arbiter classifies in logical pixels
+ * (Phaser.Scale.FIT maps the CSS-displayed canvas back to the fixed logical
+ * canvas), so a fixed physical finger jitter maps to MORE logical pixels the
+ * smaller the canvas is displayed.
+ *
+ * `cssScale` = displayed CSS width / logical width (see layout.cssScaleX). A
+ * ~10px physical jitter is therefore `10 / cssScale` logical px:
+ *   - phone, canvas shrunk (cssScale 0.5) → 20 logical px of jitter → threshold 20
+ *   - 1:1 display (cssScale 1)            → 10
+ *   - canvas enlarged (cssScale 3)        → ~3 → clamped up to the 6px floor
+ * Clamped to [6, 24]: the 6px floor keeps trackpad clicks from registering as
+ * drags on large displays (the original DRAG_THRESHOLD_PX intent); the 24px
+ * ceiling stops a pathologically tiny canvas from swallowing real short drags.
+ */
+export function thresholdLogicalPx(cssScale: number): number {
+  return Math.max(6, Math.min(24, Math.ceil(10 / cssScale)));
+}
+
 /** The outcome of a drag, once the threshold has been crossed. */
 export type DragMode = 'paint' | 'pan';
 

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -152,6 +152,7 @@ import {
   panInputState,
 } from '../input/camera-input.js';
 import { registerGestureArbiter, type GestureArbiter } from '../input/gesture-arbiter.js';
+import { thresholdLogicalPx, DRAG_THRESHOLD_PX } from '../input/gesture.js';
 import { CommandProjection } from './command-projection.js';
 import { CommandFeedforward, type FeedforwardOutcome } from './command-feedforward.js';
 import { computeGhostDelta } from './command-ghosts.js';
@@ -197,7 +198,7 @@ import {
   type FlashDirection,
 } from './screen-effects.js';
 import { ChamberType } from '../sim/enums.js';
-import { DEFAULT_LAYOUT } from './layout.js';
+import { DEFAULT_LAYOUT, cssScaleX } from './layout.js';
 import { buildHudLayout } from './hud-layout.js';
 // UIScenePhase9 — subset of UIScene public API added in Plan 06 Task 3.
 // Typed here to avoid circular imports; UIScene implements these methods.
@@ -312,6 +313,11 @@ export class GameScene extends Phaser.Scene {
   // masks read the same zone rects the HUD draws.
   private layout = DEFAULT_LAYOUT;
   private hud = buildHudLayout(this.layout);
+  // #237 PR3 — scale-tuned drag threshold in LOGICAL px, recomputed from the
+  // canvas CSS width at boot + on resize (recomputeDragThreshold) and read by the
+  // arbiter via getDragThreshold. Starts at the fixed desktop default until the
+  // first real measurement (a pre-layout width of 0 is ignored).
+  private dragThresholdPx = DRAG_THRESHOLD_PX;
   private gameLoop!: GameLoop;
   private gfx!: Phaser.GameObjects.Graphics;
   // Overlay layer for world-space primitives that must render above the sprite
@@ -463,6 +469,21 @@ export class GameScene extends Phaser.Scene {
     });
   }
 
+  /**
+   * #237 PR3 — recompute the scale-tuned drag threshold (logical px) from the
+   * canvas's current CSS width. Called at boot and on Scale RESIZE. A pre-layout
+   * or hidden canvas can report width 0; skip then and keep the current value
+   * (the fixed default at boot) rather than dividing by zero into a bogus scale.
+   *
+   * A bound arrow property (not a method) so the SAME reference registers and
+   * de-registers on the game-global Scale Manager, and `this` stays the scene.
+   */
+  private readonly recomputeDragThreshold = (): void => {
+    const cssWidth = this.game.canvas?.getBoundingClientRect().width ?? 0;
+    if (cssWidth <= 0) return;
+    this.dragThresholdPx = thresholdLogicalPx(cssScaleX(cssWidth, this.layout));
+  };
+
   /** DEV/E2E-only render-order trace (issue #193). The draw section of update()
    *  records the layer sequence each frame so a Playwright test can assert the
    *  pheromone overlay is drawn between terrain and entities — the exact
@@ -603,6 +624,9 @@ export class GameScene extends Phaser.Scene {
       // terrainBaker is off the display list (make.graphics addToScene=false), so Phaser
       // won't auto-destroy it on shutdown — free its WebGL batch explicitly.
       this.terrainBaker.destroy();
+      // #237 PR3 — the RESIZE listener is on the game-global Scale Manager, which
+      // outlives the scene; drop it so a restart can't accumulate stale callbacks.
+      this.scale.off(Phaser.Scale.Events.RESIZE, this.recomputeDragThreshold);
     });
 
     // Issue #122 — pull the playtrace endpoint out of the registry (set by
@@ -895,7 +919,14 @@ export class GameScene extends Phaser.Scene {
       onPanEffect: () => this.firstUseReactive('pan'),
       onPaintEffect: () => this.firstUseReactive('paint'),
       onWorldInput: () => this.noteWorldInput(),
+      // #237 PR3 — scale-tuned drag threshold; recomputeDragThreshold keeps the
+      // stored value current across resizes.
+      getDragThreshold: () => this.dragThresholdPx,
     });
+    // Seed the threshold from the real canvas size now the scene is live, and keep
+    // it current as the FIT-scaled canvas resizes (window resize / rotate).
+    this.recomputeDragThreshold();
+    this.scale.on(Phaser.Scale.Events.RESIZE, this.recomputeDragThreshold);
 
     // Entrance hover (Dig + surface): track the POINTER screen coords so the
     // hover outline can be re-resolved to a tile + validity from the LIVE camera

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -480,7 +480,7 @@ export class GameScene extends Phaser.Scene {
    */
   private readonly recomputeDragThreshold = (): void => {
     const cssWidth = this.game.canvas?.getBoundingClientRect().width ?? 0;
-    if (cssWidth <= 0) return;
+    if (!(cssWidth > 0)) return; // negated so NaN (NaN > 0 is false) is also skipped
     this.dragThresholdPx = thresholdLogicalPx(cssScaleX(cssWidth, this.layout));
   };
 

--- a/src/render/layout.test.ts
+++ b/src/render/layout.test.ts
@@ -1,7 +1,7 @@
 // layout.test.ts — the LayoutContext seam (issue #213).
 
 import { describe, it, expect } from 'vitest';
-import { createLayoutContext, DEFAULT_LAYOUT } from './layout.js';
+import { createLayoutContext, cssScaleX, DEFAULT_LAYOUT } from './layout.js';
 import { CANVAS_W, CANVAS_H } from './sprites.js';
 
 describe('LayoutContext (issue #213)', () => {
@@ -20,5 +20,18 @@ describe('LayoutContext (issue #213)', () => {
     const ctx = createLayoutContext(1024, 768);
     expect(ctx.w).toBe(1024);
     expect(ctx.h).toBe(768);
+  });
+});
+
+describe('cssScaleX (#237 PR3)', () => {
+  it('returns CSS pixels per logical pixel (cssWidth / layout.w)', () => {
+    const layout = createLayoutContext(800, 592);
+    expect(cssScaleX(800, layout)).toBe(1); // displayed 1:1
+    expect(cssScaleX(1600, layout)).toBe(2); // displayed 2× larger
+    expect(cssScaleX(400, layout)).toBe(0.5); // displayed half size (phone)
+  });
+
+  it('tracks the layout width, not the fixed canvas constant', () => {
+    expect(cssScaleX(512, createLayoutContext(1024, 768))).toBe(0.5);
   });
 });

--- a/src/render/layout.ts
+++ b/src/render/layout.ts
@@ -44,3 +44,16 @@ export function createLayoutContext(w: number = CANVAS_W, h: number = CANVAS_H):
  * keeps the geometry byte-for-byte identical to the pre-seam constants.
  */
 export const DEFAULT_LAYOUT: LayoutContext = createLayoutContext();
+
+/**
+ * cssScaleX — CSS pixels per logical pixel: how much the FIT-scaled canvas is
+ * displayed larger (>1) or smaller (<1) than its logical width. `cssWidth` is the
+ * canvas's on-screen width (canvas.getBoundingClientRect().width). Centralizes
+ * the ratio that both the free-text overlay positioning (ui-scene) and the
+ * touch-tuned drag threshold (#237 PR3, input.thresholdLogicalPx) need, so the
+ * two can't drift. Callers guard a zero/NaN cssWidth themselves if a pre-layout
+ * measurement is possible.
+ */
+export function cssScaleX(cssWidth: number, layout: LayoutContext): number {
+  return cssWidth / layout.w;
+}

--- a/src/render/layout.ts
+++ b/src/render/layout.ts
@@ -46,13 +46,14 @@ export function createLayoutContext(w: number = CANVAS_W, h: number = CANVAS_H):
 export const DEFAULT_LAYOUT: LayoutContext = createLayoutContext();
 
 /**
- * cssScaleX — CSS pixels per logical pixel: how much the FIT-scaled canvas is
+ * cssScaleX — CSS pixels per logical pixel (X): how much the FIT-scaled canvas is
  * displayed larger (>1) or smaller (<1) than its logical width. `cssWidth` is the
- * canvas's on-screen width (canvas.getBoundingClientRect().width). Centralizes
- * the ratio that both the free-text overlay positioning (ui-scene) and the
- * touch-tuned drag threshold (#237 PR3, input.thresholdLogicalPx) need, so the
- * two can't drift. Callers guard a zero/NaN cssWidth themselves if a pre-layout
- * measurement is possible.
+ * canvas's on-screen width (canvas.getBoundingClientRect().width). Centralizes the
+ * X ratio shared by the free-text overlay positioning (ui-scene) and the touch-
+ * tuned drag threshold (#237 PR3, input.thresholdLogicalPx). (ui-scene keeps its
+ * own inline Y ratio; FIT preserves aspect so X≈Y, and only X feeds the threshold
+ * — a cssScaleY can be added if a Y consumer ever needs it.) Callers guard a
+ * zero/NaN cssWidth themselves if a pre-layout measurement is possible.
  */
 export function cssScaleX(cssWidth: number, layout: LayoutContext): number {
   return cssWidth / layout.w;

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -237,7 +237,7 @@ import {
   sameTooltipTarget,
   type TooltipTarget,
 } from './tooltips.js';
-import { DEFAULT_LAYOUT, type LayoutContext } from './layout.js';
+import { DEFAULT_LAYOUT, cssScaleX, type LayoutContext } from './layout.js';
 import { buildHudLayout, type HudLayout } from './hud-layout.js';
 import { setViewportSize } from './camera-adapter.js';
 import {
@@ -2834,7 +2834,7 @@ export class UIScene extends Phaser.Scene {
     const canvas = this.game.canvas;
     if (canvas === null) return;
     const canvasRect = canvas.getBoundingClientRect();
-    const scaleX = canvasRect.width / this.layout.w;
+    const scaleX = cssScaleX(canvasRect.width, this.layout); // shared with the #237 drag threshold
     const scaleY = canvasRect.height / this.layout.h;
     const ta = this.surveyTextarea;
     // The textarea is absolutely-positioned and sits in `document.body` or


### PR DESCRIPTION
**#237 PR3 of 5** — touch-tuned drag threshold. The fixed 6px threshold (tuned for trackpad micro-movement) misclassifies touch taps as pans on a phone: `Phaser.Scale.FIT` shrinks the logical pixel, so a ~10px physical finger jitter spans far more than 6 *logical* px. Input/render only — no `simVersion`.

## Changes
- **`gesture.ts`**: `thresholdLogicalPx(cssScale)` = `clamp(ceil(10 / cssScale), 6, 24)` — a ~10px physical jitter expressed in logical px (÷ the display scale), **floored at the historical 6px (never looser than desktop)** and ceilinged at 24.
- **`layout.ts`**: `cssScaleX(cssWidth, layout)` = `cssWidth / layout.w` — the CSS-per-logical-px ratio, **centralized** so ui-scene's free-text overlay positioning (which already computed it inline) and the threshold can't drift; ui-scene now calls it.
- **`gesture-arbiter.ts`**: optional dep `getDragThreshold?: () => number`; the classify site uses `getDragThreshold?.() ?? DRAG_THRESHOLD_PX`, so **omitting the dep (every existing test) keeps the fixed desktop behavior**.
- **`game-scene.ts`**: `recomputeDragThreshold()` (bound arrow) derives the value from the canvas CSS width at boot and on `Phaser.Scale.Events.RESIZE`, **de-registered on `SHUTDOWN`** so a restart can't accumulate listeners; a width-0 pre-layout read is ignored.

## Behavior
On a typical desktop the canvas displays ≥ its logical width (`cssScale ≥ 1`) so the threshold floors at 6 (unchanged); a shrunk phone canvas (`cssScale < 1`) raises it (e.g. 0.5 → 20 logical px) to swallow finger jitter.

## Verification
- `npm run verify` green — **2823 passed** (+7: `thresholdLogicalPx` scale/clamp/floor, `cssScaleX` ratio, arbiter honors an injected larger threshold + a sub-threshold move still taps).
- Smoke e2e green (boot + left-drag pan, which exercises the classify path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Touch drag gestures now use a scale-aware threshold, making pan behavior feel more consistent across different screen sizes and zoom levels.
  - Survey overlay positioning now follows the same screen-to-logical scaling logic for better alignment.

- **Bug Fixes**
  - Improved gesture handling so touch presses are less likely to become accidental drags.
  - Drag behavior now stays stable during resize and rotation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->