### PR TITLE
test(e2e): #254 — add a WebKit/JSC axis to the cross-engine determinism proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - run: npm run build:lib
 
   e2e:
-    name: e2e (Playwright chromium)
+    name: e2e (Playwright chromium + webkit)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,5 +71,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx playwright install --with-deps chromium
+      # webkit (#254) runs ONLY the cross-engine-determinism spec (JSC axis); the
+      # rendering/touch specs stay chromium-only. See playwright.config.ts projects.
+      - run: npx playwright install --with-deps chromium webkit
       - run: npm run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,11 @@ name: CI
 #            targets (`npm run build` + `build:lib`) as a smoke gate. The
 #            `verify` command itself is what contributors run locally before
 #            pushing.
-#   e2e    — `npm run test:e2e` (Playwright, chromium headless). The webServer
-#            pins VITE_PLAYTRACE_ENDPOINT empty so the run is deterministic
-#            regardless of a developer's .env.local (see playwright.config.ts).
+#   e2e    — `npm run test:e2e` (Playwright, headless). Chromium runs the full
+#            suite; a webkit project (#254) runs ONLY the cross-engine determinism
+#            spec (the JSC axis). The webServer pins VITE_PLAYTRACE_ENDPOINT empty
+#            so the run is deterministic regardless of a developer's .env.local
+#            (see playwright.config.ts).
 #
 # Coverage (`npm run test:coverage`) is intentionally a LOCAL-ONLY pre-push tool,
 # by design — not a CI gate. The 80% thresholds pass, but v8 instrumentation on a

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,6 +52,20 @@ export default defineConfig({
         },
       },
     },
+    {
+      // #254 — WebKit/JSC axis for the cross-engine determinism proof. The
+      // chromium project already covers Node↔V8; the actual Phase-6 target is
+      // iOS Safari / WKWebView, which runs JSC (JavaScriptCore), not V8. Scoped
+      // to ONLY the cross-engine spec — it's pure compute (no canvas/WebGL), so
+      // WebKit-headless is low-flake, and the other specs (which need Chrome
+      // WebGL/touch behavior) must NOT run under WebKit. Kept a distinct project
+      // so a WebKit-only flake is attributable and never masks the chromium proof.
+      name: 'webkit',
+      testMatch: /[\\/]cross-engine-determinism\.spec\.ts$/,
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
   ],
   webServer: {
     command: 'npm run dev',

--- a/tests/cross-engine-determinism.spec.ts
+++ b/tests/cross-engine-determinism.spec.ts
@@ -6,18 +6,21 @@
  * for the same (seed, script) — and cross-engine byte identity is the single
  * load-bearing assumption of Phase 7 lockstep (and Phase 6 mobile Safari/WebView).
  *
- * SCOPE: this covers the Node(V8) <-> Chromium(V8) axis — transform-vs-loader,
- * embedder, and future V8-version drift. The JSC/WebKit axis (iOS Safari /
- * WKWebView, the actual Phase-6 target) is NOT yet exercised here — tracked as a
- * follow-up (#254); the harness is engine-agnostic, so it only needs a Playwright
- * `webkit` project + a CI browser install.
+ * SCOPE: this runs under BOTH the `chromium` (V8) and `webkit` (JSC) projects,
+ * each comparing its browser hash to the same Node(V8) baseline. So it covers the
+ * transform-vs-loader / embedder / future-V8-drift axis (chromium) AND the JSC
+ * axis (webkit — iOS Safari / WKWebView, the actual Phase-6 target; #254). The
+ * harness is pure compute (no canvas/WebGL), so the `webkit` project is low-flake;
+ * it is scoped to this spec alone in playwright.config.ts and installed alongside
+ * chromium in the CI e2e job.
  *
- * Auto-matched by testMatch:/.*\.spec\.ts/ — runs in the existing e2e job.
+ * Auto-matched by testMatch:/.*\.spec\.ts/ for chromium; the webkit project's
+ * testMatch narrows to this file. Both run in the existing e2e job.
  */
 import { test, expect } from '@playwright/test';
 import { execFileSync } from 'node:child_process';
 
-test('Node and headless Chromium produce byte-identical sim state for the canned scenario', async ({
+test('Node and the browser engine produce byte-identical sim state for the canned scenario', async ({
   page,
 }) => {
   // --- Node side: run the canned scenario under bare `node --experimental-strip-types`.
@@ -49,7 +52,7 @@ test('Node and headless Chromium produce byte-identical sim state for the canned
     [seed, ticks] as [number, number],
   );
 
-  expect(browserHash, 'Node hash !== Chromium hash — engine-dependent nondeterminism').toBe(
+  expect(browserHash, 'Node hash !== browser hash — engine-dependent nondeterminism').toBe(
     nodeHash,
   );
 });


### PR DESCRIPTION
Closes #254. Follow-up to #229 (surfaced by Fable's review of PR #253).

## What
The cross-engine determinism spec compared Node(V8) to headless Chromium(V8) — but **both are V8**, so it never exercised the JSC divergence its own motivation cites: the load-bearing Phase-6 target is **iOS Safari / WKWebView, which runs JavaScriptCore, not V8**.

## How
- Added a Playwright **`webkit` project** scoped (via `testMatch`) to **only** the `cross-engine-determinism` spec — it's pure compute (no canvas/WebGL), so WebKit-headless is low-flake, and the rendering/touch specs stay chromium-only.
- The spec is engine-agnostic (`page` is whatever project's browser), so it now runs under both `chromium` (V8) and `webkit` (JSC), each comparing its hash to the **same Node baseline** — no spec logic change, only generalized wording.
- CI installs `webkit` alongside `chromium` in the e2e job.

## Result — JSC agrees with V8
Verified locally: the canned scenario hashes **byte-identical under Node, Chromium, AND WebKit**, stable across repeated runs. The integer-deterministic sim (Mulberry32 + fixed-point) holds across engines — so this is a clean proof, not a divergence. Project mapping confirmed: `chromium`=27 specs, `chromium-touch`=2, `webkit`=1 (cross-engine only).

Kept a distinct project so a WebKit-only flake is attributable and never masks the chromium proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)