### PR TITLE
perf(render): #236 PR3 — diffTerrainShadow tick-gate + tileInView dedup + NEAREST sprites

### DIFF
--- a/src/render/draw-surface.ts
+++ b/src/render/draw-surface.ts
@@ -134,9 +134,14 @@ export function visibleTileRange(
  * (worldX, worldY). Mirrors the prior screen cull (one-tile left/top margin, right/
  * bottom at the visible edge), now in world px so it is correct under any zoom.
  * `margin` widens the box for primitives that spill past their tile (entrance mounds,
- * spider sprite).
+ * spider sprite). #236 PR3: exported so draw-underground reuses it (was a verbatim copy).
  */
-function tileInView(worldX: number, worldY: number, rect: WorldRect, margin: number): boolean {
+export function tileInView(
+  worldX: number,
+  worldY: number,
+  rect: WorldRect,
+  margin: number,
+): boolean {
   return (
     worldX >= rect.left - margin &&
     worldX <= rect.right + margin &&

--- a/src/render/draw-underground.ts
+++ b/src/render/draw-underground.ts
@@ -18,6 +18,7 @@
 export type { GfxLike } from './draw-surface.js';
 
 import type { GfxLike } from './draw-surface.js';
+import { tileInView } from './draw-surface.js'; // #236 PR3 — shared (was a verbatim copy)
 import type {
   AntSpriteLayer,
   AntSpriteDrawOptions,
@@ -361,23 +362,6 @@ export function restampUndergroundTiles(
     gfx.fillRect(tx * TILE_SIZE_PX, ty * TILE_SIZE_PX, TILE_SIZE_PX, TILE_SIZE_PX);
     drawOneUndergroundTile(gfx, grid, entranceXSet, tx, ty, neighbors);
   }
-}
-
-// ---------------------------------------------------------------------------
-// tileInView — world-space cull (copied verbatim from draw-surface.ts, where it
-// is a private helper and not exported). A tile-anchored primitive whose top-left
-// is at world (worldX, worldY) is kept when it lies within the visible world rect
-// expanded by `margin`. `margin` widens the box for primitives that spill past
-// their tile.
-// ---------------------------------------------------------------------------
-
-function tileInView(worldX: number, worldY: number, rect: WorldRect, margin: number): boolean {
-  return (
-    worldX >= rect.left - margin &&
-    worldX <= rect.right + margin &&
-    worldY >= rect.top - margin &&
-    worldY <= rect.bottom + margin
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/render/game-scene.ts
+++ b/src/render/game-scene.ts
@@ -338,6 +338,12 @@ export class GameScene extends Phaser.Scene {
   // #236 PR1 — the culled tile set (visibleTileRange) also depends on the logical
   // viewport, so a future responsive resize must invalidate a cached overlay.
   private readonly lastPheromoneViewport = { w: NaN, h: NaN };
+  // #236 PR3 — gate the O(grid) diffTerrainShadow scan on a sim-tick change, per
+  // active colony (the underground grid mutates only on a tick). Cleared on
+  // session reset. Plus a reused scratch Set for the entrance columns (was a fresh
+  // Set per bakeAndShowTerrain).
+  private readonly lastShadowDiffTick = new Map<number, number>();
+  private readonly entranceColsScratch = new Set<number>();
   private antSprites!: AntSpritePool;
   // Stage 2 (issue #18): the Phaser-bound camera driver. Wraps cameras.main and is
   // driven from the active view's world-pixel CameraView every frame (setZoom +
@@ -609,6 +615,20 @@ export class GameScene extends Phaser.Scene {
     this.pheromoneGfx = this.add.graphics();
     this.pheromoneGfx.setDepth(-5);
     this.antSprites = new AntSpritePool(this);
+    // #236 PR3 — NEAREST-filter the pooled sprite textures (they finished loading in
+    // preload), matching the terrain RT's filter below, so ants / brood / food-cache
+    // / spider stay crisp at high zoom instead of the default LINEAR blur (relevant
+    // when the Phase-5a art lands). Perf-neutral; purely a sampling-quality fix.
+    for (const key of [
+      ANT_TEXTURE_WORKER,
+      ANT_TEXTURE_QUEEN,
+      EGG_TEXTURE,
+      LARVA_TEXTURE,
+      FOOD_CACHE_TEXTURE,
+      SPIDER_TEXTURE,
+    ]) {
+      this.textures.get(key).setFilter(Phaser.Textures.FilterMode.NEAREST);
+    }
     // Stage 2 (issue #18): bind the continuous-zoom camera. cameras.main is now the
     // world→screen projection (driven from the CameraView each frame); roundPixels is
     // disabled inside the controller for smooth sub-pixel pan.
@@ -1118,6 +1138,9 @@ export class GameScene extends Phaser.Scene {
     // force a pheromone-layer redraw next frame rather than trusting a coincidental
     // tick match against the prior session.
     this.lastPheromoneTick = -1;
+    // #236 PR3 — same for the shadow-diff tick gate: a new session's grids differ,
+    // so clear the per-colony cache (the first frame rebakes + re-seeds it anyway).
+    this.lastShadowDiffTick.clear();
     // S6 — reset per-session render-side scratch.
     this.lastProcessedEventTick = -1;
     this.prevQueenCombinedHp = null;
@@ -1962,14 +1985,17 @@ export class GameScene extends Phaser.Scene {
     const baker = this.terrainBaker as unknown as GfxLike;
 
     // Entrance ceiling-gap columns for the viewed underground colony (used by the
-    // shadow-diff + autotile ceiling row).
+    // shadow-diff + autotile ceiling row). #236 PR3 — refill a REUSED scratch Set
+    // rather than allocating one per call. Retention-safe: createTerrainShadow /
+    // diffTerrainShadow read `.has(x)` synchronously into their own arrays and
+    // never store the Set reference (terrain-bake.ts).
     const entranceCols = (): Set<number> => {
-      const set = new Set<number>();
+      this.entranceColsScratch.clear();
       const colony = this.world?.colonies[colonyId];
       if (colony?.entrances) {
-        for (const e of colony.entrances) set.add(e.surfaceTileX);
+        for (const e of colony.entrances) this.entranceColsScratch.add(e.surfaceTileX);
       }
-      return set;
+      return this.entranceColsScratch;
     };
 
     if (entry.needsRebake) {
@@ -1984,16 +2010,25 @@ export class GameScene extends Phaser.Scene {
         entry.rt.draw(this.terrainBaker);
         const grid = this.world.undergroundGrids[colonyId];
         this.terrainCache.markBaked(key, grid ? createTerrainShadow(grid, entranceCols()) : null);
+        // #236 PR3 — a fresh shadow == the grid at this tick, so the next same-tick
+        // diff would find nothing; record the tick so the gate below skips it.
+        this.lastShadowDiffTick.set(colonyId, this.world.tick);
       }
     } else if (!isSurface && entry.shadow !== null) {
       const grid = this.world.undergroundGrids[colonyId];
-      if (grid !== undefined) {
+      // #236 PR3 — the underground grid mutates only on a sim tick (ugSet is
+      // sim-only), so re-diffing at the same tick can't find new dirty tiles. Gate
+      // the O(grid) scan on a per-colony tick change. A toggle-away colony the AI
+      // kept excavating still reconciles on return: the tick advanced while it was
+      // inactive, so tick !== last → the diff runs (R4-2 reconcile-on-activate).
+      if (grid !== undefined && this.world.tick !== this.lastShadowDiffTick.get(colonyId)) {
         const dirty = diffTerrainShadow(entry.shadow, grid, entranceCols());
         if (dirty.size > 0) {
           this.terrainBaker.clear();
           restampUndergroundTiles(baker, this.world, colonyId, dirty);
           entry.rt.draw(this.terrainBaker);
         }
+        this.lastShadowDiffTick.set(colonyId, this.world.tick);
       }
     }
     // Free the off-screen baker's command buffer now — a full bake holds the entire
@@ -2002,8 +2037,9 @@ export class GameScene extends Phaser.Scene {
     // session (Codex P2).
     this.terrainBaker.clear();
 
-    // Show only the active view's RT.
-    for (const k of this.terrainCache.allocatedKeys()) {
+    // Show only the active view's RT. #236 PR3 — iterate the cache keys directly
+    // (no per-frame array allocation from allocatedKeys()).
+    for (const k of this.terrainCache.keys()) {
       const e = this.terrainCache.get(k);
       if (e !== undefined) e.rt.setVisible(k === key);
     }

--- a/src/render/terrain-bake.ts
+++ b/src/render/terrain-bake.ts
@@ -197,6 +197,12 @@ export class TerrainCache<RT> {
     return [...this.entries.keys()];
   }
 
+  /** #236 PR3 — the live key iterator (no array allocation), for the per-frame
+   *  visibility sweep. allocatedKeys() stays for callers that need a snapshot. */
+  keys(): IterableIterator<TerrainCacheKey> {
+    return this.entries.keys();
+  }
+
   /**
    * Fetch (or lazily allocate) the entry for a key. A new entry is created at origin
    * (0,0) with needsRebake=true and no shadow; the RT factory runs exactly once per key.


### PR DESCRIPTION
**#236 PR3 of 3** (perf/quality, no visual change). Three of the four PR3 items; the fourth — baking the static minimap dapple — is split to **#278** (a Phaser RT/Image lifecycle change).

## Changes
- **`diffTerrainShadow` O(grid) tick-gate** (`bakeAndShowTerrain`): the ~8,192-tile underground shadow scan ran **every frame**, but the grid mutates only on a sim tick (`ugSet` is sim-only). Gate on a **per-colony tick change** (`lastShadowDiffTick`, cleared on session reset). A dig still restamps on the tick it changes a tile; a toggle-away colony the AI kept excavating still reconciles on return (the tick advanced while inactive → `tick !== last` → the diff runs; `diffTerrainShadow` self-updates the shadow, so a skipped same-tick re-diff can't miss anything). Also: `entranceCols` Set → reused scratch (retention-safe — `create`/`diffTerrainShadow` read `.has()` synchronously, never store the Set); `allocatedKeys()` array spread → new `TerrainCache.keys()` iterator in the per-frame visibility sweep.
- **`tileInView`** (§9a): export the draw-surface helper, DELETE the verbatim draw-underground copy, import it — single source of truth.
- **NEAREST sprite filtering** (§9b): filter the pooled ant/queen/egg/larva/food-cache/spider textures NEAREST (matching the terrain RT) so sprites stay crisp at high zoom instead of the default LINEAR blur (Phase-5a art).

## Verification
- `npm run verify` green (2852); terrain-bake + draw suites green (161).
- Underground/terrain e2e green (the `phase-09` X-keybind HUD-label failure **reproduces on `main`** with these changes stashed — a pre-existing flake, unrelated; CI runs `retries:2`).

No `WorldState` mutation. The shadow gate + scratch are frame-rate decoupling; `tileInView` is byte-identical; NEAREST is a sampling-quality fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)