### PR TITLE
feat(input): #237 PR4 — touch long-press → chamber menu

### DIFF
--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -1273,6 +1273,20 @@ describe('#237 PR4 — touch long-press', () => {
     expect(h.world.commandQueue.length).toBe(before);
   });
 
+  it('targets the SNAPSHOTTED tile even if the camera pans during the hold (Codex #274)', () => {
+    const h = makeHarness('underground', 'command', undefined, true);
+    const p = tileCenter(5, 8, h.vs); // press down on tile (5,8)
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y));
+    // A keyboard pan shifts the camera during the hold — the SAME screen point now
+    // reprojects to a different tile (reconcileContext does not cancel on a pan).
+    h.vs.undergroundCamera.centerX += 3 * TILE_SIZE_PX;
+    h.fireTimers();
+    // The menu still opens on the DOWN tile (5,8), matching the tap — NOT the
+    // reprojected (8,8) that a live re-projection would have picked.
+    expect(contextMenuState.pendingShow).toBe(true);
+    expect([contextMenuState.anchorTileX, contextMenuState.anchorTileY]).toEqual([5, 8]);
+  });
+
   it('a MOUSE press does not arm a long-press (right-click is the mouse path)', () => {
     const h = makeHarness('underground', 'command', undefined, true);
     const p = tileCenter(5, 8, h.vs);

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -108,6 +108,10 @@ interface Harness {
   lastQueueFullPaused: () => boolean | undefined;
   /** Every `paused` argument passed to onPausedQueueFull, in order (Fix 3). */
   queueFullPausedCalls: () => boolean[];
+  /** #237 PR4 — fire every pending fake long-press timer once (simulates 500ms). */
+  fireTimers: () => void;
+  /** #237 PR4 — armed long-press timers not yet fired or cancelled. */
+  pendingTimerCount: () => number;
 }
 
 function makeHarness(
@@ -117,6 +121,10 @@ function makeHarness(
   // arbiter exercises its `?? DRAG_THRESHOLD_PX` fallback (as in production before
   // GameScene wires the dep, and every pre-PR3 test).
   dragThreshold?: number,
+  // #237 PR4 — wire a fake scheduleTimeout so long-press timers can be fired
+  // deterministically (h.fireTimers()). OMITTED by default so pre-PR4 tests keep
+  // the no-long-press fallback (mouse right-click still works).
+  enableLongPress = false,
 ): Harness {
   const world = makeWorld();
   const vs = makeViewState(view, tool);
@@ -152,6 +160,18 @@ function makeHarness(
     },
   };
   if (dragThreshold !== undefined) deps.getDragThreshold = () => dragThreshold;
+  // #237 PR4 — a fake scheduleTimeout: record each timer; the returned canceller
+  // (or a fire) marks it done so it can't run twice. fireTimers() runs all pending.
+  const timers: Array<{ cb: () => void; done: boolean }> = [];
+  if (enableLongPress) {
+    deps.scheduleTimeout = (cb) => {
+      const t = { cb, done: false };
+      timers.push(t);
+      return () => {
+        t.done = true;
+      };
+    };
+  }
   const arbiter = new GestureArbiter(deps);
   return {
     arbiter,
@@ -168,6 +188,15 @@ function makeHarness(
     pausedFullCount: () => pausedFull,
     lastQueueFullPaused: () => queueFullPaused[queueFullPaused.length - 1],
     queueFullPausedCalls: () => queueFullPaused,
+    fireTimers: () => {
+      for (const t of timers) {
+        if (!t.done) {
+          t.done = true;
+          t.cb();
+        }
+      }
+    },
+    pendingTimerCount: () => timers.filter((t) => !t.done).length,
   };
 }
 
@@ -1218,5 +1247,82 @@ describe('#237 PR3 — injected drag threshold (touch-gated)', () => {
     // a 10px move therefore crosses it and pans.
     h.arbiter.onPointerMove(ev(LEFT_BUTTON, start.x + 10, start.y, 1, true));
     expect(panInputState.isPanning).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #237 PR4 — touch long-press → chamber menu (scheduleTimeout dep)
+// makeHarness(..., enableLongPress=true) wires a fake timer; h.fireTimers()
+// simulates the 500ms elapsing. beforeEach's hideContextMenu resets the menu.
+// ---------------------------------------------------------------------------
+
+describe('#237 PR4 — touch long-press', () => {
+  const touch = (button: number, x: number, y: number, id = 1) => ev(button, x, y, id, true);
+
+  it('a touch long-press underground opens the chamber menu and abandons the tap', () => {
+    const h = makeHarness('underground', 'command', undefined, true);
+    const p = tileCenter(5, 8, h.vs); // an editable Solid tile (same as the right-click test)
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y));
+    expect(h.pendingTimerCount()).toBe(1); // long-press armed
+    h.fireTimers(); // 500ms elapse
+    expect(contextMenuState.pendingShow).toBe(true);
+    expect([contextMenuState.anchorTileX, contextMenuState.anchorTileY]).toEqual([5, 8]);
+    // The pending tap is abandoned — lifting the finger enqueues nothing.
+    const before = h.world.commandQueue.length;
+    h.arbiter.onPointerUp(touch(LEFT_BUTTON, p.x, p.y));
+    expect(h.world.commandQueue.length).toBe(before);
+  });
+
+  it('a MOUSE press does not arm a long-press (right-click is the mouse path)', () => {
+    const h = makeHarness('underground', 'command', undefined, true);
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y, 1, false)); // MOUSE
+    expect(h.pendingTimerCount()).toBe(0);
+    h.fireTimers();
+    expect(contextMenuState.pendingShow).toBe(false);
+  });
+
+  it('a long-press on the SURFACE opens no menu and leaves the tap pending', () => {
+    const h = makeHarness('surface', 'command', undefined, true);
+    const p = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y));
+    h.fireTimers(); // fires, but surface has no chamber menu
+    expect(contextMenuState.pendingShow).toBe(false);
+    expect(h.arbiter.hasPendingGesture()).toBe(true); // tap NOT abandoned
+    h.arbiter.onPointerUp(touch(LEFT_BUTTON, p.x, p.y)); // → normal tap
+    expect(h.world.commandQueue.some((c) => c.type === 'SetRallyPoint')).toBe(true);
+  });
+
+  it('a drag before the long-press fires cancels it (no menu)', () => {
+    const h = makeHarness('surface', 'command', undefined, true);
+    const start = tileCenter(6, 4, h.vs);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, start.x, start.y));
+    expect(h.pendingTimerCount()).toBe(1);
+    h.arbiter.onPointerMove(touch(LEFT_BUTTON, start.x + 40, start.y)); // crosses threshold → drag
+    expect(h.pendingTimerCount()).toBe(0); // cancelled at drag-resolve
+    h.fireTimers();
+    expect(contextMenuState.pendingShow).toBe(false);
+  });
+
+  it('lifting before the long-press fires cancels it (menu never opens)', () => {
+    const h = makeHarness('underground', 'command', undefined, true);
+    const p = tileCenter(5, 8, h.vs);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(touch(LEFT_BUTTON, p.x, p.y)); // quick tap, well under 500ms
+    expect(h.pendingTimerCount()).toBe(0);
+    h.fireTimers();
+    expect(contextMenuState.pendingShow).toBe(false);
+  });
+
+  it('a 2nd finger (entering pinch) cancels the long-press', () => {
+    const h = makeHarness('underground', 'command', undefined, true);
+    const p1 = tileCenter(5, 8, h.vs);
+    const p2 = tileCenter(9, 8, h.vs);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p1.x, p1.y, 1));
+    expect(h.pendingTimerCount()).toBe(1);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p2.x, p2.y, 2)); // → pinch
+    expect(h.pendingTimerCount()).toBe(0); // the single→pinch handoff cancelled it
+    h.fireTimers();
+    expect(contextMenuState.pendingShow).toBe(false);
   });
 });

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -966,25 +966,29 @@ export class GestureArbiter {
   }
 
   private handleRightClick(ev: ArbiterPointerEvent): void {
-    this.tryContextMenuAt(ev.x, ev.y);
+    // Right-click acts on the LIVE tile under the cursor (the click just happened).
+    const { tileX, tileY } = screenToTileZoom(ev.x, ev.y, activeCamera(this.deps.viewState));
+    this.tryContextMenuAt(ev.x, ev.y, tileX, tileY);
   }
 
   /**
-   * tryContextMenuAt — open the underground chamber menu at a screen point when
-   * eligible. Shared by right-click (handleRightClick) and the #237 PR4 touch
-   * long-press. Returns tryOpenChamberMenu's result (did the menu open?), so the
-   * long-press can leave a pending tap intact when nothing opens (surface / HUD /
-   * non-editable tile / no world).
+   * tryContextMenuAt — open the underground chamber menu for a screen point +
+   * target tile when eligible. Shared by right-click and the #237 PR4 touch
+   * long-press; the CALLER supplies the tile so each picks the right frame:
+   * right-click reprojects the live cursor, but the long-press passes the
+   * SNAPSHOTTED down-tile (single.tileX/tileY) so it agrees with the tap — a
+   * keyboard-pan / wheel-zoom during the hold must not retarget the menu to a
+   * tile the finger never pressed (Codex #274). Returns tryOpenChamberMenu's
+   * result (did the menu open?), so the long-press can leave a pending tap intact
+   * when nothing opens (surface / HUD / non-editable tile / no world).
    */
-  private tryContextMenuAt(x: number, y: number): boolean {
+  private tryContextMenuAt(x: number, y: number, tileX: number, tileY: number): boolean {
     if (!this.deps.canEditWorld()) return false;
     const vs = this.deps.viewState;
     if (vs.activeView !== 'underground') return false; // surface has no chamber menu
     if (this.deps.isPointerOverHUD(x, y)) return false;
     const world = this.deps.getWorld();
     if (!world) return false;
-    const cam = activeCamera(vs);
-    const { tileX, tileY } = screenToTileZoom(x, y, cam);
     return tryOpenChamberMenu(world, this.deps.getProjectedWorld(), vs, x, y, tileX, tileY);
   }
 
@@ -999,8 +1003,10 @@ export class GestureArbiter {
   private fireLongPress(): void {
     this.longPressCancel = null; // the timer just fired — nothing left to cancel
     if (this.mode !== 'single' || this.single === null || this.dragMode !== null) return;
-    const { downX, downY } = this.single;
-    if (!this.tryContextMenuAt(downX, downY)) return;
+    const snap = this.single;
+    // Use the SNAPSHOTTED down-tile (not a live reprojection of downX/downY) so the
+    // menu targets the tile the finger pressed, matching the tap — see Codex #274.
+    if (!this.tryContextMenuAt(snap.downX, snap.downY, snap.tileX, snap.tileY)) return;
     this.cancelGesture(); // menu opened → the press belongs to the menu, not a tap
   }
 

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -94,6 +94,10 @@ export const LEFT_BUTTON = 0;
 export const MIDDLE_BUTTON = 1;
 export const RIGHT_BUTTON = 2;
 
+/** #237 PR4 — hold a touch press this long (ms) without dragging → chamber menu
+ *  (the touch analog of right-click). Tuned in UAT alongside DRAG_THRESHOLD_PX. */
+export const LONG_PRESS_MS = 500;
+
 /** A device-agnostic pointer event the arbiter core consumes (no Phaser type). */
 export interface ArbiterPointerEvent {
   /** Phaser pointer.id — used to ignore moves/ups from a different pointer. */
@@ -218,6 +222,13 @@ export interface GestureArbiterDeps {
    * unit test) → even touch falls back to DRAG_THRESHOLD_PX.
    */
   getDragThreshold?: () => number;
+  /**
+   * #237 PR4 — schedule `cb` after `ms`, returning a canceller. Keeps the arbiter
+   * core Phaser-free (GameScene passes scene.time.delayedCall + its .remove()).
+   * Used only for the touch long-press; omitted → no long-press (mouse right-click
+   * still works). The canceller must be safe to call after the timer has fired.
+   */
+  scheduleTimeout?: (cb: () => void, ms: number) => () => void;
 }
 
 /** Return the active CameraView for the current view. */
@@ -264,6 +275,8 @@ export class GestureArbiter {
    * must not dispatch a tap (Codex #272 P1). Reset on every fresh arm / abandon.
    */
   private singleFromPinch = false;
+  /** #237 PR4 — canceller for the in-flight touch long-press timer, or null. */
+  private longPressCancel: (() => void) | null = null;
   /** Once the threshold is crossed, the resolved drag mode ('paint' | 'pan'); null while still a tap. */
   private dragMode: 'paint' | 'pan' | null = null;
   /** Last pointer position seen during a pan drag (for incremental camera delta). */
@@ -389,6 +402,7 @@ export class GestureArbiter {
     this.single = null;
     this.dragMode = null;
     this.singleFromPinch = false;
+    this.cancelLongPress(); // #237 PR4 — abandoning the gesture cancels its long-press
     resetPaintStrokeState(this.paintStroke);
   }
 
@@ -497,6 +511,15 @@ export class GestureArbiter {
     // session (the nudge gate reads view/undergroundVisited, which a pan/dig press
     // does not change, so firing at press-time is safe).
     this.deps.onWorldInput?.();
+
+    // #237 PR4 — a held TOUCH press is the touch analog of right-click → chamber
+    // menu. Arm a timer (touch only — mouse has real right-click); fireLongPress
+    // re-checks eligibility and leaves the tap pending if nothing opens. Cancelled
+    // the moment the press resolves to a drag (onPointerMove) or is abandoned
+    // (clearLeftGesture).
+    if ((ev.wasTouch ?? false) && this.deps.scheduleTimeout !== undefined) {
+      this.longPressCancel = this.deps.scheduleTimeout(() => this.fireLongPress(), LONG_PRESS_MS);
+    }
   }
 
   /**
@@ -621,6 +644,7 @@ export class GestureArbiter {
       if (!hasCrossedDragThreshold(snap.downX, snap.downY, ev.x, ev.y, threshold)) {
         return; // still a potential tap
       }
+      this.cancelLongPress(); // #237 PR4 — the press resolved to a drag, not a long-press
       this.dragMode = classifyDragMode(snap.tool, snap.view);
       if (this.dragMode === 'paint') {
         // Paint writes to the world, so it obeys canEditWorld (a menu pause /
@@ -942,15 +966,50 @@ export class GestureArbiter {
   }
 
   private handleRightClick(ev: ArbiterPointerEvent): void {
-    if (!this.deps.canEditWorld()) return;
+    this.tryContextMenuAt(ev.x, ev.y);
+  }
+
+  /**
+   * tryContextMenuAt — open the underground chamber menu at a screen point when
+   * eligible. Shared by right-click (handleRightClick) and the #237 PR4 touch
+   * long-press. Returns tryOpenChamberMenu's result (did the menu open?), so the
+   * long-press can leave a pending tap intact when nothing opens (surface / HUD /
+   * non-editable tile / no world).
+   */
+  private tryContextMenuAt(x: number, y: number): boolean {
+    if (!this.deps.canEditWorld()) return false;
     const vs = this.deps.viewState;
-    if (vs.activeView !== 'underground') return; // surface RMB no-op
-    if (this.deps.isPointerOverHUD(ev.x, ev.y)) return;
+    if (vs.activeView !== 'underground') return false; // surface has no chamber menu
+    if (this.deps.isPointerOverHUD(x, y)) return false;
     const world = this.deps.getWorld();
-    if (!world) return;
+    if (!world) return false;
     const cam = activeCamera(vs);
-    const { tileX, tileY } = screenToTileZoom(ev.x, ev.y, cam);
-    tryOpenChamberMenu(world, this.deps.getProjectedWorld(), vs, ev.x, ev.y, tileX, tileY);
+    const { tileX, tileY } = screenToTileZoom(x, y, cam);
+    return tryOpenChamberMenu(world, this.deps.getProjectedWorld(), vs, x, y, tileX, tileY);
+  }
+
+  /**
+   * fireLongPress — #237 PR4 timer callback: a touch press held past LONG_PRESS_MS
+   * without dragging. Opens the chamber menu at the snapshotted down-point; only if
+   * it ACTUALLY opens do we abandon the pending tap (via cancelGesture — a full
+   * reset that keeps the mode==='single' ⇒ single!==null invariant, unlike a bare
+   * clearLeftGesture). If nothing opens (surface / HUD / non-editable), the tap
+   * stays armed so a normal lift still taps.
+   */
+  private fireLongPress(): void {
+    this.longPressCancel = null; // the timer just fired — nothing left to cancel
+    if (this.mode !== 'single' || this.single === null || this.dragMode !== null) return;
+    const { downX, downY } = this.single;
+    if (!this.tryContextMenuAt(downX, downY)) return;
+    this.cancelGesture(); // menu opened → the press belongs to the menu, not a tap
+  }
+
+  /** Cancel a pending long-press timer (drag-resolve, abandon, or gesture end). */
+  private cancelLongPress(): void {
+    if (this.longPressCancel !== null) {
+      this.longPressCancel();
+      this.longPressCancel = null;
+    }
   }
 }
 

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -922,6 +922,13 @@ export class GameScene extends Phaser.Scene {
       // #237 PR3 — scale-tuned drag threshold; recomputeDragThreshold keeps the
       // stored value current across resizes.
       getDragThreshold: () => this.dragThresholdPx,
+      // #237 PR4 — Phaser timer seam for the touch long-press → chamber menu. The
+      // returned canceller removes the pending event; Phaser's remove() is a no-op
+      // once the event has fired, matching the dep's "safe after fire" contract.
+      scheduleTimeout: (cb: () => void, ms: number): (() => void) => {
+        const event = this.time.delayedCall(ms, cb);
+        return () => event.remove();
+      },
     });
     // Seed the threshold from the real canvas size now the scene is live, and keep
     // it current as the FIT-scaled canvas resizes (window resize / rotate).


### PR DESCRIPTION
**#237 PR4 of 5** — touch long-press. A held touch press is the touch analog of right-click: after **500ms** without dragging it opens the underground chamber menu. Input/render only — no `simVersion`.

## Arbiter (`gesture-arbiter.ts`)
- New optional dep `scheduleTimeout(cb, ms) → canceller` (keeps the core Phaser-free).
- On a **touch** single-press (`snap.wasTouch` + dep present) arm a `LONG_PRESS_MS` timer → `longPressCancel`.
- `fireLongPress` re-checks (still a pending single, not dragged) and opens the menu via the extracted **`tryContextMenuAt`** (the factored `handleRightClick` body → `tryOpenChamberMenu`). It only abandons the tap (`cancelGesture`, preserving the PR1 `mode==='single' ⇒ single!==null` invariant) when the menu **actually opens**, so a long-hold on surface / a HUD zone / a non-editable tile still taps normally.
- The timer is cancelled on **drag-resolve** (`onPointerMove`), on **any abandon** (`clearLeftGesture` — covers the single→pinch handoff, blur, tool/view change, bails), and on a **quick lift**.

## Glue (`game-scene.ts`)
`scheduleTimeout` = `scene.time.delayedCall` + its `.remove()` (a no-op after fire, matching the dep's "safe after fire" contract).

## Scope
Mouse is unaffected — only touch presses arm the long-press (mouse has real right-click). `getDragThreshold`/`scheduleTimeout` are both optional, so every pre-PR4 test keeps the no-long-press fallback.

## Verification
- `npm run verify` green — **2832 passed** (+6 long-press tests via a fake `scheduleTimeout` / `h.fireTimers()`: underground long-press opens the menu + abandons the tap; mouse never arms; surface long-press opens nothing + leaves the tap; drag / quick-lift / 2nd-finger each cancel the timer).
- Verified the menu-open test **fails against a neutered `fireLongPress`** (teeth).
- Smoke e2e green (mouse boot + left-drag pan unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added touch long-press support for opening the chamber menu.
  * Long-press behavior now works alongside existing tap and right-click interactions.

* **Bug Fixes**
  * Improved gesture handling so long-presses are cancelled when the finger moves, lifts, or a second touch begins.
  * Prevented mouse presses from triggering long-press behavior.

* **Tests**
  * Expanded coverage for touch long-press, cancellation, and menu-opening behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->