### PR TITLE
chore(ci): add CodeRabbit config (assertive + sim-boundary path instructions)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -55,15 +55,19 @@ reviews:
   path_instructions:
     - path: "src/sim/**"
       instructions: >-
-        Deterministic simulation boundary — must stay pure. Flag as a blocking
-        issue ANY: Math.random() (a seeded Mulberry32 PRNG is the only allowed
-        randomness); Date, Date.now(), performance.now(), or other wall-clock
-        time; floating-point arithmetic or float literals (all math is
-        fixed-point integer, FP_SHIFT=8 / FP_ONE=256); and any import of Phaser,
-        the DOM, or browser/Node APIs. Entities are plain data + free functions,
-        never classes. Anything that could break deterministic replay across
-        runs or JS engines is a P0. Also flag a save-shape change that is missing
-        a simVersion bump.
+        Applies to PRODUCTION simulation code only. Co-located test files (any
+        path ending in `.test.ts`) are EXEMPT from the bans below — they
+        legitimately import node:fs / node:path / node:url and other Node APIs
+        for fixtures and may use helper values; never flag those in a test file.
+        For production sim code, flag as a blocking issue ANY: Math.random()
+        (a seeded Mulberry32 PRNG is the only allowed randomness); Date,
+        Date.now(), performance.now(), or other wall-clock time; floating-point
+        arithmetic or float literals (all math is fixed-point integer,
+        FP_SHIFT=8 / FP_ONE=256); and any import of Phaser, the DOM, or
+        browser/Node APIs. Entities are plain data + free functions, never
+        classes. Anything that could break deterministic replay across runs or
+        JS engines is a P0. Also flag a save-shape change that is missing a
+        simVersion bump.
     - path: "src/render/**"
       instructions: >-
         Render / Phaser layer. It may read sim state but must never mutate it,

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -85,9 +85,17 @@ reviews:
         production or gameplay policy.
     - path: "tests/**"
       instructions: >-
-        Flag tests that assert on wall-clock timing or unseeded randomness, or
-        that would be non-deterministic across runs or JS engines. Prefer tests
-        that pin exact deterministic outputs.
+        End-to-end (Playwright) specs. Flag tests that assert on wall-clock
+        timing or unseeded randomness, or that would be non-deterministic across
+        runs or JS engines; prefer tests that pin exact deterministic outputs.
+    - path: "**/*.test.ts"
+      instructions: >-
+        Vitest unit tests, including the many co-located under src/ (e.g.
+        src/sim/**/*.test.ts and src/sim/ant/*.test.ts). The production
+        sim-boundary bans do NOT apply here — but this is the suite that protects
+        deterministic replay, so flag tests that assert on wall-clock timing or
+        unseeded randomness, or that would be non-deterministic across runs or JS
+        engines; prefer tests that pin exact deterministic outputs.
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,80 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit configuration for LightAxe/subterrans.
+#
+# CodeRabbit is the second external PR reviewer alongside Codex (ADR 0010,
+# plan/decisions/0010-dual-reviewer-pr-process.md): two independent AI reviewers
+# with different perspectives catch more of the subtle architectural violations
+# an AI-authored diff can introduce. The open-source plan grants Pro+ features,
+# so custom path instructions and all linters below are available at no cost.
+
+language: en-US
+
+# <= 250 chars. Sets the reviewer's stance; the sim-boundary specifics live in
+# path_instructions below.
+tone_instructions: >-
+  Terse and technical, with a high bar. This is a long-term foundation: favour
+  tight, well-factored code and flag design and maintainability smells, not just
+  bugs, beyond what eslint/prettier/tsc already gate in CI.
+
+reviews:
+  # assertive = the most thorough profile: adds dead-code, null-safety, type,
+  # and design nitpicks on top of bug-finding. Deliberate — we want a tight
+  # codebase now while the foundation is being laid.
+  profile: assertive
+
+  high_level_summary: true
+  poem: false
+
+  # Submit a formal "Changes requested" review state (not just comments) and
+  # auto-approve once the threads are resolved and checks pass. Two reasons:
+  #   1. It marks findings as things that must be resolved, like Codex does.
+  #   2. The resulting APPROVED review state is machine-detectable, so the
+  #      /ship skill can poll it as CodeRabbit's clean verdict (symmetric to
+  #      Codex's 👍). This does NOT grant merge rights or lower any gate:
+  #      merging still requires write access + branch protection (required
+  #      approvals = 0, auto-merge disabled), which this setting never touches.
+  request_changes_workflow: true
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true # re-review on each push
+    drafts: false                 # skip drafts (matches .github/workflows/codex-auto-review.yml)
+
+  # Keep generated / vendored output out of review — saves the file-rate budget
+  # and cuts noise. CodeRabbit ignores common cases by default; these are explicit.
+  path_filters:
+    - "!dist/**"
+    - "!dist-lib/**"
+    - "!coverage/**"
+    - "!test-results/**"
+    - "!package-lock.json"
+
+  # Natural-language, per-path review guidance — this is where CodeRabbit becomes
+  # boundary-aware and earns its keep as the semantic reviewer (ADR 0010).
+  path_instructions:
+    - path: "src/sim/**"
+      instructions: >-
+        Deterministic simulation boundary — must stay pure. Flag as a blocking
+        issue ANY: Math.random() (a seeded Mulberry32 PRNG is the only allowed
+        randomness); Date, Date.now(), performance.now(), or other wall-clock
+        time; floating-point arithmetic or float literals (all math is
+        fixed-point integer, FP_SHIFT=8 / FP_ONE=256); and any import of Phaser,
+        the DOM, or browser/Node APIs. Entities are plain data + free functions,
+        never classes. Anything that could break deterministic replay across
+        runs or JS engines is a P0. Also flag a save-shape change that is missing
+        a simVersion bump.
+    - path: "src/render/**"
+      instructions: >-
+        Render / Phaser layer. It may read sim state but must never mutate it,
+        and simulation/gameplay decisions must not live here. Flag sim logic
+        leaking into render, and any place render reaches back into mutable sim
+        state.
+    - path: "tests/**"
+      instructions: >-
+        Flag tests that assert on wall-clock timing or unseeded randomness, or
+        that would be non-deterministic across runs or JS engines. Prefer tests
+        that pin exact deterministic outputs.
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -67,8 +67,11 @@ reviews:
         typed-array or Map structure-of-arrays stores) — but non-entity utility
         classes such as `Rng` are fine. Anything that breaks deterministic
         replay across runs or JS engines is a P0. Do NOT flag (carve-outs):
-        co-located `*.test.ts` files (they legitimately import node:* for
-        fixtures); and a bare balance-constant retune in src/sim/constants.ts
+        co-located `*.test.ts` files are exempt from the Node/Phaser/DOM import,
+        wall-clock, and dynamic-`import()` bans (they legitimately import node:*
+        and load modules at runtime for fixtures) — but the fixed-point
+        float/division discipline STILL applies to sim test files (issue #241).
+        And a bare balance-constant retune in src/sim/constants.ts
         (a numeric-literal change with no new WorldState field, tick-order
         change, or PRNG draw-count/order change is not tech debt and needs no
         simVersion bump — ADR-0015). Do flag a genuine save-shape change that is
@@ -82,7 +85,10 @@ reviews:
         (src/render/ai-controller.ts) and legitimately makes gameplay decisions
         and enqueues SimCommands via world.commandQueue (src/sim/commands.ts).
         Flag only direct sim-state mutation from render — never command
-        production or gameplay policy.
+        production or gameplay policy. Co-located `*.test.ts` files are EXEMPT:
+        render tests legitimately mutate WorldState/stores to build fixtures
+        (e.g. src/render/ai-controller.test.ts sets ant positions); never flag
+        fixture setup in a test file.
     - path: "tests/**"
       instructions: >-
         End-to-end (Playwright) specs. Flag tests that assert on wall-clock
@@ -91,11 +97,13 @@ reviews:
     - path: "**/*.test.ts"
       instructions: >-
         Vitest unit tests, including the many co-located under src/ (e.g.
-        src/sim/**/*.test.ts and src/sim/ant/*.test.ts). The production
-        sim-boundary bans do NOT apply here — but this is the suite that protects
-        deterministic replay, so flag tests that assert on wall-clock timing or
-        unseeded randomness, or that would be non-deterministic across runs or JS
-        engines; prefer tests that pin exact deterministic outputs.
+        src/sim/**/*.test.ts and src/render/*.test.ts). Test files legitimately
+        import node:* and mutate WorldState/store fixtures — do not flag those.
+        This is the suite that protects deterministic replay, so DO flag tests
+        that assert on wall-clock timing or unseeded randomness, or that would be
+        non-deterministic across runs or JS engines; prefer pinned deterministic
+        outputs. (Sim test files still keep the fixed-point float/division ban —
+        see the src/sim rule, #241.)
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -55,25 +55,34 @@ reviews:
   path_instructions:
     - path: "src/sim/**"
       instructions: >-
-        Applies to PRODUCTION simulation code only. Co-located test files (any
-        path ending in `.test.ts`) are EXEMPT from the bans below — they
-        legitimately import node:fs / node:path / node:url and other Node APIs
-        for fixtures and may use helper values; never flag those in a test file.
-        For production sim code, flag as a blocking issue ANY: Math.random()
-        (a seeded Mulberry32 PRNG is the only allowed randomness); Date,
-        Date.now(), performance.now(), or other wall-clock time; floating-point
-        arithmetic or float literals (all math is fixed-point integer,
-        FP_SHIFT=8 / FP_ONE=256); and any import of Phaser, the DOM, or
-        browser/Node APIs. Entities are plain data + free functions, never
-        classes. Anything that could break deterministic replay across runs or
-        JS engines is a P0. Also flag a save-shape change that is missing a
-        simVersion bump.
+        Deterministic simulation core — enforce the "Banned in src/sim/" rules
+        from AGENTS.md. In PRODUCTION (non-`*.test.ts`) files, flag as blocking
+        P0: Math.random() (all randomness goes through the seeded Mulberry32 in
+        src/sim/rng.ts); Date / Date.now() / performance.now() / any wall-clock
+        time; floating-point — float literals, the `/` division operator, and
+        Math.sqrt/sin/cos/atan2 (fixed-point integer only, FP_SHIFT=8 /
+        FP_ONE=256, src/sim/fixed.ts); and any Phaser / DOM / browser / Node API
+        import. Simulation ENTITIES must not be classes (no `class Ant` /
+        `class Pheromone`; entities are integer IDs with components in
+        typed-array or Map structure-of-arrays stores) — but non-entity utility
+        classes such as `Rng` are fine. Anything that breaks deterministic
+        replay across runs or JS engines is a P0. Do NOT flag (carve-outs):
+        co-located `*.test.ts` files (they legitimately import node:* for
+        fixtures); and a bare balance-constant retune in src/sim/constants.ts
+        (a numeric-literal change with no new WorldState field, tick-order
+        change, or PRNG draw-count/order change is not tech debt and needs no
+        simVersion bump — ADR-0015). Do flag a genuine save-shape change that is
+        missing a simVersion bump.
     - path: "src/render/**"
       instructions: >-
-        Render / Phaser layer. It may read sim state but must never mutate it,
-        and simulation/gameplay decisions must not live here. Flag sim logic
-        leaking into render, and any place render reaches back into mutable sim
-        state.
+        Render / Phaser layer. It reads sim state and PRODUCES commands; it must
+        never DIRECTLY write or mutate WorldState or any sim store — a direct
+        sim-store write from outside src/sim/ is a blocker (AGENTS.md). ALLOWED,
+        do not flag: the AI-controller policy lives here
+        (src/render/ai-controller.ts) and legitimately makes gameplay decisions
+        and enqueues SimCommands via world.commandQueue (src/sim/commands.ts).
+        Flag only direct sim-state mutation from render — never command
+        production or gameplay policy.
     - path: "tests/**"
       instructions: >-
         Flag tests that assert on wall-clock timing or unseeded randomness, or


### PR DESCRIPTION
## What

Adds `.coderabbit.yaml` to configure the CodeRabbit reviewer — the second external PR reviewer alongside Codex per **ADR 0010** (`plan/decisions/0010-dual-reviewer-pr-process.md`). Until now CodeRabbit ran on pure defaults.

## Key choices

- **`profile: assertive`** — the most thorough profile (dead-code, null-safety, type, and design nitpicks on top of bug-finding). Deliberate: hold a tight bar now while the foundation is laid.
- **`request_changes_workflow: true`** — CodeRabbit submits a formal *"Changes requested"* review state (marking findings for resolution, like Codex) and auto-approves once threads resolve and checks pass. The resulting `APPROVED` state is machine-detectable, so `/ship` can poll it as CodeRabbit's clean verdict (symmetric to Codex's 👍).
  - **Merge safety:** this grants no merge rights and changes no gate. `main` requires 0 approvals, auto-merge is disabled repo-wide, and merging requires write access — so a bot approval can never enable a merge. It only affects how CodeRabbit submits its own review.
- **`path_instructions` for `src/sim/**`** — encodes the deterministic-sim boundary (no `Math.random`/`Date`/floats/Phaser; fixed-point `FP_SHIFT=8`; plain-data entities; `simVersion` bumps) so the semantic reviewer is boundary-aware, plus render-purity and test-determinism guidance.
- **`path_filters`** — drop `dist`/`dist-lib`/`coverage`/`test-results`/lockfile from review (noise + rate-budget).

## Scope

Config only — no source or behavior change. `verify` and the sim boundary are untouched. CodeRabbit will review this PR (from base-branch defaults, since the new config isn't merged yet); the assertive/request-changes behavior takes effect on subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a complete CodeRabbit configuration with customized review language and assertive “request changes” workflow, including automatic incremental re-reviews on each push.
  * Enabled high-level summaries and automatic chat auto-replies during review interactions.
  * Excluded generated/lockfile/coverage/test/package artifacts from review scope and added path-scoped checks for deterministic simulation rules, render/simulation boundaries, and nondeterministic test assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->