### PR TITLE
feat(input): #237 PR5 — touch hover preview + wheel-zoom relocation

### DIFF
--- a/src/input/camera-input.test.ts
+++ b/src/input/camera-input.test.ts
@@ -19,11 +19,14 @@ import {
   isPointerOverHUD,
   processCameraInput,
   registerDragPan,
+  registerWheelZoom,
+  wheelZoomFactor,
   panInputState,
   resetPanInputState,
   resetDragState,
   type DragState,
   type PanInputs,
+  type WheelZoomDeps,
 } from './camera-input.js';
 import type * as Phaser from 'phaser';
 import { TILE_SIZE_PX } from '../render/sprites.js';
@@ -247,18 +250,20 @@ describe('processCameraInput', () => {
  */
 function makeFakeScene(): {
   scene: Phaser.Scene;
-  emit: (event: string, pointer: unknown) => void;
+  emit: (event: string, ...args: unknown[]) => void;
 } {
-  const handlers = new Map<string, (pointer: unknown) => void>();
+  // varargs so a 'wheel' handler (pointer, over, dx, dy) can be driven as well as
+  // the single-arg pointer handlers registerDragPan uses.
+  const handlers = new Map<string, (...args: unknown[]) => void>();
   const scene = {
     input: {
-      on: (event: string, fn: (pointer: unknown) => void) => {
+      on: (event: string, fn: (...args: unknown[]) => void) => {
         handlers.set(event, fn);
       },
     },
   } as unknown as Phaser.Scene;
-  const emit = (event: string, pointer: unknown): void => {
-    handlers.get(event)?.(pointer);
+  const emit = (event: string, ...args: unknown[]): void => {
+    handlers.get(event)?.(...args);
   };
   return { scene, emit };
 }
@@ -332,5 +337,106 @@ describe('reset helpers', () => {
     resetDragState(ds);
     expect(ds).toBe(ref);
     expect(ds).toEqual({ isDragging: false, lastX: 0, lastY: 0, active: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #237 PR5 — wheel zoom (relocated from game-scene)
+// ---------------------------------------------------------------------------
+
+describe('wheelZoomFactor (#237 PR5)', () => {
+  it('dy<0 (scroll up) zooms IN (>1), dy>0 zooms OUT (<1), dy=0 is a no-op (1)', () => {
+    expect(wheelZoomFactor(-100, 2, 100)).toBeCloseTo(2, 6); // one notch up = ×step
+    expect(wheelZoomFactor(100, 2, 100)).toBeCloseTo(0.5, 6); // one notch down = ÷step
+    expect(wheelZoomFactor(0, 2, 100)).toBe(1);
+  });
+
+  it('scales by the deltaY magnitude (half a notch = sqrt(step))', () => {
+    expect(wheelZoomFactor(-50, 2, 100)).toBeCloseTo(Math.SQRT2, 6);
+  });
+});
+
+describe('registerWheelZoom (#237 PR5)', () => {
+  function wheelPointer(
+    x: number,
+    y: number,
+    mods: { ctrl?: boolean; meta?: boolean } = {},
+  ): Phaser.Input.Pointer {
+    return {
+      x,
+      y,
+      event: { ctrlKey: !!mods.ctrl, metaKey: !!mods.meta },
+    } as unknown as Phaser.Input.Pointer;
+  }
+
+  it('a wheel-up event zooms in and fires the accepted + world-input hooks', () => {
+    const { scene, emit } = makeFakeScene();
+    const cam = makeCameraView(100, 100, 1);
+    let beginCalls = 0;
+    let lastFactor = 0;
+    let accepted = 0;
+    let worldInput = 0;
+    registerWheelZoom(scene, {
+      canAcceptWorldHotkey: () => true,
+      isPointerOverHUD: () => false,
+      getActiveCamera: () => cam,
+      beginZoom: (c, factor) => {
+        beginCalls++;
+        lastFactor = factor;
+        c.targetZoom = c.targetZoom * factor;
+      },
+      onZoomAccepted: () => {
+        accepted++;
+      },
+      noteWorldInput: () => {
+        worldInput++;
+      },
+    });
+    emit('wheel', wheelPointer(400, 300), undefined, 0, -100); // scroll up
+    expect(beginCalls).toBe(1);
+    expect(lastFactor).toBeGreaterThan(1); // zoom IN
+    expect(cam.targetZoom).toBeGreaterThan(1);
+    expect(accepted).toBe(1); // targetZoom changed → hint fires
+    expect(worldInput).toBe(1);
+  });
+
+  it.each([
+    ['blocked hotkey', { canAcceptWorldHotkey: () => false } as Partial<WheelZoomDeps>, {}, -100],
+    ['over HUD', { isPointerOverHUD: () => true } as Partial<WheelZoomDeps>, {}, -100],
+    ['ctrl-wheel (OS pinch)', {} as Partial<WheelZoomDeps>, { ctrl: true }, -100],
+    ['cmd-wheel (OS pinch)', {} as Partial<WheelZoomDeps>, { meta: true }, -100],
+    ['dy === 0', {} as Partial<WheelZoomDeps>, {}, 0],
+  ])('is gated: %s → no beginZoom', (_label, overrides, mods, dy) => {
+    const { scene, emit } = makeFakeScene();
+    let beginCalls = 0;
+    registerWheelZoom(scene, {
+      canAcceptWorldHotkey: () => true,
+      isPointerOverHUD: () => false,
+      getActiveCamera: () => makeCameraView(0, 0, 1),
+      beginZoom: () => {
+        beginCalls++;
+      },
+      ...overrides,
+    });
+    emit('wheel', wheelPointer(400, 300, mods), undefined, 0, dy);
+    expect(beginCalls).toBe(0);
+  });
+
+  it('does NOT fire onZoomAccepted when targetZoom is unchanged (clamped no-op at the limit)', () => {
+    const { scene, emit } = makeFakeScene();
+    let accepted = 0;
+    registerWheelZoom(scene, {
+      canAcceptWorldHotkey: () => true,
+      isPointerOverHUD: () => false,
+      getActiveCamera: () => makeCameraView(0, 0, 1),
+      beginZoom: () => {
+        /* already at the zoom limit — leaves targetZoom unchanged */
+      },
+      onZoomAccepted: () => {
+        accepted++;
+      },
+    });
+    emit('wheel', wheelPointer(400, 300), undefined, 0, -100);
+    expect(accepted).toBe(0);
   });
 });

--- a/src/input/camera-input.ts
+++ b/src/input/camera-input.ts
@@ -34,6 +34,9 @@ import {
   panByScreenDelta,
   panByKeyboard,
 } from '../render/camera-adapter.js';
+// #237 PR5 — wheel-zoom constants (type-free numbers; camera-controller has no
+// Phaser runtime import, so this keeps camera-input Phaser-runtime-free).
+import { WHEEL_ZOOM_STEP, WHEEL_NOTCH_PX } from '../render/camera-controller.js';
 
 // ---------------------------------------------------------------------------
 // panInputState — module-level singleton
@@ -318,4 +321,61 @@ export function registerDragPan(
   scene.input.on('pointerupoutside', releaseDrag);
 
   return dragState;
+}
+
+// ---------------------------------------------------------------------------
+// Wheel zoom (#237 PR5 — relocated from game-scene's inline closure)
+// ---------------------------------------------------------------------------
+
+/**
+ * wheelZoomFactor — the multiplicative zoom for one wheel event:
+ * `step ** (−dy / notch)`. dy < 0 (scroll up) → factor > 1 (zoom in). Scaling by
+ * the deltaY magnitude keeps a continuous trackpad / high-res wheel (many small
+ * events per gesture) smooth instead of slamming a full step per event and
+ * hitting the zoom limit (Codex P1). Pure — unit-tested.
+ */
+export function wheelZoomFactor(dy: number, step: number, notch: number): number {
+  return Math.pow(step, -dy / notch);
+}
+
+/** Injected seams for registerWheelZoom (keeps the wire Phaser-testable). */
+export interface WheelZoomDeps {
+  /** World input allowed right now (no modal / menu / game-over owns input). */
+  canAcceptWorldHotkey: () => boolean;
+  /** True if a screen point falls on a HUD zone (bind hud + viewState at the call site). */
+  isPointerOverHUD: (x: number, y: number) => boolean;
+  /** The active CameraView to zoom. */
+  getActiveCamera: () => CameraView;
+  /** Apply an anchored zoom (cameraController.beginZoom). */
+  beginZoom: (cam: CameraView, factor: number, screenX: number, screenY: number) => void;
+  /** Fired when the zoom was ACCEPTED (targetZoom changed — not a clamped no-op). */
+  onZoomAccepted?: () => void;
+  /** A wheel is a world input (proactive [Tab] nudge). */
+  noteWorldInput?: () => void;
+}
+
+/**
+ * registerWheelZoom — wire mouse-wheel / trackpad zoom to a scene, mirroring
+ * registerDragPan. Gated exactly like world pan (canAcceptWorldHotkey + HUD);
+ * ctrl/cmd-wheel is left to the OS/browser pinch-zoom, and dy===0 is ignored.
+ * Wheel-up (dy < 0) zooms IN. #237 PR5 — moved out of game-scene so the gesture
+ * the pinch extends has an input-layer home + a unit test.
+ */
+export function registerWheelZoom(scene: Phaser.Scene, deps: WheelZoomDeps): void {
+  scene.input.on(
+    'wheel',
+    (pointer: Phaser.Input.Pointer, _over: unknown, _dx: number, dy: number) => {
+      if (!deps.canAcceptWorldHotkey()) return;
+      if (deps.isPointerOverHUD(pointer.x, pointer.y)) return;
+      const native = pointer.event as WheelEvent | undefined;
+      if (native?.ctrlKey || native?.metaKey) return;
+      if (dy === 0) return;
+      const cam = deps.getActiveCamera();
+      const factor = wheelZoomFactor(dy, WHEEL_ZOOM_STEP, WHEEL_NOTCH_PX);
+      const beforeZoom = cam.targetZoom;
+      deps.beginZoom(cam, factor, pointer.x, pointer.y);
+      if (cam.targetZoom !== beforeZoom) deps.onZoomAccepted?.();
+      deps.noteWorldInput?.();
+    },
+  );
 }

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -21,6 +21,7 @@ import {
   LEFT_BUTTON,
   MIDDLE_BUTTON,
   RIGHT_BUTTON,
+  HOVER_PREVIEW_MS,
   type GestureArbiterDeps,
   type ArbiterPointerEvent,
 } from './gesture-arbiter.js';
@@ -108,10 +109,18 @@ interface Harness {
   lastQueueFullPaused: () => boolean | undefined;
   /** Every `paused` argument passed to onPausedQueueFull, in order (Fix 3). */
   queueFullPausedCalls: () => boolean[];
-  /** #237 PR4 — fire every pending fake long-press timer once (simulates 500ms). */
-  fireTimers: () => void;
-  /** #237 PR4 — armed long-press timers not yet fired or cancelled. */
+  /**
+   * #237 PR4/PR5 — fire pending fake timers whose delay ≤ untilMs, in delay order
+   * (default Infinity = all). Lets a test advance to HOVER_PREVIEW_MS (200) without
+   * also firing the LONG_PRESS_MS (500) timer.
+   */
+  fireTimers: (untilMs?: number) => void;
+  /** #237 PR4/PR5 — armed timers not yet fired or cancelled. */
   pendingTimerCount: () => number;
+  /** #237 PR5 — every onHoverPreview(x, y) call, in order. */
+  hoverPreviewCalls: () => Array<{ x: number; y: number }>;
+  /** #237 PR5 — number of onHoverPreviewEnd() calls. */
+  hoverPreviewEndCount: () => number;
 }
 
 function makeHarness(
@@ -125,6 +134,9 @@ function makeHarness(
   // deterministically (h.fireTimers()). OMITTED by default so pre-PR4 tests keep
   // the no-long-press fallback (mouse right-click still works).
   enableLongPress = false,
+  // #237 PR5 — wire onHoverPreview/onHoverPreviewEnd (recorded on the harness).
+  // Requires enableLongPress (the hover uses the same scheduleTimeout seam).
+  enableHoverPreview = false,
 ): Harness {
   const world = makeWorld();
   const vs = makeViewState(view, tool);
@@ -160,16 +172,28 @@ function makeHarness(
     },
   };
   if (dragThreshold !== undefined) deps.getDragThreshold = () => dragThreshold;
-  // #237 PR4 — a fake scheduleTimeout: record each timer; the returned canceller
-  // (or a fire) marks it done so it can't run twice. fireTimers() runs all pending.
-  const timers: Array<{ cb: () => void; done: boolean }> = [];
+  // #237 PR4/PR5 — a fake scheduleTimeout: record each timer's cb + delay; the
+  // returned canceller (or a fire) marks it done so it can't run twice.
+  const timers: Array<{ cb: () => void; ms: number; done: boolean }> = [];
   if (enableLongPress) {
-    deps.scheduleTimeout = (cb) => {
-      const t = { cb, done: false };
+    deps.scheduleTimeout = (cb, ms) => {
+      const t = { cb, ms, done: false };
       timers.push(t);
       return () => {
         t.done = true;
       };
+    };
+  }
+  // #237 PR5 — record hover-preview callbacks (and wire them only when asked, so
+  // the hover timer stays un-armed for the PR4 long-press-only tests).
+  const hoverCalls: Array<{ x: number; y: number }> = [];
+  let hoverEnds = 0;
+  if (enableHoverPreview) {
+    deps.onHoverPreview = (x, y) => {
+      hoverCalls.push({ x, y });
+    };
+    deps.onHoverPreviewEnd = () => {
+      hoverEnds++;
     };
   }
   const arbiter = new GestureArbiter(deps);
@@ -188,15 +212,18 @@ function makeHarness(
     pausedFullCount: () => pausedFull,
     lastQueueFullPaused: () => queueFullPaused[queueFullPaused.length - 1],
     queueFullPausedCalls: () => queueFullPaused,
-    fireTimers: () => {
-      for (const t of timers) {
-        if (!t.done) {
-          t.done = true;
-          t.cb();
-        }
+    fireTimers: (untilMs = Infinity) => {
+      // Fire due (ms ≤ untilMs) pending timers in delay order, so a 200ms hover
+      // resolves before a 500ms long-press when both are due.
+      const due = timers.filter((t) => !t.done && t.ms <= untilMs).sort((a, b) => a.ms - b.ms);
+      for (const t of due) {
+        t.done = true;
+        t.cb();
       }
     },
     pendingTimerCount: () => timers.filter((t) => !t.done).length,
+    hoverPreviewCalls: () => hoverCalls,
+    hoverPreviewEndCount: () => hoverEnds,
   };
 }
 
@@ -1338,5 +1365,66 @@ describe('#237 PR4 — touch long-press', () => {
     expect(h.pendingTimerCount()).toBe(0); // the single→pinch handoff cancelled it
     h.fireTimers();
     expect(contextMenuState.pendingShow).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #237 PR5 — touch hover preview (onHoverPreview / onHoverPreviewEnd)
+// makeHarness(..., enableLongPress=true, enableHoverPreview=true) wires the
+// timer seam + records the callbacks. fireTimers(HOVER_PREVIEW_MS) advances to
+// the 200ms hover without also firing the 500ms long-press.
+// ---------------------------------------------------------------------------
+
+describe('#237 PR5 — touch hover preview', () => {
+  const touch = (button: number, x: number, y: number, id = 1) => ev(button, x, y, id, true);
+
+  it('a still touch press shows the preview at HOVER_PREVIEW_MS without abandoning the tap', () => {
+    const h = makeHarness('surface', 'command', undefined, true, true);
+    const p = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y));
+    h.fireTimers(HOVER_PREVIEW_MS); // fire the 200ms hover, NOT the 500ms long-press
+    expect(h.hoverPreviewCalls()).toEqual([{ x: p.x, y: p.y }]); // preview at the down-point
+    expect(h.arbiter.hasPendingGesture()).toBe(true); // hover is additive — tap NOT abandoned
+    // Release → the preview ends AND the tap still commits.
+    h.arbiter.onPointerUp(touch(LEFT_BUTTON, p.x, p.y));
+    expect(h.hoverPreviewEndCount()).toBe(1);
+    expect(h.world.commandQueue.some((c) => c.type === 'SetRallyPoint')).toBe(true);
+  });
+
+  it('under-threshold drift forwards the preview under the finger', () => {
+    const h = makeHarness('surface', 'command', undefined, true, true);
+    const p = tileCenter(6, 4, h.vs);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y));
+    h.fireTimers(HOVER_PREVIEW_MS);
+    h.arbiter.onPointerMove(touch(LEFT_BUTTON, p.x + 3, p.y)); // 3px, under the threshold
+    const calls = h.hoverPreviewCalls();
+    expect(calls[calls.length - 1]).toEqual({ x: p.x + 3, y: p.y }); // tracked the finger
+  });
+
+  it('a drag ends the hover preview (a drag is not a hover)', () => {
+    const h = makeHarness('surface', 'command', undefined, true, true);
+    const p = tileCenter(6, 4, h.vs);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y));
+    h.fireTimers(HOVER_PREVIEW_MS); // preview showing
+    h.arbiter.onPointerMove(touch(LEFT_BUTTON, p.x + 40, p.y)); // crosses threshold → drag
+    expect(h.hoverPreviewEndCount()).toBe(1);
+  });
+
+  it('a MOUSE press shows no hover preview (mouse has a real hover)', () => {
+    const h = makeHarness('surface', 'command', undefined, true, true);
+    const p = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(ev(LEFT_BUTTON, p.x, p.y, 1, false)); // MOUSE
+    h.fireTimers(); // fire everything
+    expect(h.hoverPreviewCalls()).toEqual([]);
+  });
+
+  it('a quick lift before HOVER_PREVIEW_MS shows no preview', () => {
+    const h = makeHarness('surface', 'command', undefined, true, true);
+    const p = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y));
+    h.arbiter.onPointerUp(touch(LEFT_BUTTON, p.x, p.y)); // lift before the timer fires
+    h.fireTimers(); // both timers were cancelled on lift
+    expect(h.hoverPreviewCalls()).toEqual([]);
+    expect(h.hoverPreviewEndCount()).toBe(0); // never fired → no End
   });
 });

--- a/src/input/gesture-arbiter.test.ts
+++ b/src/input/gesture-arbiter.test.ts
@@ -1427,4 +1427,46 @@ describe('#237 PR5 — touch hover preview', () => {
     expect(h.hoverPreviewCalls()).toEqual([]);
     expect(h.hoverPreviewEndCount()).toBe(0); // never fired → no End
   });
+
+  it('endHoverPreview cancels a PENDING hover timer so a canvas exit cannot resurrect it (Codex #275)', () => {
+    const h = makeHarness('surface', 'command', undefined, true, true);
+    const p = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y)); // hover timer armed (still pending)
+    h.arbiter.endHoverPreview(); // canvas exit (pointerout/gameout) before 200ms
+    h.fireTimers(HOVER_PREVIEW_MS); // the 200ms timer would fire — but it was cancelled
+    expect(h.hoverPreviewCalls()).toEqual([]); // no resurrect at the stale down-point
+  });
+
+  it('endHoverPreview ends an ACTIVE preview (End fired, flag synced) without abandoning the gesture (Codex #275)', () => {
+    const h = makeHarness('surface', 'command', undefined, true, true);
+    const p = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y));
+    h.fireTimers(HOVER_PREVIEW_MS); // preview showing
+    expect(h.hoverPreviewCalls().length).toBe(1);
+    h.arbiter.endHoverPreview(); // canvas exit while showing
+    expect(h.hoverPreviewEndCount()).toBe(1); // ended
+    expect(h.arbiter.hasPendingGesture()).toBe(true); // gesture NOT abandoned (hover-only)
+    // A later under-threshold move no longer re-forwards (preview flag synced off).
+    h.arbiter.onPointerMove(touch(LEFT_BUTTON, p.x + 3, p.y));
+    expect(h.hoverPreviewCalls().length).toBe(1);
+  });
+
+  it('a touchcancel (wasCanceled) up abandons the gesture with NO tap (Codex #275)', () => {
+    const h = makeHarness('surface', 'command', undefined, true, true);
+    const p = tileCenter(6, 1, h.vs);
+    h.arbiter.onPointerDown(touch(LEFT_BUTTON, p.x, p.y));
+    const before = h.world.commandQueue.length;
+    // Phaser routes a touchcancel through the pointerup path with wasCanceled=true.
+    h.arbiter.onPointerUp({
+      pointerId: 1,
+      button: LEFT_BUTTON,
+      x: p.x,
+      y: p.y,
+      wasTouch: true,
+      wasCanceled: true,
+    });
+    expect(h.world.commandQueue.length).toBe(before); // NO tap
+    expect(h.arbiter.hasPendingGesture()).toBe(false); // gesture abandoned
+    expect(h.hoverPreviewEndCount()).toBe(0); // preview never fired; timers cancelled
+  });
 });

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -98,6 +98,11 @@ export const RIGHT_BUTTON = 2;
  *  (the touch analog of right-click). Tuned in UAT alongside DRAG_THRESHOLD_PX. */
 export const LONG_PRESS_MS = 500;
 
+/** #237 PR5 — hold a touch press this long (ms) without dragging → show the
+ *  feedforward hover preview (touch has no real hover). Shorter than LONG_PRESS_MS
+ *  so the preview appears well before the long-press chamber menu. */
+export const HOVER_PREVIEW_MS = 200;
+
 /** A device-agnostic pointer event the arbiter core consumes (no Phaser type). */
 export interface ArbiterPointerEvent {
   /** Phaser pointer.id — used to ignore moves/ups from a different pointer. */
@@ -229,6 +234,17 @@ export interface GestureArbiterDeps {
    * still works). The canceller must be safe to call after the timer has fired.
    */
   scheduleTimeout?: (cb: () => void, ms: number) => () => void;
+  /**
+   * #237 PR5 — touch press-and-hold feedforward preview (touch has no hover).
+   * onHoverPreview(x, y) is called when a still touch press passes
+   * HOVER_PREVIEW_MS, and again as the finger drifts under the drag threshold;
+   * onHoverPreviewEnd() on release / drag-out / cancel. GameScene points these at
+   * the same hoverScreenX/Y fields its mouse pointermove handler drives, so the
+   * existing per-frame hover resolution renders the preview. Both omitted → no
+   * touch preview (mouse hover unaffected).
+   */
+  onHoverPreview?: (x: number, y: number) => void;
+  onHoverPreviewEnd?: () => void;
 }
 
 /** Return the active CameraView for the current view. */
@@ -277,6 +293,11 @@ export class GestureArbiter {
   private singleFromPinch = false;
   /** #237 PR4 — canceller for the in-flight touch long-press timer, or null. */
   private longPressCancel: (() => void) | null = null;
+  /** #237 PR5 — canceller for the in-flight touch hover-preview timer, or null. */
+  private hoverPreviewCancel: (() => void) | null = null;
+  /** #237 PR5 — true once the hover preview has FIRED (so under-threshold moves
+   *  forward to onHoverPreview and release/drag-out calls onHoverPreviewEnd). */
+  private hoverPreviewActive = false;
   /** Once the threshold is crossed, the resolved drag mode ('paint' | 'pan'); null while still a tap. */
   private dragMode: 'paint' | 'pan' | null = null;
   /** Last pointer position seen during a pan drag (for incremental camera delta). */
@@ -403,6 +424,7 @@ export class GestureArbiter {
     this.dragMode = null;
     this.singleFromPinch = false;
     this.cancelLongPress(); // #237 PR4 — abandoning the gesture cancels its long-press
+    this.cancelHoverPreview(); // #237 PR5 — ...and ends/cancels its hover preview
     resetPaintStrokeState(this.paintStroke);
   }
 
@@ -512,12 +534,20 @@ export class GestureArbiter {
     // does not change, so firing at press-time is safe).
     this.deps.onWorldInput?.();
 
-    // #237 PR4 — a held TOUCH press is the touch analog of right-click → chamber
-    // menu. Arm a timer (touch only — mouse has real right-click); fireLongPress
-    // re-checks eligibility and leaves the tap pending if nothing opens. Cancelled
-    // the moment the press resolves to a drag (onPointerMove) or is abandoned
-    // (clearLeftGesture).
+    // A held TOUCH press drives two touch-only timers (mouse has real hover +
+    // right-click), both cancelled the moment the press resolves to a drag
+    // (onPointerMove) or is abandoned (clearLeftGesture):
+    //   - #237 PR5 hover preview at HOVER_PREVIEW_MS (feedforward cue), and
+    //   - #237 PR4 long-press → chamber menu at LONG_PRESS_MS.
     if ((ev.wasTouch ?? false) && this.deps.scheduleTimeout !== undefined) {
+      // Hover preview only when a consumer wants it (onHoverPreview wired); the
+      // long-press always arms (fireLongPress re-checks menu eligibility).
+      if (this.deps.onHoverPreview !== undefined) {
+        this.hoverPreviewCancel = this.deps.scheduleTimeout(
+          () => this.fireHoverPreview(),
+          HOVER_PREVIEW_MS,
+        );
+      }
       this.longPressCancel = this.deps.scheduleTimeout(() => this.fireLongPress(), LONG_PRESS_MS);
     }
   }
@@ -642,9 +672,13 @@ export class GestureArbiter {
           ? this.deps.getDragThreshold()
           : DRAG_THRESHOLD_PX;
       if (!hasCrossedDragThreshold(snap.downX, snap.downY, ev.x, ev.y, threshold)) {
-        return; // still a potential tap
+        // Still a potential tap. #237 PR5 — if the hover preview is showing, track
+        // it under the (under-threshold) finger drift.
+        if (this.hoverPreviewActive) this.deps.onHoverPreview?.(ev.x, ev.y);
+        return;
       }
       this.cancelLongPress(); // #237 PR4 — the press resolved to a drag, not a long-press
+      this.cancelHoverPreview(); // #237 PR5 — a drag ends the hover preview
       this.dragMode = classifyDragMode(snap.tool, snap.view);
       if (this.dragMode === 'paint') {
         // Paint writes to the world, so it obeys canEditWorld (a menu pause /
@@ -1015,6 +1049,36 @@ export class GestureArbiter {
     if (this.longPressCancel !== null) {
       this.longPressCancel();
       this.longPressCancel = null;
+    }
+  }
+
+  /**
+   * fireHoverPreview — #237 PR5 timer callback: a still touch press held past
+   * HOVER_PREVIEW_MS. Show the feedforward preview at the snapshotted down-point;
+   * under-threshold moves then track it (onPointerMove), and any gesture end /
+   * drag-out clears it (cancelHoverPreview). Does NOT abandon the tap — a lift
+   * still taps; the preview is purely additive on-screen state.
+   */
+  private fireHoverPreview(): void {
+    this.hoverPreviewCancel = null; // the timer just fired
+    if (this.mode !== 'single' || this.single === null || this.dragMode !== null) return;
+    this.hoverPreviewActive = true;
+    this.deps.onHoverPreview?.(this.single.downX, this.single.downY);
+  }
+
+  /**
+   * cancelHoverPreview — drop a pending hover-preview timer AND, if the preview
+   * already fired, end it (onHoverPreviewEnd). Called on drag-resolve and from
+   * clearLeftGesture (release / abandon / pinch-handoff / reconcile).
+   */
+  private cancelHoverPreview(): void {
+    if (this.hoverPreviewCancel !== null) {
+      this.hoverPreviewCancel();
+      this.hoverPreviewCancel = null;
+    }
+    if (this.hoverPreviewActive) {
+      this.hoverPreviewActive = false;
+      this.deps.onHoverPreviewEnd?.();
     }
   }
 }

--- a/src/input/gesture-arbiter.ts
+++ b/src/input/gesture-arbiter.ts
@@ -119,6 +119,12 @@ export interface ArbiterPointerEvent {
    * preview). Optional so existing unit tests need not set it (mouse paths).
    */
   wasTouch?: boolean;
+  /**
+   * #237 PR5 — Phaser `pointer.wasCanceled`: an OS/browser touchcancel (a system
+   * gesture took over). Phaser routes it through the pointerup path, so onPointerUp
+   * must abandon the gesture with NO tap. Only meaningful on an up event.
+   */
+  wasCanceled?: boolean;
 }
 
 /** Snapshot taken at left pointer-down; the tap acts on these, not live state. */
@@ -327,6 +333,18 @@ export class GestureArbiter {
   /** True while a single (tap/drag) gesture is pending (down seen, up not yet). */
   hasPendingGesture(): boolean {
     return this.single !== null;
+  }
+
+  /**
+   * #237 PR5 — end just the touch hover preview (cancel its pending timer + fire
+   * onHoverPreviewEnd if it was showing), WITHOUT abandoning the gesture. Called by
+   * GameScene on canvas exit (pointerout / gameout): the preview must not linger or
+   * a pending timer resurrect it at the stale down-point while the finger is off
+   * the canvas — but a live drag (mouse or touch) should keep running until its own
+   * up/upoutside, so this does NOT cancel the whole gesture.
+   */
+  endHoverPreview(): void {
+    this.cancelHoverPreview();
   }
 
   /**
@@ -748,6 +766,14 @@ export class GestureArbiter {
   }
 
   onPointerUp(ev: ArbiterPointerEvent): void {
+    // #237 PR5 — a touchcancel (OS/browser took over the gesture) arrives on the
+    // pointerup path with wasCanceled=true. Abandon everything with NO tap — the
+    // finger never "lifted" intentionally. cancelGesture also ends any hover
+    // preview / long-press timer via clearLeftGesture.
+    if (ev.wasCanceled) {
+      this.cancelGesture();
+      return;
+    }
     // #237 PR1 — a pinch finger lifted: NO tap. Drop it and re-snapshot the
     // survivor as a fresh single (so lifting it later taps, moving it pans/paints).
     if (this.mode === 'pinch') {
@@ -1136,6 +1162,7 @@ export function registerGestureArbiter(
       x: pointer.x,
       y: pointer.y,
       wasTouch: pointer.wasTouch,
+      wasCanceled: pointer.wasCanceled, // #237 PR5 — touchcancel → abandon, no tap
     });
   });
   scene.input.on('pointerupoutside', () => {

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -80,7 +80,7 @@ import {
   resolveDotMode,
   setViewportSize,
 } from './camera-adapter.js';
-import { CameraController, WHEEL_ZOOM_STEP, WHEEL_NOTCH_PX } from './camera-controller.js';
+import { CameraController } from './camera-controller.js';
 import {
   TerrainCache,
   surfaceCacheKey,
@@ -146,6 +146,7 @@ import { SUBTERRANS_READY_EVENT } from './lifecycle.js';
 import {
   processCameraInput,
   registerDragPan,
+  registerWheelZoom,
   resetDragState,
   resetPanInputState,
   isPointerOverHUD,
@@ -667,37 +668,23 @@ export class GameScene extends Phaser.Scene {
     // still works while paused — intended.
     this.dragState = registerDragPan(this, this.viewState, this.hud, () => this.isModalOpen());
 
-    // Stage 2 (issue #18): mouse-wheel zoom. Gated exactly like world pan — ignored
-    // over HUD zones and whenever a modal / menu / game-over owns input
-    // (canAcceptWorldHotkey). ctrl/cmd-wheel is ignored so the OS/browser pinch-zoom
-    // gesture is never hijacked for game zoom. Wheel-up (deltaY < 0) zooms IN; the
-    // controller runs the cursor-anchored zoom-lerp from here.
-    this.input.on(
-      'wheel',
-      (pointer: Phaser.Input.Pointer, _over: unknown, _dx: number, dy: number) => {
-        if (!this.canAcceptWorldHotkey()) return;
-        if (isPointerOverHUD(pointer.x, pointer.y, this.hud, this.viewState)) return;
-        const native = pointer.event as WheelEvent | undefined;
-        if (native?.ctrlKey || native?.metaKey) return;
-        if (dy === 0) return;
-        const cam =
-          this.viewState.activeView === 'surface'
-            ? this.viewState.surfaceCamera
-            : this.viewState.undergroundCamera;
-        // Scale by deltaY magnitude so continuous trackpad / high-res-wheel scrolling
-        // (many small events per gesture) zooms smoothly instead of jumping a full step
-        // every event and slamming to the zoom limit (Codex P1). One ~WHEEL_NOTCH_PX notch
-        // = one ×WHEEL_ZOOM_STEP; dy<0 (scroll up) zooms in.
-        const factor = Math.pow(WHEEL_ZOOM_STEP, -dy / WHEEL_NOTCH_PX);
-        // Stage 3b (#3): fire the "Scroll to zoom" hint only on an ACCEPTED zoom
-        // (targetZoom actually changed — not a clamped no-op at the zoom limit).
-        const beforeZoom = cam.targetZoom;
-        this.cameraController.beginZoom(cam, factor, pointer.x, pointer.y);
-        if (cam.targetZoom !== beforeZoom) this.firstUseReactive('zoom');
-        // A wheel is a world input → evaluate the proactive [Tab] nudge.
-        this.noteWorldInput();
-      },
-    );
+    // Stage 2 (issue #18): mouse-wheel / trackpad zoom. #237 PR5 — relocated to
+    // camera-input.registerWheelZoom (mirrors registerDragPan) so the gesture the
+    // pinch extends has an input-layer home + a unit test. Gated exactly like world
+    // pan (canAcceptWorldHotkey + HUD); ctrl/cmd-wheel is left to the OS/browser
+    // pinch-zoom; wheel-up (dy < 0) zooms IN. onZoomAccepted fires the "Scroll to
+    // zoom" hint only when targetZoom actually changed (not a clamped no-op).
+    registerWheelZoom(this, {
+      canAcceptWorldHotkey: () => this.canAcceptWorldHotkey(),
+      isPointerOverHUD: (x, y) => isPointerOverHUD(x, y, this.hud, this.viewState),
+      getActiveCamera: () =>
+        this.viewState.activeView === 'surface'
+          ? this.viewState.surfaceCamera
+          : this.viewState.undergroundCamera,
+      beginZoom: (cam, factor, sx, sy) => this.cameraController.beginZoom(cam, factor, sx, sy),
+      onZoomAccepted: () => this.firstUseReactive('zoom'),
+      noteWorldInput: () => this.noteWorldInput(),
+    });
 
     // Issue #116 — Esc opens the pause menu overlay (which also pauses the
     // sim). The Esc keybinding itself lives in UIScene (which already owned
@@ -929,6 +916,18 @@ export class GameScene extends Phaser.Scene {
         const event = this.time.delayedCall(ms, cb);
         return () => event.remove();
       },
+      // #237 PR5 — touch press-and-hold drives the SAME hover fields the mouse
+      // pointermove handler sets (below), so the existing per-frame feedforward
+      // hover resolution renders the touch preview. onHoverPreviewEnd clears it on
+      // release — pointerout/gameout don't fire on a touch-up inside the canvas.
+      onHoverPreview: (x: number, y: number) => {
+        this.hoverScreenX = x;
+        this.hoverScreenY = y;
+      },
+      onHoverPreviewEnd: () => {
+        this.hoverScreenX = null;
+        this.hoverScreenY = null;
+      },
     });
     // Seed the threshold from the real canvas size now the scene is live, and keep
     // it current as the FIT-scaled canvas resizes (window resize / rotate).
@@ -940,6 +939,10 @@ export class GameScene extends Phaser.Scene {
     // every frame (Codex R3-4 — a stationary cursor over a panning camera must
     // still highlight the tile under it). Cleared on pointer-out.
     this.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+      // #237 PR5 — MOUSE hover only. Touch has no real hover; its feedforward
+      // preview is the arbiter's press-and-hold (onHoverPreview above), so a raw
+      // touch-drag must NOT paint the hover outline the instant a finger moves.
+      if (pointer.wasTouch) return;
       this.hoverScreenX = pointer.x;
       this.hoverScreenY = pointer.y;
     });

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -947,6 +947,10 @@ export class GameScene extends Phaser.Scene {
       this.hoverScreenY = pointer.y;
     });
     this.input.on('pointerout', () => {
+      // #237 PR5 — sync the arbiter's touch hover preview (cancel its timer, end it
+      // if showing) so a canvas exit can't resurrect it at the stale down-point;
+      // then clear the fields for the mouse case (endHoverPreview no-ops on mouse).
+      this.arbiter.endHoverPreview();
       this.hoverScreenX = null;
       this.hoverScreenY = null;
     });
@@ -957,6 +961,7 @@ export class GameScene extends Phaser.Scene {
     // selected left stale hover coords, so the entrance hover outline lingered
     // and drifted across tiles during keyboard pan. Clear the hover here too.
     this.input.on('gameout', () => {
+      this.arbiter.endHoverPreview(); // #237 PR5 — as pointerout above
       this.hoverScreenX = null;
       this.hoverScreenY = null;
     });


### PR DESCRIPTION
**#237 PR5 of 5** — the last touch-readiness PR. Two parts; input/render only, no `simVersion`.

## (a) Press-and-hold hover preview
Touch has no real hover, but the feedforward cues (entrance/dig outlines) are load-bearing. New arbiter deps `onHoverPreview(x,y)` / `onHoverPreviewEnd`:
- On a **touch** single-press held past `HOVER_PREVIEW_MS` (200), the preview shows at the down-point, then **tracks under-threshold finger drift**; it ends on release / drag-out / cancel.
- **Purely additive** — it does *not* abandon the tap (unlike the PR4 long-press).
- GameScene points these at the **same `hoverScreenX/Y` fields** its mouse `pointermove` handler drives — and that handler now **ignores touch** (`pointer.wasTouch`), so touch hover is exclusively the press-and-hold, and `onHoverPreviewEnd` clears it on touch-up (which `pointerout`/`gameout` miss inside the canvas).
- A **second** `scheduleTimeout` consumer → its own `hoverPreviewCancel`; the hover timer only arms when `onHoverPreview` is wired (so the PR4 long-press-only tests stay at one timer).

## (b) Wheel-zoom relocation
Moved game-scene's inline `'wheel'` closure into **`camera-input.ts` `registerWheelZoom(scene, deps)`** (mirrors `registerDragPan`) + a pure **`wheelZoomFactor(dy, step, notch)`**, so the gesture the pinch extends has an input-layer home and a unit test. **Behavior-identical**: same `canAcceptWorldHotkey` + HUD gating, ctrl/cmd-wheel left to the OS, `dy===0` ignored, `onZoomAccepted` fires only when `targetZoom` actually changed. `WHEEL_ZOOM_STEP`/`WHEEL_NOTCH_PX` now import into camera-input (camera-controller has no Phaser *runtime* import → no cycle; `check:cycles` clean).

## Verification
- `npm run verify` green — **2847 passed** (+5 arbiter hover-preview via a fake `scheduleTimeout` + `fireTimers(untilMs)` to hit the 200ms hover without the 500ms long-press; +`wheelZoomFactor` + `registerWheelZoom` glue: gating, accepted-only-on-change).
- **Full chromium e2e green** (25 passed; 2 unrelated pre-existing flakes — incl. the one literally named "pre-existing draw-order bug" — pass on retry, and CI runs `retries:2`).
- `check:cycles` clean.

Closes out the #237 touch-readiness series (PR1 two-pointer · PR2 pinch · PR3 threshold · PR4 long-press · PR5 hover+wheel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)