### PR TITLE
perf(render): #236 PR2 — detailed-mode allocation churn → reused scratch

### DIFF
--- a/src/render/draw-surface.test.ts
+++ b/src/render/draw-surface.test.ts
@@ -27,7 +27,7 @@ import { createWorldState } from '../sim/types.js';
 import { sgSet, SurfaceTileState } from '../sim/terrain.js';
 import { initAnt } from '../sim/ant/ant-store.js';
 import { FP_SHIFT } from '../sim/fixed.js';
-import { PLAYER_COLONY_ID, SPIDER_HP_FULL } from '../sim/constants.js';
+import { PLAYER_COLONY_ID, ENEMY_COLONY_ID, SPIDER_HP_FULL } from '../sim/constants.js';
 import { createColonyRecord } from '../sim/colony/colony-store.js';
 import { AntFacingCache } from './ant-facing-cache.js';
 import {
@@ -40,6 +40,7 @@ import {
   COLOR_PLAYER_COLONY,
   COLOR_ENEMY_COLONY,
   COLOR_RALLY_POINT,
+  COLOR_NEUTRAL_CONTESTED_GLOW,
 } from './sprites.js';
 import { COLOR_BARREN_EARTH } from './terrain-atlas.js';
 import { makeCameraView, type CameraView } from './camera-adapter.js';
@@ -299,6 +300,51 @@ describe('drawSurfaceEntities', () => {
     gfx = new MockGfx();
     sprites = new MockAntSprites();
     world = createWorldState(1);
+  });
+
+  it('#236 PR2 — the reused contested-glow scratch is cleared per call (no stale glow)', () => {
+    // Two ants of DIFFERENT colonies on the SAME surface tile → that tile is
+    // "contested" and draws COLOR_NEUTRAL_CONTESTED_GLOW.
+    const quietColony = (id: number, seed: number) => {
+      const c = createColonyRecord(id, seed);
+      c.entrances = [];
+      c.rallyPoint = null;
+      c.digFlowFieldDirty = false;
+      return c;
+    };
+    const makeAnts = (ax: number, ay: number, bx: number, by: number): WorldState => {
+      const w = createWorldState(1);
+      w.colonies[PLAYER_COLONY_ID] = quietColony(PLAYER_COLONY_ID, 1);
+      w.colonies[ENEMY_COLONY_ID] = quietColony(ENEMY_COLONY_ID, 2);
+      initAnt(w.ants, 0, {
+        colonyId: PLAYER_COLONY_ID,
+        posX: ax << FP_SHIFT,
+        posY: ay << FP_SHIFT,
+        zone: 0,
+      });
+      initAnt(w.ants, 1, {
+        colonyId: ENEMY_COLONY_ID,
+        posX: bx << FP_SHIFT,
+        posY: by << FP_SHIFT,
+        zone: 0,
+      });
+      return w;
+    };
+    const cam = makeCamera(6, 6); // sees tiles 5..9
+    const glowStyles = (): number =>
+      gfx.callsOf('fillStyle').filter((c) => c.args[0] === COLOR_NEUTRAL_CONTESTED_GLOW).length;
+
+    // Frame 1: both ants on tile (5,5) → contested → glow drawn.
+    const world1 = makeAnts(5, 5, 5, 5);
+    drawSurfaceEntities(gfx, sprites, world1, world1, 0, cam);
+    expect(glowStyles()).toBeGreaterThan(0);
+
+    // Frame 2: ants on DIFFERENT tiles → NOT contested. If the Map/Set scratch
+    // weren't cleared per call, frame 1's contested (5,5) would draw a stale glow.
+    gfx.reset();
+    const world2 = makeAnts(5, 5, 9, 9);
+    drawSurfaceEntities(gfx, sprites, world2, world2, 0, cam);
+    expect(glowStyles()).toBe(0);
   });
 
   it('draws 2 fillCircle calls for two food piles (one marked, one normal)', () => {

--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -21,7 +21,7 @@ import { isAlive } from '../sim/ant/ant-store.js';
 import { FP_ONE } from '../sim/fixed.js';
 import { PLAYER_COLONY_ID } from '../sim/constants.js';
 import type { WorldState } from '../sim/types.js';
-import type { AntSpriteLayer } from './ant-sprite-layer.js';
+import type { AntSpriteLayer, AntSpriteDrawOptions } from './ant-sprite-layer.js';
 import { computeAntRotation, SPIDER_FACING_ID, type AntFacingCache } from './ant-facing-cache.js';
 import {
   TILE_SIZE_PX,
@@ -60,6 +60,35 @@ import {
 import { SPIDER_SPRITE_HEIGHT, SPIDER_SPRITE_WIDTH } from './ant-sprite-layer.js';
 import { SPIDER_HUNGER_MAX_TICKS, SPIDER_HP_FULL } from '../sim/constants.js';
 import { tierIndex } from '../sim/ai-state.js';
+
+// ---------------------------------------------------------------------------
+// #236 PR2 render-scratch — module-level buffers reused across frames.
+//
+// Render layer only (no sim determinism constraint): declared once at module
+// scope and reset (.clear() / .length = 0 / full field overwrite) at the START
+// of each use, so a frame never inherits the prior frame's contents.
+// drawSurfaceEntities runs once per frame (XOR drawUndergroundEntities) — no
+// re-entrancy — so the reset is the whole correctness guarantee.
+// ---------------------------------------------------------------------------
+
+// #236 PR2 render-scratch: reset per use
+const glowTileColony = new Map<number, number>(); // tileKey → first colonyId
+const glowContested = new Set<number>();
+const glowDrawKeys: number[] = [];
+
+// #236 PR2 render-scratch: reset per use (all fields overwritten each draw).
+// Retention-safe: AntSpritePool.drawAnt (ant-sprite-pool.ts:63-72) reads every
+// field synchronously (setTexture/Position/Tint/Rotation/Scale) and never stores
+// the opts reference — so mutate-then-pass is safe. The test mock also clones via
+// `{ ...opts }`, so recorded calls snapshot the fields at draw time.
+const scratchAntOpts: AntSpriteDrawOptions = {
+  kind: 'worker',
+  x: 0,
+  y: 0,
+  tint: 0,
+  rotation: 0,
+  scale: 1,
+};
 
 // ---------------------------------------------------------------------------
 // GfxLike — minimal Graphics interface (Phaser.GameObjects.Graphics satisfies this)
@@ -269,8 +298,9 @@ export function drawSurfaceEntities(
   // is tracked via contestedGlowFrames. Skipped in strategic dot mode (allocation-free
   // pass — no per-entity Map/Set scan; §C13/R3-2).
   if (!dotMode) {
-    const tileColony = new Map<number, number>(); // tileKey → first colonyId
-    const contested = new Set<number>();
+    // #236 PR2 render-scratch: reset per use (see module-level decls).
+    glowTileColony.clear();
+    glowContested.clear();
     const n = curr.ants.alive.length;
     for (let id = 0; id < n; id++) {
       if (!isAlive(curr.ants, id)) continue;
@@ -279,25 +309,29 @@ export function drawSurfaceEntities(
       const ty = curr.ants.posY[id]! >> 8;
       const key = (ty << 16) | tx;
       const cid = curr.ants.colonyId[id]!;
-      const existing = tileColony.get(key);
-      if (existing === undefined) tileColony.set(key, cid);
-      else if (existing !== cid) contested.add(key);
+      const existing = glowTileColony.get(key);
+      if (existing === undefined) glowTileColony.set(key, cid);
+      else if (existing !== cid) glowContested.add(key);
     }
     // Stamp active contested tiles with the current frame number.
     if (contestedGlowFrames) {
-      for (const key of contested) {
+      for (const key of glowContested) {
         contestedGlowFrames.set(key, currentFrame);
       }
     }
     // Draw glows for all tiles contested within the last 5 frames.
     const GLOW_FADE_FRAMES = 5;
     const tilesToDraw = contestedGlowFrames ? contestedGlowFrames : null;
-    const drawKeys = tilesToDraw
-      ? Array.from(tilesToDraw.entries())
-          .filter(([, frame]) => currentFrame - frame < GLOW_FADE_FRAMES)
-          .map(([key]) => key)
-      : Array.from(contested);
-    for (const key of drawKeys) {
+    // #236 PR2 render-scratch: rebuild the reused key list (same order as the prior
+    // Array.from(...).filter().map() — Map/Set iterate in insertion order).
+    glowDrawKeys.length = 0;
+    if (tilesToDraw) {
+      for (const [key, frame] of tilesToDraw)
+        if (currentFrame - frame < GLOW_FADE_FRAMES) glowDrawKeys.push(key);
+    } else {
+      for (const key of glowContested) glowDrawKeys.push(key);
+    }
+    for (const key of glowDrawKeys) {
       const tx = key & 0xffff;
       const ty = (key >> 16) & 0xffff;
       const wx = tx * TILE_SIZE_PX;
@@ -405,16 +439,18 @@ export function drawSurfaceEntities(
     const rotation = computeAntRotation(facing, id, curr.ants.zone[id]!, dx, dy, useInterp);
 
     const isFighter = curr.ants.task[id] === AntTask.Fighting;
-    sprites.drawAnt({
-      kind: isQueen ? 'queen' : 'worker',
-      x: worldX,
-      y: worldY,
-      // S1: fighters get a red tint blended over their colony color.
-      tint: isFighter && !isQueen ? lerpColor(color, COLOR_FIGHTER_TINT, 0.45) : color,
-      rotation,
-      // S1: fighters render slightly larger.
-      scale: isFighter && !isQueen ? 1.25 : 1.0,
-    });
+    // #236 PR2 render-scratch: mutate the reused opts (every field set) then pass.
+    // Retention-safe (drawAnt reads fields synchronously; see decl).
+    scratchAntOpts.kind = isQueen ? 'queen' : 'worker';
+    scratchAntOpts.x = worldX;
+    scratchAntOpts.y = worldY;
+    // S1: fighters get a red tint blended over their colony color.
+    scratchAntOpts.tint =
+      isFighter && !isQueen ? lerpColor(color, COLOR_FIGHTER_TINT, 0.45) : color;
+    scratchAntOpts.rotation = rotation;
+    // S1: fighters render slightly larger.
+    scratchAntOpts.scale = isFighter && !isQueen ? 1.25 : 1.0;
+    sprites.drawAnt(scratchAntOpts);
   }
 
   // --- Spider sprite + hunger ring (S3) ---

--- a/src/render/draw-underground.ts
+++ b/src/render/draw-underground.ts
@@ -18,7 +18,11 @@
 export type { GfxLike } from './draw-surface.js';
 
 import type { GfxLike } from './draw-surface.js';
-import type { AntSpriteLayer } from './ant-sprite-layer.js';
+import type {
+  AntSpriteLayer,
+  AntSpriteDrawOptions,
+  StaticSpriteDrawOptions,
+} from './ant-sprite-layer.js';
 import {
   WORKER_SPRITE_WIDTH,
   WORKER_SPRITE_HEIGHT,
@@ -94,6 +98,48 @@ const CHAMBER_COLORS: Record<number, number> = {
 // the chamber is dug-out but not yet promoted to colony.chambers). Low so it reads as
 // "forming" against the solid built-chamber fill.
 const PENDING_CHAMBER_OUTLINE_ALPHA = 0.25;
+
+// ---------------------------------------------------------------------------
+// #236 PR2 render-scratch — module-level buffers reused across frames.
+//
+// Render layer only (no sim determinism constraint): declared once at module
+// scope and reset (.clear() / .length = 0 / full field overwrite) at the START
+// of each use, so a frame never inherits the prior frame's contents.
+// drawUndergroundEntities runs once per frame (XOR drawSurfaceEntities) — no
+// re-entrancy — so the reset is the whole correctness guarantee. Names are
+// independent of draw-surface's scratch (a different module / a different view).
+// ---------------------------------------------------------------------------
+
+// #236 PR2 render-scratch: reset per use
+const ugGlowTileColony = new Map<number, number>(); // tileKey → first colonyId
+const ugGlowContested = new Set<number>();
+const ugGlowDrawKeys: number[] = [];
+
+// #236 PR2 render-scratch: reset per use — brood-id set, rebuilt (.clear()) each call.
+const ugBroodIds = new Set<number>();
+
+// #236 PR2 render-scratch: reset per use (all fields overwritten each draw).
+// Retention-safe: AntSpritePool.drawAnt (ant-sprite-pool.ts:63-72) reads every field
+// synchronously and never stores the opts reference — so mutate-then-pass is safe.
+const scratchAntOptsUg: AntSpriteDrawOptions = {
+  kind: 'worker',
+  x: 0,
+  y: 0,
+  tint: 0,
+  rotation: 0,
+  scale: 1,
+};
+
+// #236 PR2 render-scratch: reset per use — SHARED by the food-cache and brood drawStatic
+// sites. EVERY field (incl. tint) is set at each call site so a shared object never leaks a
+// prior draw's tint (pixel-identical). Retention-safe: AntSpritePool.drawStatic
+// (ant-sprite-pool.ts:74-85) reads every field synchronously, never stores the opts reference.
+const scratchStaticOptsUg: StaticSpriteDrawOptions = {
+  kind: 'egg',
+  x: 0,
+  y: 0,
+  tint: undefined,
+};
 
 // ---------------------------------------------------------------------------
 // drawOutlineSegment — draw a thick line segment between two arbitrary points
@@ -472,12 +518,12 @@ export function drawUndergroundEntities(
           for (let col = 0; col < dims.width && placed < filledTiles; col++) {
             const cx = worldX + col * TILE_SIZE_PX + TILE_SIZE_PX / 2;
             const cy = worldY + row * TILE_SIZE_PX + TILE_SIZE_PX / 2;
-            sprites.drawStatic({
-              kind: 'food-cache',
-              x: cx,
-              y: cy,
-              tint: COLOR_CHAMBER_FOOD_STORAGE_FILL,
-            });
+            // #236 PR2 render-scratch: mutate the reused opts (every field set) then pass.
+            scratchStaticOptsUg.kind = 'food-cache';
+            scratchStaticOptsUg.x = cx;
+            scratchStaticOptsUg.y = cy;
+            scratchStaticOptsUg.tint = COLOR_CHAMBER_FOOD_STORAGE_FILL;
+            sprites.drawStatic(scratchStaticOptsUg);
             placed++;
           }
         }
@@ -565,8 +611,9 @@ export function drawUndergroundEntities(
     const GLOW_FADE_FRAMES = 5;
 
     // Collect tiles that have ants from 2+ colonies.
-    const tileColony = new Map<number, number>(); // tileKey → first colonyId
-    const contested = new Set<number>();
+    // #236 PR2 render-scratch: reset per use (see module-level decls).
+    ugGlowTileColony.clear();
+    ugGlowContested.clear();
     const n = curr.ants.alive.length;
     for (let id = 0; id < n; id++) {
       if (!isAlive(curr.ants, id)) continue;
@@ -578,26 +625,28 @@ export function drawUndergroundEntities(
       // different colony views don't collide when the player switches grids.
       const key = (activeUndergroundColonyId << 24) | (ty << 16) | tx;
       const cid = curr.ants.colonyId[id]!;
-      const existing = tileColony.get(key);
-      if (existing === undefined) tileColony.set(key, cid);
-      else if (existing !== cid) contested.add(key);
+      const existing = ugGlowTileColony.get(key);
+      if (existing === undefined) ugGlowTileColony.set(key, cid);
+      else if (existing !== cid) ugGlowContested.add(key);
     }
     // Stamp active tiles with current frame.
     if (undergoundGlowFrames) {
-      for (const key of contested) {
+      for (const key of ugGlowContested) {
         undergoundGlowFrames.set(key, currentFrame);
       }
     }
     // Draw glows for all contested or recently-contested tiles.
-    const drawKeys = undergoundGlowFrames
-      ? Array.from(undergoundGlowFrames.entries())
-          .filter(
-            ([key, frame]) =>
-              key >>> 24 === activeUndergroundColonyId && currentFrame - frame < GLOW_FADE_FRAMES,
-          )
-          .map(([key]) => key)
-      : Array.from(contested);
-    for (const key of drawKeys) {
+    // #236 PR2 render-scratch: rebuild the reused key list (same filter + insertion order
+    // as the prior Array.from(...).filter().map()).
+    ugGlowDrawKeys.length = 0;
+    if (undergoundGlowFrames) {
+      for (const [key, frame] of undergoundGlowFrames)
+        if (key >>> 24 === activeUndergroundColonyId && currentFrame - frame < GLOW_FADE_FRAMES)
+          ugGlowDrawKeys.push(key);
+    } else {
+      for (const key of ugGlowContested) ugGlowDrawKeys.push(key);
+    }
+    for (const key of ugGlowDrawKeys) {
       const tx = key & 0xff; // bits 0-7; tx max = 127
       const ty = (key >> 16) & 0xff; // bits 16-23; top byte (24+) holds colony ID
       const worldX = tx * TILE_SIZE_PX;
@@ -625,18 +674,20 @@ export function drawUndergroundEntities(
     }
   }
 
-  const broodIds = new Set<number>();
+  // #236 PR2 render-scratch: reset per use (see module-level decls). Rebuilt every call
+  // (incl. dotMode — the ants loop below reads it before the dot-draw branch).
+  ugBroodIds.clear();
   for (const c of Object.values(curr.colonies)) {
     if (c === undefined) continue;
-    for (let i = 0; i < c.eggs.length; i++) broodIds.add(c.eggs[i]!);
-    for (let i = 0; i < c.larvae.length; i++) broodIds.add(c.larvae[i]!);
+    for (let i = 0; i < c.eggs.length; i++) ugBroodIds.add(c.eggs[i]!);
+    for (let i = 0; i < c.larvae.length; i++) ugBroodIds.add(c.larvae[i]!);
   }
   const maxId = curr.ants.alive.length;
   for (let id = 0; id < maxId; id++) {
     if (!isAlive(curr.ants, id)) continue;
     if (curr.ants.zone[id] !== 1) continue; // underground only
     if (curr.ants.currentGridColonyId[id] !== activeUndergroundColonyId) continue; // grid-of-occupancy filter
-    if (broodIds.has(id)) continue; // issue #22 — brood is rendered by drawBrood, not as worker sprites
+    if (ugBroodIds.has(id)) continue; // issue #22 — brood is rendered by drawBrood, not as worker sprites
 
     const useInterp = isAlive(prev.ants, id) && prev.ants.zone[id] === curr.ants.zone[id];
 
@@ -731,14 +782,15 @@ export function drawUndergroundEntities(
       drawX = placed.cxPx;
       drawY = placed.cyPx;
     }
-    sprites.drawAnt({
-      kind: isQueen ? 'queen' : 'worker',
-      x: drawX,
-      y: drawY,
-      tint: isFighter2 && !isQueen ? COLOR_FIGHTER_TINT : tint,
-      rotation,
-      scale,
-    });
+    // #236 PR2 render-scratch: mutate the reused opts (every field set) then pass.
+    // Retention-safe (drawAnt reads fields synchronously; see decl).
+    scratchAntOptsUg.kind = isQueen ? 'queen' : 'worker';
+    scratchAntOptsUg.x = drawX;
+    scratchAntOptsUg.y = drawY;
+    scratchAntOptsUg.tint = isFighter2 && !isQueen ? COLOR_FIGHTER_TINT : tint;
+    scratchAntOptsUg.rotation = rotation;
+    scratchAntOptsUg.scale = scale;
+    sprites.drawAnt(scratchAntOptsUg);
   }
 
   // Eggs + larvae (nursery brood). Route through the sprite layer so both
@@ -791,11 +843,14 @@ function drawBrood(
     // above the carrier instead of being hidden under the ant sprite.
     const carrierId = ants.carriedBy[id]!;
     const carryDy = carrierId !== -1 && isAlive(ants, carrierId) ? CARRY_RENDER_DY_PX : 0;
-    sprites.drawStatic({
-      kind,
-      x: worldX + TILE_SIZE_PX / 2,
-      y: worldY + TILE_SIZE_PX / 2 + carryDy,
-    });
+    // #236 PR2 render-scratch: mutate the reused opts then pass. tint is explicitly reset to
+    // undefined (the original literal omitted it) so a prior food-cache draw's tint can't leak;
+    // drawStatic applies `?? 0xffffff`, so this stays pixel-identical to the omitted-tint literal.
+    scratchStaticOptsUg.kind = kind;
+    scratchStaticOptsUg.x = worldX + TILE_SIZE_PX / 2;
+    scratchStaticOptsUg.y = worldY + TILE_SIZE_PX / 2 + carryDy;
+    scratchStaticOptsUg.tint = undefined;
+    sprites.drawStatic(scratchStaticOptsUg);
   }
 }
 


### PR DESCRIPTION
**#236 PR2 of 3** — perf-only, **pixel-identical**. The detailed (non-dot) render paths allocated fresh `Map`/`Set`/`Array` + a per-entity options literal **every frame** (steady GC pressure on the Phase-6 mobile target; dot-LOD mode is already allocation-free, proving the discipline). The render layer has no determinism constraint, so hoist to module-level scratch reset per use.

## Changes
- **draw-surface** contested-glow: `new Map`/`new Set` → module `glowTileColony`/`glowContested` (`.clear()` per call); the `Array.from(...).filter().map()` `drawKeys` chain → reused `glowDrawKeys` (`length=0` + insertion-order push loop — same order + filter).
- **draw-underground**: same glow hoist with independent `ug*` names (**preserving the extra colony-view filter clause**); per-frame `broodIds` Set → `ugBroodIds` (`.clear()` before rebuild).
- **Per-entity options literals** → reused scratch: `drawAnt` → `scratchAntOpts`/`scratchAntOptsUg`; **both** underground `drawStatic` sites (food-cache + brood) → `scratchStaticOptsUg`. Every field is set at each call site — the brood site explicitly sets `tint = undefined` so the shared object never leaks the food-cache tint (`drawStatic` maps `?? 0xffffff`, byte-identical to the original omitted-tint literal). **Retention-safe**: `AntSpritePool.drawAnt`/`drawStatic` read every field synchronously and never store the `opts` reference.

## Verification
- **Scratch-clearing test**: drive `drawSurfaceEntities` twice (a contested tile, then none) → the second call draws **no stale glow** (verified it FAILS without the `.clear()`).
- draw-surface + draw-underground suites green (98); `npm run verify` green (2852).
- **Manual UAT note:** at a detailed zoom, watch ants (incl. a fighter at 1.25×), contested-tile glows (surface + underground), food-cache + carried brood — all unchanged vs `main`.

No `WorldState` mutation; visuals pixel-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where contested ground highlights could briefly persist between frames.
  * Prevented visual settings from carrying over incorrectly between different underground draws.

* **Refactor**
  * Improved rendering performance by reusing temporary drawing state instead of creating new objects each frame.
  * Streamlined surface and underground entity rendering for smoother updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->