### PR TITLE
docs(license): add AGPL §7 App Store distribution exception

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest! Subterrans is a spiritual successor to SimAnt (1991), 
 
 ## License & Inbound=Outbound
 
-Subterrans is licensed under **AGPL-3.0-or-later** (see [LICENSE](../LICENSE)). By submitting a contribution you agree it is licensed under the same terms. We do not require a CLA — your copyright stays yours, we just need the AGPL license to the project.
+Subterrans is licensed under **AGPL-3.0-or-later** plus the **Subterrans App Store Exception** (v1.0 or, at your option, any later version the project publishes — see [LICENSE-EXCEPTIONS.md](../LICENSE-EXCEPTIONS.md)). By submitting a contribution you agree it is licensed under those same terms, and you certify that you have the right to license it that way (e.g. it's your own work, or you have permission — don't paste in code from another project unless its license is compatible **and** carries an equivalent app-store permission). We do not require a CLA — your copyright stays yours; we just need the AGPL license, plus the exception so anyone can ship store builds.
 
 If you can't accept AGPL terms for your employer or other reason, please don't submit code changes; issue reports and documentation corrections are still welcome.
 

--- a/LICENSE-EXCEPTIONS.md
+++ b/LICENSE-EXCEPTIONS.md
@@ -1,0 +1,64 @@
+# License Exceptions
+
+Subterrans is licensed under the **GNU Affero General Public License, version 3
+or later** (AGPL-3.0-or-later); see [LICENSE](LICENSE) for the full text.
+
+In addition, the copyright holders grant the following additional permission
+under section 7 of that license. This permission is granted to **everyone** — not
+only the original authors — so that anyone may build and distribute Subterrans
+through app stores and similar platforms while the project remains fully open
+source under the AGPL.
+
+---
+
+## Subterrans App Store Exception, version 1.0
+
+**Additional permission under section 7 of the GNU Affero General Public License,
+version 3 (or, at your option, any later version).**
+
+As an additional permission under section 7 of the AGPL, you are permitted to
+convey this Program, or a covered work based on it, through an application store
+or other software distribution platform or channel — including, without
+limitation, the Apple App Store, Google Play, Microsoft Store, Steam, and console
+storefronts — and to accept and comply with that platform's terms of service and
+technical measures (including, without limitation, code signing, mandatory
+account acceptance, device or installation limits, and digital rights management),
+**even where those terms or measures would otherwise be incompatible with the
+AGPL**, provided that:
+
+1. the complete Corresponding Source (as defined by the AGPL) for the version you
+   convey is **also** made available to recipients under the AGPL — with or
+   without this additional permission — through at least one channel that does
+   **not** impose those restrictive terms or measures; and
+
+2. you otherwise comply with the AGPL in all respects, including providing the
+   license text and preserving license and copyright notices.
+
+### Later versions of this exception
+
+The Subterrans project may publish revised and/or new versions of this exception.
+Such versions will be similar in spirit to the present version, and will **only
+grant additional permissions — never impose new restrictions**. You may follow the
+terms of this version 1.0 or of any later version published by the project, at
+your option.
+
+### Scope and removal
+
+This additional permission applies only to material whose copyright holders have
+granted it. It does **not** extend to any third-party components that are
+distributed with Subterrans under their own licenses; those components remain
+governed solely by their respective licenses.
+
+As provided by section 7 of the AGPL, a recipient may remove this additional
+permission from any copy of the covered work, or from any part of it, that they
+convey. Doing so affects only that recipient's copies; it does not remove the
+permission from the project's canonical distribution, and it does not act
+retroactively on copies already conveyed.
+
+---
+
+_Note: `package.json` continues to declare `"license": "AGPL-3.0-or-later"`. That
+identifier deliberately understates the permissions granted here (npm's SPDX field
+does not cleanly express a custom exception), which is the safe direction — it
+never claims more permission than is actually granted. This file is the
+authoritative statement of the exception._

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Subterrans is licensed under the **GNU Affero General Public License v3.0 or lat
 
 In plain English: you can use, modify, and redistribute Subterrans freely, but any derivative work must be licensed under the same terms, and if you run a modified version as a network service, you must share your modifications with the users of that service. Your surrounding website, infrastructure, and account systems are not derivative works and are not covered.
 
-Additionally, **everyone** is granted the **Subterrans App Store Exception** — an AGPL section 7 additional permission that lets anyone build and distribute Subterrans through app stores and similar platforms (Apple App Store, Google Play, Steam, console storefronts, etc.) whose terms would otherwise conflict with the AGPL, so long as the complete source stays available under the AGPL through an unrestricted channel. See [LICENSE-EXCEPTIONS.md](LICENSE-EXCEPTIONS.md). This keeps Subterrans fully open source while allowing you (or anyone) to ship store binaries.
+Subterrans additionally grants the **Subterrans App Store Exception**, an AGPL section 7 additional permission that lets anyone distribute the project through app stores whose terms would otherwise conflict with the AGPL, while it stays fully open source. See [LICENSE-EXCEPTIONS.md](LICENSE-EXCEPTIONS.md) for the exact grant, conditions, and scope.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Subterrans is licensed under the **GNU Affero General Public License v3.0 or lat
 
 In plain English: you can use, modify, and redistribute Subterrans freely, but any derivative work must be licensed under the same terms, and if you run a modified version as a network service, you must share your modifications with the users of that service. Your surrounding website, infrastructure, and account systems are not derivative works and are not covered.
 
+Additionally, **everyone** is granted the **Subterrans App Store Exception** — an AGPL section 7 additional permission that lets anyone build and distribute Subterrans through app stores and similar platforms (Apple App Store, Google Play, Steam, console storefronts, etc.) whose terms would otherwise conflict with the AGPL, so long as the complete source stays available under the AGPL through an unrestricted channel. See [LICENSE-EXCEPTIONS.md](LICENSE-EXCEPTIONS.md). This keeps Subterrans fully open source while allowing you (or anyone) to ship store binaries.
+
 ## Acknowledgements
 
 - Maxis and the original _SimAnt_ (1991) team, for making the game that made this one necessary.


### PR DESCRIPTION
## What

Adds an **AGPL section 7 "App Store" additional permission**, granted to **everyone**, so that anyone — the maintainer or any downstream user — can build and distribute Subterrans through app stores and similar platforms whose terms would otherwise conflict with the AGPL, while the project stays **fully open source under the AGPL**.

## Why

AGPL's "no further restrictions" clause conflicts with app-store terms (DRM, device/installation limits, mandatory ToS acceptance) — the classic VLC-2011 / GPL-on-App-Store problem. The big AGPL apps (Signal, Bitwarden, Nextcloud) solve this by consolidating copyright via a **CLA** and shipping only their own official binary — which empowers only the copyright owner.

We want the opposite: keep copyleft, require **no CLA**, and let **anyone** ship store builds. A public §7 additional permission (the KDE / wger approach) does exactly that. Because the exception is part of the outbound license and we keep **inbound=outbound**, external contributions carry it automatically — no CLA, no signing gate.

## What changed

- **`LICENSE-EXCEPTIONS.md`** (new) — the exception text: *Subterrans App Store Exception, v1.0*. Granted to everyone; conditioned on full source staying available under the AGPL through an unrestricted channel; **versioned & project-updatable** (v1.0-or-later, permissions-only — so future platforms/wording fixes need no contributor sign-off); third-party components carved out; removable per §7 (forward-only).
- **`README.md`** §License — plain-English summary + link.
- **`.github/CONTRIBUTING.md`** — inbound=outbound now includes the exception, plus a provenance-certification line and a rule against vendoring incompatible copyleft code.

## Notes

- **`LICENSE` and `package.json` untouched** — GitHub still detects the repo as `AGPL-3.0-or-later`, and npm's SPDX field stays valid (deliberately understating the granted permissions — the safe direction).
- **One-way door:** once released, the exception is permanent for that code — everyone has it forever. Intentional.
- No code changed; this is a licensing/docs change.
- Not legal advice; adopted as a deliberate owner decision after a cross-model (Claude + Fable) review of the options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShzYQ9mtDjHeUNmte3X2i6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and documented the Subterrans App Store Exception for distribution through app stores and similar platforms.
  * Clarified licensing terms, contributor licensing expectations, and source availability requirements.
  * Added a dedicated reference describing the exception’s scope and conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->