### PR TITLE
refactor(render): #270 — drain camera.ts's CANVAS_H into the viewport-owning adapter

### DIFF
--- a/scripts/check-layout-discipline.sh
+++ b/scripts/check-layout-discipline.sh
@@ -53,20 +53,20 @@ echo "layout-discipline bare-800/592 guard: clean."
 # `sprites.CANVAS_W` namespace access would evade an import-only pattern while
 # still coupling render/input geometry to the fixed canvas size.
 # File allowlist: sprites.ts (defines them), layout.ts (the default-context
-# seam), camera-adapter.ts (the screen↔world authority — AGENTS.md §"Layout
-# discipline" sanctions its canvas-size dependency), and camera.ts (owns the
-# underground initial-center-Y = CANVAS_H/2 dependency; deferred adapter-owned
-# move tracked in #270). src/main.ts is outside SCOPE (render/input), so no entry.
+# seam), and camera-adapter.ts (the screen↔world authority — AGENTS.md §"Layout
+# discipline" sanctions its canvas-size dependency; it owns the viewport-height
+# derivations incl. the underground initial-center-Y that #270 drained out of
+# camera.ts). src/main.ts is outside SCOPE (render/input), so no entry.
 USE_HITS=$( { grep -rnE '\bCANVAS_[WH]\b' "${SCOPE[@]}" --include='*.ts' --exclude='*.test.ts' || true; } \
   | grep -vE "$COMMENT_FILTER" \
-  | grep -vE '/(sprites|layout|camera-adapter|camera)\.ts:' \
+  | grep -vE '/(sprites|layout|camera-adapter)\.ts:' \
   || true )
 
 if [[ -n "$USE_HITS" ]]; then
   echo "Layout discipline (#238): CANVAS_W/CANVAS_H used outside the authority files:"
   echo "$USE_HITS"
   echo ""
-  echo "Only sprites.ts / layout.ts / camera-adapter.ts / camera.ts may reference"
+  echo "Only sprites.ts / layout.ts / camera-adapter.ts may reference"
   echo "CANVAS_W/CANVAS_H. Elsewhere, take a LayoutContext and derive from layout.w / layout.h."
   exit 1
 fi

--- a/src/render/camera-adapter.ts
+++ b/src/render/camera-adapter.ts
@@ -57,6 +57,22 @@ export function getViewportHeight(): number {
   return viewportH;
 }
 
+/**
+ * Initial underground-camera CENTER Y (world px) on fresh boot / reset / first
+ * view toggle. `viewportH / 2` places world y=0 (the ceiling / surface-entrance
+ * row) at the very top of the viewport at zoom 1 — the "shaft anchored to the
+ * top" framing. It is also the clamp minimum for the 1024-px-tall underground
+ * world at zoom 1, so the shaft stays anchored as zoom changes.
+ *
+ * #270 — the derivation lives here (the viewport-height authority) rather than in
+ * camera.ts, which no longer needs the CANVAS_H import. Byte-identical to the old
+ * `CANVAS_H / 2` const while the viewport is fixed at CANVAS_H (296); a future
+ * responsive resize now reflows the initial framing for free.
+ */
+export function initialUndergroundCenterYPx(): number {
+  return viewportH / 2;
+}
+
 // ---------------------------------------------------------------------------
 // Zoom limits
 // ---------------------------------------------------------------------------

--- a/src/render/camera.test.ts
+++ b/src/render/camera.test.ts
@@ -12,14 +12,13 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-  UNDERGROUND_INITIAL_CENTER_Y_PX,
   UNDERGROUND_WORLD_PX_H,
   createViewState,
   resetViewState,
   toggleView,
   toggleUndergroundColony,
 } from './camera.js';
-import { DEFAULT_ZOOM, viewWorldHeight } from './camera-adapter.js';
+import { DEFAULT_ZOOM, viewWorldHeight, initialUndergroundCenterYPx } from './camera-adapter.js';
 import { TILE_SIZE_PX, CANVAS_H } from './sprites.js';
 import { PLAYER_COLONY_ID, ENEMY_COLONY_ID } from '../sim/constants.js';
 
@@ -40,12 +39,12 @@ describe('createViewState', () => {
   });
 
   it('undergroundCamera starts X-aligned with the start tile and Y at the shaft-top anchor', () => {
-    // UNDERGROUND_INITIAL_CENTER_Y_PX = CANVAS_H/2 places world y=0 (the ceiling /
-    // surface-entrance row) at the very top of the viewport at zoom 1.
+    // initialUndergroundCenterYPx() = viewportH/2 (= CANVAS_H/2 at the fixed viewport)
+    // places world y=0 (the ceiling / surface-entrance row) at the very top at zoom 1.
     const vs = createViewState(24, 64);
     expect(vs.undergroundCamera.centerX).toBe(tileCenterPx(24));
-    expect(vs.undergroundCamera.centerY).toBe(UNDERGROUND_INITIAL_CENTER_Y_PX);
-    expect(UNDERGROUND_INITIAL_CENTER_Y_PX).toBe(CANVAS_H / 2); // 296
+    expect(vs.undergroundCamera.centerY).toBe(initialUndergroundCenterYPx());
+    expect(initialUndergroundCenterYPx()).toBe(CANVAS_H / 2); // 296
     expect(vs.undergroundCamera.zoom).toBe(DEFAULT_ZOOM);
   });
 
@@ -109,7 +108,7 @@ describe('resetViewState', () => {
     vs.undergroundCamera.zoom = 0.4;
     resetViewState(vs, 24, 64);
     expect(vs.undergroundCamera.centerX).toBe(tileCenterPx(24));
-    expect(vs.undergroundCamera.centerY).toBe(UNDERGROUND_INITIAL_CENTER_Y_PX);
+    expect(vs.undergroundCamera.centerY).toBe(initialUndergroundCenterYPx());
     expect(vs.undergroundCamera.zoom).toBe(DEFAULT_ZOOM);
   });
 
@@ -122,7 +121,7 @@ describe('resetViewState', () => {
     expect(vs.undergroundVisited).toBe(false);
     vs.undergroundCamera.centerY = 5;
     toggleView(vs);
-    expect(vs.undergroundCamera.centerY).toBe(UNDERGROUND_INITIAL_CENTER_Y_PX);
+    expect(vs.undergroundCamera.centerY).toBe(initialUndergroundCenterYPx());
   });
 
   it('preserves the ViewState + camera object identities (mutates in place)', () => {
@@ -164,7 +163,7 @@ describe('toggleView', () => {
       const vs = createViewState(24, 64);
       vs.undergroundCamera.centerY = 900; // a stale value the first-visit anchor must win over
       toggleView(vs);
-      expect(vs.undergroundCamera.centerY).toBe(UNDERGROUND_INITIAL_CENTER_Y_PX);
+      expect(vs.undergroundCamera.centerY).toBe(initialUndergroundCenterYPx());
     });
 
     it('marks undergroundVisited and sets activeView=underground', () => {

--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -12,13 +12,14 @@
 // pure adapter, sim world dimensions, and persisted settings only. Fully testable
 // under Node + Vitest.
 
-import { CANVAS_H, TILE_SIZE_PX } from './sprites.js';
+import { TILE_SIZE_PX } from './sprites.js';
 import {
   type CameraView,
   makeCameraView,
   DEFAULT_ZOOM,
   cancelZoomLerp,
   settleEnteringView,
+  initialUndergroundCenterYPx,
 } from './camera-adapter.js';
 import {
   PLAYER_COLONY_ID,
@@ -43,15 +44,6 @@ export const SURFACE_WORLD_PX_H = SURFACE_GRID_HEIGHT * TILE_SIZE_PX;
 export const UNDERGROUND_WORLD_PX_W = UNDERGROUND_GRID_WIDTH * TILE_SIZE_PX;
 /** Underground world height in pixels (64 tiles × 16 = 1024). */
 export const UNDERGROUND_WORLD_PX_H = UNDERGROUND_GRID_HEIGHT * TILE_SIZE_PX;
-
-/**
- * Initial underground-camera CENTER Y (world px) on fresh boot / reset / first
- * view toggle. CANVAS_H/2 places world y=0 (the ceiling / surface-entrance row)
- * at the very top of the viewport at zoom 1 — the same "shaft anchored to the
- * top" framing as before Stage 2. It is also the clamp minimum for the 1024-px-
- * tall underground world at zoom 1, so the shaft stays anchored as zoom changes.
- */
-export const UNDERGROUND_INITIAL_CENTER_Y_PX = CANVAS_H / 2;
 
 /** World-pixel [width, height] for a view. */
 export function worldPxDimensions(view: 'surface' | 'underground'): [number, number] {
@@ -103,7 +95,7 @@ export interface ViewState {
   /**
    * Whether the underground view has been visited at least once.
    * Used for first-visit Y-centering (PRD §7c): undergroundCamera.centerY is set
-   * to UNDERGROUND_INITIAL_CENTER_Y_PX (shaft row near the top) on the FIRST
+   * to initialUndergroundCenterYPx() (shaft row near the top) on the FIRST
    * toggle to underground only.
    */
   undergroundVisited: boolean;
@@ -141,7 +133,7 @@ function tileCenterPx(tile: number): number {
  *
  * surfaceCamera is centered (world px) on the start tile. undergroundCamera is
  * centered horizontally on the starter entrance column and vertically at
- * UNDERGROUND_INITIAL_CENTER_Y_PX so the shaft / surface-entrance row sits near
+ * initialUndergroundCenterYPx() so the shaft / surface-entrance row sits near
  * the top of the viewport. Both start at DEFAULT_ZOOM. undergroundVisited is
  * false; activeView is 'surface'. Each camera is an independent object instance.
  *
@@ -155,7 +147,7 @@ export function createViewState(startTileX: number, startTileY: number): ViewSta
     surfaceCamera: makeCameraView(tileCenterPx(startTileX), tileCenterPx(startTileY), DEFAULT_ZOOM),
     undergroundCamera: makeCameraView(
       tileCenterPx(startTileX),
-      UNDERGROUND_INITIAL_CENTER_Y_PX,
+      initialUndergroundCenterYPx(),
       DEFAULT_ZOOM,
     ),
     undergroundVisited: false,
@@ -190,7 +182,7 @@ export function resetViewState(viewState: ViewState, startTileX: number, startTi
   viewState.surfaceCamera.targetZoom = DEFAULT_ZOOM;
 
   viewState.undergroundCamera.centerX = tileCenterPx(startTileX);
-  viewState.undergroundCamera.centerY = UNDERGROUND_INITIAL_CENTER_Y_PX;
+  viewState.undergroundCamera.centerY = initialUndergroundCenterYPx();
   viewState.undergroundCamera.zoom = DEFAULT_ZOOM;
   viewState.undergroundCamera.targetZoom = DEFAULT_ZOOM;
 
@@ -228,7 +220,7 @@ export function toggleView(viewState: ViewState): void {
     // First-underground-visit centering BEFORE the X-link (independent axes, but
     // spec order): set the shaft-at-top Y on the first visit only.
     if (!viewState.undergroundVisited) {
-      viewState.undergroundCamera.centerY = UNDERGROUND_INITIAL_CENTER_Y_PX;
+      viewState.undergroundCamera.centerY = initialUndergroundCenterYPx();
       viewState.undergroundVisited = true;
     }
     viewState.undergroundCamera.centerX = viewState.surfaceCamera.centerX; // X-link (world px)

--- a/src/render/game-scene.test.ts
+++ b/src/render/game-scene.test.ts
@@ -23,12 +23,8 @@ import {
   computeInterpAlpha,
   type CursorTool,
 } from './game-scene-logic.js';
-import {
-  createViewState,
-  resetViewState,
-  toggleView,
-  UNDERGROUND_INITIAL_CENTER_Y_PX,
-} from './camera.js';
+import { createViewState, resetViewState, toggleView } from './camera.js';
+import { initialUndergroundCenterYPx } from './camera-adapter.js';
 import { resetPaintStrokeState, type PaintStrokeState } from '../input/underground-input.js';
 import {
   panInputState,
@@ -474,7 +470,7 @@ describe('session reset orchestration (bootFresh / bootFromSave precondition)', 
     expect(s.viewState.surfaceCamera.centerX).toBe((PLAYER_START_X + 0.5) * TILE_SIZE_PX);
     expect(s.viewState.surfaceCamera.centerY).toBe((PLAYER_START_Y + 0.5) * TILE_SIZE_PX);
     expect(s.viewState.undergroundCamera.centerX).toBe((PLAYER_START_X + 0.5) * TILE_SIZE_PX);
-    expect(s.viewState.undergroundCamera.centerY).toBe(UNDERGROUND_INITIAL_CENTER_Y_PX);
+    expect(s.viewState.undergroundCamera.centerY).toBe(initialUndergroundCenterYPx());
     expect(s.viewState.undergroundVisited).toBe(false);
     expect(s.paintStroke.active).toBe(false);
     expect(s.paintStroke.lastMarkedTileX).toBe(-1);


### PR DESCRIPTION
Closes #270. Follow-up to #238 (surfaced by Fable's review of PR #269).

## What
`camera.ts:54` still derived `UNDERGROUND_INITIAL_CENTER_Y_PX = CANVAS_H / 2` and imported `CANVAS_H` for it — the last render-layer `CANVAS_H` dependency outside the sanctioned `{sprites, layout, camera-adapter}` authority set, kept on the layout-discipline guard's allowlist as deferred debt.

## How
- Relocated the derivation into `camera-adapter.ts` as **`initialUndergroundCenterYPx() = viewportH / 2`** — the adapter already owns the viewport height (`setViewportSize` / `getViewportHeight`, #238 PR3).
- `camera.ts` (createViewState / resetViewState / toggleView) + both test files consume the function; the exported const is removed (only `camera.test.ts` + `game-scene.test.ts` referenced it).
- Removed `camera.ts` from the guard's CANVAS-use allowlist so it matches the sanctioned `{sprites, layout, camera-adapter}` set exactly.

## Byte-identical
`viewportH` is initialised to `CANVAS_H` (camera-adapter.ts:37) and stays there until a responsive layout passes a real size, so `viewportH/2 == CANVAS_H/2 == 296` today — regardless of `setViewportSize`-vs-`createViewState` call order. A future reflow now re-frames the initial underground view for free. **Render-only; no `WorldState` touch, no `simVersion`.**

## Verification
- `npm run verify` green (2853 passed).
- **Teeth-verified** the tightened guard now flags a reintroduced `CANVAS_H` in camera.ts (was silently exempt before).
- Smoke e2e green (boot + Tab-to-underground framing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved underground camera positioning to adapt correctly when the viewport is resized.
  * Updated camera initialization, resetting, and first-visit behavior for responsive layouts.

* **Tests**
  * Updated camera and game-scene checks to verify viewport-aware underground positioning.

* **Chores**
  * Tightened layout validation to restrict canvas dimension references to approved sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->