### PR TITLE
refactor(sim): #256 — migrate larva-maturation nurseScratch to the per-world arena

### DIFF
--- a/src/sim/colony/larva-maturation.ts
+++ b/src/sim/colony/larva-maturation.ts
@@ -16,8 +16,9 @@
 //      workers) — mirrors the promotion logic in tickLifecycleTransitions Loop 2.
 //
 // Hot-path discipline (QC Pass 4 AR-P1-002):
-//   - No per-tick allocations. nurseScratch is allocated once at module load
-//     (Uint32Array, not serialized, not persisted).
+//   - No per-tick allocations. The nurse stamp lives in the per-world scratch
+//     arena (#256; getScratch(world).nurse), allocated once per world on first
+//     use (Uint32Array, not serialized, not persisted).
 //   - Mark-stamp pattern: currentStamp increments once per tick. Claiming a
 //     nurse writes the current stamp into usedStamp[nurseId]. Checking is
 //     `usedStamp[nurseId] === currentStamp`. Wraps at Uint32 max (~4 billion

--- a/src/sim/colony/larva-maturation.ts
+++ b/src/sim/colony/larva-maturation.ts
@@ -46,31 +46,21 @@ import {
   WORKER_BASE_SPEED,
 } from '../constants.js';
 import type { AntComponents } from '../ant/ant-store.js';
-import { MAX_ENTITIES } from '../constants.js';
+import { getScratch } from '../scratch.js';
 
 // ---------------------------------------------------------------------------
-// Module-level scratch — allocated once, not serialized, not per-tick.
+// Nurse-claim scratch — the per-tick bookkeeping stamp lives in the per-world
+// ScratchArena (#256; getScratch(world).nurse), NOT a module global, so no
+// process-global mutable sim state survives (Phase-7 rollback / multi-world).
 //
-// Save/load safety: this scratch holds NO inter-tick state. Its only role is
-// to track which nurses have already been claimed as accelerators within the
-// current tick's backward loop. Once tickLarvaMaturation returns, all nurse
-// claims are already reflected in WorldState (ants.age, ants.task, etc.) and
-// the stamp values are stale. On reload from a snapshot, currentStamp resets
-// to 0 and usedStamp is all-zeros; the first post-load tick increments stamp
-// to 1 and correctly sees no nurses pre-claimed — identical to a fresh start.
-//
-// This is the same pattern used throughout ant-system.ts (Issues #67, #69) for
-// hot-path scratch objects: one allocation at module load, stamp-or-fill per tick,
-// never serialized, deterministic within any contiguous run or replay.
+// It holds NO inter-tick state: its only role is to track which nurses have been
+// claimed as accelerators within the current tick's backward loop. Once
+// tickLarvaMaturation returns, every claim is already reflected in WorldState
+// (ants.age, ants.task, …) and the stamp values are stale. A snapshot reload gets
+// a fresh arena (currentStamp 0, usedStamp all-zeros); the first post-load tick
+// bumps the stamp to 1 and correctly sees no nurse pre-claimed — a fresh start.
+// The stamp is never serialized, so the per-world move is byte-identical.
 // ---------------------------------------------------------------------------
-
-// sim-scratch: per-tick nurse bookkeeping, stamp-invalidated each pass; never serialized (object — not lint-enforced).
-const nurseScratch = {
-  /** Per-nurse stamp: nurseScratch.usedStamp[nurseId] === currentStamp means used this tick. */
-  usedStamp: new Uint32Array(MAX_ENTITIES),
-  /** Incremented once per tick before the acceleration pass. Uint32 wrap is safe. */
-  currentStamp: 0,
-};
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -89,6 +79,10 @@ export function tickLarvaMaturation(world: WorldState, colony: ColonyRecord): vo
 
   const cap = largestNurseryTileCount(colony);
   if (cap <= 0) return;
+
+  // #256 — per-world nurse-claim stamp (was a module global). Same object shape;
+  // the body below is unchanged.
+  const nurseScratch = getScratch(world).nurse;
 
   // Advance the stamp. Skip 0: usedStamp[] is zero-initialized, so stamp===0
   // would falsely treat every nurse as "used this tick" after a full Uint32

--- a/src/sim/scratch.test.ts
+++ b/src/sim/scratch.test.ts
@@ -110,7 +110,23 @@ describe('per-world scratch arena (#231) — object independence (discriminating
     expect(a.motion.detourResult).not.toBe(b.motion.detourResult);
     expect(a.queenIds).not.toBe(b.queenIds);
     expect(a.surfaceMoveCache).not.toBe(b.surfaceMoveCache);
+    expect(a.nurse).not.toBe(b.nurse); // #256 — the migrated nurse-claim stamp
+    expect(a.nurse.usedStamp).not.toBe(b.nurse.usedStamp);
     expect(getScratch(wB)).toBe(b); // same world → same arena
+  });
+
+  it('#256 — a world-B nurse-stamp bump does not advance world A (shared counter would leak)', () => {
+    resetScratchArenas();
+    const nurseA = getScratch(createWorldState(1)).nurse;
+    nurseA.currentStamp = 42;
+    nurseA.usedStamp[3] = 42;
+    // A fresh world's nurse stamp must start at 0 with an all-zero usedStamp —
+    // independent of world A. The pre-#256 module global would show 42 / a set mark.
+    const nurseB = getScratch(createWorldState(2)).nurse;
+    expect(nurseB.currentStamp).toBe(0);
+    expect(nurseB.usedStamp[3]).toBe(0);
+    // World A is untouched by allocating B.
+    expect(nurseA.currentStamp).toBe(42);
   });
 
   it('a world-B motion out-param write does not alias world A (shared buffer would clobber)', () => {

--- a/src/sim/scratch.test.ts
+++ b/src/sim/scratch.test.ts
@@ -115,7 +115,7 @@ describe('per-world scratch arena (#231) — object independence (discriminating
     expect(getScratch(wB)).toBe(b); // same world → same arena
   });
 
-  it('#256 — a world-B nurse-stamp bump does not advance world A (shared counter would leak)', () => {
+  it('#256 — a world-A nurse-stamp bump does not leak into world B (shared counter would)', () => {
     resetScratchArenas();
     const nurseA = getScratch(createWorldState(1)).nurse;
     nurseA.currentStamp = 42;

--- a/src/sim/scratch.ts
+++ b/src/sim/scratch.ts
@@ -13,9 +13,10 @@
  * reset semantics, and iteration order are preserved verbatim, so replay stays
  * byte-identical (no simVersion bump).
  *
- * NOT migrated: larva-maturation.ts's `nurseScratch` — a monotonic per-tick STAMP
- * (not a reset buffer), provably byte-safe even when shared; tracked for a
- * per-world move in the Phase-7 follow-up (#256).
+ * #256 — larva-maturation.ts's `nurseScratch` (a monotonic per-tick STAMP, not a
+ * reset buffer) is now in the arena too (`nurse`), completing the migration: no
+ * process-global mutable sim state remains. It was byte-safe even when shared, so
+ * the move is byte-identical — a single world's stamp sequence is unchanged.
  *
  * Layering: this sits at `src/sim/` root (NOT under `src/sim/ant/`), so it stays
  * outside the ant-cycle graph that check-ant-cycles.mjs enforces. Its only
@@ -23,7 +24,7 @@
  */
 import type { WorldState } from './types.js';
 import type { CardinalStep } from './ant/ant-motion.js';
-import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT } from './constants.js';
+import { SURFACE_GRID_WIDTH, SURFACE_GRID_HEIGHT, MAX_ENTITIES } from './constants.js';
 import { createSurfaceMovementCache, type SurfaceMovementCache } from './surface-features.js';
 
 export interface ScratchArena {
@@ -56,6 +57,14 @@ export interface ScratchArena {
   surfaceMoveCache: SurfaceMovementCache;
   /** ant-motion.ts — cross-module cardinal-step + detour out-params. */
   motion: { cardinalStep: CardinalStep; detourResult: CardinalStep };
+  /**
+   * larva-maturation.ts — per-tick nurse-claim STAMP (#256). NOT a reset-before-use
+   * buffer: `currentStamp` is a monotonic counter bumped once per acceleration pass,
+   * and `usedStamp[nurseId] === currentStamp` marks "claimed this tick". Provably
+   * byte-safe even when shared across worlds (each pass bumps a fresh stamp), but
+   * moved here so no process-global mutable sim state survives (Phase-7 rollback).
+   */
+  nurse: { usedStamp: Uint32Array; currentStamp: number };
 }
 
 // eslint-disable-next-line subterrans/sim-module-state -- sim-cache: per-world scratch arena keyed by WorldState identity; transient, never serialized, recreated per world (same pattern as tick.ts cachesByWorld)
@@ -93,6 +102,9 @@ export function getScratch(world: WorldState): ScratchArena {
       queenIds: new Set(),
       surfaceMoveCache: createSurfaceMovementCache(),
       motion: { cardinalStep: { dx: 0, dy: 0 }, detourResult: { dx: 0, dy: 0 } },
+      // #256 — nurse stamp starts at 0 (matches the old module-global init); the
+      // first acceleration pass bumps it to 1, so no nurse is ever falsely pre-claimed.
+      nurse: { usedStamp: new Uint32Array(MAX_ENTITIES), currentStamp: 0 },
     };
     SCRATCH.set(world, a);
   }


### PR DESCRIPTION
Closes #256. Follow-up to #231 (per-world ScratchArena).

## What
#231 explicitly left `larva-maturation.ts`'s `nurseScratch` unmigrated — it's a monotonic per-tick **STAMP** (`usedStamp[nurseId] === currentStamp` marks "claimed this tick"), not a reset-before-use buffer, and was provably byte-safe even when shared across worlds. But it was the **last process-global mutable sim state**, which Phase-7 rollback/prediction machinery would otherwise have to reason about.

## How
Moved it into `getScratch(world).nurse` (`usedStamp` + `currentStamp`), alongside the other arena buffers. `tickLarvaMaturation` reads the per-world object once; the loop body is unchanged.

## Byte-identical
The stamp is never serialized and only compared **within** a tick, so a single world's stamp sequence (0→1→2…) is unchanged — the pre-#256 cross-world sharing was incidental, never relied upon. **No `simVersion` bump.**

## Verification
- `npm run verify` green (2853 passed); **cross-engine determinism** (byte-identical Node vs Chromium) + smoke e2e green.
- Extended `scratch.test.ts`'s discriminating "object independence" test to assert `a.nurse !== b.nurse` (+ distinct `usedStamp`), and added a stamp-independence test (a world-B bump must not advance world A). **Teeth-proofed**: aliasing `nurse` to one shared module object turns both red.
- Audited the "also confirm" clause: no other uninventoried module scratch remains — combat.ts's `ACTIVE_COMBAT_KEYS` is a sort-comparator pointer into the arena's `keyBySlot`; surface-features.ts's max-feature dims are immutable module-load memos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)