### PR TITLE
perf(render): #278 — bake static minimap layer into a RenderTexture (once, not per-frame)

### DIFF
--- a/src/render/minimap.test.ts
+++ b/src/render/minimap.test.ts
@@ -15,6 +15,7 @@ import {
   MINIMAP_SCALE_X,
   MINIMAP_SCALE_Y,
   drawMinimap,
+  bakeMinimapDapple,
 } from './minimap.js';
 import type { GfxLike } from './draw-surface.js';
 import type { WorldState } from '../sim/types.js';
@@ -264,60 +265,95 @@ const stubFoodPiles: WorldState['foodPiles'] = [
 ];
 
 describe('drawMinimap smoke test', () => {
-  it('calls fillRect for background, food piles, colonies, and viewport outline', () => {
+  it('calls fillRect for food piles, colonies, and viewport outline (base baked separately)', () => {
     const gfx = new MockGfx();
     const world = makeMinimalWorld({ foodPiles: stubFoodPiles, colonies: stubColonies });
     const vs = createViewState(PLAYER_START_X, PLAYER_START_Y);
     drawMinimap(gfx, world, vs, hud);
 
     const fillRects = gfx.callsOf('fillRect');
-    // Should have at least: 1 background + 1 food pile + 1 colony + 4 viewport outline = 7
-    expect(fillRects.length).toBeGreaterThanOrEqual(7);
+    // #278 — the static base + dapple moved to bakeMinimapDapple, so drawMinimap
+    // now emits only the DYNAMIC overlays: 1 food pile + 1 colony + 4 viewport = 6.
+    expect(fillRects.length).toBeGreaterThanOrEqual(6);
 
-    // First fillRect is the grass background covering the full minimap
-    const bg = fillRects[0]!;
-    expect(bg.args[0]).toBe(hud.MINIMAP.x);
-    expect(bg.args[1]).toBe(hud.MINIMAP.y);
-    expect(bg.args[2]).toBe(hud.MINIMAP.w);
-    expect(bg.args[3]).toBe(hud.MINIMAP.h);
+    // #278 regression guard: drawMinimap must NOT redraw the full-minimap base —
+    // no fillRect should span the whole minimap rect (that's the baked layer's job).
+    const drawsFullBase = fillRects.some(
+      (r) => r.args[2] === hud.MINIMAP.w && r.args[3] === hud.MINIMAP.h,
+    );
+    expect(drawsFullBase).toBe(false);
+
+    // The first overlay is the food pile (2×2 centered on its minimap px).
+    const mm = hud.MINIMAP;
+    const sx = mm.w / SURFACE_GRID_WIDTH;
+    const sy = mm.h / SURFACE_GRID_HEIGHT;
+    const food = fillRects[0]!;
+    expect(food.args[0]).toBeCloseTo(mm.x + 20 * sx - 1, 5);
+    expect(food.args[1]).toBeCloseTo(mm.y + 30 * sy - 1, 5);
   });
 
   it('MINIMAP_SCALE_X and MINIMAP_SCALE_Y equal 1.25 for 128-tile world', () => {
     expect(MINIMAP_SCALE_X).toBeCloseTo(1.25, 5);
     expect(MINIMAP_SCALE_Y).toBeCloseTo(1.25, 5);
   });
+});
 
-  it('renders a surface overview (not a black box) — PRD §7a', () => {
-    // Regression: prior version hardcoded 0x000000 as the minimap background,
-    // so the minimap read as a black debug overlay. The fix uses grass as the
-    // base and overlays dirt tiles from world.surface.
+// ---------------------------------------------------------------------------
+// bakeMinimapDapple — the STATIC minimap layer (#278). UIScene stamps this once
+// into a RenderTexture behind the per-frame overlays instead of redrawing the
+// ~16k-tile dapple every frame. Coords are TEXTURE-LOCAL (origin 0,0).
+// ---------------------------------------------------------------------------
+
+describe('bakeMinimapDapple', () => {
+  it('fills a barren-earth base + darker dapple, never a black box — PRD §7a', () => {
+    // Regression (issue #40): the old minimap hardcoded 0x000000 as its base and
+    // read as a black debug overlay. The baked layer uses barren-earth + a
+    // deterministic darker dapple. Scatter dirt so the per-tile scan is exercised.
     const gfx = new MockGfx();
-    // Scatter a few dirt tiles so we can assert the dirt path fires
     sgSet(stubSurface, 10, 10, SurfaceTileState.Dirt);
     sgSet(stubSurface, 20, 30, SurfaceTileState.Dirt);
     sgSet(stubSurface, 50, 50, SurfaceTileState.Dirt);
 
     const world = makeMinimalWorld({ foodPiles: [], colonies: stubColonies });
-    const vs = createViewState(PLAYER_START_X, PLAYER_START_Y);
-    drawMinimap(gfx, world, vs, hud);
+    bakeMinimapDapple(gfx, world, hud.MINIMAP.w, hud.MINIMAP.h);
 
     const styles = gfx.callsOf('fillStyle');
-    // No black background anywhere.
     const hasBlack = styles.some((c) => c.args[0] === 0x000000);
     expect(hasBlack).toBe(false);
-    // Issue #40 reframe: minimap base is barren-earth, not grass-green. The
-    // surface terrain at large now reads as ant-scale ground, and the
-    // minimap must mirror that so the player's mental model matches.
     const hasEarth = styles.some((c) => c.args[0] === COLOR_BARREN_EARTH);
     expect(hasEarth).toBe(true);
-    // A darker dapple is sprinkled deterministically per tile — gives the
-    // minimap a textured feel rather than a flat brown rectangle.
     const hasDapple = styles.some((c) => c.args[0] === COLOR_BARREN_EARTH_DARK);
     expect(hasDapple).toBe(true);
 
-    // Cleanup so other tests see a clean surface
     sgSet(stubSurface, 10, 10, SurfaceTileState.Grass);
     sgSet(stubSurface, 20, 30, SurfaceTileState.Grass);
     sgSet(stubSurface, 50, 50, SurfaceTileState.Grass);
+  });
+
+  it('bakes in TEXTURE-LOCAL coords: base at (0,0,w,h) and every dapple inside the rect', () => {
+    // The RT is positioned at (mm.x, mm.y), so the bake must use 0-based coords —
+    // NOT mm.x/mm.y offsets — or it would double-offset once drawn into the RT.
+    // This guards the pixel-identity rationale (integer anchor + floored local
+    // dapple == the old mm-anchored inline draw).
+    const gfx = new MockGfx();
+    const world = makeMinimalWorld({ foodPiles: [], colonies: {} });
+    const mmW = hud.MINIMAP.w;
+    const mmH = hud.MINIMAP.h;
+    bakeMinimapDapple(gfx, world, mmW, mmH);
+
+    const fillRects = gfx.callsOf('fillRect');
+    // First fillRect is the full-rect base at the texture origin.
+    const base = fillRects[0]!;
+    expect(base.args).toEqual([0, 0, mmW, mmH]);
+    // Every subsequent dapple pixel is a 1×1 rect strictly inside [0,mmW)×[0,mmH).
+    for (const r of fillRects.slice(1)) {
+      const [x, y, w, h] = r.args as [number, number, number, number];
+      expect(w).toBe(1);
+      expect(h).toBe(1);
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThan(mmW);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(y).toBeLessThan(mmH);
+    }
   });
 });

--- a/src/render/minimap.ts
+++ b/src/render/minimap.ts
@@ -59,6 +59,40 @@ function clamp(v: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, v));
 }
 
+/**
+ * #278 — bake the STATIC minimap layer (barren-earth base + hash-driven dapple)
+ * into a TEXTURE-LOCAL gfx (origin 0,0), sized mmW × mmH. The surface is frozen
+ * post-scenario (sgSet is generation-only), so UIScene bakes this ONCE into a
+ * RenderTexture positioned at the minimap rect instead of redrawing the ~16k-tile
+ * dapple every frame (was an O(world) per-frame pass — #236 debt #2). The dynamic
+ * overlays (food, colony markers, viewport, ants) still draw per frame in
+ * drawMinimap below.
+ *
+ * Pixel-identical to the old inline draw: mm.x/mm.y are integers, so a local dapple
+ * floored at (tx*sx)|0 and placed at the RT's screen anchor (mm.x, mm.y) equals the
+ * old (mm.x + tx*sx)|0 (integer + floor(frac) = floor(integer + frac)).
+ */
+export function bakeMinimapDapple(gfx: GfxLike, world: WorldState, mmW: number, mmH: number): void {
+  const sx = mmW / SURFACE_GRID_WIDTH;
+  const sy = mmH / SURFACE_GRID_HEIGHT;
+  gfx.fillStyle(COLOR_BARREN_EARTH, 1);
+  gfx.fillRect(0, 0, mmW, mmH);
+  const surface = world.surface;
+  if (surface === undefined) return;
+  gfx.fillStyle(COLOR_BARREN_EARTH_DARK, 0.7);
+  const SALT_MINIMAP_DAPPLE = 901;
+  for (let ty = 0; ty < surface.height; ty++) {
+    for (let tx = 0; tx < surface.width; tx++) {
+      // Read the surface tile so a future SurfaceTileState extension can bias
+      // dapple density per tile type without a renderer rewrite.
+      void sgGet(surface, tx, ty);
+      const h = spatialHash(tx, ty, SALT_MINIMAP_DAPPLE);
+      if ((h & 0xff) >= 32) continue; // ~12% coverage
+      gfx.fillRect((tx * sx) | 0, (ty * sy) | 0, 1, 1);
+    }
+  }
+}
+
 export function drawMinimap(
   gfx: GfxLike,
   world: WorldState,
@@ -72,46 +106,9 @@ export function drawMinimap(
   const sx = mm.w / SURFACE_GRID_WIDTH;
   const sy = mm.h / SURFACE_GRID_HEIGHT;
 
-  // Surface terrain (issue #40 reframe — barren-earth-default). Base layer
-  // is the warm tan barren-earth color used by the surface render; a sparse
-  // darker-earth dapple gives the minimap a textured "ant scale" feel
-  // rather than a flat brown rectangle.
-  //
-  // The minimap stays a surface overview per PRD §7a — single colour layer
-  // with a hash-driven dapple, NO multi-tile features (would be too small
-  // to read at 1.25 px/tile) and NO single-tile motifs (same problem).
-  // The intent is "you are looking at a faraway ground", not "every blade
-  // of grass and pebble visible".
-  gfx.fillStyle(COLOR_BARREN_EARTH, 1);
-  gfx.fillRect(mm.x, mm.y, mm.w, mm.h);
-
-  const surface = world.surface;
-  if (surface !== undefined) {
-    // Sparse darker-earth dapple — ~12% of tiles, deterministic per (tx, ty).
-    // Codex P2 fix from PR #41 review (which got squash-merged before this
-    // commit landed): each dapple is a 1×1 pixel dot, NOT a `ceil(scale)+1`
-    // sized cell. With sx = 1.25, drawing 3×3 cells caused each dapple to
-    // overlap ~2 neighboring cells, so 12% of tiles ended up covering ~50%
-    // of the minimap area — darkening the whole map and making colony /
-    // food markers harder to read.
-    gfx.fillStyle(COLOR_BARREN_EARTH_DARK, 0.7);
-    const SALT_MINIMAP_DAPPLE = 901;
-    for (let ty = 0; ty < surface.height; ty++) {
-      for (let tx = 0; tx < surface.width; tx++) {
-        // Read the surface tile so a future SurfaceTileState extension can
-        // bias dapple density per tile type without needing a renderer
-        // rewrite.
-        void sgGet(surface, tx, ty);
-        const h = spatialHash(tx, ty, SALT_MINIMAP_DAPPLE);
-        if ((h & 0xff) >= 32) continue; // ~12% coverage
-        // Floor to integer pixel for crisp rendering — avoids sub-pixel
-        // sampling artifacts on Phaser's WebGL pipeline.
-        const px = (mm.x + tx * sx) | 0;
-        const py = (mm.y + ty * sy) | 0;
-        gfx.fillRect(px, py, 1, 1);
-      }
-    }
-  }
+  // #278 — the STATIC barren-earth base + hash-driven dapple now live on a baked
+  // RenderTexture (bakeMinimapDapple, drawn once by UIScene behind this gfx layer);
+  // this per-frame path draws only the DYNAMIC overlays on top of it.
 
   // Food piles (2x2 pixels per pile)
   for (const pile of world.foodPiles) {

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -162,7 +162,7 @@ import {
   sliderGeometry,
   type SliderDragState,
 } from './triangle-widget.js';
-import { drawMinimap, applyMinimapClick } from './minimap.js';
+import { drawMinimap, bakeMinimapDapple, applyMinimapClick } from './minimap.js';
 import {
   TOOL_ORDER,
   TOOL_LABEL,
@@ -478,6 +478,14 @@ export class UIScene extends Phaser.Scene {
   private lastTooltipView: ViewState['activeView'] | null = null;
   private lastTooltipColonyId: ViewState['activeUndergroundColonyId'] | null = null;
   private gfx!: Phaser.GameObjects.Graphics;
+  // #278 — the STATIC minimap layer (barren-earth base + dapple) baked once into a
+  // RenderTexture behind the per-frame HUD gfx, so the ~16k-tile dapple loop stops
+  // running every frame. `minimapBaker` is an off-display-list Graphics stamped
+  // into the RT; `minimapBakedWorld` tracks which world the RT was baked for so a
+  // restart/load (which assigns a NEW WorldState) triggers a rebake.
+  private minimapRT?: Phaser.GameObjects.RenderTexture;
+  private minimapBaker?: Phaser.GameObjects.Graphics;
+  private minimapBakedWorld?: WorldState;
   private antsText!: Phaser.GameObjects.Text;
   private foodText!: Phaser.GameObjects.Text;
   private queenLabelText!: Phaser.GameObjects.Text;
@@ -575,6 +583,26 @@ export class UIScene extends Phaser.Scene {
     // today; both scenes set it at boot (idempotent — they share DEFAULT_LAYOUT).
     setViewportSize(this.layout.w, this.layout.h);
     this.gfx = this.add.graphics();
+    // #278 — the minimap's static barren-earth base + dapple, baked once into a
+    // RenderTexture behind the per-frame HUD gfx (depth -1 < gfx's 0), so the
+    // ~16k-tile dapple loop no longer runs every frame. Baked lazily in update()
+    // once the world is available (and re-baked on a world swap / WebGL restore).
+    const mm = this.hud.MINIMAP;
+    this.minimapRT = this.add.renderTexture(mm.x, mm.y, mm.w, mm.h);
+    this.minimapRT.setOrigin(0, 0).setDepth(-1).setScrollFactor(0);
+    this.minimapRT.texture.setFilter(Phaser.Textures.FilterMode.NEAREST);
+    this.minimapBaker = this.make.graphics({}, false); // off the display list
+    // A WebGL context restore blanks the RT framebuffer — force a rebake next frame.
+    const renderer = this.game.renderer as unknown as Phaser.Events.EventEmitter;
+    const onMinimapRestore = (): void => {
+      this.minimapBakedWorld = undefined;
+    };
+    renderer.on('restorewebgl', onMinimapRestore);
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      renderer.off('restorewebgl', onMinimapRestore);
+      this.minimapRT?.destroy();
+      this.minimapBaker?.destroy();
+    });
     this.dragState = createSliderDragState();
     // Stage 3b (#2): seed the in-mem hint-strip visibility from persisted
     // settings so a returning player's "hide legend" choice is honored on boot.
@@ -1047,6 +1075,27 @@ export class UIScene extends Phaser.Scene {
     });
   }
 
+  /**
+   * #278 — (re)bake the static minimap layer into its RenderTexture. Stamps
+   * bakeMinimapDapple (texture-LOCAL coords, origin 0,0) via the off-display-list
+   * baker, then draws the baker into the RT (positioned at the minimap rect). The
+   * baker's command buffer is freed after — a full dapple holds ~2k 1×1 rects.
+   */
+  private rebakeMinimap(world: WorldState): void {
+    if (this.minimapRT === undefined || this.minimapBaker === undefined) return;
+    const mm = this.hud.MINIMAP;
+    this.minimapBaker.clear();
+    bakeMinimapDapple(
+      this.minimapBaker as unknown as import('./draw-surface.js').GfxLike,
+      world,
+      mm.w,
+      mm.h,
+    );
+    this.minimapRT.clear();
+    this.minimapRT.draw(this.minimapBaker);
+    this.minimapBaker.clear();
+  }
+
   update() {
     // Apply any pending show/hide from the previous frame's pointerdown dispatch
     // BEFORE reading the state, so cross-scene race conditions are resolved
@@ -1062,6 +1111,14 @@ export class UIScene extends Phaser.Scene {
     // pre-boot (SavePrompt phase) and on any future world swap between frames.
     const world = this.getWorld();
     if (!world) return;
+
+    // #278 — (re)bake the static minimap layer when the world changes (first boot,
+    // restart, load — each assigns a NEW WorldState) or after a WebGL restore
+    // cleared the tracked world. The ~16k-tile dapple then runs once, not per frame.
+    if (this.minimapBakedWorld !== world) {
+      this.rebakeMinimap(world);
+      this.minimapBakedWorld = world;
+    }
 
     // Auto-dismiss the underground context menu if the player switches away
     // from the underground view (via Tab key, toggle button, or minimap click).

--- a/src/render/ui-scene.ts
+++ b/src/render/ui-scene.ts
@@ -587,6 +587,11 @@ export class UIScene extends Phaser.Scene {
     // RenderTexture behind the per-frame HUD gfx (depth -1 < gfx's 0), so the
     // ~16k-tile dapple loop no longer runs every frame. Baked lazily in update()
     // once the world is available (and re-baked on a world swap / WebGL restore).
+    // NOTE (Phase-6 responsive layout): unlike the per-frame HUD draws, which
+    // re-read this.hud.MINIMAP every update(), this RT bakes its position AND its
+    // dapple scale from the layout at create() time. A future reflow that mutates
+    // this.hud must reposition/resize the RT and clear minimapBakedWorld to rebake;
+    // no current runtime path changes the layout after create().
     const mm = this.hud.MINIMAP;
     this.minimapRT = this.add.renderTexture(mm.x, mm.y, mm.w, mm.h);
     this.minimapRT.setOrigin(0, 0).setDepth(-1).setScrollFactor(0);


### PR DESCRIPTION
Closes #278.

## What
`drawMinimap` recomputed a spatial-hash dapple over **all ~16,384 surface tiles every frame** to paint the static barren-earth base + ~12% darker-earth 1×1 dots. The surface is frozen post-scenario (`sgSet` is generation-only), so this was a per-frame O(world) pass producing an unchanging image — the last remaining sub-item of #236 PR3, split out because it's a Phaser RenderTexture **lifecycle** change (not a pure refactor) warranting isolated pixel-identity verification.

## How
- **`bakeMinimapDapple(gfx, world, mmW, mmH)`** (minimap.ts) — a pure function drawing the base + dapple in **texture-local (0-based)** coords (the coordinate remap the spec calls for). The per-frame base+dapple block is deleted from `drawMinimap`, which now draws only the dynamic overlays (food, colony markers, viewport) on top.
- **UIScene** bakes it **once** into a `RenderTexture` positioned at the minimap rect, **depth −1** (behind the per-frame HUD `gfx` at depth 0), via an off-display-list baker `Graphics`. Rebake fires only when the tracked world reference changes (`getWorld()` returns `this.world` directly — a fresh `WorldState` per boot/restart/load) or after a **WebGL context restore** (`'restorewebgl'` → `minimapBakedWorld = undefined`), mirroring the terrain-bake RT lifecycle. `SHUTDOWN` destroys the RT + baker and unhooks the listener.

## Pixel-identical
`MINIMAP.x/y` are integers, so a local dapple floored at `(tx*sx)|0` placed at the RT's screen anchor `(mm.x, mm.y)` equals the old `(mm.x + tx*sx)|0` (`int + floor(frac) = floor(int + frac)`). The baker composites base(α1)+dapple(α0.7) then stamps into the fully-opaque RT, matching the old inline draw over the GameScene world. No HUD zone overlaps the minimap rect, so depth −1 changes nothing visible.

**Render-only** — no `WorldState` mutation, no `simVersion` bump.

## Tests
- `minimap.test.ts` split: `drawMinimap` smoke now asserts **overlays-only** (+ a regression guard that it never redraws the full-minimap base); a new `bakeMinimapDapple` describe asserts the barren-earth base + dapple and **texture-local** coords (base at `(0,0,w,h)`, every dapple strictly inside the rect).
- **Teeth-proofed**: a non-local bake turns the local-coord test red.
- `npm run verify` green (2853 passed). Full e2e green except the pre-existing `phase-09-session:297` X-keybind flake (confirmed intermittent on the clean base too — 3/5 fail in isolation — not caused by this change; `getWorld()` is a stable reference so the rebake is one-time and nothing touches the X-toggle path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved minimap rendering by pre-baking its static terrain and texture details.
  * Reduced repeated drawing during updates for smoother minimap performance.

* **Reliability**
  * Automatically refreshes the minimap after world changes and graphics context restoration.
  * Preserved dynamic markers, food piles, and viewport indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->