### PR TITLE
perf(render): #236 PR1 — pheromone overlay LOD-gate + tick cache

### DIFF
--- a/src/render/camera-adapter.test.ts
+++ b/src/render/camera-adapter.test.ts
@@ -23,6 +23,8 @@ import {
   viewWorldWidth,
   viewWorldHeight,
   setViewportSize,
+  getViewportWidth,
+  getViewportHeight,
   visibleWorldRect,
   screenToWorld,
   worldToScreen,
@@ -164,6 +166,18 @@ describe('setViewportSize (#238 PR3 — non-default viewport)', () => {
     // No setViewportSize here — the prior case's afterEach has reset it.
     expect(viewWorldWidth(1)).toBe(CANVAS_W);
     expect(viewWorldHeight(1)).toBe(CANVAS_H);
+  });
+});
+
+describe('getViewportWidth / getViewportHeight (#236 PR1 — pheromone cache key)', () => {
+  afterEach(() => setViewportSize(CANVAS_W, CANVAS_H));
+
+  it('return the default canvas size, then reflect setViewportSize', () => {
+    expect(getViewportWidth()).toBe(CANVAS_W);
+    expect(getViewportHeight()).toBe(CANVAS_H);
+    setViewportSize(360, 640);
+    expect(getViewportWidth()).toBe(360);
+    expect(getViewportHeight()).toBe(640);
   });
 });
 

--- a/src/render/camera-adapter.ts
+++ b/src/render/camera-adapter.ts
@@ -44,6 +44,14 @@ export function setViewportSize(w: number, h: number): void {
   viewportH = h;
 }
 
+/** Read the current logical viewport size. #236 PR1 — the pheromone-layer cache
+ *  keys on this: visibleTileRange depends on the viewport, so a future responsive
+ *  resize (setViewportSize with new dims) must invalidate a cached overlay even
+ *  when the camera/tick/view are unchanged. Fixed at CANVAS_W×CANVAS_H today. */
+export function getViewportSize(): { w: number; h: number } {
+  return { w: viewportW, h: viewportH };
+}
+
 // ---------------------------------------------------------------------------
 // Zoom limits
 // ---------------------------------------------------------------------------

--- a/src/render/camera-adapter.ts
+++ b/src/render/camera-adapter.ts
@@ -44,12 +44,17 @@ export function setViewportSize(w: number, h: number): void {
   viewportH = h;
 }
 
-/** Read the current logical viewport size. #236 PR1 — the pheromone-layer cache
- *  keys on this: visibleTileRange depends on the viewport, so a future responsive
- *  resize (setViewportSize with new dims) must invalidate a cached overlay even
- *  when the camera/tick/view are unchanged. Fixed at CANVAS_W×CANVAS_H today. */
-export function getViewportSize(): { w: number; h: number } {
-  return { w: viewportW, h: viewportH };
+/** Read the current logical viewport width / height. #236 PR1 — the pheromone-
+ *  layer cache keys on these: visibleTileRange depends on the viewport, so a
+ *  future responsive resize (setViewportSize with new dims) must invalidate a
+ *  cached overlay even when the camera/tick/view are unchanged. SCALAR getters
+ *  (not an object) so the per-frame cache check allocates nothing. Fixed at
+ *  CANVAS_W×CANVAS_H today. */
+export function getViewportWidth(): number {
+  return viewportW;
+}
+export function getViewportHeight(): number {
+  return viewportH;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -79,6 +79,7 @@ import {
   screenToTileZoom,
   resolveDotMode,
   setViewportSize,
+  getViewportSize,
 } from './camera-adapter.js';
 import { CameraController } from './camera-controller.js';
 import {
@@ -333,6 +334,9 @@ export class GameScene extends Phaser.Scene {
   private lastPheromoneTick = -1;
   private readonly lastPheromoneCam = { centerX: NaN, centerY: NaN, zoom: NaN };
   private lastPheromoneView = '';
+  // #236 PR1 — the culled tile set (visibleTileRange) also depends on the logical
+  // viewport, so a future responsive resize must invalidate a cached overlay.
+  private readonly lastPheromoneViewport = { w: NaN, h: NaN };
   private antSprites!: AntSpritePool;
   // Stage 2 (issue #18): the Phaser-bound camera driver. Wraps cameras.main and is
   // driven from the active view's world-pixel CameraView every frame (setZoom +
@@ -2294,13 +2298,17 @@ export class GameScene extends Phaser.Scene {
     // terrain and entities whether or not it redrew), so the e2e trace stays
     // consistent. Only the drawPheromoneOverlay call below is cache-gated.
     this.recordDrawLayer('pheromone');
-    // Gate (b) — redraw only on a tick / camera / view change.
+    // Gate (b) — redraw only on a tick / camera / view / viewport change (all the
+    // inputs to drawPheromoneOverlay's culled fillRect set).
+    const viewport = getViewportSize();
     if (
       this.world.tick === this.lastPheromoneTick &&
       cam.centerX === this.lastPheromoneCam.centerX &&
       cam.centerY === this.lastPheromoneCam.centerY &&
       cam.zoom === this.lastPheromoneCam.zoom &&
-      view === this.lastPheromoneView
+      view === this.lastPheromoneView &&
+      viewport.w === this.lastPheromoneViewport.w &&
+      viewport.h === this.lastPheromoneViewport.h
     ) {
       return;
     }
@@ -2311,6 +2319,8 @@ export class GameScene extends Phaser.Scene {
     this.lastPheromoneCam.centerY = cam.centerY;
     this.lastPheromoneCam.zoom = cam.zoom;
     this.lastPheromoneView = view;
+    this.lastPheromoneViewport.w = viewport.w;
+    this.lastPheromoneViewport.h = viewport.h;
   }
 
   /**

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -325,6 +325,14 @@ export class GameScene extends Phaser.Scene {
   // pool (e.g. the spider health bar, issue #148). Depth sits just above
   // SPIDER_SPRITE_DEPTH so it clears every in-world sprite.
   private overlayGfx!: Phaser.GameObjects.Graphics;
+  // #236 PR1 — the pheromone overlay on its OWN persistent layer (not the
+  // per-frame-cleared gfx) so it can be cached: the grids mutate only on a sim
+  // tick, so a static detailed view redraws at 20 Hz not 60 fps. Sentinels drive
+  // the cache; reset on session boot/restart/load (next to antFacingCache.reset).
+  private pheromoneGfx!: Phaser.GameObjects.Graphics;
+  private lastPheromoneTick = -1;
+  private readonly lastPheromoneCam = { centerX: NaN, centerY: NaN, zoom: NaN };
+  private lastPheromoneView = '';
   private antSprites!: AntSpritePool;
   // Stage 2 (issue #18): the Phaser-bound camera driver. Wraps cameras.main and is
   // driven from the active view's world-pixel CameraView every frame (setZoom +
@@ -589,6 +597,12 @@ export class GameScene extends Phaser.Scene {
     this.gfx = this.add.graphics();
     this.overlayGfx = this.add.graphics();
     this.overlayGfx.setDepth(SPIDER_SPRITE_DEPTH + 1);
+    // #236 PR1 — pheromone overlay layer. Depth -5: above the terrain RT (-10),
+    // below the dynamic gfx (0) → pheromone under entities, over terrain,
+    // preserving the pre-#236 draw order. Persistent (not cleared each frame) so
+    // updatePheromoneLayer can skip the redraw when nothing changed.
+    this.pheromoneGfx = this.add.graphics();
+    this.pheromoneGfx.setDepth(-5);
     this.antSprites = new AntSpritePool(this);
     // Stage 2 (issue #18): bind the continuous-zoom camera. cameras.main is now the
     // world→screen projection (driven from the CameraView each frame); roundPixels is
@@ -1095,6 +1109,10 @@ export class GameScene extends Phaser.Scene {
     // would lock a freshly-spawned ant into the prior ant's direction until
     // the smoothing relaxes. Clearing here keeps boot visually clean.
     this.antFacingCache.reset();
+    // #236 PR1 — a new session replaces the pheromone grids (and tick resets), so
+    // force a pheromone-layer redraw next frame rather than trusting a coincidental
+    // tick match against the prior session.
+    this.lastPheromoneTick = -1;
     // S6 — reset per-session render-side scratch.
     this.lastProcessedEventTick = -1;
     this.prevQueenCombinedHp = null;
@@ -2133,10 +2151,7 @@ export class GameScene extends Phaser.Scene {
     const showPreview = this.canShowWorldPreview();
     if (this.viewState.activeView === 'surface') {
       this.recordDrawLayer('terrain');
-      if (this.viewState.showPheromoneOverlay) {
-        this.recordDrawLayer('pheromone');
-        drawPheromoneOverlay(gfx, this.world, cam, 'surface');
-      }
+      this.updatePheromoneLayer(cam, 'surface', dotMode); // #236 PR1 — cached persistent layer
       this.recordDrawLayer('entities');
       // Stage 1 controls rework (issue #18): the entrance hover outline. Shown
       // only while the Dig tool is active on the surface and the pointer is on
@@ -2173,10 +2188,7 @@ export class GameScene extends Phaser.Scene {
       if (showPreview) drawGhostDelta(overlayGfx, ghostDelta, 'surface', PLAYER_COLONY_ID);
     } else {
       this.recordDrawLayer('terrain');
-      if (this.viewState.showPheromoneOverlay) {
-        this.recordDrawLayer('pheromone');
-        drawPheromoneOverlay(gfx, this.world, cam, 'underground');
-      }
+      this.updatePheromoneLayer(cam, 'underground', dotMode); // #236 PR1 — cached persistent layer
       this.recordDrawLayer('entities');
       drawUndergroundEntities(
         gfx,
@@ -2252,6 +2264,53 @@ export class GameScene extends Phaser.Scene {
     if (text === null) return;
     const ui = this.scene.get('UIScene') as unknown as UIScenePhase9;
     ui.showCaption(text, this.layout.w / 2, 60, 'autosaveFailed');
+  }
+
+  /**
+   * #236 PR1 — redraw the persistent pheromone layer only when it can have
+   * changed. The grids mutate ONLY on a sim tick, and the culled tile set
+   * (visibleTileRange) is camera-dependent, so a STATIC detailed view redraws at
+   * the 20 Hz tick rate instead of 60 fps; a pan/zoom/view-switch still redraws
+   * (new tiles enter the visible window). In the strategic dot-LOD zoom-out — the
+   * MIN_ZOOM worst case #236 names — the overlay is dropped entirely (it was never
+   * legible there). Output is byte-identical to the old per-frame draw: the layer
+   * is world-space so cameras.main re-projects it, and any change forces a full
+   * clear + redraw.
+   */
+  private updatePheromoneLayer(
+    cam: CameraView,
+    view: 'surface' | 'underground',
+    dotMode: boolean,
+  ): void {
+    // Gate (a) — dot-LOD / toggle-off: no overlay. Clear it and force a redraw
+    // (lastPheromoneTick = -1) for when it next becomes visible.
+    if (dotMode || !this.viewState.showPheromoneOverlay) {
+      this.pheromoneGfx.clear();
+      this.lastPheromoneTick = -1;
+      return;
+    }
+    // The overlay is logically active this frame — record it for the draw-order
+    // telemetry EVERY active frame (the persistent layer sits at depth -5 between
+    // terrain and entities whether or not it redrew), so the e2e trace stays
+    // consistent. Only the drawPheromoneOverlay call below is cache-gated.
+    this.recordDrawLayer('pheromone');
+    // Gate (b) — redraw only on a tick / camera / view change.
+    if (
+      this.world.tick === this.lastPheromoneTick &&
+      cam.centerX === this.lastPheromoneCam.centerX &&
+      cam.centerY === this.lastPheromoneCam.centerY &&
+      cam.zoom === this.lastPheromoneCam.zoom &&
+      view === this.lastPheromoneView
+    ) {
+      return;
+    }
+    this.pheromoneGfx.clear();
+    drawPheromoneOverlay(this.pheromoneGfx as unknown as GfxLike, this.world, cam, view);
+    this.lastPheromoneTick = this.world.tick;
+    this.lastPheromoneCam.centerX = cam.centerX;
+    this.lastPheromoneCam.centerY = cam.centerY;
+    this.lastPheromoneCam.zoom = cam.zoom;
+    this.lastPheromoneView = view;
   }
 
   /**

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -79,7 +79,8 @@ import {
   screenToTileZoom,
   resolveDotMode,
   setViewportSize,
-  getViewportSize,
+  getViewportWidth,
+  getViewportHeight,
 } from './camera-adapter.js';
 import { CameraController } from './camera-controller.js';
 import {
@@ -2299,16 +2300,18 @@ export class GameScene extends Phaser.Scene {
     // consistent. Only the drawPheromoneOverlay call below is cache-gated.
     this.recordDrawLayer('pheromone');
     // Gate (b) — redraw only on a tick / camera / view / viewport change (all the
-    // inputs to drawPheromoneOverlay's culled fillRect set).
-    const viewport = getViewportSize();
+    // inputs to drawPheromoneOverlay's culled fillRect set). Scalar getters so the
+    // per-frame cache-hit path allocates nothing.
+    const vpW = getViewportWidth();
+    const vpH = getViewportHeight();
     if (
       this.world.tick === this.lastPheromoneTick &&
       cam.centerX === this.lastPheromoneCam.centerX &&
       cam.centerY === this.lastPheromoneCam.centerY &&
       cam.zoom === this.lastPheromoneCam.zoom &&
       view === this.lastPheromoneView &&
-      viewport.w === this.lastPheromoneViewport.w &&
-      viewport.h === this.lastPheromoneViewport.h
+      vpW === this.lastPheromoneViewport.w &&
+      vpH === this.lastPheromoneViewport.h
     ) {
       return;
     }
@@ -2319,8 +2322,8 @@ export class GameScene extends Phaser.Scene {
     this.lastPheromoneCam.centerY = cam.centerY;
     this.lastPheromoneCam.zoom = cam.zoom;
     this.lastPheromoneView = view;
-    this.lastPheromoneViewport.w = viewport.w;
-    this.lastPheromoneViewport.h = viewport.h;
+    this.lastPheromoneViewport.w = vpW;
+    this.lastPheromoneViewport.h = vpH;
   }
 
   /**


### PR DESCRIPTION
**#236 PR1 of 3** (PR4 chunked-RT design deferred to Phase 4 per the issue). Addresses render debt #4: the pheromone overlay was immediate-mode (one `fillRect` per visible `value>0` tile, per type, **every frame**), worst at `MIN_ZOOM` where the visible window exceeds the whole grid (~16k×2 Graphics commands/frame).

## Two wins
1. **Dot-LOD gate** (the issue's debt-#4 fix, user-confirmed) — drop the overlay entirely at strategic zoom-out (dot-mode, zoom ≤ 0.55), eliminating the MIN_ZOOM worst case. **This is a deliberate visual change** (the overlay is hidden when zoomed way out, where ants already render as dots) — *not* globally pixel-identical.
2. **Tick cache** (pixel-identical at detailed zoom) — the grids mutate only on a sim tick, so redraw only on a tick/camera/view/viewport change; a static detailed view redraws at **20 Hz not 60 fps**.

## Change
- **Persistent layer** `pheromoneGfx` (depth **-5**: over the terrain RT at -10, under the dynamic `gfx` at 0 → pheromone under entities, over terrain — preserving the pre-#236 order) so it survives `gfx.clear()` and can be cached.
- **`updatePheromoneLayer(cam, view, dotMode)`**: gate (a) dot-LOD/toggle drops the overlay; gate (b) redraws only on a `tick / centerX / centerY / zoom / view / viewport` change. `drawPheromoneOverlay` draws in **world space**, so `cameras.main` re-projects the cached layer.
- `recordDrawLayer('pheromone')` still fires **every active frame** (the layer is logically present whether it redrew or not) → the draw-order trace/e2e stays consistent; only the draw is cache-gated. Cache invalidated on session boot/restart/load.

## Verification
- `npm run verify` green (2850).
- **Pheromone draw-order e2e passes** — at detailed zoom the overlay still renders between terrain and entities when ON, drops when OFF.
- **Manual UAT note:** toggle the overlay; pan+zoom across the LOD band (0.55/0.65) and confirm the overlay is unchanged at detailed zoom and cleanly disappears/reappears crossing into/out of dot-mode; switch surface↔underground.

Inline 5-field cache compare (no per-frame allocation). No `WorldState` mutation; `draw-pheromone.ts` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pheromone overlay rendering so it updates only when needed, helping the scene feel smoother and more responsive.
  * Added viewport size tracking for more consistent camera-related rendering.

* **Bug Fixes**
  * Preserved the correct visual order between terrain, overlays, and moving entities.
  * Ensured the overlay resets properly when switching views or changing display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->